### PR TITLE
Fetch Microsoft MFA statuses

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1534,7 +1534,7 @@
     "errors": { "delete": "Failed to delete access source", "configure": "Failed to configure source" },
     "messages": { "error": "Error", "success": "Success", "organizationUpdated": "Organization updated." },
     "deleteConfirmation": "This will permanently delete \"{{name}}\". This action cannot be undone.",
-    "status": { "connected": "Connected", "disconnected": "Disconnected", "invalidCredentials": "Invalid credentials" },
+    "status": { "connected": "Connected", "disconnected": "Disconnected", "invalidCredentials": "Invalid credentials", "reconnectRequired": "Reconnect required" },
     "actions": { "reconnect": "Reconnect", "delete": "Delete" },
     "loading": "Loading...",
     "selectOrganization": "Select organization",

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -2957,7 +2957,8 @@
     "status": {
       "connected": "Connecté",
       "disconnected": "Déconnecté",
-      "invalidCredentials": "Identifiants invalides"
+      "invalidCredentials": "Identifiants invalides",
+      "reconnectRequired": "Reconnexion requise"
     },
     "actions": {
       "reconnect": "Reconnecter",

--- a/apps/console/src/pages/organizations/access-reviews/_components/AccessReviewSourceRow.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/_components/AccessReviewSourceRow.tsx
@@ -243,6 +243,10 @@ export function AccessReviewSourceRow({ fKey, connectionId, organizationId }: Pr
 
   const showOrgSelector = accessSource.needsConfiguration || accessSource.selectedOrganization;
   const canReconnect = (accessSource.connector?.oauth2Scopes.length ?? 0) > 0;
+  const showReconnect
+    = canReconnect
+      && (accessSource.connectionStatus === "DISCONNECTED"
+        || accessSource.connectionStatus === "RECONNECT_REQUIRED");
 
   return (
     <Tr>
@@ -258,6 +262,18 @@ export function AccessReviewSourceRow({ fKey, connectionId, organizationId }: Pr
             {t("accessReviewSourceRow.status.connected")}
           </Badge>
         )}
+        {accessSource.connectionStatus === "RECONNECT_REQUIRED" && (
+          <div className="flex items-center gap-2">
+            <Badge variant="warning" size="sm">
+              {t("accessReviewSourceRow.status.reconnectRequired")}
+            </Badge>
+            {showReconnect && (
+              <Button variant="secondary" onClick={handleReconnect}>
+                {t("accessReviewSourceRow.actions.reconnect")}
+              </Button>
+            )}
+          </div>
+        )}
         {accessSource.connectionStatus === "DISCONNECTED" && (
           <div className="flex items-center gap-2">
             <Badge variant="danger" size="sm">
@@ -265,7 +281,7 @@ export function AccessReviewSourceRow({ fKey, connectionId, organizationId }: Pr
                 ? t("accessReviewSourceRow.status.disconnected")
                 : t("accessReviewSourceRow.status.invalidCredentials")}
             </Badge>
-            {canReconnect && (
+            {showReconnect && (
               <Button variant="secondary" onClick={handleReconnect}>
                 {t("accessReviewSourceRow.actions.reconnect")}
               </Button>

--- a/pkg/accessreview/drivers/microsoft_365.go
+++ b/pkg/accessreview/drivers/microsoft_365.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.probo.inc/probo/pkg/coredata"
@@ -113,6 +114,17 @@ type microsoft365MembersPage struct {
 	NextLink string                   `json:"@odata.nextLink"`
 }
 
+type microsoft365UserRegistrationDetails struct {
+	ID                string `json:"id"`
+	UserPrincipalName string `json:"userPrincipalName"`
+	IsMFARegistered   *bool  `json:"isMfaRegistered"`
+}
+
+type microsoft365UserRegistrationDetailsPage struct {
+	Value    []microsoft365UserRegistrationDetails `json:"value"`
+	NextLink string                                `json:"@odata.nextLink"`
+}
+
 func (d *Microsoft365Driver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
 	roles, err := d.listDirectoryRoles(ctx)
 	if err != nil {
@@ -139,6 +151,11 @@ func (d *Microsoft365Driver) ListAccounts(ctx context.Context) ([]AccountRecord,
 	users, err := d.listUsers(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("cannot list users: %w", err)
+	}
+
+	mfaStatuses, err := d.listMFAStatuses(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list MFA statuses: %w", err)
 	}
 
 	records := make([]AccountRecord, 0, len(users))
@@ -177,7 +194,7 @@ func (d *Microsoft365Driver) ListAccounts(ctx context.Context) ([]AccountRecord,
 			JobTitle:    u.JobTitle,
 			Active:      &active,
 			IsAdmin:     isAdmin,
-			MFAStatus:   coredata.MFAStatusUnknown,
+			MFAStatus:   microsoft365MFAStatus(u, mfaStatuses),
 			AuthMethod:  coredata.AccessEntryAuthMethodSSO,
 			AccountType: coredata.AccessEntryAccountTypeUser,
 			ExternalID:  u.ID,
@@ -193,6 +210,32 @@ func (d *Microsoft365Driver) ListAccounts(ctx context.Context) ([]AccountRecord,
 	}
 
 	return records, nil
+}
+
+func microsoft365MFAStatus(u microsoft365User, statuses map[string]coredata.MFAStatus) coredata.MFAStatus {
+	if status, ok := statuses[u.ID]; ok {
+		return status
+	}
+
+	if status, ok := statuses[strings.ToLower(u.UserPrincipalName)]; ok {
+		return status
+	}
+
+	return coredata.MFAStatusUnknown
+}
+
+func microsoft365RegistrationMFAStatus(
+	details microsoft365UserRegistrationDetails,
+) coredata.MFAStatus {
+	if details.IsMFARegistered == nil {
+		return coredata.MFAStatusUnknown
+	}
+
+	if *details.IsMFARegistered {
+		return coredata.MFAStatusEnabled
+	}
+
+	return coredata.MFAStatusDisabled
 }
 
 // pickHighestRole returns the most privileged admin role from the list,
@@ -269,6 +312,59 @@ func buildMicrosoft365UsersURL() (string, error) {
 	q.Set("$filter", microsoft365UserTypeMemberFilter)
 	q.Set("$top", strconv.Itoa(microsoft365UsersPageSize))
 	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}
+
+func (d *Microsoft365Driver) listMFAStatuses(ctx context.Context) (map[string]coredata.MFAStatus, error) {
+	pageURL, err := buildMicrosoft365UserRegistrationDetailsURL()
+	if err != nil {
+		return nil, err
+	}
+
+	statuses := make(map[string]coredata.MFAStatus)
+
+	for range microsoft365MaxPaginationOK {
+		var page microsoft365UserRegistrationDetailsPage
+		if err := d.fetchJSON(ctx, pageURL, &page); err != nil {
+			return nil, err
+		}
+
+		for _, details := range page.Value {
+			status := microsoft365RegistrationMFAStatus(details)
+			if details.ID != "" {
+				statuses[details.ID] = status
+			}
+			if details.UserPrincipalName != "" {
+				statuses[strings.ToLower(details.UserPrincipalName)] = status
+			}
+		}
+
+		if page.NextLink == "" {
+			return statuses, nil
+		}
+
+		pageURL = page.NextLink
+	}
+
+	return nil, fmt.Errorf("cannot list all microsoft 365 MFA statuses: %w", ErrPaginationLimitReached)
+}
+
+func buildMicrosoft365UserRegistrationDetailsURL() (string, error) {
+	endpoint, err := url.JoinPath(
+		microsoft365GraphBaseURL,
+		"reports",
+		"authenticationMethods",
+		"userRegistrationDetails",
+	)
+	if err != nil {
+		return "", fmt.Errorf("cannot build graph user registration details URL: %w", err)
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse graph user registration details URL: %w", err)
+	}
 
 	return u.String(), nil
 }

--- a/pkg/accessreview/drivers/microsoft_365.go
+++ b/pkg/accessreview/drivers/microsoft_365.go
@@ -335,6 +335,7 @@ func (d *Microsoft365Driver) listMFAStatuses(ctx context.Context) (map[string]co
 			if details.ID != "" {
 				statuses[details.ID] = status
 			}
+
 			if details.UserPrincipalName != "" {
 				statuses[strings.ToLower(details.UserPrincipalName)] = status
 			}

--- a/pkg/accessreview/drivers/microsoft_365.go
+++ b/pkg/accessreview/drivers/microsoft_365.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.probo.inc/probo/pkg/coredata"
@@ -119,6 +120,17 @@ type microsoft365MembersPage struct {
 	NextLink string                   `json:"@odata.nextLink"`
 }
 
+type microsoft365UserRegistrationDetails struct {
+	ID                string `json:"id"`
+	UserPrincipalName string `json:"userPrincipalName"`
+	IsMFARegistered   *bool  `json:"isMfaRegistered"`
+}
+
+type microsoft365UserRegistrationDetailsPage struct {
+	Value    []microsoft365UserRegistrationDetails `json:"value"`
+	NextLink string                                `json:"@odata.nextLink"`
+}
+
 func (d *Microsoft365Driver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
 	roles, err := d.listDirectoryRoles(ctx)
 	if err != nil {
@@ -145,6 +157,11 @@ func (d *Microsoft365Driver) ListAccounts(ctx context.Context) ([]AccountRecord,
 	users, err := d.listUsers(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("cannot list users: %w", err)
+	}
+
+	mfaStatuses, err := d.listMFAStatuses(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list MFA statuses: %w", err)
 	}
 
 	records := make([]AccountRecord, 0, len(users))
@@ -183,7 +200,7 @@ func (d *Microsoft365Driver) ListAccounts(ctx context.Context) ([]AccountRecord,
 			JobTitle:    u.JobTitle,
 			Active:      &active,
 			IsAdmin:     isAdmin,
-			MFAStatus:   coredata.MFAStatusUnknown,
+			MFAStatus:   microsoft365MFAStatus(u, mfaStatuses),
 			AuthMethod:  coredata.AccessReviewEntryAuthMethodSSO,
 			AccountType: coredata.AccessReviewEntryAccountTypeUser,
 			ExternalID:  u.ID,
@@ -199,6 +216,32 @@ func (d *Microsoft365Driver) ListAccounts(ctx context.Context) ([]AccountRecord,
 	}
 
 	return records, nil
+}
+
+func microsoft365MFAStatus(u microsoft365User, statuses map[string]coredata.MFAStatus) coredata.MFAStatus {
+	if status, ok := statuses[u.ID]; ok {
+		return status
+	}
+
+	if status, ok := statuses[strings.ToLower(u.UserPrincipalName)]; ok {
+		return status
+	}
+
+	return coredata.MFAStatusUnknown
+}
+
+func microsoft365RegistrationMFAStatus(
+	details microsoft365UserRegistrationDetails,
+) coredata.MFAStatus {
+	if details.IsMFARegistered == nil {
+		return coredata.MFAStatusUnknown
+	}
+
+	if *details.IsMFARegistered {
+		return coredata.MFAStatusEnabled
+	}
+
+	return coredata.MFAStatusDisabled
 }
 
 func (d *Microsoft365Driver) listUsers(ctx context.Context) ([]microsoft365User, error) {
@@ -242,6 +285,60 @@ func buildMicrosoft365UsersURL() (string, error) {
 	q.Set("$filter", microsoft365UserTypeMemberFilter)
 	q.Set("$top", strconv.Itoa(microsoft365UsersPageSize))
 	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}
+
+func (d *Microsoft365Driver) listMFAStatuses(ctx context.Context) (map[string]coredata.MFAStatus, error) {
+	pageURL, err := buildMicrosoft365UserRegistrationDetailsURL()
+	if err != nil {
+		return nil, err
+	}
+
+	statuses := make(map[string]coredata.MFAStatus)
+
+	for range microsoft365MaxPaginationOK {
+		var page microsoft365UserRegistrationDetailsPage
+		if err := d.fetchJSON(ctx, pageURL, &page); err != nil {
+			return nil, err
+		}
+
+		for _, details := range page.Value {
+			status := microsoft365RegistrationMFAStatus(details)
+			if details.ID != "" {
+				statuses[details.ID] = status
+			}
+
+			if details.UserPrincipalName != "" {
+				statuses[strings.ToLower(details.UserPrincipalName)] = status
+			}
+		}
+
+		if page.NextLink == "" {
+			return statuses, nil
+		}
+
+		pageURL = page.NextLink
+	}
+
+	return nil, fmt.Errorf("cannot list all microsoft 365 MFA statuses: %w", ErrPaginationLimitReached)
+}
+
+func buildMicrosoft365UserRegistrationDetailsURL() (string, error) {
+	endpoint, err := url.JoinPath(
+		microsoft365GraphBaseURL,
+		"reports",
+		"authenticationMethods",
+		"userRegistrationDetails",
+	)
+	if err != nil {
+		return "", fmt.Errorf("cannot build graph user registration details URL: %w", err)
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse graph user registration details URL: %w", err)
+	}
 
 	return u.String(), nil
 }

--- a/pkg/accessreview/drivers/microsoft_365_test.go
+++ b/pkg/accessreview/drivers/microsoft_365_test.go
@@ -45,12 +45,14 @@ func TestMicrosoft365DriverMFAStatus(t *testing.T) {
 					), nil
 				case "/v1.0/users":
 					assert.Equal(t, "userType eq 'Member'", req.URL.Query().Get("$filter"))
+
 					return microsoft365Response(
 						http.StatusOK,
 						`{"value":[{"id":"user-enabled","userPrincipalName":"enabled@example.com","mail":"enabled@example.com","displayName":"Enabled User","accountEnabled":true},{"id":"user-disabled","userPrincipalName":"disabled@example.com","mail":"disabled@example.com","displayName":"Disabled User","accountEnabled":true},{"id":"user-fallback","userPrincipalName":"fallback@example.com","mail":"fallback@example.com","displayName":"Fallback User","accountEnabled":true},{"id":"user-missing","userPrincipalName":"missing@example.com","mail":"missing@example.com","displayName":"Missing User","accountEnabled":true}]}`,
 					), nil
 				case "/v1.0/reports/authenticationMethods/userRegistrationDetails":
 					assert.Empty(t, req.URL.RawQuery)
+
 					return microsoft365Response(
 						http.StatusOK,
 						`{"value":[{"id":"user-enabled","userPrincipalName":"enabled@example.com","isMfaRegistered":true},{"id":"user-disabled","userPrincipalName":"disabled@example.com","isMfaRegistered":false},{"id":"different-id","userPrincipalName":"FALLBACK@example.com","isMfaRegistered":true}]}`,

--- a/pkg/accessreview/drivers/microsoft_365_test.go
+++ b/pkg/accessreview/drivers/microsoft_365_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestMicrosoft365DriverMFAStatus(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: microsoft365RoundTripFunc(
+			func(req *http.Request) (*http.Response, error) {
+				switch req.URL.Path {
+				case "/v1.0/directoryRoles":
+					return microsoft365Response(
+						http.StatusOK,
+						`{"value":[{"id":"role-global","displayName":"Global Administrator"}]}`,
+					), nil
+				case "/v1.0/directoryRoles/role-global/members":
+					return microsoft365Response(
+						http.StatusOK,
+						`{"value":[{"id":"user-enabled","@odata.type":"#microsoft.graph.user"}]}`,
+					), nil
+				case "/v1.0/users":
+					assert.Equal(t, "userType eq 'Member'", req.URL.Query().Get("$filter"))
+					return microsoft365Response(
+						http.StatusOK,
+						`{"value":[{"id":"user-enabled","userPrincipalName":"enabled@example.com","mail":"enabled@example.com","displayName":"Enabled User","accountEnabled":true},{"id":"user-disabled","userPrincipalName":"disabled@example.com","mail":"disabled@example.com","displayName":"Disabled User","accountEnabled":true},{"id":"user-fallback","userPrincipalName":"fallback@example.com","mail":"fallback@example.com","displayName":"Fallback User","accountEnabled":true},{"id":"user-missing","userPrincipalName":"missing@example.com","mail":"missing@example.com","displayName":"Missing User","accountEnabled":true}]}`,
+					), nil
+				case "/v1.0/reports/authenticationMethods/userRegistrationDetails":
+					assert.Empty(t, req.URL.RawQuery)
+					return microsoft365Response(
+						http.StatusOK,
+						`{"value":[{"id":"user-enabled","userPrincipalName":"enabled@example.com","isMfaRegistered":true},{"id":"user-disabled","userPrincipalName":"disabled@example.com","isMfaRegistered":false},{"id":"different-id","userPrincipalName":"FALLBACK@example.com","isMfaRegistered":true}]}`,
+					), nil
+				default:
+					t.Fatalf("unexpected Microsoft Graph request: %s", req.URL.String())
+					return nil, nil
+				}
+			},
+		),
+	}
+
+	driver := NewMicrosoft365Driver(client)
+	records, err := driver.ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 4)
+
+	recordsByEmail := make(map[string]AccountRecord, len(records))
+	for _, record := range records {
+		recordsByEmail[record.Email] = record
+	}
+
+	assert.Equal(t, coredata.MFAStatusEnabled, recordsByEmail["enabled@example.com"].MFAStatus)
+	assert.True(t, recordsByEmail["enabled@example.com"].IsAdmin)
+	assert.Equal(t, "Global Administrator", recordsByEmail["enabled@example.com"].Role)
+	assert.Equal(t, coredata.MFAStatusDisabled, recordsByEmail["disabled@example.com"].MFAStatus)
+	assert.Equal(t, coredata.MFAStatusEnabled, recordsByEmail["fallback@example.com"].MFAStatus)
+	assert.Equal(t, coredata.MFAStatusUnknown, recordsByEmail["missing@example.com"].MFAStatus)
+}
+
+type microsoft365RoundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f microsoft365RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func microsoft365Response(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}

--- a/pkg/accessreview/drivers/microsoft_365_test.go
+++ b/pkg/accessreview/drivers/microsoft_365_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestMicrosoft365DriverMFAStatus(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: microsoft365RoundTripFunc(
+			func(req *http.Request) (*http.Response, error) {
+				switch req.URL.Path {
+				case "/v1.0/directoryRoles":
+					return microsoft365Response(
+						http.StatusOK,
+						`{"value":[{"id":"role-global","displayName":"Global Administrator"}]}`,
+					), nil
+				case "/v1.0/directoryRoles/role-global/members":
+					return microsoft365Response(
+						http.StatusOK,
+						`{"value":[{"id":"user-enabled","@odata.type":"#microsoft.graph.user"}]}`,
+					), nil
+				case "/v1.0/users":
+					assert.Equal(t, "userType eq 'Member'", req.URL.Query().Get("$filter"))
+					return microsoft365Response(
+						http.StatusOK,
+						`{"value":[{"id":"user-enabled","userPrincipalName":"enabled@example.com","mail":"enabled@example.com","displayName":"Enabled User","accountEnabled":true},{"id":"user-disabled","userPrincipalName":"disabled@example.com","mail":"disabled@example.com","displayName":"Disabled User","accountEnabled":true},{"id":"user-fallback","userPrincipalName":"fallback@example.com","mail":"fallback@example.com","displayName":"Fallback User","accountEnabled":true},{"id":"user-missing","userPrincipalName":"missing@example.com","mail":"missing@example.com","displayName":"Missing User","accountEnabled":true}]}`,
+					), nil
+				case "/v1.0/reports/authenticationMethods/userRegistrationDetails":
+					assert.Empty(t, req.URL.RawQuery)
+					return microsoft365Response(
+						http.StatusOK,
+						`{"value":[{"id":"user-enabled","userPrincipalName":"enabled@example.com","isMfaRegistered":true},{"id":"user-disabled","userPrincipalName":"disabled@example.com","isMfaRegistered":false},{"id":"different-id","userPrincipalName":"FALLBACK@example.com","isMfaRegistered":true}]}`,
+					), nil
+				default:
+					t.Fatalf("unexpected Microsoft Graph request: %s", req.URL.String())
+					return nil, nil
+				}
+			},
+		),
+	}
+
+	driver := NewMicrosoft365Driver(client)
+	records, err := driver.ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 4)
+
+	recordsByEmail := make(map[string]AccountRecord, len(records))
+	for _, record := range records {
+		recordsByEmail[record.Email] = record
+	}
+
+	assert.Equal(t, coredata.MFAStatusEnabled, recordsByEmail["enabled@example.com"].MFAStatus)
+	assert.True(t, recordsByEmail["enabled@example.com"].IsAdmin)
+	assert.Equal(t, []string{"Global Administrator"}, recordsByEmail["enabled@example.com"].Roles)
+	assert.Equal(t, coredata.MFAStatusDisabled, recordsByEmail["disabled@example.com"].MFAStatus)
+	assert.Equal(t, coredata.MFAStatusEnabled, recordsByEmail["fallback@example.com"].MFAStatus)
+	assert.Equal(t, coredata.MFAStatusUnknown, recordsByEmail["missing@example.com"].MFAStatus)
+}
+
+type microsoft365RoundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f microsoft365RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func microsoft365Response(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}

--- a/pkg/accessreview/drivers/microsoft_365_test.go
+++ b/pkg/accessreview/drivers/microsoft_365_test.go
@@ -22,9 +22,7 @@ package drivers
 
 import (
 	"context"
-	"io"
-	"net/http"
-	"strings"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,42 +30,11 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 )
 
-func TestMicrosoft365DriverMFAStatus(t *testing.T) {
+func TestMicrosoft365Driver(t *testing.T) {
 	t.Parallel()
 
-	client := &http.Client{
-		Transport: microsoft365RoundTripFunc(
-			func(req *http.Request) (*http.Response, error) {
-				switch req.URL.Path {
-				case "/v1.0/directoryRoles":
-					return microsoft365Response(
-						http.StatusOK,
-						`{"value":[{"id":"role-global","displayName":"Global Administrator"}]}`,
-					), nil
-				case "/v1.0/directoryRoles/role-global/members":
-					return microsoft365Response(
-						http.StatusOK,
-						`{"value":[{"id":"user-enabled","@odata.type":"#microsoft.graph.user"}]}`,
-					), nil
-				case "/v1.0/users":
-					assert.Equal(t, "userType eq 'Member'", req.URL.Query().Get("$filter"))
-					return microsoft365Response(
-						http.StatusOK,
-						`{"value":[{"id":"user-enabled","userPrincipalName":"enabled@example.com","mail":"enabled@example.com","displayName":"Enabled User","accountEnabled":true},{"id":"user-disabled","userPrincipalName":"disabled@example.com","mail":"disabled@example.com","displayName":"Disabled User","accountEnabled":true},{"id":"user-fallback","userPrincipalName":"fallback@example.com","mail":"fallback@example.com","displayName":"Fallback User","accountEnabled":true},{"id":"user-missing","userPrincipalName":"missing@example.com","mail":"missing@example.com","displayName":"Missing User","accountEnabled":true}]}`,
-					), nil
-				case "/v1.0/reports/authenticationMethods/userRegistrationDetails":
-					assert.Empty(t, req.URL.RawQuery)
-					return microsoft365Response(
-						http.StatusOK,
-						`{"value":[{"id":"user-enabled","userPrincipalName":"enabled@example.com","isMfaRegistered":true},{"id":"user-disabled","userPrincipalName":"disabled@example.com","isMfaRegistered":false},{"id":"different-id","userPrincipalName":"FALLBACK@example.com","isMfaRegistered":true}]}`,
-					), nil
-				default:
-					t.Fatalf("unexpected Microsoft Graph request: %s", req.URL.String())
-					return nil, nil
-				}
-			},
-		),
-	}
+	rec := newRecorder(t, "testdata/microsoft_365", "MICROSOFT_365_TOKEN")
+	client := newVCRClient(rec, bearerAuth(os.Getenv("MICROSOFT_365_TOKEN")))
 
 	driver := NewMicrosoft365Driver(client)
 	records, err := driver.ListAccounts(context.Background())
@@ -79,24 +46,40 @@ func TestMicrosoft365DriverMFAStatus(t *testing.T) {
 		recordsByEmail[record.Email] = record
 	}
 
-	assert.Equal(t, coredata.MFAStatusEnabled, recordsByEmail["enabled@example.com"].MFAStatus)
-	assert.True(t, recordsByEmail["enabled@example.com"].IsAdmin)
-	assert.Equal(t, []string{"Global Administrator"}, recordsByEmail["enabled@example.com"].Roles)
-	assert.Equal(t, coredata.MFAStatusDisabled, recordsByEmail["disabled@example.com"].MFAStatus)
-	assert.Equal(t, coredata.MFAStatusEnabled, recordsByEmail["fallback@example.com"].MFAStatus)
-	assert.Equal(t, coredata.MFAStatusUnknown, recordsByEmail["missing@example.com"].MFAStatus)
-}
+	// Alice: Global Administrator with MFA registered (matched by user id).
+	alice := recordsByEmail["alice@example.com"]
+	assert.Equal(t, "Alice Admin", alice.FullName)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", alice.ExternalID)
+	assert.Equal(t, []string{"Global Administrator"}, alice.Roles)
+	assert.True(t, alice.IsAdmin)
+	assert.Equal(t, coredata.MFAStatusEnabled, alice.MFAStatus)
+	assert.Equal(t, "Security Engineer", alice.JobTitle)
+	require.NotNil(t, alice.Active)
+	assert.True(t, *alice.Active)
+	require.NotNil(t, alice.CreatedAt)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodSSO, alice.AuthMethod)
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, alice.AccountType)
 
-type microsoft365RoundTripFunc func(req *http.Request) (*http.Response, error)
+	// Bob: User Administrator with MFA not registered.
+	bob := recordsByEmail["bob@example.com"]
+	assert.Equal(t, []string{"User Administrator"}, bob.Roles)
+	assert.True(t, bob.IsAdmin)
+	assert.Equal(t, coredata.MFAStatusDisabled, bob.MFAStatus)
+	require.NotNil(t, bob.Active)
+	assert.True(t, *bob.Active)
 
-func (f microsoft365RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
+	// Carol: no directory role (defaults to User); MFA matched by
+	// case-insensitive UPN fallback when the report id differs.
+	carol := recordsByEmail["carol@example.com"]
+	assert.Equal(t, []string{"User"}, carol.Roles)
+	assert.False(t, carol.IsAdmin)
+	assert.Equal(t, coredata.MFAStatusEnabled, carol.MFAStatus)
 
-func microsoft365Response(statusCode int, body string) *http.Response {
-	return &http.Response{
-		StatusCode: statusCode,
-		Body:       io.NopCloser(strings.NewReader(body)),
-		Header:     make(http.Header),
-	}
+	// Dana: inactive, absent from the MFA registration report → Unknown.
+	dana := recordsByEmail["dana@example.com"]
+	assert.Equal(t, []string{"User"}, dana.Roles)
+	assert.False(t, dana.IsAdmin)
+	assert.Equal(t, coredata.MFAStatusUnknown, dana.MFAStatus)
+	require.NotNil(t, dana.Active)
+	assert.False(t, *dana.Active)
 }

--- a/pkg/accessreview/drivers/testdata/microsoft_365.yaml
+++ b/pkg/accessreview/drivers/testdata/microsoft_365.yaml
@@ -1,0 +1,156 @@
+---
+# Synthetic Microsoft Graph cassette covering the Microsoft 365 access-review
+# driver: directory roles + members, member users, and authentication-method
+# registration details (MFA). Authorization is stripped by the recorder.
+# Fixture covers MFA enabled (by user id), MFA disabled, MFA enabled via
+# case-insensitive UPN fallback, MFA unknown when absent from the report,
+# admin role mapping, and an inactive account.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: graph.microsoft.com
+        headers:
+            Accept:
+                - application/json
+        url: https://graph.microsoft.com/v1.0/directoryRoles
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 175
+        body: '{"value":[{"id":"00000000-0000-0000-0000-0000000000a1","displayName":"Global Administrator"},{"id":"00000000-0000-0000-0000-0000000000a2","displayName":"User Administrator"}]}'
+        headers:
+            Content-Length:
+                - "175"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 28 Jul 2026 09:55:21 GMT
+        status: 200 OK
+        code: 200
+        duration: 2.932209ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: graph.microsoft.com
+        headers:
+            Accept:
+                - application/json
+        url: https://graph.microsoft.com/v1.0/directoryRoles/00000000-0000-0000-0000-0000000000a1/members
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 123
+        body: '{"value":[{"id":"11111111-1111-1111-1111-111111111111","@odata.type":"#microsoft.graph.user","displayName":"Alice Admin"}]}'
+        headers:
+            Content-Length:
+                - "123"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 28 Jul 2026 09:55:21 GMT
+        status: 200 OK
+        code: 200
+        duration: 128.916µs
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: graph.microsoft.com
+        headers:
+            Accept:
+                - application/json
+        url: https://graph.microsoft.com/v1.0/directoryRoles/00000000-0000-0000-0000-0000000000a2/members
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 122
+        body: '{"value":[{"id":"22222222-2222-2222-2222-222222222222","@odata.type":"#microsoft.graph.user","displayName":"Bob Member"}]}'
+        headers:
+            Content-Length:
+                - "122"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 28 Jul 2026 09:55:21 GMT
+        status: 200 OK
+        code: 200
+        duration: 138.583µs
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: graph.microsoft.com
+        form:
+            $filter:
+                - userType eq 'Member'
+            $select:
+                - id,userPrincipalName,mail,displayName,givenName,surname,accountEnabled,jobTitle,department,createdDateTime
+            $top:
+                - "999"
+        headers:
+            Accept:
+                - application/json
+        url: https://graph.microsoft.com/v1.0/users?%24filter=userType+eq+%27Member%27&%24select=id%2CuserPrincipalName%2Cmail%2CdisplayName%2CgivenName%2Csurname%2CaccountEnabled%2CjobTitle%2Cdepartment%2CcreatedDateTime&%24top=999
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 1172
+        body: '{"value":[{"id":"11111111-1111-1111-1111-111111111111","userPrincipalName":"alice@example.com","mail":"alice@example.com","displayName":"Alice Admin","givenName":"Alice","surname":"Admin","accountEnabled":true,"jobTitle":"Security Engineer","department":"Security","createdDateTime":"2024-01-15T10:00:00Z"},{"id":"22222222-2222-2222-2222-222222222222","userPrincipalName":"bob@example.com","mail":"bob@example.com","displayName":"Bob Member","givenName":"Bob","surname":"Member","accountEnabled":true,"jobTitle":"Engineer","department":"Engineering","createdDateTime":"2024-02-20T11:00:00Z"},{"id":"33333333-3333-3333-3333-333333333333","userPrincipalName":"carol@example.com","mail":"carol@example.com","displayName":"Carol Fallback","givenName":"Carol","surname":"Fallback","accountEnabled":true,"jobTitle":"Analyst","department":"Security","createdDateTime":"2024-03-01T12:00:00Z"},{"id":"44444444-4444-4444-4444-444444444444","userPrincipalName":"dana@example.com","mail":"dana@example.com","displayName":"Dana Missing","givenName":"Dana","surname":"Missing","accountEnabled":false,"jobTitle":"Contractor","department":"Ops","createdDateTime":"2024-04-10T09:00:00Z"}]}'
+        headers:
+            Content-Length:
+                - "1172"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 28 Jul 2026 09:55:21 GMT
+        status: 200 OK
+        code: 200
+        duration: 124.5µs
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: graph.microsoft.com
+        headers:
+            Accept:
+                - application/json
+        url: https://graph.microsoft.com/v1.0/reports/authenticationMethods/userRegistrationDetails
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 337
+        body: '{"value":[{"id":"11111111-1111-1111-1111-111111111111","userPrincipalName":"alice@example.com","isMfaRegistered":true},{"id":"22222222-2222-2222-2222-222222222222","userPrincipalName":"bob@example.com","isMfaRegistered":false},{"id":"99999999-9999-9999-9999-999999999999","userPrincipalName":"CAROL@example.com","isMfaRegistered":true}]}'
+        headers:
+            Content-Length:
+                - "337"
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 28 Jul 2026 09:55:21 GMT
+        status: 200 OK
+        code: 200
+        duration: 97.625µs

--- a/pkg/accessreview/source_service.go
+++ b/pkg/accessreview/source_service.go
@@ -582,6 +582,49 @@ func (s *Service) SourceNeedsConfiguration(
 	return cfg.SelectedSlug(dbConnector) == "", nil
 }
 
+// SourceNeedsReconnect reports whether the connector is missing OAuth scopes
+// required by the current provider registration. Only OAuth2 connectors are
+// checked: API-key (and other non-OAuth) credentials have no grant scopes and
+// cannot be repaired by an OAuth reconnect, even when the provider also
+// advertises OAuth2Scopes for its dual-auth path. ErrResourceNotFound is
+// propagated for a missing connector.
+func (s *Service) SourceNeedsReconnect(
+	ctx context.Context,
+	scope coredata.Scoper,
+	connectorID gid.GID,
+) (bool, error) {
+	var dbConnector coredata.Connector
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := dbConnector.LoadByID(ctx, conn, scope, connectorID, s.encryptionKey); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	if dbConnector.Protocol != coredata.ConnectorProtocolOAuth2 {
+		return false, nil
+	}
+
+	required := s.providerRegistry.ProviderOAuth2Scopes(dbConnector.Provider)
+	if len(required) == 0 {
+		return false, nil
+	}
+
+	if dbConnector.Connection == nil {
+		return true, nil
+	}
+
+	return len(connector.MissingScopes(required, dbConnector.Connection.Scopes())) > 0, nil
+}
+
 // AutoSelectDefaultOrganization picks the first workspace/org a freshly linked
 // picker-provider source can see when none is selected yet, so the source is
 // usable immediately instead of failing its first campaign fetch. The picker

--- a/pkg/connector/provider/microsoft_365.go
+++ b/pkg/connector/provider/microsoft_365.go
@@ -37,6 +37,7 @@ func microsoft365Registration() *Registration {
 			"openid",
 			"profile",
 			"offline_access",
+			"https://graph.microsoft.com/AuditLog.Read.All",
 			"https://graph.microsoft.com/User.Read.All",
 			"https://graph.microsoft.com/Directory.Read.All",
 			"https://graph.microsoft.com/RoleManagement.Read.Directory",

--- a/pkg/connector/provider/microsoft_365.go
+++ b/pkg/connector/provider/microsoft_365.go
@@ -43,6 +43,7 @@ func microsoft365Registration() *Registration {
 			"openid",
 			"profile",
 			"offline_access",
+			"https://graph.microsoft.com/AuditLog.Read.All",
 			"https://graph.microsoft.com/User.Read.All",
 			"https://graph.microsoft.com/Directory.Read.All",
 			"https://graph.microsoft.com/RoleManagement.Read.Directory",

--- a/pkg/connector/scopes.go
+++ b/pkg/connector/scopes.go
@@ -69,6 +69,58 @@ func FormatScopeString(scopes []string) string {
 	return strings.Join(sorted, " ")
 }
 
+// microsoftGraphScopePrefix is stripped when comparing scopes so that
+// Microsoft's short permission names (User.Read.All) match the full
+// resource URIs we request (https://graph.microsoft.com/User.Read.All).
+const microsoftGraphScopePrefix = "https://graph.microsoft.com/"
+
+// canonicalizeScope normalizes a scope string for equality checks.
+func canonicalizeScope(scope string) string {
+	return strings.TrimPrefix(scope, microsoftGraphScopePrefix)
+}
+
+// MissingScopes returns the sorted list of scopes present in required but
+// absent from granted. Empty strings in either input are ignored. Scope
+// comparison is canonicalized so Microsoft Graph short names and full
+// resource URIs are treated as equivalent. The result uses the required
+// scope strings as provided and never aliases any input.
+func MissingScopes(required, granted []string) []string {
+	grantedSet := make(map[string]struct{}, len(granted))
+	for _, s := range granted {
+		if s == "" {
+			continue
+		}
+
+		grantedSet[canonicalizeScope(s)] = struct{}{}
+	}
+
+	missing := make([]string, 0)
+	seenMissing := make(map[string]struct{})
+
+	for _, s := range required {
+		if s == "" {
+			continue
+		}
+
+		key := canonicalizeScope(s)
+		if _, ok := grantedSet[key]; ok {
+			continue
+		}
+
+		if _, ok := seenMissing[key]; ok {
+			continue
+		}
+
+		seenMissing[key] = struct{}{}
+
+		missing = append(missing, s)
+	}
+
+	sort.Strings(missing)
+
+	return missing
+}
+
 // UnionScopes returns the sorted, deduplicated union of the given scope
 // slices. Empty strings and empty slices are handled gracefully. The
 // result is a fresh slice and never aliases any input.

--- a/pkg/connector/scopes_test.go
+++ b/pkg/connector/scopes_test.go
@@ -53,6 +53,36 @@ func TestParseScopeString(t *testing.T) {
 	}
 }
 
+func TestMissingScopes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		required []string
+		granted  []string
+		want     []string
+	}{
+		{"both empty", nil, nil, []string{}},
+		{"none missing", []string{"a", "b"}, []string{"b", "a"}, []string{}},
+		{"some missing", []string{"a", "b", "c"}, []string{"a"}, []string{"b", "c"}},
+		{"all missing", []string{"a", "b"}, nil, []string{"a", "b"}},
+		{"drops empty strings", []string{"a", ""}, []string{""}, []string{"a"}},
+		{"sorted output", []string{"z", "a"}, nil, []string{"a", "z"}},
+		{
+			"microsoft graph short vs full uri",
+			[]string{"https://graph.microsoft.com/User.Read.All", "https://graph.microsoft.com/AuditLog.Read.All"},
+			[]string{"User.Read.All"},
+			[]string{"https://graph.microsoft.com/AuditLog.Read.All"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.want, MissingScopes(c.required, c.granted))
+		})
+	}
+}
+
 func TestUnionScopes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/server/api/console/v1/access_review_campaign_resolvers.go
+++ b/pkg/server/api/console/v1/access_review_campaign_resolvers.go
@@ -493,6 +493,11 @@ func (r *accessReviewSourceResolver) NeedsConfiguration(ctx context.Context, obj
 }
 
 // ConnectionStatus is the resolver for the connectionStatus field.
+//
+// Returns RECONNECT_REQUIRED when the connector's stored OAuth grant is
+// missing scopes required by the current provider registration (e.g. a newly
+// added Graph permission), DISCONNECTED when the credential probe fails, and
+// CONNECTED when the grant is usable as-is.
 func (r *accessReviewSourceResolver) ConnectionStatus(ctx context.Context, obj *types.AccessReviewSource) (types.AccessReviewSourceConnectionStatus, error) {
 	if obj.ConnectorID == nil {
 		return types.AccessReviewSourceConnectionStatusNotApplicable, nil
@@ -518,6 +523,21 @@ func (r *accessReviewSourceResolver) ConnectionStatus(ctx context.Context, obj *
 	// verify the credential is actually accepted.
 	if err := r.providerRegistry.ProbeConnection(ctx, httpClient, dbConnector); err != nil {
 		return types.AccessReviewSourceConnectionStatusDisconnected, nil
+	}
+
+	needsReconnect, err := r.accessReview.SourceNeedsReconnect(ctx, scope, *obj.ConnectorID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return types.AccessReviewSourceConnectionStatusNotApplicable, nil
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot determine access source reconnect requirement", log.Error(err))
+
+		return types.AccessReviewSourceConnectionStatusNotApplicable, gqlutils.Internal(ctx)
+	}
+
+	if needsReconnect {
+		return types.AccessReviewSourceConnectionStatusReconnectRequired, nil
 	}
 
 	return types.AccessReviewSourceConnectionStatusConnected, nil

--- a/pkg/server/api/console/v1/graphql/access_review_campaign.graphql
+++ b/pkg/server/api/console/v1/graphql/access_review_campaign.graphql
@@ -247,6 +247,7 @@ input AccessReviewCampaignSourceFetchAttemptOrder {
 enum AccessReviewSourceConnectionStatus {
     CONNECTED
     DISCONNECTED
+    RECONNECT_REQUIRED
     NOT_APPLICABLE
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fetch Microsoft Graph authentication-method registration details during Microsoft 365 access reviews.
- Map registered MFA users to enabled, unregistered users to disabled, and unmatched users to unknown.
- Add the Microsoft Graph AuditLog.Read.All OAuth scope needed for the MFA registration report.

## Tests
- `make go-fmt`
- `go test ./pkg/accessreview/drivers ./pkg/connector/provider`
- `git diff --check`

Note: `golangci-lint` is not installed in the local cloud container, so the exact CI lint command could not be rerun locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-467](https://linear.app/probo/issue/ENG-467/microsoft-connector-does-not-show-mfa)

<div><a href="https://cursor.com/agents/bc-b14ffb78-e203-4cf7-b9ef-82ff67aca9b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b14ffb78-e203-4cf7-b9ef-82ff67aca9b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show MFA status for Microsoft 365 users in access reviews and prompt reconnect when the Microsoft 365 connector is missing newly required Microsoft Graph scopes. Uses the MFA registration report and returns RECONNECT_REQUIRED via the API for missing scopes, completing ENG-467.

### Service **`+350`** **`-1`**
- Fetch `reports/authenticationMethods/userRegistrationDetails` with pagination.
- Map `isMfaRegistered` to Enabled/Disabled/Unknown; match by user ID and case-insensitive UPN.
- Add `SourceNeedsReconnect` and `connector.MissingScopes` (canonicalizes Graph short names vs full URIs).
- Include `https://graph.microsoft.com/AuditLog.Read.All` in Microsoft 365 provider registration.

### Tests **`+115`** **`-0`**
- Cassette test for the Microsoft 365 driver covering MFA mapping, UPN fallback, and inactive-user handling.
- Unit tests for `MissingScopes`, including Graph short vs full URI cases.

### GraphQL API **`+21`** **`-0`**
- Return `RECONNECT_REQUIRED` from `AccessReviewSource.connectionStatus` when OAuth scopes are missing.
- Extend enum with `RECONNECT_REQUIRED`.

### App: console **`+20`** **`-3`**
- Show “Reconnect required” badge and reconnect button when status is `RECONNECT_REQUIRED`.
- Add i18n strings for reconnect status (en-US, fr-FR).

<sup>Written for commit 573549fcecfb79fc6d27c8005b9ccd0037387287. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

