### PR TITLE
Migrate all Generate*URL to stable file URLs and delete dead code

### DIFF
--- a/pkg/filesign/service.go
+++ b/pkg/filesign/service.go
@@ -37,31 +37,6 @@ func NewService(pgClient *pg.Client, fileManager *filemanager.Service) *Service 
 	}
 }
 
-// GeneratePresignedFileURL returns a short-lived S3 presigned URL for a PUBLIC file.
-// Prefer file.Service.GenerateFileURL in most cases — it returns a stable, cacheable
-// application URL. Only use this when a direct S3 URL with a controlled TTL is required
-// (e.g. the /api/files/v1 HTTP handler that issues the presign-on-redirect).
-func (s *Service) GeneratePresignedFileURL(
-	ctx context.Context,
-	fileID gid.GID,
-	expiresIn time.Duration,
-) (string, error) {
-	file := &coredata.File{}
-
-	err := s.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		if err := file.LoadPublicByID(ctx, conn, fileID); err != nil {
-			return fmt.Errorf("cannot load public file: %w", err)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return "", err
-	}
-
-	return s.fileManager.GenerateFileUrl(ctx, file, expiresIn)
-}
-
 // LoadFile loads a non-deleted file by ID scoped to the given tenant.
 // The scope should be obtained from a prior IAM authorize call.
 func (s *Service) LoadFile(

--- a/pkg/iam/compliance_page_service.go
+++ b/pkg/iam/compliance_page_service.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"time"
 
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/packages/emails"
@@ -40,28 +39,19 @@ func NewCompliancePageService(svc *Service) *CompliancePageService {
 func (s *CompliancePageService) GenerateLogoURL(
 	ctx context.Context,
 	compliancePageID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
-	file := &coredata.File{}
-	compliancePage := &coredata.TrustCenter{}
-
+	var logoFileID *gid.GID
 	scope := coredata.NewScopeFromObjectID(compliancePageID)
 
 	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
+			compliancePage := &coredata.TrustCenter{}
 			if err := compliancePage.LoadByID(ctx, conn, scope, compliancePageID); err != nil {
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
-			if compliancePage.LogoFileID == nil {
-				return nil
-			}
-
-			if err := file.LoadByID(ctx, conn, scope, *compliancePage.LogoFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			logoFileID = compliancePage.LogoFileID
 			return nil
 		},
 	)
@@ -69,20 +59,16 @@ func (s *CompliancePageService) GenerateLogoURL(
 		return nil, err
 	}
 
-	if compliancePage.LogoFileID == nil {
+	if logoFileID == nil {
 		return nil, nil
 	}
 
-	if file.FileKey == "" {
-		return nil, nil
-	}
-
-	presignedURL, err := s.fm.GenerateFileUrl(ctx, file, expiresIn)
+	url, err := s.file.GenerateFileURLForID(*logoFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return &presignedURL, nil
+	return &url, nil
 }
 
 func (s *CompliancePageService) EmailPresenterConfig(ctx context.Context, compliancePageID gid.GID) (emails.PresenterConfig, error) {

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1374,13 +1374,9 @@ func (s *OrganizationService) GetOrganizationForMembership(ctx context.Context, 
 func (s OrganizationService) GenerateLogoURL(
 	ctx context.Context,
 	organizationID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
-	var (
-		errNoLogoFile = errors.New("no logo file found")
-		scope         = coredata.NewScopeFromObjectID(organizationID)
-		file          = &coredata.File{}
-	)
+	var logoFileID *gid.GID
+	scope := coredata.NewScopeFromObjectID(organizationID)
 
 	err := s.pg.WithConn(
 		ctx,
@@ -1390,43 +1386,32 @@ func (s OrganizationService) GenerateLogoURL(
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			if organization.LogoFileID == nil {
-				return errNoLogoFile
-			}
-
-			if err := file.LoadByID(ctx, conn, scope, *organization.LogoFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			logoFileID = organization.LogoFileID
 			return nil
 		},
 	)
-	if err == errNoLogoFile {
-		return nil, nil
-	}
-
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate logo URL: %w", err)
 	}
 
-	presignedURL, err := s.fm.GenerateFileUrl(ctx, file, expiresIn)
+	if logoFileID == nil {
+		return nil, nil
+	}
+
+	url, err := s.file.GenerateFileURLForID(*logoFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return &presignedURL, nil
+	return &url, nil
 }
 
 func (s OrganizationService) GenerateHorizontalLogoURL(
 	ctx context.Context,
 	organizationID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
-	var (
-		errNoLogoFile = errors.New("no logo file found")
-		scope         = coredata.NewScopeFromObjectID(organizationID)
-		file          = &coredata.File{}
-	)
+	var horizontalLogoFileID *gid.GID
+	scope := coredata.NewScopeFromObjectID(organizationID)
 
 	err := s.pg.WithConn(
 		ctx,
@@ -1436,31 +1421,24 @@ func (s OrganizationService) GenerateHorizontalLogoURL(
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			if organization.HorizontalLogoFileID == nil {
-				return errNoLogoFile
-			}
-
-			if err := file.LoadByID(ctx, conn, scope, *organization.HorizontalLogoFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			horizontalLogoFileID = organization.HorizontalLogoFileID
 			return nil
 		},
 	)
-	if err == errNoLogoFile {
-		return nil, nil
-	}
-
 	if err != nil {
 		return nil, err
 	}
 
-	presignedURL, err := s.fm.GenerateFileUrl(ctx, file, expiresIn)
+	if horizontalLogoFileID == nil {
+		return nil, nil
+	}
+
+	url, err := s.file.GenerateFileURLForID(*horizontalLogoFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return &presignedURL, nil
+	return &url, nil
 }
 
 func (s OrganizationService) DeleteSAMLConfiguration(

--- a/pkg/iam/service.go
+++ b/pkg/iam/service.go
@@ -31,6 +31,7 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/crypto/cipher"
 	"go.probo.inc/probo/pkg/crypto/passwdhash"
+	"go.probo.inc/probo/pkg/file"
 	"go.probo.inc/probo/pkg/filemanager"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam/oauth2server"
@@ -44,6 +45,7 @@ type (
 	Service struct {
 		pg                         *pg.Client
 		fm                         *filemanager.Service
+		file                       *file.Service
 		hp                         *passwdhash.Profile
 		dummyHash                  []byte
 		baseURL                    string
@@ -113,6 +115,7 @@ func NewService(
 	ctx context.Context,
 	pgClient *pg.Client,
 	fm *filemanager.Service,
+	fileSvc *file.Service,
 	hp *passwdhash.Profile,
 	cfg Config,
 ) (*Service, error) {
@@ -135,6 +138,7 @@ func NewService(
 	svc := &Service{
 		pg:                         pgClient,
 		fm:                         fm,
+		file:                       fileSvc,
 		hp:                         hp,
 		dummyHash:                  mustHashDummy(hp),
 		baseURL:                    cfg.BaseURL.String(),

--- a/pkg/probo/framework_service.go
+++ b/pkg/probo/framework_service.go
@@ -835,9 +835,8 @@ func (s *FrameworkService) BuildAndUploadExport(ctx context.Context, scope cored
 func (s FrameworkService) GenerateLightLogoURL(
 	ctx context.Context, scope coredata.Scoper,
 	frameworkID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
-	file := &coredata.File{}
+	var lightLogoFileID *gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -847,14 +846,7 @@ func (s FrameworkService) GenerateLightLogoURL(
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
-			if framework.LightLogoFileID == nil {
-				return nil
-			}
-
-			if err := file.LoadByID(ctx, conn, scope, *framework.LightLogoFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			lightLogoFileID = framework.LightLogoFileID
 			return nil
 		},
 	)
@@ -862,24 +854,23 @@ func (s FrameworkService) GenerateLightLogoURL(
 		return nil, err
 	}
 
-	if file.FileKey == "" {
+	if lightLogoFileID == nil {
 		return nil, nil
 	}
 
-	presignedURL, err := s.svc.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+	url, err := s.svc.file.GenerateFileURLForID(*lightLogoFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return &presignedURL, nil
+	return &url, nil
 }
 
 func (s FrameworkService) GenerateDarkLogoURL(
 	ctx context.Context, scope coredata.Scoper,
 	frameworkID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
-	file := &coredata.File{}
+	var darkLogoFileID *gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -889,14 +880,7 @@ func (s FrameworkService) GenerateDarkLogoURL(
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
-			if framework.DarkLogoFileID == nil {
-				return nil
-			}
-
-			if err := file.LoadByID(ctx, conn, scope, *framework.DarkLogoFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			darkLogoFileID = framework.DarkLogoFileID
 			return nil
 		},
 	)
@@ -904,14 +888,14 @@ func (s FrameworkService) GenerateDarkLogoURL(
 		return nil, err
 	}
 
-	if file.FileKey == "" {
+	if darkLogoFileID == nil {
 		return nil, nil
 	}
 
-	presignedURL, err := s.svc.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+	url, err := s.svc.file.GenerateFileURLForID(*darkLogoFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return &presignedURL, nil
+	return &url, nil
 }

--- a/pkg/probo/organization_service.go
+++ b/pkg/probo/organization_service.go
@@ -419,9 +419,8 @@ func (s OrganizationService) Update(
 func (s OrganizationService) GenerateLogoURL(
 	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
-	file := &coredata.File{}
+	var logoFileID *gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -431,14 +430,7 @@ func (s OrganizationService) GenerateLogoURL(
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			if organization.LogoFileID == nil {
-				return nil
-			}
-
-			if err := file.LoadByID(ctx, conn, scope, *organization.LogoFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			logoFileID = organization.LogoFileID
 			return nil
 		},
 	)
@@ -446,24 +438,23 @@ func (s OrganizationService) GenerateLogoURL(
 		return nil, err
 	}
 
-	if file.FileKey == "" {
+	if logoFileID == nil {
 		return nil, nil
 	}
 
-	presignedURL, err := s.svc.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+	url, err := s.svc.file.GenerateFileURLForID(*logoFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return &presignedURL, nil
+	return &url, nil
 }
 
 func (s OrganizationService) GenerateHorizontalLogoURL(
 	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
-	file := &coredata.File{}
+	var horizontalLogoFileID *gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -473,14 +464,7 @@ func (s OrganizationService) GenerateHorizontalLogoURL(
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			if organization.HorizontalLogoFileID == nil {
-				return nil
-			}
-
-			if err := file.LoadByID(ctx, conn, scope, *organization.HorizontalLogoFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			horizontalLogoFileID = organization.HorizontalLogoFileID
 			return nil
 		},
 	)
@@ -488,16 +472,16 @@ func (s OrganizationService) GenerateHorizontalLogoURL(
 		return nil, err
 	}
 
-	if file.FileKey == "" {
+	if horizontalLogoFileID == nil {
 		return nil, nil
 	}
 
-	presignedURL, err := s.svc.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+	url, err := s.svc.file.GenerateFileURLForID(*horizontalLogoFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return &presignedURL, nil
+	return &url, nil
 }
 
 func (s OrganizationService) DeleteHorizontalLogo(

--- a/pkg/probo/third_party_business_associate_agreement_service.go
+++ b/pkg/probo/third_party_business_associate_agreement_service.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"mime"
-	"net/url"
 	"path/filepath"
 	"time"
 
@@ -231,9 +230,8 @@ func (s ThirdPartyBusinessAssociateAgreementService) Get(
 func (s ThirdPartyBusinessAssociateAgreementService) GenerateFileURL(
 	ctx context.Context, scope coredata.Scoper,
 	thirdPartyBusinessAssociateAgreementID gid.GID,
-	expiresIn time.Duration,
 ) (string, error) {
-	var file *coredata.File
+	var fileID gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -243,11 +241,7 @@ func (s ThirdPartyBusinessAssociateAgreementService) GenerateFileURL(
 				return fmt.Errorf("cannot load thirdParty business associate agreement: %w", err)
 			}
 
-			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, scope, thirdPartyBusinessAssociateAgreement.FileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			fileID = thirdPartyBusinessAssociateAgreement.FileID
 			return nil
 		},
 	)
@@ -255,25 +249,12 @@ func (s ThirdPartyBusinessAssociateAgreementService) GenerateFileURL(
 		return "", err
 	}
 
-	presignClient := s3.NewPresignClient(s.svc.s3)
-
-	encodedFilename := url.QueryEscape(file.FileName)
-	contentDisposition := fmt.Sprintf("attachment; filename=\"%s\"; filename*=UTF-8''%s",
-		encodedFilename, encodedFilename)
-
-	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-		Bucket:                     new(s.svc.bucket),
-		Key:                        new(file.FileKey),
-		ResponseCacheControl:       new("max-age=3600, public"),
-		ResponseContentDisposition: new(contentDisposition),
-	}, func(opts *s3.PresignOptions) {
-		opts.Expires = expiresIn
-	})
+	fileURL, err := s.svc.file.GenerateFileURLForID(fileID)
 	if err != nil {
-		return "", fmt.Errorf("cannot presign GetObject request: %w", err)
+		return "", fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return presignedReq.URL, nil
+	return fileURL, nil
 }
 
 func (s ThirdPartyBusinessAssociateAgreementService) Update(

--- a/pkg/probo/third_party_data_privacy_agreement_service.go
+++ b/pkg/probo/third_party_data_privacy_agreement_service.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"mime"
-	"net/url"
 	"path/filepath"
 	"time"
 
@@ -231,9 +230,8 @@ func (s ThirdPartyDataPrivacyAgreementService) Get(
 func (s ThirdPartyDataPrivacyAgreementService) GenerateFileURL(
 	ctx context.Context, scope coredata.Scoper,
 	thirdPartyDataPrivacyAgreementID gid.GID,
-	expiresIn time.Duration,
 ) (string, error) {
-	var file *coredata.File
+	var fileID gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -243,11 +241,7 @@ func (s ThirdPartyDataPrivacyAgreementService) GenerateFileURL(
 				return fmt.Errorf("cannot load thirdParty data privacy agreement: %w", err)
 			}
 
-			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, scope, thirdPartyDataPrivacyAgreement.FileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			fileID = thirdPartyDataPrivacyAgreement.FileID
 			return nil
 		},
 	)
@@ -255,25 +249,12 @@ func (s ThirdPartyDataPrivacyAgreementService) GenerateFileURL(
 		return "", err
 	}
 
-	presignClient := s3.NewPresignClient(s.svc.s3)
-
-	encodedFilename := url.QueryEscape(file.FileName)
-	contentDisposition := fmt.Sprintf("attachment; filename=\"%s\"; filename*=UTF-8''%s",
-		encodedFilename, encodedFilename)
-
-	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-		Bucket:                     new(s.svc.bucket),
-		Key:                        new(file.FileKey),
-		ResponseCacheControl:       new("max-age=3600, public"),
-		ResponseContentDisposition: new(contentDisposition),
-	}, func(opts *s3.PresignOptions) {
-		opts.Expires = expiresIn
-	})
+	fileURL, err := s.svc.file.GenerateFileURLForID(fileID)
 	if err != nil {
-		return "", fmt.Errorf("cannot presign GetObject request: %w", err)
+		return "", fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return presignedReq.URL, nil
+	return fileURL, nil
 }
 
 func (s ThirdPartyDataPrivacyAgreementService) Update(

--- a/pkg/probo/trust_center_file_service.go
+++ b/pkg/probo/trust_center_file_service.go
@@ -289,23 +289,18 @@ func (s TrustCenterFileService) Delete(
 func (s TrustCenterFileService) GenerateFileURL(
 	ctx context.Context, scope coredata.Scoper,
 	trustCenterFileID gid.GID,
-	duration time.Duration,
 ) (string, error) {
-	var storedFile *coredata.File
+	var fileID gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			file := &coredata.TrustCenterFile{}
-			if err := file.LoadByID(ctx, conn, scope, trustCenterFileID); err != nil {
+			tcFile := &coredata.TrustCenterFile{}
+			if err := tcFile.LoadByID(ctx, conn, scope, trustCenterFileID); err != nil {
 				return fmt.Errorf("cannot load trust center file: %w", err)
 			}
 
-			storedFile = &coredata.File{}
-			if err := storedFile.LoadByID(ctx, conn, scope, file.FileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			fileID = tcFile.FileID
 			return nil
 		},
 	)
@@ -313,12 +308,12 @@ func (s TrustCenterFileService) GenerateFileURL(
 		return "", err
 	}
 
-	fileURL, err := s.svc.fileManager.GenerateFileUrl(ctx, storedFile, duration)
+	url, err := s.svc.file.GenerateFileURLForID(fileID)
 	if err != nil {
 		return "", fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return fileURL, nil
+	return url, nil
 }
 
 func (s TrustCenterFileService) uploadFile(

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -467,28 +467,18 @@ func (s TrustCenterService) uploadFile(
 func (s TrustCenterService) GenerateNDAFileURL(
 	ctx context.Context, scope coredata.Scoper,
 	trustCenterID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
-	var file *coredata.File
-
-	trustCenter := &coredata.TrustCenter{}
+	var ndaFileID *gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
+			trustCenter := &coredata.TrustCenter{}
 			if err := trustCenter.LoadByID(ctx, conn, scope, trustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
-			if trustCenter.NonDisclosureAgreementFileID == nil {
-				return nil
-			}
-
-			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			ndaFileID = trustCenter.NonDisclosureAgreementFileID
 			return nil
 		},
 	)
@@ -496,22 +486,21 @@ func (s TrustCenterService) GenerateNDAFileURL(
 		return nil, err
 	}
 
-	if trustCenter.NonDisclosureAgreementFileID == nil {
+	if ndaFileID == nil {
 		return nil, nil
 	}
 
-	presignedURL, err := s.svc.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+	url, err := s.svc.file.GenerateFileURLForID(*ndaFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return &presignedURL, nil
+	return &url, nil
 }
 
 func (s TrustCenterService) GenerateLogoURL(
 	ctx context.Context, scope coredata.Scoper,
 	compliancePageID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
 	file := &coredata.File{}
 	compliancePage := &coredata.TrustCenter{}
@@ -546,7 +535,7 @@ func (s TrustCenterService) GenerateLogoURL(
 		return nil, nil
 	}
 
-	presignedURL, err := s.svc.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+	presignedURL, err := s.svc.file.GenerateFileURLForID(file.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
@@ -557,7 +546,6 @@ func (s TrustCenterService) GenerateLogoURL(
 func (s TrustCenterService) GenerateDarkLogoURL(
 	ctx context.Context, scope coredata.Scoper,
 	compliancePageID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
 	file := &coredata.File{}
 	compliancePage := &coredata.TrustCenter{}
@@ -592,7 +580,7 @@ func (s TrustCenterService) GenerateDarkLogoURL(
 		return nil, nil
 	}
 
-	presignedURL, err := s.svc.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+	presignedURL, err := s.svc.file.GenerateFileURLForID(file.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -445,10 +445,13 @@ func (impl *Implm) Run(
 		return fmt.Errorf("cannot upload email static assets: %w", err)
 	}
 
+	fileService := file.NewService(pgClient, baseURL)
+
 	iamService, err := iam.NewService(
 		ctx,
 		pgClient,
 		fileManagerService,
+		fileService,
 		hp,
 		iam.Config{
 			DisableSignup:                  impl.cfg.Auth.DisableSignup,
@@ -539,7 +542,6 @@ func (impl *Implm) Run(
 
 	cookieBannerService := cookiebanner.NewService(pgClient, impl.cfg.Branding)
 
-	fileService := file.NewService(pgClient, baseURL)
 	filesignService := filesign.NewService(pgClient, fileManagerService)
 
 	proboService, err := probo.NewService(

--- a/pkg/server/api/connect/v1/organization_resolvers.go
+++ b/pkg/server/api/connect/v1/organization_resolvers.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/coredata"
@@ -164,7 +163,7 @@ func (r *organizationResolver) LogoURL(ctx context.Context, obj *types.Organizat
 		return nil, err
 	}
 
-	presignedURL, err := r.iam.OrganizationService.GenerateLogoURL(ctx, obj.ID, 1*time.Hour)
+	presignedURL, err := r.iam.OrganizationService.GenerateLogoURL(ctx, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo URL", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -179,7 +178,7 @@ func (r *organizationResolver) HorizontalLogoURL(ctx context.Context, obj *types
 		return nil, err
 	}
 
-	presignedURL, err := r.iam.OrganizationService.GenerateHorizontalLogoURL(ctx, obj.ID, 1*time.Hour)
+	presignedURL, err := r.iam.OrganizationService.GenerateHorizontalLogoURL(ctx, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate horizontal logo URL", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/framework_resolvers.go
+++ b/pkg/server/api/console/v1/framework_resolvers.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"time"
 
 	"github.com/vikstrous/dataloadgen"
 	"go.gearno.de/kit/log"
@@ -88,7 +87,7 @@ func (r *frameworkResolver) LightLogoURL(ctx context.Context, obj *types.Framewo
 		return nil, err
 	}
 
-	return r.probo.Frameworks.GenerateLightLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	return r.probo.Frameworks.GenerateLightLogoURL(ctx, scope, obj.ID)
 }
 
 // DarkLogoURL is the resolver for the darkLogoURL field.
@@ -98,7 +97,7 @@ func (r *frameworkResolver) DarkLogoURL(ctx context.Context, obj *types.Framewor
 		return nil, err
 	}
 
-	return r.probo.Frameworks.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	return r.probo.Frameworks.GenerateDarkLogoURL(ctx, scope, obj.ID)
 }
 
 // Permission is the resolver for the permission field.

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/agentrun"
@@ -65,7 +64,7 @@ func (r *organizationResolver) LogoURL(ctx context.Context, obj *types.Organizat
 		return nil, err
 	}
 
-	logoURL, err := r.probo.Organizations.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	logoURL, err := r.probo.Organizations.GenerateLogoURL(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo url", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -81,7 +80,7 @@ func (r *organizationResolver) HorizontalLogoURL(ctx context.Context, obj *types
 		return nil, err
 	}
 
-	horizontalLogoURL, err := r.probo.Organizations.GenerateHorizontalLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	horizontalLogoURL, err := r.probo.Organizations.GenerateHorizontalLogoURL(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate horizontal logo url", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/third_party_resolvers.go
+++ b/pkg/server/api/console/v1/third_party_resolvers.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	pgx "github.com/jackc/pgx/v5"
 	"github.com/vikstrous/dataloadgen"
@@ -989,7 +988,7 @@ func (r *thirdPartyBusinessAssociateAgreementResolver) FileURL(ctx context.Conte
 		return "", err
 	}
 
-	fileURL, err := r.probo.ThirdPartyBusinessAssociateAgreements.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
+	fileURL, err := r.probo.ThirdPartyBusinessAssociateAgreements.GenerateFileURL(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate file URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)
@@ -1180,7 +1179,7 @@ func (r *thirdPartyDataPrivacyAgreementResolver) FileURL(ctx context.Context, ob
 		return "", err
 	}
 
-	fileURL, err := r.probo.ThirdPartyDataPrivacyAgreements.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
+	fileURL, err := r.probo.ThirdPartyDataPrivacyAgreements.GenerateFileURL(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate file URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/trust_center_resolvers.go
+++ b/pkg/server/api/console/v1/trust_center_resolvers.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/vikstrous/dataloadgen"
 	"go.gearno.de/kit/log"
@@ -696,7 +695,7 @@ func (r *trustCenterResolver) LogoFileURL(ctx context.Context, obj *types.TrustC
 		return nil, err
 	}
 
-	logoURL, err := r.probo.TrustCenters.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	logoURL, err := r.probo.TrustCenters.GenerateLogoURL(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo url", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -712,7 +711,7 @@ func (r *trustCenterResolver) DarkLogoFileURL(ctx context.Context, obj *types.Tr
 		return nil, err
 	}
 
-	logoURL, err := r.probo.TrustCenters.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	logoURL, err := r.probo.TrustCenters.GenerateDarkLogoURL(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo url", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -735,7 +734,7 @@ func (r *trustCenterResolver) NdaFileURL(ctx context.Context, obj *types.TrustCe
 
 	scope := coredata.NewScopeFromObjectID(obj.ID)
 
-	fileURL, err := r.probo.TrustCenters.GenerateNDAFileURL(ctx, scope, obj.ID, 15*time.Minute)
+	fileURL, err := r.probo.TrustCenters.GenerateNDAFileURL(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate NDA file URL", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1150,7 +1149,7 @@ func (r *trustCenterFileResolver) FileURL(ctx context.Context, obj *types.TrustC
 		return "", err
 	}
 
-	fileURL, err := r.probo.TrustCenterFiles.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
+	fileURL, err := r.probo.TrustCenterFiles.GenerateFileURL(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate file URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -4908,17 +4908,17 @@ func (r *Resolver) GetTrustCenterTool(ctx context.Context, req *mcp.CallToolRequ
 
 	tc := types.NewTrustCenter(trustCenter)
 
-	logoURL, err := prb.TrustCenters.GenerateLogoURL(ctx, scope, trustCenter.ID, 1*time.Hour)
+	logoURL, err := prb.TrustCenters.GenerateLogoURL(ctx, scope, trustCenter.ID)
 	if err == nil {
 		tc.LogoFileURL = logoURL
 	}
 
-	darkLogoURL, err := prb.TrustCenters.GenerateDarkLogoURL(ctx, scope, trustCenter.ID, 1*time.Hour)
+	darkLogoURL, err := prb.TrustCenters.GenerateDarkLogoURL(ctx, scope, trustCenter.ID)
 	if err == nil {
 		tc.DarkLogoFileURL = darkLogoURL
 	}
 
-	ndaFileURL, err := prb.TrustCenters.GenerateNDAFileURL(ctx, scope, trustCenter.ID, 15*time.Minute)
+	ndaFileURL, err := prb.TrustCenters.GenerateNDAFileURL(ctx, scope, trustCenter.ID)
 	if err == nil {
 		tc.NdaFileURL = ndaFileURL
 	}
@@ -5104,7 +5104,7 @@ func (r *Resolver) ListTrustCenterFilesTool(ctx context.Context, req *mcp.CallTo
 
 	files := make([]*types.TrustCenterFile, 0, len(p.Data))
 	for _, f := range p.Data {
-		fileURL, err := prb.TrustCenterFiles.GenerateFileURL(ctx, scope, f.ID, 1*time.Hour)
+		fileURL, err := prb.TrustCenterFiles.GenerateFileURL(ctx, scope, f.ID)
 		if err != nil {
 			return nil, types.ListTrustCenterFilesOutput{}, fmt.Errorf("cannot generate file URL: %w", err)
 		}

--- a/pkg/server/api/trust/v1/nda_resolvers.go
+++ b/pkg/server/api/trust/v1/nda_resolvers.go
@@ -104,7 +104,7 @@ func (r *nonDisclosureAgreementResolver) FileURL(ctx context.Context, obj *types
 	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
 	trustService := r.trust
 
-	fileURL, err := trustService.TrustCenters.GenerateNDAFileURL(ctx, scope, trustCenter.ID, 15*time.Minute)
+	fileURL, err := trustService.TrustCenters.GenerateNDAFileURL(ctx, scope, trustCenter.ID)
 	if err != nil {
 		return "", gqlutils.Internal(ctx)
 	}

--- a/pkg/server/api/trust/v1/organization_resolvers.go
+++ b/pkg/server/api/trust/v1/organization_resolvers.go
@@ -7,7 +7,6 @@ package trust_v1
 
 import (
 	"context"
-	"time"
 
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/server/api/trust/v1/schema"
@@ -19,7 +18,7 @@ func (r *organizationResolver) LogoURL(ctx context.Context, obj *types.Organizat
 	scope := coredata.NewScopeFromObjectID(obj.ID)
 	trustService := r.trust
 
-	return trustService.Organizations.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	return trustService.Organizations.GenerateLogoURL(ctx, scope, obj.ID)
 }
 
 // Organization returns schema.OrganizationResolver implementation.

--- a/pkg/server/api/trust/v1/trust_center_resolvers.go
+++ b/pkg/server/api/trust/v1/trust_center_resolvers.go
@@ -10,7 +10,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"time"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/coredata"
@@ -266,7 +265,7 @@ func (r *frameworkResolver) LightLogoURL(ctx context.Context, obj *types.Framewo
 	scope := coredata.NewScopeFromObjectID(obj.ID)
 	trustService := r.trust
 
-	return trustService.Frameworks.GenerateLightLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	return trustService.Frameworks.GenerateLightLogoURL(ctx, scope, obj.ID)
 }
 
 // DarkLogoURL is the resolver for the darkLogoURL field.
@@ -274,7 +273,7 @@ func (r *frameworkResolver) DarkLogoURL(ctx context.Context, obj *types.Framewor
 	scope := coredata.NewScopeFromObjectID(obj.ID)
 	trustService := r.trust
 
-	return trustService.Frameworks.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	return trustService.Frameworks.GenerateDarkLogoURL(ctx, scope, obj.ID)
 }
 
 // RequestAllAccesses is the resolver for the requestAllAccesses field.
@@ -655,7 +654,7 @@ func (r *trustCenterResolver) LogoFileURL(ctx context.Context, obj *types.TrustC
 	scope := coredata.NewScopeFromObjectID(obj.ID)
 	trustService := r.trust
 
-	return trustService.TrustCenters.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	return trustService.TrustCenters.GenerateLogoURL(ctx, scope, obj.ID)
 }
 
 // DarkLogoFileURL is the resolver for the darkLogoFileUrl field.
@@ -663,7 +662,7 @@ func (r *trustCenterResolver) DarkLogoFileURL(ctx context.Context, obj *types.Tr
 	scope := coredata.NewScopeFromObjectID(obj.ID)
 	trustService := r.trust
 
-	return trustService.TrustCenters.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	return trustService.TrustCenters.GenerateDarkLogoURL(ctx, scope, obj.ID)
 }
 
 // NonDisclosureAgreement is the resolver for the nonDisclosureAgreement field.

--- a/pkg/trust/framework_service.go
+++ b/pkg/trust/framework_service.go
@@ -17,7 +17,6 @@ package trust
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
@@ -54,9 +53,8 @@ func (s FrameworkService) GenerateLightLogoURL(
 	ctx context.Context,
 	scope coredata.Scoper,
 	frameworkID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
-	file := &coredata.File{}
+	var lightLogoFileID *gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -66,14 +64,7 @@ func (s FrameworkService) GenerateLightLogoURL(
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
-			if framework.LightLogoFileID == nil {
-				return nil
-			}
-
-			if err := file.LoadByID(ctx, conn, scope, *framework.LightLogoFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			lightLogoFileID = framework.LightLogoFileID
 			return nil
 		},
 	)
@@ -81,25 +72,24 @@ func (s FrameworkService) GenerateLightLogoURL(
 		return nil, err
 	}
 
-	if file.FileKey == "" {
+	if lightLogoFileID == nil {
 		return nil, nil
 	}
 
-	presignedURL, err := s.svc.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+	url, err := s.svc.file.GenerateFileURLForID(*lightLogoFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return &presignedURL, nil
+	return &url, nil
 }
 
 func (s FrameworkService) GenerateDarkLogoURL(
 	ctx context.Context,
 	scope coredata.Scoper,
 	frameworkID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
-	file := &coredata.File{}
+	var darkLogoFileID *gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -109,14 +99,7 @@ func (s FrameworkService) GenerateDarkLogoURL(
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
-			if framework.DarkLogoFileID == nil {
-				return nil
-			}
-
-			if err := file.LoadByID(ctx, conn, scope, *framework.DarkLogoFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			darkLogoFileID = framework.DarkLogoFileID
 			return nil
 		},
 	)
@@ -124,14 +107,14 @@ func (s FrameworkService) GenerateDarkLogoURL(
 		return nil, err
 	}
 
-	if file.FileKey == "" {
+	if darkLogoFileID == nil {
 		return nil, nil
 	}
 
-	presignedURL, err := s.svc.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+	url, err := s.svc.file.GenerateFileURLForID(*darkLogoFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return &presignedURL, nil
+	return &url, nil
 }

--- a/pkg/trust/organization_service.go
+++ b/pkg/trust/organization_service.go
@@ -17,10 +17,7 @@ package trust
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"time"
 
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
@@ -98,7 +95,6 @@ func (s OrganizationService) GenerateLogoURL(
 	ctx context.Context,
 	scope coredata.Scoper,
 	organizationID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
 	organization, err := s.Get(ctx, scope, organizationID)
 	if err != nil {
@@ -109,35 +105,10 @@ func (s OrganizationService) GenerateLogoURL(
 		return nil, nil
 	}
 
-	file := &coredata.File{}
-
-	err = s.svc.pg.WithConn(
-		ctx,
-		func(ctx context.Context, conn pg.Querier) error {
-			return file.LoadByID(ctx, conn, scope, *organization.LogoFileID)
-		},
-	)
+	url, err := s.svc.file.GenerateFileURLForID(*organization.LogoFileID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load file: %w", err)
+		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	presignClient := s3.NewPresignClient(s.svc.s3)
-
-	encodedFilename := url.QueryEscape(file.FileName)
-	contentDisposition := fmt.Sprintf("attachment; filename=\"%s\"; filename*=UTF-8''%s",
-		encodedFilename, encodedFilename)
-
-	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-		Bucket:                     new(s.svc.bucket),
-		Key:                        new(file.FileKey),
-		ResponseCacheControl:       new("max-age=3600, public"),
-		ResponseContentDisposition: new(contentDisposition),
-	}, func(opts *s3.PresignOptions) {
-		opts.Expires = expiresIn
-	})
-	if err != nil {
-		return nil, fmt.Errorf("cannot presign GetObject request: %w", err)
-	}
-
-	return &presignedReq.URL, nil
+	return &url, nil
 }

--- a/pkg/trust/trust_center_service.go
+++ b/pkg/trust/trust_center_service.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"time"
 
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/packages/emails"
@@ -119,9 +118,8 @@ func (s TrustCenterService) GenerateNDAFileURL(
 	ctx context.Context,
 	scope coredata.Scoper,
 	trustCenterID gid.GID,
-	expiresIn time.Duration,
 ) (string, error) {
-	var file *coredata.File
+	var ndaFileID *gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -135,11 +133,7 @@ func (s TrustCenterService) GenerateNDAFileURL(
 				return fmt.Errorf("no NDA file found")
 			}
 
-			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			ndaFileID = trustCenter.NonDisclosureAgreementFileID
 			return nil
 		},
 	)
@@ -147,38 +141,30 @@ func (s TrustCenterService) GenerateNDAFileURL(
 		return "", err
 	}
 
-	presignedURL, err := s.svc.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+	url, err := s.svc.file.GenerateFileURLForID(*ndaFileID)
 	if err != nil {
 		return "", fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return presignedURL, nil
+	return url, nil
 }
 
 func (s TrustCenterService) GenerateLogoURL(
 	ctx context.Context,
 	scope coredata.Scoper,
 	compliancePageID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
-	file := &coredata.File{}
-	compliancePage := &coredata.TrustCenter{}
+	var logoFileID *gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
+			compliancePage := &coredata.TrustCenter{}
 			if err := compliancePage.LoadByID(ctx, conn, scope, compliancePageID); err != nil {
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
-			if compliancePage.LogoFileID == nil {
-				return nil
-			}
-
-			if err := file.LoadByID(ctx, conn, scope, *compliancePage.LogoFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			logoFileID = compliancePage.LogoFileID
 			return nil
 		},
 	)
@@ -186,46 +172,34 @@ func (s TrustCenterService) GenerateLogoURL(
 		return nil, err
 	}
 
-	if compliancePage.LogoFileID == nil {
+	if logoFileID == nil {
 		return nil, nil
 	}
 
-	if file.FileKey == "" {
-		return nil, nil
-	}
-
-	presignedURL, err := s.svc.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+	url, err := s.svc.file.GenerateFileURLForID(*logoFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return &presignedURL, nil
+	return &url, nil
 }
 
 func (s TrustCenterService) GenerateDarkLogoURL(
 	ctx context.Context,
 	scope coredata.Scoper,
 	compliancePageID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
-	file := &coredata.File{}
-	compliancePage := &coredata.TrustCenter{}
+	var darkLogoFileID *gid.GID
 
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
+			compliancePage := &coredata.TrustCenter{}
 			if err := compliancePage.LoadByID(ctx, conn, scope, compliancePageID); err != nil {
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
-			if compliancePage.DarkLogoFileID == nil {
-				return nil
-			}
-
-			if err := file.LoadByID(ctx, conn, scope, *compliancePage.DarkLogoFileID); err != nil {
-				return fmt.Errorf("cannot load file: %w", err)
-			}
-
+			darkLogoFileID = compliancePage.DarkLogoFileID
 			return nil
 		},
 	)
@@ -233,20 +207,16 @@ func (s TrustCenterService) GenerateDarkLogoURL(
 		return nil, err
 	}
 
-	if compliancePage.DarkLogoFileID == nil {
+	if darkLogoFileID == nil {
 		return nil, nil
 	}
 
-	if file.FileKey == "" {
-		return nil, nil
-	}
-
-	presignedURL, err := s.svc.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+	url, err := s.svc.file.GenerateFileURLForID(*darkLogoFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate file URL: %w", err)
 	}
 
-	return &presignedURL, nil
+	return &url, nil
 }
 
 func (s *TrustCenterService) EmailPresenterConfig(


### PR DESCRIPTION
- Wire file.Service into iam/probo/trust services
- Migrate iam.OrganizationService, iam.CompliancePageService
- Migrate probo.OrganizationService, probo.TrustCenterService, probo.TrustCenterFileService, probo.FrameworkService
- Migrate probo.ThirdPartyBusinessAssociateAgreementService, probo.ThirdPartyDataPrivacyAgreementService
- Migrate trust.TrustCenterService, trust.FrameworkService, trust.OrganizationService
- Delete unused filesign.GeneratePresignedFileURL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated all Generate*URL paths to stable, application-level file URLs and removed presigned S3 usage. This reduces S3 dependency, simplifies service APIs, and deletes dead code.

### Service **`+104`** **`-322`**
- Replaced S3 presign logic with `file.Service.GenerateFileURLForID` across IAM, Probo, and Trust services (logos, NDAs, third-party agreements, trust center files).
- Wired `file.Service` into `iam.Service` and `probod` init; removed `filesign.GeneratePresignedFileURL`.
- Dropped `expiresIn` parameters from Generate*URL methods and avoided loading full file rows when only IDs are needed.

### GraphQL API **`+18`** **`-25`**
- Updated resolvers to call new no-TTL Generate*URL methods and return stable URLs for logos, NDAs, and files.
- No schema changes; responses now use cacheable, stable file URLs.

### MCP **`+4`** **`-4`**
- Switched MCP tool resolvers to the new stable URL methods without TTL arguments.

<sup>Written for commit d321e9eb9361b3a35ffa2cb72653b7bf665d8b06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

