### PR TITLE
Let federated users activate without forcing email/password

### DIFF
--- a/apps/console/src/pages/iam/auth/ActivateAccountPage.tsx
+++ b/apps/console/src/pages/iam/auth/ActivateAccountPage.tsx
@@ -113,7 +113,7 @@ export default function ActivateAccountPage() {
 
         const search = new URLSearchParams([["continue", safeContinueUrl.toString()]]);
         void navigate({
-          pathname: "/auth/password-login",
+          pathname: "/auth/login",
           search: "?" + search.toString(),
         }, { replace: true });
       },

--- a/pkg/server/api/connect/v1/session_resolvers.go
+++ b/pkg/server/api/connect/v1/session_resolvers.go
@@ -224,7 +224,17 @@ func (r *mutationResolver) ActivateAccount(ctx context.Context, input types.Acti
 
 	var createPasswordToken *string
 
-	if identity.HashedPassword == nil {
+	// A passwordless identity normally authenticates through a federated
+	// provider such as Google or Microsoft, which is valid across every
+	// organization the user belongs to. Only force the user to create a
+	// password when no OIDC provider is available, otherwise we would dead-end
+	// an OIDC user on the create-password page instead of letting them sign in
+	// with their provider.
+	//
+	// The hashed_password column was historically NOT NULL, so a federated
+	// identity can carry an empty (but non-nil) hash; treat both nil and empty
+	// as "no password".
+	if len(identity.HashedPassword) == 0 && len(r.iam.OIDCService.EnabledProviders()) == 0 {
 		token, err := r.iam.AuthService.GetResetPasswordToken(ctx, identity.EmailAddress)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot generate password create token", log.Error(err))


### PR DESCRIPTION
[ENG-466](https://linear.app/probo/issue/ENG-466/connection-issue-in-saml-when-password-is-absent)

A federated (Google/Microsoft) identity has an empty or nil hashed password, so account activation pushed it onto the email/password page instead of letting it sign in with its provider. The hashed_password column was historically NOT NULL, so these identities carry an empty (non-nil) hash that the old `== nil` check missed.

Treat both nil and empty hashes as passwordless and only force password creation when no OIDC provider is configured, and route the activation fallback to the sign-in chooser (/auth/login) so Google/Microsoft are offered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow federated users (Google/Microsoft) to complete activation without being forced to create a password. Treat nil or empty password hashes as passwordless and only prompt for password when no OIDC provider is configured; activation fallback now goes to the sign-in chooser.

### GraphQL API **`+11`** **`-1`**
- Treat nil and empty `hashed_password` as passwordless.
- Only create a password token when no OIDC providers are enabled.
- Avoids dead-ending OIDC users on the create-password page.

### App: console **`+1`** **`-1`**
- Activation fallback now navigates to `/auth/login` instead of `/auth/password-login`.
- Keeps the continue URL intact.

<sup>Written for commit 71b7fe4dc0fe70663d369aa53c26ff371d8129bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

