### PR TITLE
Make keyset cursor pagination NULL-aware

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -465,7 +465,7 @@ jobs:
           GOTESTSUM_JUNITFILE: "junit-e2e.xml"
         run: |
           ACME_ROOT_CA="$(cat compose/pebble/certs/rootCA.pem)" \
-            CGO_ENABLED=1 go tool gotestsum -- -race -cover -coverprofile=coverage.out -count=1 ./e2e/console/...
+            CGO_ENABLED=1 go tool gotestsum -- -race -cover -coverprofile=coverage.out -count=1 ./e2e/console/... ./e2e/page/...
       - name: "Upload test results"
         uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7
         if: "always()"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -167,7 +167,7 @@ test-e2e: CGO_ENABLED=1
 test-e2e: $(PROBOD_BIN) ## Run console e2e tests
 	PROBO_E2E_BINARY=$(CURDIR)/$(PROBOD_BIN) \
 	PROBO_E2E_CONFIG=$(E2E_CONFIG) \
-	GOTESTSUM_FORMAT=testname $(GO_TEST) -count=1 ./e2e/console/...
+	GOTESTSUM_FORMAT=testname $(GO_TEST) -count=1 ./e2e/console/... ./e2e/page/...
 
 bin/probod-coverage:
 	CGO_ENABLED=0 $(GO_BUILD) $(PROBOD_LDFLAGS) -cover -o $@ $(PROBOD_SRC)

--- a/e2e/page/cursor_pagination_test.go
+++ b/e2e/page/cursor_pagination_test.go
@@ -1,0 +1,280 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+// Package page_test exercises the keyset cursor (pkg/page) against a real
+// Postgres instance, without going through GraphQL. It builds adversarial
+// datasets (NULL boundaries, ties, NULL blocks larger than the page) that are
+// hard to construct over the API, then walks every page forward and backward
+// using the production Cursor.SQLFragment/SQLArguments and asserts the walk
+// reconstructs the exact unpaged order with no row dropped or duplicated.
+package page_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+)
+
+// orderColumn is the nullable keyset column under test.
+const orderColumn = orderField("valid_from")
+
+type orderField string
+
+func (f orderField) Column() string { return string(f) }
+func (f orderField) String() string { return string(f) }
+
+// item is a Paginable row backed by a (id, valid_from) tuple where valid_from
+// may be NULL.
+type item struct {
+	id  gid.GID
+	val *time.Time
+}
+
+func (i item) CursorKey(_ orderField) page.CursorKey {
+	if i.val == nil {
+		return page.NewCursorKey(i.id, nil)
+	}
+
+	return page.NewCursorKey(i.id, *i.val)
+}
+
+func TestCursorPaginationNullAware(t *testing.T) {
+	t.Parallel()
+
+	datasets := []struct {
+		name string
+		rows []item
+	}{
+		{"empty", build()},
+		{"single non-null", build(at(10))},
+		{"single null", build(null())},
+		{"no nulls", build(at(0), at(3), at(6), at(9), at(12), at(15), at(18), at(21))},
+		{"all nulls", build(null(), null(), null(), null(), null(), null())},
+		// NULL block larger than the page: a boundary is forced to land on a
+		// NULL value, the case the old predicate silently truncated.
+		{"nulls exceed page", build(at(40), at(35), at(30), at(25), null(), null(), null(), null(), null(), null(), null(), null(), null(), null())},
+		// NULL block smaller than the page.
+		{"nulls below page", build(at(50), at(45), at(40), at(35), at(30), at(25), null(), null())},
+		// Repeated values exercise the id tie-break alongside NULLs.
+		{"ties with nulls", build(at(10), at(10), at(10), at(10), at(20), at(20), at(20), null(), null(), null(), null(), null())},
+		// Ties straddling the NULL block boundary at every page size.
+		{"ties at boundary", build(at(5), at(5), at(5), null(), null(), null())},
+	}
+
+	for _, ds := range datasets {
+		t.Run(ds.name, func(t *testing.T) {
+			t.Parallel()
+
+			conn := connect(t)
+			seed(t, conn, ds.rows)
+
+			for _, dir := range []page.OrderDirection{page.OrderDirectionAsc, page.OrderDirectionDesc} {
+				for _, size := range []int{1, 2, 3, 5, 100} {
+					want := groundTruth(ds.rows, dir)
+
+					t.Run(fmt.Sprintf("%s/size=%d/forward", dir, size), func(t *testing.T) {
+						got := walk(t, conn, dir, size, page.Head)
+						require.Equal(t, want, got, "forward walk must match unpaged order")
+					})
+
+					t.Run(fmt.Sprintf("%s/size=%d/backward", dir, size), func(t *testing.T) {
+						got := walk(t, conn, dir, size, page.Tail)
+						require.Equal(t, want, got, "backward (Tail) walk must reconstruct the same order")
+					})
+				}
+			}
+		})
+	}
+}
+
+// walk paginates the whole set in pages of the given size using the production
+// Cursor + NewPage, faithfully serializing/parsing the cursor between pages as
+// the GraphQL layer does, and returns the collected ids in display order.
+func walk(t *testing.T, conn *pgx.Conn, dir page.OrderDirection, size int, pos page.Position) []string {
+	t.Helper()
+
+	orderBy := page.OrderBy[orderField]{Field: orderColumn, Direction: dir}
+
+	var key *page.CursorKey
+
+	collected := []string{}
+
+	for guard := 0; ; guard++ {
+		require.Less(t, guard, 10000, "pagination did not terminate")
+
+		cur := page.NewCursor[orderField](size, key, pos, orderBy)
+		pg := page.NewPage[item, orderField](fetch(t, conn, cur), cur)
+
+		ids := make([]string, 0, len(pg.Data))
+		for _, r := range pg.Data {
+			ids = append(ids, r.id.String())
+		}
+
+		switch pos {
+		case page.Head:
+			collected = append(collected, ids...)
+			if !pg.Info.HasNext {
+				return collected
+			}
+
+			next := roundTrip(t, pg.Last().CursorKey(orderColumn))
+			key = &next
+		case page.Tail:
+			collected = append(ids, collected...)
+			if !pg.Info.HasPrev {
+				return collected
+			}
+
+			next := roundTrip(t, pg.First().CursorKey(orderColumn))
+			key = &next
+		}
+	}
+}
+
+// roundTrip serializes a cursor key and parses it back, mirroring the
+// client<->server round-trip so the boundary value arrives as the decoded JSON
+// type (a string for timestamps), exactly as the API binds it.
+func roundTrip(t *testing.T, k page.CursorKey) page.CursorKey {
+	t.Helper()
+
+	parsed, err := page.ParseCursorKey(k.String())
+	require.NoError(t, err)
+
+	return parsed
+}
+
+// fetch runs the production SQL fragment + named arguments against Postgres.
+func fetch(t *testing.T, conn *pgx.Conn, cur *page.Cursor[orderField]) []item {
+	t.Helper()
+
+	sql := "SELECT id, valid_from FROM items WHERE " + cur.SQLFragment()
+
+	rows, err := conn.Query(context.Background(), sql, cur.SQLArguments())
+	require.NoError(t, err)
+
+	defer rows.Close()
+
+	var out []item
+
+	for rows.Next() {
+		var r item
+
+		require.NoError(t, rows.Scan(&r.id, &r.val))
+
+		out = append(out, r)
+	}
+
+	require.NoError(t, rows.Err())
+
+	return out
+}
+
+// groundTruth is the independent oracle: the canonical unpaged order Postgres
+// produces for "ORDER BY valid_from <dir> NULLS LAST, id <dir>".
+func groundTruth(rows []item, dir page.OrderDirection) []string {
+	asc := dir == page.OrderDirectionAsc
+
+	sorted := append([]item(nil), rows...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		a, b := sorted[i], sorted[j]
+
+		switch {
+		case a.val == nil && b.val == nil:
+			return idLess(a.id, b.id, asc)
+		case a.val == nil:
+			return false // NULLS LAST: a sorts after b.
+		case b.val == nil:
+			return true
+		case a.val.Equal(*b.val):
+			return idLess(a.id, b.id, asc)
+		case asc:
+			return a.val.Before(*b.val)
+		default:
+			return a.val.After(*b.val)
+		}
+	})
+
+	ids := make([]string, 0, len(sorted))
+	for _, r := range sorted {
+		ids = append(ids, r.id.String())
+	}
+
+	return ids
+}
+
+func idLess(a, b gid.GID, asc bool) bool {
+	if asc {
+		return a.String() < b.String()
+	}
+
+	return a.String() > b.String()
+}
+
+func connect(t *testing.T) *pgx.Conn {
+	t.Helper()
+
+	url := os.Getenv("PROBO_TEST_PG_URL")
+	if url == "" {
+		url = "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"
+	}
+
+	conn, err := pgx.Connect(context.Background(), url)
+	require.NoError(t, err, "connect to postgres (override with PROBO_TEST_PG_URL)")
+
+	t.Cleanup(func() { _ = conn.Close(context.Background()) })
+
+	return conn
+}
+
+// seed creates a per-session temp table (id ordered by byte value to match the
+// Go oracle) and inserts the dataset.
+func seed(t *testing.T, conn *pgx.Conn, rows []item) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	_, err := conn.Exec(ctx, `CREATE TEMP TABLE items (id TEXT COLLATE "C" PRIMARY KEY, valid_from TIMESTAMPTZ)`)
+	require.NoError(t, err)
+
+	for _, r := range rows {
+		_, err := conn.Exec(ctx, `INSERT INTO items (id, valid_from) VALUES ($1, $2)`, r.id, r.val)
+		require.NoError(t, err)
+	}
+}
+
+// build materializes a dataset from cell specs.
+func build(cells ...*time.Time) []item {
+	rows := make([]item, 0, len(cells))
+	for _, c := range cells {
+		rows = append(rows, item{id: gid.New(gid.NewTenantID(), 1), val: c})
+	}
+
+	return rows
+}
+
+func at(sec int64) *time.Time {
+	v := time.Unix(sec, 0).UTC()
+	return &v
+}
+
+func null() *time.Time { return nil }

--- a/pkg/page/cursor.go
+++ b/pkg/page/cursor.go
@@ -15,6 +15,9 @@
 package page
 
 import (
+	"strings"
+	"text/template"
+
 	"github.com/jackc/pgx/v5"
 )
 
@@ -57,32 +60,72 @@ func NewCursor[T OrderField](size int, from *CursorKey, pos Position, orderBy Or
 	}
 }
 
+// sqlFragmentData drives sqlFragmentTemplate. Boundary nullness and NULLS
+// placement are resolved here (in Go) and select the matching branch, so
+// @cursor_field_value only appears in the non-null seek where its type is
+// inferable from the column (a bare "@cursor_field_value IS NULL" is not).
+type sqlFragmentData struct {
+	Column      string
+	Cmp         string // strict comparison: < or >
+	IDCmp       string // id tie-break: <= or >=
+	Direction   string // ASC or DESC
+	NullsFirst  bool   // NULLS FIRST when true, else NULLS LAST
+	HasKey      bool
+	ValueIsNull bool
+}
+
+// The null and non-null boundaries are different predicates: a non-null
+// boundary spills into the whole NULL block (OR col IS NULL), while a null
+// boundary is already inside it and must continue from the cursor id only
+// (col IS NULL AND id <op> @cursor_id) to avoid re-seeing rows.
+// The null branch also never references @cursor_field_value, whose type
+// Postgres cannot infer from a bare NULL bind.
+var sqlFragmentTemplate = template.Must(template.New("cursor").Parse(`
+	{{if not .HasKey}}
+		TRUE
+	{{else if .ValueIsNull}}
+		(
+			{{.Column}} IS NULL AND id {{.IDCmp}} @cursor_id
+			{{if .NullsFirst}} OR {{.Column}} IS NOT NULL {{end}}
+		)
+	{{else}}
+		(
+			{{.Column}} {{.Cmp}} @cursor_field_value
+			OR ( {{.Column}} = @cursor_field_value AND id {{.IDCmp}} @cursor_id )
+			{{if not .NullsFirst}} OR {{.Column}} IS NULL {{end}}
+		)
+	{{end}}
+	ORDER BY {{.Column}} {{.Direction}} {{if .NullsFirst}} NULLS FIRST{{else}} NULLS LAST{{end}}, id {{.Direction}}
+	LIMIT @cursor_limit
+`))
+
 func (c *Cursor[T]) SQLFragment() string {
-	fieldName := c.OrderBy.Field.Column()
-
-	var orderDirection string
-
-	switch {
-	case c.OrderBy.Direction == OrderDirectionAsc && c.Position == Head:
-		orderDirection = "ASC"
-	case c.OrderBy.Direction == OrderDirectionDesc && c.Position == Head:
-		orderDirection = "DESC"
-	case c.OrderBy.Direction == OrderDirectionAsc && c.Position == Tail:
-		orderDirection = "DESC"
-	case c.OrderBy.Direction == OrderDirectionDesc && c.Position == Tail:
-		orderDirection = "ASC"
+	// Tail paging is the exact inverse of Head: flip direction and NULLs placement.
+	ascending := c.OrderBy.Direction == OrderDirectionAsc
+	if c.Position == Tail {
+		ascending = !ascending
 	}
 
-	whereClause := "TRUE"
-	if c.Key != nil && orderDirection == "DESC" {
-		whereClause = "(" + fieldName + " <= @cursor_field_value) AND NOT (" + fieldName + " = @cursor_field_value AND id > @cursor_id)"
-	} else if c.Key != nil && orderDirection == "ASC" {
-		whereClause = "(" + fieldName + " >= @cursor_field_value) AND NOT (" + fieldName + " = @cursor_field_value AND id < @cursor_id)"
+	data := sqlFragmentData{
+		Column:      c.OrderBy.Field.Column(),
+		Cmp:         "<",
+		IDCmp:       "<=",
+		Direction:   "DESC",
+		NullsFirst:  c.Position == Tail,
+		HasKey:      c.Key != nil,
+		ValueIsNull: c.Key != nil && c.Key.Value == nil,
 	}
 
-	orderByClause := fieldName + " " + orderDirection + ", id " + orderDirection
+	if ascending {
+		data.Cmp, data.IDCmp, data.Direction = ">", ">=", "ASC"
+	}
 
-	return whereClause + " ORDER BY " + orderByClause + " LIMIT @cursor_limit"
+	var buf strings.Builder
+	if err := sqlFragmentTemplate.Execute(&buf, data); err != nil {
+		panic("page: rendering cursor SQL fragment: " + err.Error())
+	}
+
+	return strings.Join(strings.Fields(buf.String()), " ")
 }
 
 func (c *Cursor[T]) SQLArguments() pgx.NamedArgs {
@@ -99,7 +142,10 @@ func (c *Cursor[T]) SQLArguments() pgx.NamedArgs {
 
 	if c.Key != nil {
 		arguments["cursor_id"] = c.Key.ID
-		arguments["cursor_field_value"] = c.Key.Value
+
+		if c.Key.Value != nil {
+			arguments["cursor_field_value"] = c.Key.Value
+		}
 	}
 
 	return arguments

--- a/pkg/page/cursor_key_test.go
+++ b/pkg/page/cursor_key_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package page
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.probo.inc/probo/pkg/gid"
+)
+
+// b64 encodes a raw JSON payload the way a cursor string is wire-encoded, so
+// error-path tests can feed deliberately malformed cursors.
+func b64(payload string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(payload))
+}
+
+func TestCursorKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	id := mkID(7)
+
+	tests := []struct {
+		name      string
+		value     any
+		wantValue any // value after a wire round-trip (JSON-decoded type)
+	}{
+		{"nil value", nil, nil},
+		{"string value", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"},
+		// JSON has no integer type: numbers decode back as float64.
+		{"int value", 42, float64(42)},
+		{"float value", 3.5, 3.5},
+		{"bool value", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			key := NewCursorKey(id, tt.value)
+
+			// String <-> ParseCursorKey.
+			parsed, err := ParseCursorKey(key.String())
+			require.NoError(t, err)
+			assert.Equal(t, id, parsed.ID)
+			assert.Equal(t, tt.wantValue, parsed.Value)
+
+			// Bytes == MarshalBinary, and UnmarshalBinary reverses it.
+			bin, err := key.MarshalBinary()
+			require.NoError(t, err)
+			assert.Equal(t, bin, key.Bytes())
+
+			var fromBin CursorKey
+			require.NoError(t, fromBin.UnmarshalBinary(bin))
+			assert.Equal(t, id, fromBin.ID)
+			assert.Equal(t, tt.wantValue, fromBin.Value)
+
+			// MarshalText <-> UnmarshalText.
+			txt, err := key.MarshalText()
+			require.NoError(t, err)
+			assert.Equal(t, key.String(), string(txt))
+
+			var fromTxt CursorKey
+			require.NoError(t, fromTxt.UnmarshalText(txt))
+			assert.Equal(t, parsed, fromTxt)
+
+			// MarshalJSON wraps the opaque string; UnmarshalJSON reverses it.
+			js, err := json.Marshal(key)
+			require.NoError(t, err)
+
+			var fromJS CursorKey
+			require.NoError(t, json.Unmarshal(js, &fromJS))
+			assert.Equal(t, parsed, fromJS)
+
+			assert.Equal(t, tt.value, key.FieldValue())
+		})
+	}
+}
+
+// TestParseCursorKeyErrors covers every rejection path: a client-supplied
+// cursor must fail with ErrInvalidFormat rather than panicking or silently
+// decoding to a bogus key.
+func TestParseCursorKeyErrors(t *testing.T) {
+	t.Parallel()
+
+	validID := mkID(1).String()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"not base64", "not*base64*"},
+		{"not a json array", b64(`"just a string"`)},
+		{"array too short", b64(`["` + validID + `"]`)},
+		{"array too long", b64(`["` + validID + `", 1, 2]`)},
+		{"id not a string", b64(`[123, 1]`)},
+		{"id not a valid gid", b64(`["not-a-gid", 1]`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseCursorKey(tt.input)
+			assert.ErrorIs(t, err, ErrInvalidFormat)
+		})
+	}
+}
+
+func TestCursorKeyUnmarshalRejectsInvalid(t *testing.T) {
+	t.Parallel()
+
+	var ck CursorKey
+
+	assert.Error(t, ck.UnmarshalText([]byte("not*base64*")))
+	assert.Error(t, ck.UnmarshalBinary([]byte(`["only-one"]`)))
+	assert.Error(t, ck.UnmarshalJSON([]byte(`{"not":"a string"}`)))
+}
+
+func TestParseGIDCursorKeyValue(t *testing.T) {
+	t.Parallel()
+
+	id := gid.New(gid.NewTenantID(), 1)
+	key := NewCursorKey(id, "x")
+
+	parsed, err := ParseCursorKey(key.String())
+	require.NoError(t, err)
+	assert.Equal(t, id, parsed.ID)
+}

--- a/pkg/page/cursor_test.go
+++ b/pkg/page/cursor_test.go
@@ -15,9 +15,13 @@
 package page
 
 import (
+	"encoding/binary"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"go.probo.inc/probo/pkg/gid"
 )
 
 type testOrderField string
@@ -68,4 +72,160 @@ func TestNewCursor(t *testing.T) {
 			assert.Equal(t, tt.expectedSize, cursor.Size)
 		})
 	}
+}
+
+const testField = "valid_from"
+
+func newKey(value any) *CursorKey {
+	k := NewCursorKey(mkID(0), value)
+	return &k
+}
+
+// TestSQLFragment locks the exact SQL emitted for every direction/position/key
+// combination. keyKind picks the boundary: none (first page), a non-NULL value,
+// or a NULL value. @cursor_field_value must appear only in the non-NULL seek.
+func TestSQLFragment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		direction OrderDirection
+		position  Position
+		keyKind   string
+		want      string
+	}{
+		{
+			name:      "Head ASC without key",
+			direction: OrderDirectionAsc,
+			position:  Head,
+			keyKind:   "none",
+			want:      "TRUE ORDER BY valid_from ASC NULLS LAST, id ASC LIMIT @cursor_limit",
+		},
+		{
+			name:      "Head DESC without key",
+			direction: OrderDirectionDesc,
+			position:  Head,
+			keyKind:   "none",
+			want:      "TRUE ORDER BY valid_from DESC NULLS LAST, id DESC LIMIT @cursor_limit",
+		},
+		{
+			name:      "Head ASC, non-NULL boundary (NULLS LAST)",
+			direction: OrderDirectionAsc,
+			position:  Head,
+			keyKind:   "nonnull",
+			want: "( valid_from > @cursor_field_value OR ( valid_from = @cursor_field_value AND id >= @cursor_id ) OR valid_from IS NULL ) " +
+				"ORDER BY valid_from ASC NULLS LAST, id ASC LIMIT @cursor_limit",
+		},
+		{
+			name:      "Head DESC, non-NULL boundary (NULLS LAST)",
+			direction: OrderDirectionDesc,
+			position:  Head,
+			keyKind:   "nonnull",
+			want: "( valid_from < @cursor_field_value OR ( valid_from = @cursor_field_value AND id <= @cursor_id ) OR valid_from IS NULL ) " +
+				"ORDER BY valid_from DESC NULLS LAST, id DESC LIMIT @cursor_limit",
+		},
+		{
+			name:      "Head ASC, NULL boundary (NULLS LAST)",
+			direction: OrderDirectionAsc,
+			position:  Head,
+			keyKind:   "null",
+			want:      "( valid_from IS NULL AND id >= @cursor_id ) ORDER BY valid_from ASC NULLS LAST, id ASC LIMIT @cursor_limit",
+		},
+		{
+			name:      "Head DESC, NULL boundary (NULLS LAST)",
+			direction: OrderDirectionDesc,
+			position:  Head,
+			keyKind:   "null",
+			want:      "( valid_from IS NULL AND id <= @cursor_id ) ORDER BY valid_from DESC NULLS LAST, id DESC LIMIT @cursor_limit",
+		},
+		{
+			name:      "Tail DESC, non-NULL boundary (reversed to ASC NULLS FIRST)",
+			direction: OrderDirectionDesc,
+			position:  Tail,
+			keyKind:   "nonnull",
+			want: "( valid_from > @cursor_field_value OR ( valid_from = @cursor_field_value AND id >= @cursor_id ) ) " +
+				"ORDER BY valid_from ASC NULLS FIRST, id ASC LIMIT @cursor_limit",
+		},
+		{
+			name:      "Tail ASC, non-NULL boundary (reversed to DESC NULLS FIRST)",
+			direction: OrderDirectionAsc,
+			position:  Tail,
+			keyKind:   "nonnull",
+			want: "( valid_from < @cursor_field_value OR ( valid_from = @cursor_field_value AND id <= @cursor_id ) ) " +
+				"ORDER BY valid_from DESC NULLS FIRST, id DESC LIMIT @cursor_limit",
+		},
+		{
+			name:      "Tail DESC, NULL boundary (reversed to ASC NULLS FIRST)",
+			direction: OrderDirectionDesc,
+			position:  Tail,
+			keyKind:   "null",
+			want: "( valid_from IS NULL AND id >= @cursor_id OR valid_from IS NOT NULL ) " +
+				"ORDER BY valid_from ASC NULLS FIRST, id ASC LIMIT @cursor_limit",
+		},
+		{
+			name:      "Tail ASC, NULL boundary (reversed to DESC NULLS FIRST)",
+			direction: OrderDirectionAsc,
+			position:  Tail,
+			keyKind:   "null",
+			want: "( valid_from IS NULL AND id <= @cursor_id OR valid_from IS NOT NULL ) " +
+				"ORDER BY valid_from DESC NULLS FIRST, id DESC LIMIT @cursor_limit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var key *CursorKey
+
+			switch tt.keyKind {
+			case "nonnull":
+				key = newKey(time.Unix(0, 0))
+			case "null":
+				key = newKey(nil)
+			}
+
+			cur := NewCursor[testOrderField](
+				10,
+				key,
+				tt.position,
+				OrderBy[testOrderField]{Field: testField, Direction: tt.direction},
+			)
+
+			assert.Equal(t, tt.want, cur.SQLFragment())
+		})
+	}
+}
+
+// TestSQLArguments checks that @cursor_field_value is bound only for the
+// non-NULL seek that references it, keeping StrictNamedArgs consistent with
+// the generated SQL.
+func TestSQLArguments(t *testing.T) {
+	t.Parallel()
+
+	orderBy := OrderBy[testOrderField]{Field: testField, Direction: OrderDirectionDesc}
+
+	noKey := NewCursor[testOrderField](10, nil, Head, orderBy).SQLArguments()
+	assert.NotContains(t, noKey, "cursor_id")
+	assert.NotContains(t, noKey, "cursor_field_value")
+	// One look-ahead row over the page size when there is no boundary.
+	assert.Equal(t, 11, noKey["cursor_limit"])
+
+	nonNull := NewCursor[testOrderField](10, newKey(time.Unix(0, 0)), Head, orderBy).SQLArguments()
+	assert.Contains(t, nonNull, "cursor_id")
+	assert.Contains(t, nonNull, "cursor_field_value")
+	// Inclusive boundary row plus one look-ahead row.
+	assert.Equal(t, 12, nonNull["cursor_limit"])
+
+	nullVal := NewCursor[testOrderField](10, newKey(nil), Tail, orderBy).SQLArguments()
+	assert.Contains(t, nullVal, "cursor_id")
+	assert.NotContains(t, nullVal, "cursor_field_value")
+	assert.Equal(t, 12, nullVal["cursor_limit"])
+}
+
+func mkID(n int) gid.GID {
+	var id gid.GID
+	binary.BigEndian.PutUint64(id[16:24], uint64(n+1))
+
+	return id
 }

--- a/pkg/page/order_direction_test.go
+++ b/pkg/page/order_direction_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package page
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrderDirectionText(t *testing.T) {
+	t.Parallel()
+
+	for _, dir := range []OrderDirection{OrderDirectionAsc, OrderDirectionDesc} {
+		assert.Equal(t, string(dir), dir.String())
+
+		txt, err := dir.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, string(dir), string(txt))
+
+		var got OrderDirection
+		require.NoError(t, got.UnmarshalText(txt))
+		assert.Equal(t, dir, got)
+	}
+}
+
+func TestOrderDirectionUnmarshalInvalid(t *testing.T) {
+	t.Parallel()
+
+	var dir OrderDirection
+	assert.Error(t, dir.UnmarshalText([]byte("sideways")))
+	assert.Error(t, dir.UnmarshalText([]byte("asc"))) // case-sensitive
+}

--- a/pkg/page/page_test.go
+++ b/pkg/page/page_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package page
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPageFirstLast(t *testing.T) {
+	t.Parallel()
+
+	empty := &Page[*loadAllItem, testOrderField]{}
+	assert.Nil(t, empty.First())
+	assert.Nil(t, empty.Last())
+
+	a := &loadAllItem{id: mkID(0), value: 10}
+	b := &loadAllItem{id: mkID(1), value: 20}
+	full := &Page[*loadAllItem, testOrderField]{Data: []*loadAllItem{a, b}}
+	assert.Same(t, a, full.First())
+	assert.Same(t, b, full.Last())
+}
+
+// TestNewPage locks the over-fetch/trim contract: callers fetch one extra row
+// with no key (Size+1) or two extra with a key (Size+2, the inclusive boundary
+// row plus the look-ahead), and NewPage trims them while deriving HasNext/
+// HasPrev. Tail fetches the window in reverse (boundary first) and NewPage
+// flips it back to display order.
+func TestNewPage(t *testing.T) {
+	t.Parallel()
+
+	// Fixed ascending dataset A<B<C<D<E by both value and id.
+	a := &loadAllItem{id: mkID(0), value: 10}
+	b := &loadAllItem{id: mkID(1), value: 20}
+	c := &loadAllItem{id: mkID(2), value: 30}
+	d := &loadAllItem{id: mkID(3), value: 40}
+	e := &loadAllItem{id: mkID(4), value: 50}
+
+	keyFor := func(it *loadAllItem) *CursorKey {
+		k := CursorKey{ID: it.id, Value: it.value}
+		return &k
+	}
+
+	const size = 2
+
+	tests := []struct {
+		name     string
+		position Position
+		key      *CursorKey
+		data     []*loadAllItem // raw fetched window, in SQL return order
+		want     []int
+		wantNext bool
+		wantPrev bool
+	}{
+		{
+			name:     "head/no key/empty",
+			position: Head,
+			data:     nil,
+			want:     []int{},
+		},
+		{
+			name:     "head/no key/partial page",
+			position: Head,
+			data:     []*loadAllItem{a, b},
+			want:     []int{10, 20},
+		},
+		{
+			name:     "head/no key/full page has next",
+			position: Head,
+			data:     []*loadAllItem{a, b, c}, // Size+1
+			want:     []int{10, 20},
+			wantNext: true,
+		},
+		{
+			name:     "head/key/full page has next and prev",
+			position: Head,
+			key:      keyFor(b),
+			data:     []*loadAllItem{b, c, d, e}, // Size+2, boundary b first
+			want:     []int{30, 40},
+			wantNext: true,
+			wantPrev: true,
+		},
+		{
+			name:     "head/key/last page keeps prev only",
+			position: Head,
+			key:      keyFor(c),
+			data:     []*loadAllItem{c, d, e}, // boundary + remainder
+			want:     []int{40, 50},
+			wantPrev: true,
+		},
+		{
+			name:     "tail/no key/empty",
+			position: Tail,
+			data:     nil,
+			want:     []int{},
+		},
+		{
+			name:     "tail/no key/partial page",
+			position: Tail,
+			data:     []*loadAllItem{b, a}, // reversed order, fewer than Size+1
+			want:     []int{10, 20},
+		},
+		{
+			name:     "tail/no key/full last page has prev",
+			position: Tail,
+			data:     []*loadAllItem{e, d, c}, // Size+1, reversed
+			want:     []int{40, 50},
+			wantPrev: true,
+		},
+		{
+			name:     "tail/key/full page has next and prev",
+			position: Tail,
+			key:      keyFor(d),
+			data:     []*loadAllItem{d, c, b, a}, // Size+2, boundary d first
+			want:     []int{20, 30},
+			wantNext: true,
+			wantPrev: true,
+		},
+		{
+			name:     "tail/key/first page keeps next only",
+			position: Tail,
+			key:      keyFor(c),
+			data:     []*loadAllItem{c, b, a}, // boundary + remainder
+			want:     []int{10, 20},
+			wantNext: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cur := NewCursor(size, tt.key, tt.position, ascOrderBy())
+			pg := NewPage(tt.data, cur)
+
+			assert.Equal(t, tt.want, loadAllValues(pg.Data), "trimmed page contents")
+			assert.Equal(t, tt.wantNext, pg.Info.HasNext, "HasNext")
+			assert.Equal(t, tt.wantPrev, pg.Info.HasPrev, "HasPrev")
+		})
+	}
+}


### PR DESCRIPTION
Cursor.SQLFragment emitted a seek predicate with no NULL handling, so once a page boundary landed on a NULL order value the WHERE matched no rows and pagination terminated early, silently dropping the remaining rows.

Rewrite SQLFragment to emit explicit NULLS placement and a null-aware, type-agnostic seek predicate, mirroring the direction and NULLS placement on the Head/Tail inversion so backward paging stays an exact inverse. For NOT NULL columns it reduces to the previous predicate.

Add white-box pagination tests that evaluate the generated SQL with three-valued logic and walk the whole set forward and backward across the NULL boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes keyset cursor pagination NULL-aware so pages don’t truncate when the sort column has NULLs. Adds explicit NULLS placement and a null-aware seek; backward paging mirrors forward exactly.

### Tests **`+785`** **`-0`**
- Add Postgres-backed e2e walk over adversarial datasets (NULL blocks, ties) to confirm forward/backward paging reconstruct full order.
- Lock exact SQL and named args across direction/position/key cases; `@cursor_field_value` appears only for non-NULL seeks.
- Add unit tests for `CursorKey` round-trip and invalid formats, `OrderDirection` text marshaling, and `Page` trimming/HasNext/HasPrev for Head/Tail.

### Service **`+67`** **`-21`**
- Rewrite `Cursor.SQLFragment` via a template that sets ASC/DESC, NULLS FIRST/LAST, and id tiebreak; Tail flips both for symmetry.
- Use a null-aware, type-agnostic seek; bind `@cursor_field_value` only when non-NULL.

### Other **`+2`** **`-2`**
- Run the new e2e suite in CI and Makefile by including `./e2e/page/...`.

<sup>Written for commit 00d4d5f62f5561900dde09fb57a9cb967519282f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

