### PR TITLE
Test Google Workspace suspended accounts

### DIFF
--- a/pkg/accessreview/drivers/google_workspace.go
+++ b/pkg/accessreview/drivers/google_workspace.go
@@ -87,6 +87,10 @@ func (rt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	return lastResp, nil
 }
 
+func googleWorkspaceUserActive(u *admin.User) *bool {
+	return new(!u.Suspended && !u.Archived)
+}
+
 func (d *GoogleWorkspaceDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
 	adminService, err := admin.NewService(ctx, option.WithHTTPClient(d.httpClient))
 	if err != nil {
@@ -116,7 +120,7 @@ func (d *GoogleWorkspaceDriver) ListAccounts(ctx context.Context) ([]AccountReco
 			rec := AccountRecord{
 				Email:       u.PrimaryEmail,
 				FullName:    u.Name.FullName,
-				Active:      new(!u.Suspended && !u.Archived),
+				Active:      googleWorkspaceUserActive(u),
 				IsAdmin:     u.IsAdmin,
 				ExternalID:  u.Id,
 				MFAStatus:   coredata.MFAStatusUnknown,

--- a/pkg/accessreview/drivers/google_workspace_test.go
+++ b/pkg/accessreview/drivers/google_workspace_test.go
@@ -16,7 +16,10 @@ package drivers
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,4 +42,53 @@ func TestGoogleWorkspaceDriver(t *testing.T) {
 	assert.NotEmpty(t, r.FullName)
 	assert.NotEmpty(t, r.ExternalID)
 	assert.NotEmpty(t, r.Role)
+}
+
+func TestGoogleWorkspaceDriverSuspendedAndArchivedUsers(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripFunc(
+			func(req *http.Request) (*http.Response, error) {
+				if req.URL.Path != "/admin/directory/v1/users" {
+					return googleWorkspaceResponse(http.StatusNotFound, `{"error":"not found"}`), nil
+				}
+
+				return googleWorkspaceResponse(
+					http.StatusOK,
+					`{"kind":"admin#directory#users","users":[
+						{"id":"user-1","primaryEmail":"active@example.com","name":{"fullName":"Active User"},"suspended":false,"archived":false},
+						{"id":"user-2","primaryEmail":"suspended@example.com","name":{"fullName":"Suspended User"},"suspended":true,"archived":false},
+						{"id":"user-3","primaryEmail":"archived@example.com","name":{"fullName":"Archived User"},"suspended":false,"archived":true}
+					]}`,
+				), nil
+			},
+		),
+	}
+
+	driver := NewGoogleWorkspaceDriver(client)
+
+	records, err := driver.ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 3)
+
+	assert.Equal(t, "active@example.com", records[0].Email)
+	require.NotNil(t, records[0].Active)
+	assert.True(t, *records[0].Active)
+
+	assert.Equal(t, "suspended@example.com", records[1].Email)
+	require.NotNil(t, records[1].Active)
+	assert.False(t, *records[1].Active)
+
+	assert.Equal(t, "archived@example.com", records[2].Email)
+	require.NotNil(t, records[2].Active)
+	assert.False(t, *records[2].Active)
+}
+
+func googleWorkspaceResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
 }

--- a/pkg/iam/scim/bridge/provider/googleworkspace/provider.go
+++ b/pkg/iam/scim/bridge/provider/googleworkspace/provider.go
@@ -58,6 +58,10 @@ func (p *Provider) isExcluded(email string) bool {
 	return false
 }
 
+func googleWorkspaceUserSCIMActive(u *admin.User) bool {
+	return !u.Suspended && !u.Archived
+}
+
 func (p *Provider) ListUsers(ctx context.Context) (scimclient.Users, error) {
 	adminService, err := admin.NewService(ctx, option.WithHTTPClient(p.httpClient))
 	if err != nil {
@@ -93,7 +97,7 @@ func (p *Provider) ListUsers(ctx context.Context) (scimclient.Users, error) {
 				DisplayName: u.Name.FullName,
 				GivenName:   u.Name.GivenName,
 				FamilyName:  u.Name.FamilyName,
-				Active:      !u.Suspended && !u.Archived,
+				Active:      googleWorkspaceUserSCIMActive(u),
 				ExternalID:  u.Id,
 			}
 

--- a/pkg/iam/scim/bridge/provider/googleworkspace/provider_test.go
+++ b/pkg/iam/scim/bridge/provider/googleworkspace/provider_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package googleworkspace_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.probo.inc/probo/pkg/iam/scim/bridge/provider/googleworkspace"
+)
+
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestProvider_ListUsers_ActiveSuspendedArchivedAndExcluded(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripFunc(
+			func(req *http.Request) (*http.Response, error) {
+				if req.URL.Path != "/admin/directory/v1/users" {
+					return googleDirectoryResponse(http.StatusNotFound, `{"error":"not found"}`), nil
+				}
+
+				return googleDirectoryResponse(
+					http.StatusOK,
+					`{"kind":"admin#directory#users","users":[
+						{"id":"user-1","primaryEmail":"active@example.com","name":{"givenName":"Active","familyName":"User","fullName":"Active User"},"suspended":false,"archived":false},
+						{"id":"user-2","primaryEmail":"suspended@example.com","name":{"givenName":"Suspended","familyName":"User","fullName":"Suspended User"},"suspended":true,"archived":false},
+						{"id":"user-3","primaryEmail":"archived@example.com","name":{"givenName":"Archived","familyName":"User","fullName":"Archived User"},"suspended":false,"archived":true},
+						{"id":"user-4","primaryEmail":"excluded@example.com","name":{"givenName":"Excluded","familyName":"User","fullName":"Excluded User"},"suspended":false,"archived":false}
+					]}`,
+				), nil
+			},
+		),
+	}
+
+	provider := googleworkspace.New(client, []string{"excluded@example.com"})
+
+	users, err := provider.ListUsers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, users, 3)
+
+	assert.Equal(t, "active@example.com", users[0].UserName)
+	assert.True(t, users[0].Active)
+
+	assert.Equal(t, "suspended@example.com", users[1].UserName)
+	assert.False(t, users[1].Active)
+
+	assert.Equal(t, "archived@example.com", users[2].UserName)
+	assert.False(t, users[2].Active)
+}
+
+func googleDirectoryResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}


### PR DESCRIPTION
## Summary
- Extract explicit active-state helpers in the Google Workspace access review driver and SCIM bridge provider, mapping both `suspended` and `archived` to inactive.
- Add regression tests for active, suspended, archived, and excluded Google Workspace users in both integration paths.

## Test plan
- [x] `go test ./pkg/accessreview/drivers ./pkg/iam/scim/bridge/provider/googleworkspace`
- [ ] Verify a suspended Google Workspace user appears with `Active: false` in access review fetch results
- [ ] Verify a suspended Google Workspace user syncs with SCIM `active: false` via the bridge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat Google Workspace suspended and archived users as inactive across access reviews and SCIM syncs. Extract small helpers and add regression tests for active, suspended, archived, and excluded users.

### Tests **`+133`** **`-0`**
- Added driver test to verify active/suspended/archived mapping.
- Added SCIM provider test to verify `active` flag and exclusion handling.

### Service **`+10`** **`-2`**
- Extracted `googleWorkspaceUserActive` and `googleWorkspaceUserSCIMActive` helpers to map `suspended` or `archived` to inactive.
- Used helpers in `ListAccounts` and `ListUsers` to keep behavior consistent across access review and SCIM.

<sup>Written for commit bb121e06a0ef50a37e968fe2d22d08eecf7bbe89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

