### PR TITLE
Add common third party enricher worker

### DIFF
--- a/.cursor/rules/prompt-style.mdc
+++ b/.cursor/rules/prompt-style.mdc
@@ -1,0 +1,44 @@
+---
+description: Agent prompt template structure (role/task/instructions XML style)
+globs: "**/prompts/**/*.tmpl"
+alwaysApply: false
+---
+
+# Agent prompt style
+
+See full guide: `contrib/claude/prompt-style.md`
+
+Agent prompt templates use an XML-tag structure with three top-level sections,
+in this order:
+
+```
+<role>
+One short paragraph: who the agent is and its single objective.
+</role>
+
+<task>
+What the agent is given and the fields it must return. Describe the structured
+output here as a bullet list (one bullet per field).
+</task>
+
+<instructions>
+1. A numbered list of directives, most important first.
+2. ...
+</instructions>
+```
+
+## Rules
+
+- Always use the three sections `<role>`, `<task>`, `<instructions>` in that order.
+- `<instructions>` is an ordered (numbered) list; put the most decisive rule first.
+- Keep `<role>` to one short paragraph stating the objective.
+- Describe every output field in `<task>` as a bullet, mirroring the typed result struct.
+- Never hardcode enum values or source-of-truth lists; use a `{{.Placeholder}}`
+  and substitute at runtime (see `template-files.mdc`).
+- No commentary outside the tags; the prompt body is the system instruction.
+
+## Examples
+
+- `pkg/thirdparty/prompts/disambiguation.txt.tmpl`
+- `pkg/cookiebanner/prompts/tracker_identification.txt.tmpl`
+- `pkg/thirdparty/prompts/common_third_party_company_profile.txt.tmpl`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ Detailed guides for specific subsystems live in `contrib/claude/`:
 - [`contrib/claude/ui.md`](contrib/claude/ui.md) — @probo/ui, Tailwind, tailwind-variants, folders, skeletons, compound components
 - [`contrib/claude/config.md`](contrib/claude/config.md) — Configuration propagation (all files to update when config changes)
 - [`contrib/claude/file-naming.md`](contrib/claude/file-naming.md) — File naming conventions (template files, extensions)
+- [`contrib/claude/prompt-style.md`](contrib/claude/prompt-style.md) — Agent prompt template structure (role/task/instructions XML style)
+- [`contrib/claude/prompt-style.md`](contrib/claude/prompt-style.md) — Agent prompt template structure (role/task/instructions XML style)
 - [`contrib/claude/commit.md`](contrib/claude/commit.md) — Commit message conventions
 - [`contrib/claude/license.md`](contrib/claude/license.md) — ISC license header (all file types)
 - [`contrib/claude/release.md`](contrib/claude/release.md) — Release process (version bump, changelog, tag, push)

--- a/contrib/claude/prompt-style.md
+++ b/contrib/claude/prompt-style.md
@@ -1,0 +1,60 @@
+# Agent prompt style
+
+Agent prompt templates (the `//go:embed`-ed `*.txt.tmpl` files that back an
+agent's instructions) follow a consistent XML-tag structure. This keeps prompts
+scannable, makes the contract between the prompt and the typed result struct
+explicit, and matches what the models in use respond to best.
+
+## Structure
+
+Three top-level sections, always in this order:
+
+```
+<role>
+One short paragraph: who the agent is and its single objective.
+</role>
+
+<task>
+What the agent is given and the fields it must return. Describe the structured
+output as a bullet list, one bullet per field, mirroring the typed result.
+</task>
+
+<instructions>
+1. A numbered list of directives, ordered most-decisive first.
+2. Each rule is a single, actionable directive.
+3. ...
+</instructions>
+```
+
+## Rules
+
+- Use `<role>`, `<task>`, `<instructions>` in that order. Do not invent other
+  top-level sections (no loose `Method:` / `Rules:` prose blocks).
+- `<role>` is one short paragraph stating who the agent is and its objective.
+- `<task>` enumerates the inputs and the output fields. List one bullet per
+  field so the prompt stays in sync with the typed result struct.
+- `<instructions>` is an ordered (numbered) list. Put the most important rule
+  first. Keep each item to a single directive.
+- Never hardcode enum values or source-of-truth lists. Use a `{{.Placeholder}}`
+  and substitute at runtime. See [`file-naming.md`](file-naming.md) and the
+  `template-files` cursor rule.
+- No commentary outside the tags; the whole body is the system instruction.
+
+## Per-row input
+
+The embedded template is the static system instruction. The dynamic per-row
+input (the specific entity being processed) is built separately in Go and sent
+as the user message, wrapped in its own descriptive tags:
+
+```go
+fmt.Fprintf(&b, "<name> %s </name>\n", party.Name)
+fmt.Fprintf(&b, "<website> %s </website>\n", website)
+```
+
+## Examples
+
+- `pkg/thirdparty/prompts/disambiguation.txt.tmpl`
+- `pkg/cookiebanner/prompts/tracker_identification.txt.tmpl`
+- `pkg/cookiebanner/prompts/tracker_enrichment.txt.tmpl`
+- `pkg/thirdparty/prompts/common_third_party_company_profile.txt.tmpl`
+- `pkg/thirdparty/prompts/common_third_party_compliance_docs.txt.tmpl`

--- a/contrib/helm/charts/probo/templates/deployment.yaml
+++ b/contrib/helm/charts/probo/templates/deployment.yaml
@@ -416,7 +416,7 @@ spec:
             - name: COMMON_THIRD_PARTY_ENRICHMENT_AGENT_MAX_TURNS
               value: {{ .Values.probo.commonThirdPartyEnrichmentWorker.agentMaxTurns | quote }}
             {{- end }}
-            {{- if .Values.probo.commonThirdPartyEnrichmentWorker.confidenceThreshold }}
+            {{- if ne .Values.probo.commonThirdPartyEnrichmentWorker.confidenceThreshold nil }}
             - name: COMMON_THIRD_PARTY_ENRICHMENT_CONFIDENCE_THRESHOLD
               value: {{ .Values.probo.commonThirdPartyEnrichmentWorker.confidenceThreshold | quote }}
             {{- end }}

--- a/contrib/helm/charts/probo/templates/deployment.yaml
+++ b/contrib/helm/charts/probo/templates/deployment.yaml
@@ -378,6 +378,52 @@ spec:
             - name: COMMON_PATTERN_ENRICHMENT_AGENT_MAX_TURNS
               value: {{ .Values.probo.commonPatternEnrichmentWorker.agentMaxTurns | quote }}
             {{- end }}
+            # Common Third Party Enrichment Agent
+            {{- if .Values.probo.commonThirdPartyEnrichment.provider }}
+            - name: AGENT_COMMON_THIRD_PARTY_ENRICHMENT_PROVIDER
+              value: {{ .Values.probo.commonThirdPartyEnrichment.provider | quote }}
+            {{- end }}
+            {{- if .Values.probo.commonThirdPartyEnrichment.modelName }}
+            - name: AGENT_COMMON_THIRD_PARTY_ENRICHMENT_MODEL_NAME
+              value: {{ .Values.probo.commonThirdPartyEnrichment.modelName | quote }}
+            {{- end }}
+            {{- if .Values.probo.commonThirdPartyEnrichment.temperature }}
+            - name: AGENT_COMMON_THIRD_PARTY_ENRICHMENT_TEMPERATURE
+              value: {{ .Values.probo.commonThirdPartyEnrichment.temperature | quote }}
+            {{- end }}
+            {{- if .Values.probo.commonThirdPartyEnrichment.maxTokens }}
+            - name: AGENT_COMMON_THIRD_PARTY_ENRICHMENT_MAX_TOKENS
+              value: {{ .Values.probo.commonThirdPartyEnrichment.maxTokens | quote }}
+            {{- end }}
+            # Common Third Party Enrichment Worker
+            {{- if .Values.probo.commonThirdPartyEnrichmentWorker.interval }}
+            - name: COMMON_THIRD_PARTY_ENRICHMENT_INTERVAL
+              value: {{ .Values.probo.commonThirdPartyEnrichmentWorker.interval | quote }}
+            {{- end }}
+            {{- if .Values.probo.commonThirdPartyEnrichmentWorker.maxConcurrency }}
+            - name: COMMON_THIRD_PARTY_ENRICHMENT_MAX_CONCURRENCY
+              value: {{ .Values.probo.commonThirdPartyEnrichmentWorker.maxConcurrency | quote }}
+            {{- end }}
+            {{- if .Values.probo.commonThirdPartyEnrichmentWorker.staleAfter }}
+            - name: COMMON_THIRD_PARTY_ENRICHMENT_STALE_AFTER
+              value: {{ .Values.probo.commonThirdPartyEnrichmentWorker.staleAfter | quote }}
+            {{- end }}
+            {{- if .Values.probo.commonThirdPartyEnrichmentWorker.agentTimeout }}
+            - name: COMMON_THIRD_PARTY_ENRICHMENT_AGENT_TIMEOUT
+              value: {{ .Values.probo.commonThirdPartyEnrichmentWorker.agentTimeout | quote }}
+            {{- end }}
+            {{- if .Values.probo.commonThirdPartyEnrichmentWorker.agentMaxTurns }}
+            - name: COMMON_THIRD_PARTY_ENRICHMENT_AGENT_MAX_TURNS
+              value: {{ .Values.probo.commonThirdPartyEnrichmentWorker.agentMaxTurns | quote }}
+            {{- end }}
+            {{- if .Values.probo.commonThirdPartyEnrichmentWorker.confidenceThreshold }}
+            - name: COMMON_THIRD_PARTY_ENRICHMENT_CONFIDENCE_THRESHOLD
+              value: {{ .Values.probo.commonThirdPartyEnrichmentWorker.confidenceThreshold | quote }}
+            {{- end }}
+            {{- if .Values.probo.commonThirdPartyEnrichmentWorker.maxAttempts }}
+            - name: COMMON_THIRD_PARTY_ENRICHMENT_MAX_ATTEMPTS
+              value: {{ .Values.probo.commonThirdPartyEnrichmentWorker.maxAttempts | quote }}
+            {{- end }}
             # Custom Domains
             {{- if .Values.probo.customDomains.enabled }}
             - name: CUSTOM_DOMAINS_RENEWAL_INTERVAL

--- a/contrib/helm/charts/probo/values-production.yaml.example
+++ b/contrib/helm/charts/probo/values-production.yaml.example
@@ -229,6 +229,26 @@ probo:
   #   agentTimeout: 45
   #   agentMaxTurns: 10
 
+  # Common third party enrichment agent (optional, fills common_third_parties
+  # metadata: URLs, address, certifications, logo).
+  # commonThirdPartyEnrichment:
+  #   provider: "openai"
+  #   modelName: "gpt-4o"
+  #   temperature: "0.1"
+  #   maxTokens: "8192"
+
+  # Common third party enrichment worker tuning (optional; seconds for
+  # interval/staleAfter/agentTimeout). confidenceThreshold is the 0-1 floor
+  # a value must clear before it is written.
+  # commonThirdPartyEnrichmentWorker:
+  #   interval: 10
+  #   maxConcurrency: 1
+  #   staleAfter: 900
+  #   agentTimeout: 90
+  #   agentMaxTurns: 12
+  #   confidenceThreshold: 0.7
+  #   maxAttempts: 3
+
   # OpenTelemetry tracing (optional)
   tracing:
     enabled: true

--- a/contrib/helm/charts/probo/values.yaml
+++ b/contrib/helm/charts/probo/values.yaml
@@ -331,6 +331,30 @@ probo:
     agentTimeout: 45
     agentMaxTurns: 10
 
+  # Common third party enrichment agent (optional, requires a provider
+  # key). Powers the company-profile and compliance-docs agents that fill
+  # common_third_parties metadata. Browser tools for the compliance-docs
+  # agent use the chromeDpAddr endpoint when set; web search uses
+  # firecrawl.apiKey when set.
+  commonThirdPartyEnrichment:
+    provider: ""
+    modelName: ""
+    temperature: ""
+    maxTokens: ""
+
+  # Common third party enrichment background worker tuning (optional).
+  # interval, staleAfter, and agentTimeout are in seconds.
+  # confidenceThreshold is the floor (0-1) a resolved value must clear
+  # before it is written to its column.
+  commonThirdPartyEnrichmentWorker:
+    interval: 10
+    maxConcurrency: 1
+    staleAfter: 900
+    agentTimeout: 90
+    agentMaxTurns: 12
+    confidenceThreshold: 0.7
+    maxAttempts: 3
+
   # Custom domains configuration (optional)
   customDomains:
     enabled: false

--- a/e2e/console/common_third_party_test.go
+++ b/e2e/console/common_third_party_test.go
@@ -80,11 +80,11 @@ func seedCommonThirdParty(t *testing.T, name string) gid.GID {
 
 	_, err := conn.Exec(ctx, `
 		INSERT INTO common_third_parties (
-			id, name, slug, category, certifications, created_at, updated_at
+			id, name, slug, category, certifications, enrichment_attempts, created_at, updated_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7
+			$1, $2, $3, $4, $5, $6, $7, $8
 		)
-	`, id, name, slug, "OTHER", []string{}, now, now)
+	`, id, name, slug, "OTHER", []string{}, 0, now, now)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -401,6 +401,12 @@ func coreLoop(ctx context.Context, startAgent *Agent, inputMessages []llm.Messag
 
 	emptyOutputRetries := 0
 
+	// forcedSynthesis records that the turn budget was exhausted while
+	// the agent was still exploring with a pending structured output, so
+	// the last turn was spent forcing the schema rather than failing
+	// outright. It guards against looping past the cap more than once.
+	forcedSynthesis := false
+
 	structuredFormat := resolveStructuredFormat(s.agent)
 
 	// When the agent has both tools and a structured output request,
@@ -440,7 +446,33 @@ func coreLoop(ctx context.Context, startAgent *Agent, inputMessages []llm.Messag
 		}
 
 		if s.turns >= s.agent.maxTurns {
-			return s.finishRun(ctx, nil, &MaxTurnsExceededError{MaxTurns: s.agent.maxTurns})
+			// The turn budget is exhausted. If the agent is still
+			// exploring with tools and owes a structured output, spend
+			// one final turn forcing the schema (ToolChoice=none) so it
+			// emits the best answer it can from what it has gathered,
+			// rather than failing with nothing. This runs at most once;
+			// the next iteration falls through to the error below.
+			if !exploring || forcedSynthesis || structuredFormat == nil || len(s.toolDefs) == 0 {
+				return s.finishRun(ctx, nil, &MaxTurnsExceededError{MaxTurns: s.agent.maxTurns})
+			}
+
+			forcedSynthesis = true
+			exploring = false
+
+			s.messages = append(
+				s.messages,
+				llm.Message{
+					Role:  llm.RoleUser,
+					Parts: []llm.Part{llm.TextPart{Text: synthesisNudge}},
+				},
+			)
+
+			s.logger.WarnCtx(
+				ctx,
+				"max turns reached while exploring: forcing final synthesis turn",
+				log.Int("turn", s.turns),
+				log.Int("max_turns", s.agent.maxTurns),
+			)
 		}
 
 		fullMessages := buildFullMessages(s.systemPrompt, s.messages)
@@ -533,7 +565,7 @@ func coreLoop(ctx context.Context, startAgent *Agent, inputMessages []llm.Messag
 						Parts: []llm.Part{llm.TextPart{Text: synthesisNudge}},
 					},
 				)
-				s.logger.WarnCtx(
+				s.logger.DebugCtx(
 					ctx,
 					"entering synthesis turn: forcing structured output with tool_choice=none",
 					log.Int("turn", s.turns),

--- a/pkg/agent/tools/browser/find_links.go
+++ b/pkg/agent/tools/browser/find_links.go
@@ -62,7 +62,7 @@ func FindLinksMatchingTool(b *Browser) agent.Tool {
 
 			js := fmt.Sprintf(
 				`(() => {
-					const pattern = JSON.parse(%s).toLowerCase();
+					const pattern = (%s).toLowerCase();
 					const normalize = s => s.replace(/[-_\s]+/g, "");
 					const normalizedPattern = normalize(pattern);
 					return Array.from(document.querySelectorAll("a[href]"))

--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -242,6 +242,15 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 					Temperature: b.getEnvFloatPtr("AGENT_TRACKER_ENRICHMENT_TEMPERATURE"),
 					MaxTokens:   new(b.getEnvIntOrDefault("AGENT_TRACKER_ENRICHMENT_MAX_TOKENS", 4096)),
 				},
+				CommonThirdPartyEnrichment: probodconfig.LLMAgentConfig{
+					Provider:  b.getEnvOrDefault("AGENT_COMMON_THIRD_PARTY_ENRICHMENT_PROVIDER", ""),
+					ModelName: b.getEnvOrDefault("AGENT_COMMON_THIRD_PARTY_ENRICHMENT_MODEL_NAME", ""),
+					// Agent B browses pages and emits a moderate structured
+					// output; the budget must leave headroom for reasoning
+					// models whose reasoning tokens count against max_tokens.
+					Temperature: b.getEnvFloatPtr("AGENT_COMMON_THIRD_PARTY_ENRICHMENT_TEMPERATURE"),
+					MaxTokens:   new(b.getEnvIntOrDefault("AGENT_COMMON_THIRD_PARTY_ENRICHMENT_MAX_TOKENS", 8192)),
+				},
 				Tools: probodconfig.AgentToolsConfig{
 					FirecrawlAPIKey: b.getEnv("FIRECRAWL_API_KEY"),
 				},
@@ -291,6 +300,15 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 				StaleAfter:     b.getEnvIntOrDefault("COMMON_PATTERN_ENRICHMENT_STALE_AFTER", 600),
 				AgentTimeout:   b.getEnvIntOrDefault("COMMON_PATTERN_ENRICHMENT_AGENT_TIMEOUT", 45),
 				AgentMaxTurns:  b.getEnvIntOrDefault("COMMON_PATTERN_ENRICHMENT_AGENT_MAX_TURNS", 10),
+			},
+			CommonThirdPartyEnrichmentWorker: probodconfig.CommonThirdPartyEnrichmentWorkerConfig{
+				Interval:            b.getEnvIntOrDefault("COMMON_THIRD_PARTY_ENRICHMENT_INTERVAL", 10),
+				MaxConcurrency:      b.getEnvIntOrDefault("COMMON_THIRD_PARTY_ENRICHMENT_MAX_CONCURRENCY", 1),
+				StaleAfter:          b.getEnvIntOrDefault("COMMON_THIRD_PARTY_ENRICHMENT_STALE_AFTER", 900),
+				AgentTimeout:        b.getEnvIntOrDefault("COMMON_THIRD_PARTY_ENRICHMENT_AGENT_TIMEOUT", 90),
+				AgentMaxTurns:       b.getEnvIntOrDefault("COMMON_THIRD_PARTY_ENRICHMENT_AGENT_MAX_TURNS", 12),
+				ConfidenceThreshold: b.getEnvFloatOrDefault("COMMON_THIRD_PARTY_ENRICHMENT_CONFIDENCE_THRESHOLD", 0.7),
+				MaxAttempts:         b.getEnvIntOrDefault("COMMON_THIRD_PARTY_ENRICHMENT_MAX_ATTEMPTS", 3),
 			},
 			Branding: b.getEnvBoolOrDefault("BRANDING", true),
 		},

--- a/pkg/bootstrap/builder_test.go
+++ b/pkg/bootstrap/builder_test.go
@@ -245,6 +245,13 @@ func TestBuilder_Build_Defaults(t *testing.T) {
 	assert.Equal(t, 600, cfg.Probod.CommonPatternEnrichmentWorker.StaleAfter)
 	assert.Equal(t, 45, cfg.Probod.CommonPatternEnrichmentWorker.AgentTimeout)
 	assert.Equal(t, 10, cfg.Probod.CommonPatternEnrichmentWorker.AgentMaxTurns)
+	assert.Equal(t, 10, cfg.Probod.CommonThirdPartyEnrichmentWorker.Interval)
+	assert.Equal(t, 1, cfg.Probod.CommonThirdPartyEnrichmentWorker.MaxConcurrency)
+	assert.Equal(t, 900, cfg.Probod.CommonThirdPartyEnrichmentWorker.StaleAfter)
+	assert.Equal(t, 90, cfg.Probod.CommonThirdPartyEnrichmentWorker.AgentTimeout)
+	assert.Equal(t, 12, cfg.Probod.CommonThirdPartyEnrichmentWorker.AgentMaxTurns)
+	assert.Equal(t, 0.7, cfg.Probod.CommonThirdPartyEnrichmentWorker.ConfidenceThreshold)
+	assert.Equal(t, 3, cfg.Probod.CommonThirdPartyEnrichmentWorker.MaxAttempts)
 	assert.Equal(t, 10, cfg.Probod.ThirdPartyVetting.Interval)
 	assert.Equal(t, 1500, cfg.Probod.ThirdPartyVetting.StaleAfter)
 	assert.Equal(t, 1, cfg.Probod.ThirdPartyVetting.MaxConcurrency)
@@ -369,6 +376,17 @@ func TestBuilder_Build_CustomValues(t *testing.T) {
 	env["COMMON_PATTERN_ENRICHMENT_STALE_AFTER"] = "900"
 	env["COMMON_PATTERN_ENRICHMENT_AGENT_TIMEOUT"] = "50"
 	env["COMMON_PATTERN_ENRICHMENT_AGENT_MAX_TURNS"] = "5"
+	// Common third party enrichment agent + worker tuning override
+	env["AGENT_COMMON_THIRD_PARTY_ENRICHMENT_PROVIDER"] = "openai"
+	env["AGENT_COMMON_THIRD_PARTY_ENRICHMENT_MODEL_NAME"] = "gpt-4o"
+	env["AGENT_COMMON_THIRD_PARTY_ENRICHMENT_MAX_TOKENS"] = "16384"
+	env["COMMON_THIRD_PARTY_ENRICHMENT_INTERVAL"] = "25"
+	env["COMMON_THIRD_PARTY_ENRICHMENT_MAX_CONCURRENCY"] = "2"
+	env["COMMON_THIRD_PARTY_ENRICHMENT_STALE_AFTER"] = "1200"
+	env["COMMON_THIRD_PARTY_ENRICHMENT_AGENT_TIMEOUT"] = "120"
+	env["COMMON_THIRD_PARTY_ENRICHMENT_AGENT_MAX_TURNS"] = "8"
+	env["COMMON_THIRD_PARTY_ENRICHMENT_CONFIDENCE_THRESHOLD"] = "0.85"
+	env["COMMON_THIRD_PARTY_ENRICHMENT_MAX_ATTEMPTS"] = "5"
 	env["THIRD_PARTY_VETTING_INTERVAL"] = "15"
 	env["THIRD_PARTY_VETTING_STALE_AFTER"] = "1800"
 	env["THIRD_PARTY_VETTING_MAX_CONCURRENCY"] = "2"
@@ -490,6 +508,17 @@ func TestBuilder_Build_CustomValues(t *testing.T) {
 	assert.Equal(t, 900, cfg.Probod.CommonPatternEnrichmentWorker.StaleAfter)
 	assert.Equal(t, 50, cfg.Probod.CommonPatternEnrichmentWorker.AgentTimeout)
 	assert.Equal(t, 5, cfg.Probod.CommonPatternEnrichmentWorker.AgentMaxTurns)
+	assert.Equal(t, "openai", cfg.Probod.Agents.CommonThirdPartyEnrichment.Provider)
+	assert.Equal(t, "gpt-4o", cfg.Probod.Agents.CommonThirdPartyEnrichment.ModelName)
+	require.NotNil(t, cfg.Probod.Agents.CommonThirdPartyEnrichment.MaxTokens)
+	assert.Equal(t, 16384, *cfg.Probod.Agents.CommonThirdPartyEnrichment.MaxTokens)
+	assert.Equal(t, 25, cfg.Probod.CommonThirdPartyEnrichmentWorker.Interval)
+	assert.Equal(t, 2, cfg.Probod.CommonThirdPartyEnrichmentWorker.MaxConcurrency)
+	assert.Equal(t, 1200, cfg.Probod.CommonThirdPartyEnrichmentWorker.StaleAfter)
+	assert.Equal(t, 120, cfg.Probod.CommonThirdPartyEnrichmentWorker.AgentTimeout)
+	assert.Equal(t, 8, cfg.Probod.CommonThirdPartyEnrichmentWorker.AgentMaxTurns)
+	assert.Equal(t, 0.85, cfg.Probod.CommonThirdPartyEnrichmentWorker.ConfidenceThreshold)
+	assert.Equal(t, 5, cfg.Probod.CommonThirdPartyEnrichmentWorker.MaxAttempts)
 	assert.Equal(t, 15, cfg.Probod.ThirdPartyVetting.Interval)
 	assert.Equal(t, 1800, cfg.Probod.ThirdPartyVetting.StaleAfter)
 	assert.Equal(t, 2, cfg.Probod.ThirdPartyVetting.MaxConcurrency)

--- a/pkg/cookiebanner/tracker_mapping_agent_test.go
+++ b/pkg/cookiebanner/tracker_mapping_agent_test.go
@@ -130,32 +130,6 @@ func TestNameIsCookieDatabaseAggregator(t *testing.T) {
 	}
 }
 
-func TestNormalizeAlnum(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{name: "letters lowercased", input: "Letaido", expected: "letaido"},
-		{name: "strips punctuation and spaces", input: "letaido.com - Inc", expected: "letaidocominc"},
-		{name: "keeps digits", input: "auth0", expected: "auth0"},
-		{name: "empty", input: "", expected: ""},
-		{name: "only punctuation", input: "-_.:", expected: ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(
-			tt.name,
-			func(t *testing.T) {
-				t.Parallel()
-				assert.Equal(t, tt.expected, normalizeAlnum(tt.input))
-			},
-		)
-	}
-}
-
 func TestBuildAgentPrompt(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -28,6 +28,7 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/llm"
+	"go.probo.inc/probo/pkg/strutil"
 	"go.probo.inc/probo/pkg/thirdparty"
 	"go.probo.inc/probo/pkg/uri"
 )
@@ -715,15 +716,15 @@ func nameMatchesSiteDomain(name, siteOrigin string) bool {
 		return false
 	}
 
-	normalizedName := normalizeAlnum(name)
+	normalizedName := strutil.NormalizeAlnum(name)
 	if normalizedName == "" {
 		return false
 	}
 
 	label, _, _ := strings.Cut(domain, ".")
 
-	return normalizedName == normalizeAlnum(domain) ||
-		normalizedName == normalizeAlnum(label)
+	return normalizedName == strutil.NormalizeAlnum(domain) ||
+		normalizedName == strutil.NormalizeAlnum(label)
 }
 
 // cookieDatabaseAggregators holds alphanumeric-normalised names of pure
@@ -746,18 +747,18 @@ var cookieDatabaseAggregators = map[string]struct{}{
 // is a known cookie-database directory operator that must never be
 // attributed a tracker. The agent may return either a brand name
 // ("Cookiepedia") or a domain form ("cookiedatabase.org"); the latter
-// would survive a plain normalised lookup because normalizeAlnum folds
+// would survive a plain normalised lookup because NormalizeAlnum folds
 // the eTLD into the key (e.g. "cookiedatabaseorg"). To catch both forms
 // the candidate is also reduced to its primary domain label before the
 // alphanumeric-normalised lookup. The comparison is alphanumeric-
 // normalised so spacing, punctuation, and casing differences do not
 // matter.
 func nameIsCookieDatabaseAggregator(name string) bool {
-	if _, ok := cookieDatabaseAggregators[normalizeAlnum(name)]; ok {
+	if _, ok := cookieDatabaseAggregators[strutil.NormalizeAlnum(name)]; ok {
 		return true
 	}
 
-	label := normalizeAlnum(uri.DomainLabel(name))
+	label := strutil.NormalizeAlnum(uri.DomainLabel(name))
 	if label == "" {
 		return false
 	}
@@ -765,22 +766,6 @@ func nameIsCookieDatabaseAggregator(name string) bool {
 	_, ok := cookieDatabaseAggregators[label]
 
 	return ok
-}
-
-// normalizeAlnum lowercases s and keeps only ASCII letters and digits,
-// so vendor names and domains can be compared free of spacing,
-// punctuation, and casing differences (e.g. "Letaido" and "letaido.com"
-// both reduce to a comparable form).
-func normalizeAlnum(s string) string {
-	var b strings.Builder
-
-	for _, r := range strings.ToLower(s) {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
-			b.WriteRune(r)
-		}
-	}
-
-	return b.String()
 }
 
 // persistAgentIdentification writes a confident agent identification:

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -28,7 +28,7 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/llm"
-	"go.probo.inc/probo/pkg/strutil"
+	"go.probo.inc/probo/pkg/stringsx"
 	"go.probo.inc/probo/pkg/thirdparty"
 	"go.probo.inc/probo/pkg/uri"
 )
@@ -716,15 +716,15 @@ func nameMatchesSiteDomain(name, siteOrigin string) bool {
 		return false
 	}
 
-	normalizedName := strutil.NormalizeAlnum(name)
+	normalizedName := stringsx.NormalizeAlnum(name)
 	if normalizedName == "" {
 		return false
 	}
 
 	label, _, _ := strings.Cut(domain, ".")
 
-	return normalizedName == strutil.NormalizeAlnum(domain) ||
-		normalizedName == strutil.NormalizeAlnum(label)
+	return normalizedName == stringsx.NormalizeAlnum(domain) ||
+		normalizedName == stringsx.NormalizeAlnum(label)
 }
 
 // cookieDatabaseAggregators holds alphanumeric-normalised names of pure
@@ -754,11 +754,11 @@ var cookieDatabaseAggregators = map[string]struct{}{
 // normalised so spacing, punctuation, and casing differences do not
 // matter.
 func nameIsCookieDatabaseAggregator(name string) bool {
-	if _, ok := cookieDatabaseAggregators[strutil.NormalizeAlnum(name)]; ok {
+	if _, ok := cookieDatabaseAggregators[stringsx.NormalizeAlnum(name)]; ok {
 		return true
 	}
 
-	label := strutil.NormalizeAlnum(uri.DomainLabel(name))
+	label := stringsx.NormalizeAlnum(uri.DomainLabel(name))
 	if label == "" {
 		return false
 	}

--- a/pkg/coredata/common_third_party.go
+++ b/pkg/coredata/common_third_party.go
@@ -655,6 +655,42 @@ LIMIT 20
 	return nil
 }
 
+// LoadAllIDs returns the IDs of every common third party matching the
+// filter, ignoring pagination. It is the selection primitive behind bulk
+// operator actions such as re-arming enrichment across a filtered set.
+func (t *CommonThirdParties) LoadAllIDs(
+	ctx context.Context,
+	conn pg.Querier,
+	filter *CommonThirdPartyFilter,
+) ([]gid.GID, error) {
+	q := `
+SELECT
+    id
+FROM
+    common_third_parties
+WHERE
+    %s
+ORDER BY name ASC
+`
+
+	q = fmt.Sprintf(q, filter.SQLFragment())
+
+	args := pgx.StrictNamedArgs{}
+	maps.Copy(args, filter.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query common third party ids: %w", err)
+	}
+
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[gid.GID])
+	if err != nil {
+		return nil, fmt.Errorf("cannot collect common third party ids: %w", err)
+	}
+
+	return ids, nil
+}
+
 func (t CommonThirdParty) UpdateLogoFileID(
 	ctx context.Context,
 	conn pg.Tx,
@@ -1002,4 +1038,41 @@ WHERE
 	}
 
 	return nil
+}
+
+// RequestEnrichmentByIDs re-arms enrichment on the given common third
+// parties by stamping enrichment_requested_at, which is the only column
+// the enrichment worker claims on. It resets enrichment_attempts to 0 so
+// the row gets a fresh retry budget: the claim path bumps the counter on
+// every run, and without a reset a row near the max-attempts ceiling
+// would not be re-armed by stale recovery if a re-run crashed. The
+// enrichment payload is left in place so the worker's merge keeps prior
+// per-field provenance (it only overwrites fields it owns, never curated
+// seed data or human edits). Already-enriched rows are re-processed too.
+// Returns the number of rows re-queued.
+func (t *CommonThirdParties) RequestEnrichmentByIDs(
+	ctx context.Context,
+	tx pg.Tx,
+	ids []gid.GID,
+) (int64, error) {
+	q := `
+UPDATE common_third_parties
+SET
+    enrichment_requested_at = NOW(),
+    enrichment_attempts = 0,
+    updated_at = NOW()
+WHERE
+    id = ANY(@ids)
+`
+
+	args := pgx.StrictNamedArgs{
+		"ids": ids,
+	}
+
+	result, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return 0, fmt.Errorf("cannot request common third party enrichment: %w", err)
+	}
+
+	return result.RowsAffected(), nil
 }

--- a/pkg/coredata/common_third_party.go
+++ b/pkg/coredata/common_third_party.go
@@ -16,6 +16,7 @@ package coredata
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -49,6 +50,9 @@ type (
 		SecurityPageURL               *string            `db:"security_page_url"`
 		TrustPageURL                  *string            `db:"trust_page_url"`
 		LogoFileID                    *gid.GID           `db:"logo_file_id"`
+		EnrichmentRequestedAt         *time.Time         `db:"enrichment_requested_at"`
+		Enrichment                    json.RawMessage    `db:"enrichment"`
+		EnrichmentAttempts            int                `db:"enrichment_attempts"`
 		CreatedAt                     time.Time          `db:"created_at"`
 		UpdatedAt                     time.Time          `db:"updated_at"`
 	}
@@ -124,6 +128,9 @@ SELECT
     security_page_url,
     trust_page_url,
     logo_file_id,
+    enrichment_requested_at,
+    enrichment,
+    enrichment_attempts,
     created_at,
     updated_at
 FROM
@@ -181,6 +188,9 @@ SELECT
     security_page_url,
     trust_page_url,
     logo_file_id,
+    enrichment_requested_at,
+    enrichment,
+    enrichment_attempts,
     created_at,
     updated_at
 FROM
@@ -238,6 +248,9 @@ SELECT
     security_page_url,
     trust_page_url,
     logo_file_id,
+    enrichment_requested_at,
+    enrichment,
+    enrichment_attempts,
     created_at,
     updated_at
 FROM
@@ -294,6 +307,9 @@ INSERT INTO common_third_parties (
     security_page_url,
     trust_page_url,
     logo_file_id,
+    enrichment_requested_at,
+    enrichment,
+    enrichment_attempts,
     created_at,
     updated_at
 ) VALUES (
@@ -316,6 +332,9 @@ INSERT INTO common_third_parties (
     @security_page_url,
     @trust_page_url,
     @logo_file_id,
+    @enrichment_requested_at,
+    @enrichment,
+    @enrichment_attempts,
     @created_at,
     @updated_at
 )
@@ -341,6 +360,9 @@ INSERT INTO common_third_parties (
 		"security_page_url":                t.SecurityPageURL,
 		"trust_page_url":                   t.TrustPageURL,
 		"logo_file_id":                     t.LogoFileID,
+		"enrichment_requested_at":          t.EnrichmentRequestedAt,
+		"enrichment":                       t.Enrichment,
+		"enrichment_attempts":              t.EnrichmentAttempts,
 		"created_at":                       t.CreatedAt,
 		"updated_at":                       t.UpdatedAt,
 	}
@@ -381,6 +403,9 @@ INSERT INTO common_third_parties (
     security_page_url,
     trust_page_url,
     logo_file_id,
+    enrichment_requested_at,
+    enrichment,
+    enrichment_attempts,
     created_at,
     updated_at
 ) VALUES (
@@ -403,6 +428,9 @@ INSERT INTO common_third_parties (
     @security_page_url,
     @trust_page_url,
     @logo_file_id,
+    @enrichment_requested_at,
+    @enrichment,
+    @enrichment_attempts,
     @created_at,
     @updated_at
 )
@@ -445,6 +473,9 @@ RETURNING
     security_page_url,
     trust_page_url,
     logo_file_id,
+    enrichment_requested_at,
+    enrichment,
+    enrichment_attempts,
     created_at,
     updated_at
 `
@@ -471,6 +502,9 @@ RETURNING
 		"security_page_url":                t.SecurityPageURL,
 		"trust_page_url":                   t.TrustPageURL,
 		"logo_file_id":                     t.LogoFileID,
+		"enrichment_requested_at":          t.EnrichmentRequestedAt,
+		"enrichment":                       t.Enrichment,
+		"enrichment_attempts":              t.EnrichmentAttempts,
 		"created_at":                       t.CreatedAt,
 		"updated_at":                       t.UpdatedAt,
 	}
@@ -534,6 +568,9 @@ SELECT
     security_page_url,
     trust_page_url,
     logo_file_id,
+    enrichment_requested_at,
+    enrichment,
+    enrichment_attempts,
     created_at,
     updated_at
 FROM
@@ -585,6 +622,9 @@ SELECT
     security_page_url,
     trust_page_url,
     logo_file_id,
+    enrichment_requested_at,
+    enrichment,
+    enrichment_attempts,
     created_at,
     updated_at
 FROM
@@ -690,6 +730,9 @@ SELECT
     security_page_url,
     trust_page_url,
     logo_file_id,
+    enrichment_requested_at,
+    enrichment,
+    enrichment_attempts,
     created_at,
     updated_at
 FROM
@@ -749,4 +792,214 @@ WHERE
 	}
 
 	return count, nil
+}
+
+// LoadNextForEnrichmentForUpdateSkipLocked claims the oldest row queued
+// for enrichment. The global catalog is not tenant-scoped, so the claim
+// is intentionally cross-tenant: the enrichment worker is a system
+// worker that drains the queue regardless of tenant.
+func (t *CommonThirdParty) LoadNextForEnrichmentForUpdateSkipLocked(
+	ctx context.Context,
+	tx pg.Tx,
+) error {
+	q := `
+SELECT
+    id,
+    name,
+    slug,
+    category,
+    headquarter_address,
+    legal_name,
+    website_url,
+    privacy_policy_url,
+    service_level_agreement_url,
+    service_software_agreement_url,
+    data_processing_agreement_url,
+    business_associate_agreement_url,
+    subprocessors_list_url,
+    certifications,
+    status_page_url,
+    terms_of_service_url,
+    security_page_url,
+    trust_page_url,
+    logo_file_id,
+    enrichment_requested_at,
+    enrichment,
+    enrichment_attempts,
+    created_at,
+    updated_at
+FROM
+    common_third_parties
+WHERE
+    enrichment_requested_at IS NOT NULL
+ORDER BY
+    enrichment_requested_at ASC
+FOR UPDATE SKIP LOCKED
+LIMIT 1;
+`
+
+	rows, err := tx.Query(ctx, q)
+	if err != nil {
+		return fmt.Errorf("cannot query common third party for enrichment: %w", err)
+	}
+	defer rows.Close()
+
+	row, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[CommonThirdParty])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect common third party for enrichment: %w", err)
+	}
+
+	*t = row
+
+	return nil
+}
+
+// ClearEnrichmentRequestedAt removes the row from the enrichment queue
+// and bumps the attempt counter. It bumps updated_at so the
+// stale-recovery clock starts at claim time, keeping
+// ResetStaleCommonThirdPartyEnrichments from re-arming a row that is
+// still being processed. The attempt counter is incremented up front so
+// a crash between claim and persist still counts against the retry
+// budget.
+func (t *CommonThirdParty) ClearEnrichmentRequestedAt(
+	ctx context.Context,
+	tx pg.Tx,
+) error {
+	q := `
+UPDATE common_third_parties
+SET
+    enrichment_requested_at = NULL,
+    enrichment_attempts = enrichment_attempts + 1,
+    updated_at = NOW()
+WHERE id = @id
+`
+
+	args := pgx.StrictNamedArgs{"id": t.ID}
+
+	_, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot clear enrichment requested at: %w", err)
+	}
+
+	t.EnrichmentRequestedAt = nil
+	t.EnrichmentAttempts++
+
+	return nil
+}
+
+// UpdateEnrichment persists the enrichment result: the resolved metadata
+// fields plus the per-field enrichment provenance JSON. It is a targeted
+// partial update that never touches id, slug, category, name, logo, the
+// queue column, or the attempt counter (logo is owned by
+// UpdateLogoFileID; the queue column and counter are managed by
+// ClearEnrichmentRequestedAt). The caller decides which scalar fields to
+// write versus leave untouched, then passes the merged receiver here.
+func (t CommonThirdParty) UpdateEnrichment(
+	ctx context.Context,
+	conn pg.Tx,
+) error {
+	q := `
+UPDATE common_third_parties
+SET
+    headquarter_address              = @headquarter_address,
+    legal_name                       = @legal_name,
+    website_url                      = @website_url,
+    privacy_policy_url               = @privacy_policy_url,
+    service_level_agreement_url      = @service_level_agreement_url,
+    service_software_agreement_url   = @service_software_agreement_url,
+    data_processing_agreement_url    = @data_processing_agreement_url,
+    business_associate_agreement_url = @business_associate_agreement_url,
+    subprocessors_list_url           = @subprocessors_list_url,
+    certifications                   = @certifications,
+    status_page_url                  = @status_page_url,
+    terms_of_service_url             = @terms_of_service_url,
+    security_page_url                = @security_page_url,
+    trust_page_url                   = @trust_page_url,
+    enrichment                       = @enrichment,
+    updated_at                       = @updated_at
+WHERE
+    id = @id
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":                               t.ID,
+		"headquarter_address":              t.HeadquarterAddress,
+		"legal_name":                       t.LegalName,
+		"website_url":                      t.WebsiteURL,
+		"privacy_policy_url":               t.PrivacyPolicyURL,
+		"service_level_agreement_url":      t.ServiceLevelAgreementURL,
+		"service_software_agreement_url":   t.ServiceSoftwareAgreementURL,
+		"data_processing_agreement_url":    t.DataProcessingAgreementURL,
+		"business_associate_agreement_url": t.BusinessAssociateAgreementURL,
+		"subprocessors_list_url":           t.SubprocessorsListURL,
+		"certifications":                   t.Certifications,
+		"status_page_url":                  t.StatusPageURL,
+		"terms_of_service_url":             t.TermsOfServiceURL,
+		"security_page_url":                t.SecurityPageURL,
+		"trust_page_url":                   t.TrustPageURL,
+		"enrichment":                       t.Enrichment,
+		"updated_at":                       t.UpdatedAt,
+	}
+
+	result, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update common third party enrichment: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return ErrResourceNotFound
+	}
+
+	return nil
+}
+
+// ResetStaleCommonThirdPartyEnrichments re-arms enrichment_requested_at
+// on rows whose enrichment was claimed but never completed and have been
+// idle longer than staleAfter, so a crashed or timed-out run is retried.
+//
+// A claimed row has enrichment_attempts > 0 (Claim increments it) and a
+// completed row has a non-null enrichment payload (Process always writes
+// it, even on a no-result run), so the sweep targets rows that were
+// claimed but carry no enrichment yet. Curated rows that were never
+// enqueued keep enrichment_attempts = 0 and are left untouched. The
+// max-attempts ceiling stops permanently failing rows from looping
+// forever.
+//
+// Like the claim query, this sweep is intentionally cross-tenant: the
+// enrichment worker is a system worker that drains the queue regardless
+// of tenant.
+func ResetStaleCommonThirdPartyEnrichments(
+	ctx context.Context,
+	conn pg.Querier,
+	staleAfter time.Duration,
+	maxAttempts int,
+) error {
+	q := `
+UPDATE common_third_parties
+SET
+    enrichment_requested_at = NOW(),
+    updated_at = NOW()
+WHERE
+    enrichment_requested_at IS NULL
+    AND enrichment IS NULL
+    AND enrichment_attempts > 0
+    AND enrichment_attempts < @max_attempts
+    AND updated_at < @stale_before
+`
+
+	args := pgx.StrictNamedArgs{
+		"max_attempts": maxAttempts,
+		"stale_before": time.Now().Add(-staleAfter),
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot reset stale common third party enrichments: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/coredata/common_third_party_filter.go
+++ b/pkg/coredata/common_third_party_filter.go
@@ -15,17 +15,81 @@
 package coredata
 
 import (
+	"fmt"
+
 	"github.com/jackc/pgx/v5"
+	"go.probo.inc/probo/pkg/gid"
 )
 
+// CommonThirdPartyEnrichmentState is a synthetic filter over the
+// enrichment_requested_at / enrichment columns. It is not a stored
+// column; it classifies a row's position in the enrichment lifecycle.
+// Unlike common tracker patterns, a common third party has no
+// enriched_at column: a row is "enriched" once it carries an enrichment
+// payload (Process always writes one, even on a no-result run).
+type CommonThirdPartyEnrichmentState string
+
+const (
+	// CommonThirdPartyEnrichmentStateQueued: a row armed for the
+	// enrichment worker (enrichment_requested_at IS NOT NULL).
+	CommonThirdPartyEnrichmentStateQueued CommonThirdPartyEnrichmentState = "QUEUED"
+	// CommonThirdPartyEnrichmentStateEnriched: a row whose enrichment has
+	// completed (enrichment IS NOT NULL) and is not re-queued.
+	CommonThirdPartyEnrichmentStateEnriched CommonThirdPartyEnrichmentState = "ENRICHED"
+	// CommonThirdPartyEnrichmentStateUnenriched: a row never enriched and
+	// not currently queued.
+	CommonThirdPartyEnrichmentStateUnenriched CommonThirdPartyEnrichmentState = "UNENRICHED"
+)
+
+func (s CommonThirdPartyEnrichmentState) IsValid() bool {
+	switch s {
+	case
+		CommonThirdPartyEnrichmentStateQueued,
+		CommonThirdPartyEnrichmentStateEnriched,
+		CommonThirdPartyEnrichmentStateUnenriched:
+		return true
+	}
+
+	return false
+}
+
+func (s CommonThirdPartyEnrichmentState) String() string {
+	return string(s)
+}
+
+func (s CommonThirdPartyEnrichmentState) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+func (s *CommonThirdPartyEnrichmentState) UnmarshalText(text []byte) error {
+	val := CommonThirdPartyEnrichmentState(text)
+	if !val.IsValid() {
+		return fmt.Errorf("invalid CommonThirdPartyEnrichmentState value: %q", string(text))
+	}
+
+	*s = val
+
+	return nil
+}
+
 type CommonThirdPartyFilter struct {
-	name     *string
-	category *ThirdPartyCategory
-	keyword  *string
+	ids              []gid.GID
+	name             *string
+	category         *ThirdPartyCategory
+	keyword          *string
+	state            *CommonThirdPartyEnrichmentState
+	enrichmentStatus *string
 }
 
 func NewCommonThirdPartyFilter(name *string) *CommonThirdPartyFilter {
 	return &CommonThirdPartyFilter{name: name}
+}
+
+// WithIDs restricts the result to the given common third party IDs. A
+// non-nil but empty slice matches nothing.
+func (f *CommonThirdPartyFilter) WithIDs(ids []gid.GID) *CommonThirdPartyFilter {
+	f.ids = ids
+	return f
 }
 
 func (f *CommonThirdPartyFilter) WithCategory(category *ThirdPartyCategory) *CommonThirdPartyFilter {
@@ -38,8 +102,27 @@ func (f *CommonThirdPartyFilter) WithKeyword(keyword *string) *CommonThirdPartyF
 	return f
 }
 
+func (f *CommonThirdPartyFilter) WithState(state *CommonThirdPartyEnrichmentState) *CommonThirdPartyFilter {
+	f.state = state
+	return f
+}
+
+// WithEnrichmentStatus filters on the run-level status recorded in the
+// enrichment payload (done, partial, failed). Rows with no payload never
+// match.
+func (f *CommonThirdPartyFilter) WithEnrichmentStatus(status *string) *CommonThirdPartyFilter {
+	f.enrichmentStatus = status
+	return f
+}
+
 func (f *CommonThirdPartyFilter) SQLFragment() string {
 	return `(
+	CASE
+		WHEN @filter_ids::text[] IS NOT NULL THEN
+			id = ANY(@filter_ids)
+		ELSE TRUE
+	END
+	AND
 	CASE
 		WHEN @filter_name::text IS NOT NULL THEN
 			name ILIKE '%' || @filter_name || '%'
@@ -58,14 +141,38 @@ func (f *CommonThirdPartyFilter) SQLFragment() string {
 			 OR slug ILIKE '%' || @filter_keyword || '%')
 		ELSE TRUE
 	END
+	AND
+	CASE
+		WHEN @filter_state_queued::boolean THEN enrichment_requested_at IS NOT NULL
+		WHEN @filter_state_enriched::boolean THEN
+			enrichment_requested_at IS NULL AND enrichment IS NOT NULL
+		WHEN @filter_state_unenriched::boolean THEN
+			enrichment_requested_at IS NULL AND enrichment IS NULL
+		ELSE TRUE
+	END
+	AND
+	CASE
+		WHEN @filter_enrichment_status::text IS NOT NULL THEN
+			enrichment->>'status' = @filter_enrichment_status
+		ELSE TRUE
+	END
 )`
 }
 
 func (f *CommonThirdPartyFilter) SQLArguments() pgx.StrictNamedArgs {
 	args := pgx.StrictNamedArgs{
-		"filter_name":     nil,
-		"filter_category": nil,
-		"filter_keyword":  nil,
+		"filter_ids":               nil,
+		"filter_name":              nil,
+		"filter_category":          nil,
+		"filter_keyword":           nil,
+		"filter_state_queued":      false,
+		"filter_state_enriched":    false,
+		"filter_state_unenriched":  false,
+		"filter_enrichment_status": nil,
+	}
+
+	if f.ids != nil {
+		args["filter_ids"] = f.ids
 	}
 
 	if f.name != nil {
@@ -78,6 +185,21 @@ func (f *CommonThirdPartyFilter) SQLArguments() pgx.StrictNamedArgs {
 
 	if f.keyword != nil {
 		args["filter_keyword"] = *f.keyword
+	}
+
+	if f.state != nil {
+		switch *f.state {
+		case CommonThirdPartyEnrichmentStateQueued:
+			args["filter_state_queued"] = true
+		case CommonThirdPartyEnrichmentStateEnriched:
+			args["filter_state_enriched"] = true
+		case CommonThirdPartyEnrichmentStateUnenriched:
+			args["filter_state_unenriched"] = true
+		}
+	}
+
+	if f.enrichmentStatus != nil {
+		args["filter_enrichment_status"] = *f.enrichmentStatus
 	}
 
 	return args

--- a/pkg/coredata/migrations/20260609T120000Z.sql
+++ b/pkg/coredata/migrations/20260609T120000Z.sql
@@ -1,0 +1,28 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE
+    common_third_parties
+ADD
+    COLUMN enrichment_requested_at TIMESTAMP WITH TIME ZONE,
+ADD
+    COLUMN enrichment JSONB,
+ADD
+    COLUMN enrichment_attempts INTEGER NOT NULL DEFAULT 0;
+
+-- Partial index backs the enrichment worker's claim query, which polls
+-- only rows currently queued for enrichment.
+CREATE INDEX common_third_parties_enrichment_requested_at_idx
+    ON common_third_parties (enrichment_requested_at)
+    WHERE enrichment_requested_at IS NOT NULL;

--- a/pkg/coredata/migrations/20260609T120000Z.sql
+++ b/pkg/coredata/migrations/20260609T120000Z.sql
@@ -21,6 +21,13 @@ ADD
 ADD
     COLUMN enrichment_attempts INTEGER NOT NULL DEFAULT 0;
 
+-- The DEFAULT only backfills existing rows; drop it so inserts must
+-- supply the value explicitly.
+ALTER TABLE
+    common_third_parties
+ALTER COLUMN
+    enrichment_attempts DROP DEFAULT;
+
 -- Partial index backs the enrichment worker's claim query, which polls
 -- only rows currently queued for enrichment.
 CREATE INDEX common_third_parties_enrichment_requested_at_idx

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -1475,6 +1475,68 @@ WHERE
 	return result.RowsAffected(), nil
 }
 
+// RequestMappingForUnmappedByInitiatorDomains re-arms mapping on the
+// still-unmapped org tracker patterns whose detected trackers share one
+// of the given initiator domains, so the mapping worker re-resolves them
+// via its domain-overlap signal. It is invoked by the common-third-party
+// enrichment worker when a vendor gains new owned domains, a global
+// catalog operation, so it is intentionally not tenant-scoped: a single
+// catalog domain benefits all tenants' patterns.
+//
+// Only patterns with no resolved vendor are targeted (third_party_id IS
+// NULL and an absent or unlinked catalog row), so a pattern already
+// linked to the vendor that gained the domain - or to any other vendor -
+// is never disturbed and never re-attributed. Extension-sourced patterns
+// and patterns already queued for mapping are skipped. The
+// common_tracker_patterns and detected_trackers subqueries are used only
+// for filtering. Returns the number of patterns re-armed; an empty
+// domains slice is a no-op.
+func (tps *TrackerPatterns) RequestMappingForUnmappedByInitiatorDomains(
+	ctx context.Context,
+	tx pg.Tx,
+	domains []string,
+) (int64, error) {
+	if len(domains) == 0 {
+		return 0, nil
+	}
+
+	q := `
+UPDATE tracker_patterns
+SET
+	mapping_requested_at = NOW(),
+	updated_at = NOW()
+WHERE
+	third_party_id IS NULL
+	AND mapping_requested_at IS NULL
+	AND (source IS NULL OR source != @extension_source)
+	AND (
+		common_tracker_pattern_id IS NULL
+		OR common_tracker_pattern_id IN (
+			SELECT id FROM common_tracker_patterns
+			WHERE common_third_party_id IS NULL
+		)
+	)
+	AND id IN (
+		SELECT DISTINCT tracker_pattern_id
+		FROM detected_trackers
+		WHERE initiator_domain = ANY(@domains)
+			AND tracker_pattern_id IS NOT NULL
+	)
+`
+
+	args := pgx.StrictNamedArgs{
+		"extension_source": CookieSourceExtension,
+		"domains":          domains,
+	}
+
+	result, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return 0, fmt.Errorf("cannot request mapping for unmapped tracker patterns by initiator domains: %w", err)
+	}
+
+	return result.RowsAffected(), nil
+}
+
 // ResetAndRequestMappingByCookieCategoryID detaches every pattern in the
 // given category from its catalog row, org third party, and copied
 // description, then re-arms mapping. Operators run this (via proboctl) on

--- a/pkg/coredata/tracker_pattern_test.go
+++ b/pkg/coredata/tracker_pattern_test.go
@@ -326,3 +326,186 @@ func TestResetStaleMappings(t *testing.T) {
 	assert.Nil(t, load(fresh.ID).MappingRequestedAt, "recently claimed row must not be re-armed before the window elapses")
 	assert.Nil(t, load(completed.ID).MappingRequestedAt, "completed mapping (catalog row assigned) must never be re-armed")
 }
+
+// TestRequestMappingForUnmappedByInitiatorDomains pins the new-domain
+// re-map cascade: when a vendor gains owned domains, only still-unmapped
+// org patterns whose detected trackers share one of those domains are
+// re-armed. A pattern already linked to a vendor (via a catalog row that
+// carries a common_third_party_id, or via third_party_id), an
+// extension-sourced pattern, and a pattern whose trackers were seen on a
+// different domain are all left untouched. An empty domain set is a
+// no-op.
+func TestRequestMappingForUnmappedByInitiatorDomains(t *testing.T) {
+	t.Parallel()
+
+	client := test.PGClient(t)
+	ctx := context.Background()
+	fx := seedTrackerPatternFixture(t, ctx, client)
+
+	const (
+		vendorDomain = "vendor.example"
+		otherDomain  = "unrelated.example"
+	)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	maxAge := 3600
+
+	// Cascade-deletes from the fixture's cookie_banner / organization
+	// drops cleanup take care of detected_trackers and third_parties; run
+	// these first (LIFO) so nothing is stranded if a FK lacks the cascade.
+	t.Cleanup(func() {
+		_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
+			if _, err := tx.Exec(ctx, `DELETE FROM detected_trackers WHERE cookie_banner_id = $1`, fx.cookieBannerID); err != nil {
+				return err
+			}
+
+			if _, err := tx.Exec(ctx, `DELETE FROM third_parties WHERE organization_id = $1`, fx.organizationID); err != nil {
+				return err
+			}
+
+			return nil
+		})
+	})
+
+	// A catalog row already linked to a vendor: patterns pointing at it
+	// are considered mapped and must be left alone.
+	party := seedCommonThirdParty(t, ctx, client)
+	linkedCommon := coredata.CommonTrackerPattern{
+		ID:                 gid.New(gid.NilTenant, coredata.CommonTrackerPatternEntityType),
+		CommonThirdPartyID: &party.ID,
+		TrackerType:        coredata.TrackerTypeCookie,
+		Pattern:            "linked_catalog_" + gid.New(gid.NilTenant, coredata.CommonTrackerPatternEntityType).String(),
+		MatchType:          coredata.TrackerPatternMatchTypeExact,
+		Confidence:         0.7,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	insertCommonTrackerPattern(t, ctx, client, linkedCommon)
+
+	// An org third party for the third_party_id-linked pattern.
+	orgThirdPartyID := gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType)
+	orgThirdParty := coredata.ThirdParty{
+		ID:             orgThirdPartyID,
+		OrganizationID: fx.organizationID,
+		Name:           "Org Vendor",
+		Category:       coredata.ThirdPartyCategoryAnalytics,
+		Certifications: []string{},
+		Countries:      coredata.CountryCodes{},
+		Level:          1,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return orgThirdParty.Insert(ctx, tx, fx.scope)
+	}))
+
+	newPattern := func(
+		pattern string,
+		source coredata.CookieSource,
+		commonID *gid.GID,
+		thirdPartyID *gid.GID,
+	) *coredata.TrackerPattern {
+		src := source
+		tp := &coredata.TrackerPattern{
+			ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+			OrganizationID:         fx.organizationID,
+			CookieBannerID:         fx.cookieBannerID,
+			CookieCategoryID:       fx.cookieCategoryID,
+			CommonTrackerPatternID: commonID,
+			ThirdPartyID:           thirdPartyID,
+			TrackerType:            coredata.TrackerTypeCookie,
+			Pattern:                pattern,
+			MatchType:              coredata.TrackerPatternMatchTypeExact,
+			DisplayName:            pattern,
+			MaxAgeSeconds:          &maxAge,
+			Source:                 &src,
+			CreatedAt:              now,
+			UpdatedAt:              now,
+		}
+
+		require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+			return tp.Insert(ctx, tx, fx.scope)
+		}))
+
+		return tp
+	}
+
+	seedDetectedTracker := func(patternID gid.GID, identifier, domain string) {
+		d := domain
+		dt := &coredata.DetectedTracker{
+			ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+			CookieBannerID:   fx.cookieBannerID,
+			TrackerPatternID: &patternID,
+			TrackerType:      coredata.TrackerTypeCookie,
+			Identifier:       identifier,
+			InitiatorDomain:  &d,
+			LastDetectedAt:   now,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+
+		require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+			_, err := dt.Upsert(ctx, tx, fx.scope)
+
+			return err
+		}))
+	}
+
+	unmapped := newPattern("unmapped", coredata.CookieSourceScript, nil, nil)
+	catalogLinked := newPattern("catalog_linked", coredata.CookieSourceScript, &linkedCommon.ID, nil)
+	thirdPartyLinked := newPattern("third_party_linked", coredata.CookieSourceScript, nil, &orgThirdPartyID)
+	extension := newPattern("extension", coredata.CookieSourceExtension, nil, nil)
+	otherDomainPattern := newPattern("other_domain", coredata.CookieSourceScript, nil, nil)
+
+	seedDetectedTracker(unmapped.ID, "unmapped_id", vendorDomain)
+	seedDetectedTracker(catalogLinked.ID, "catalog_linked_id", vendorDomain)
+	seedDetectedTracker(thirdPartyLinked.ID, "third_party_linked_id", vendorDomain)
+	seedDetectedTracker(extension.ID, "extension_id", vendorDomain)
+	seedDetectedTracker(otherDomainPattern.ID, "other_domain_id", otherDomain)
+
+	var count int64
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		var patterns coredata.TrackerPatterns
+
+		var err error
+
+		count, err = patterns.RequestMappingForUnmappedByInitiatorDomains(ctx, tx, []string{vendorDomain})
+
+		return err
+	}))
+
+	assert.Equal(t, int64(1), count, "only the unmapped pattern sharing the domain must be re-armed")
+
+	load := func(id gid.GID) coredata.TrackerPattern {
+		var reloaded coredata.TrackerPattern
+
+		require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+			return reloaded.LoadByID(ctx, conn, fx.scope, id)
+		}))
+
+		return reloaded
+	}
+
+	assert.NotNil(t, load(unmapped.ID).MappingRequestedAt, "unmapped pattern sharing the domain must be re-armed")
+	assert.Nil(t, load(catalogLinked.ID).MappingRequestedAt, "pattern linked to a vendor via the catalog must be left alone")
+	assert.Nil(t, load(thirdPartyLinked.ID).MappingRequestedAt, "pattern linked to an org third party must be left alone")
+	assert.Nil(t, load(extension.ID).MappingRequestedAt, "extension-sourced pattern must be skipped")
+	assert.Nil(t, load(otherDomainPattern.ID).MappingRequestedAt, "pattern seen on a different domain must not be re-armed")
+
+	// Empty domain set is a no-op.
+	var emptyCount int64
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		var patterns coredata.TrackerPatterns
+
+		var err error
+
+		emptyCount, err = patterns.RequestMappingForUnmappedByInitiatorDomains(ctx, tx, nil)
+
+		return err
+	}))
+
+	assert.Equal(t, int64(0), emptyCount, "empty domain set must be a no-op")
+}

--- a/pkg/proboctl/commonthirdparty/commonthirdparty.go
+++ b/pkg/proboctl/commonthirdparty/commonthirdparty.go
@@ -16,6 +16,7 @@ package commonthirdparty
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -27,21 +28,98 @@ import (
 	"go.probo.inc/probo/pkg/proboctl/cmdutil"
 )
 
-// NewCmdCommonThirdParty is the entry point for inspecting the global
-// common third party catalog.
+// NewCmdCommonThirdParty is the entry point for inspecting and
+// re-enriching the global common third party catalog.
 func NewCmdCommonThirdParty(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "common-third-party <command>",
 		Aliases: []string{"ctp3"},
-		Short:   "Inspect the global common third party catalog",
+		Short:   "Inspect and re-enrich the global common third party catalog",
 	}
 
 	cmd.AddCommand(newCmdList(f))
 	cmd.AddCommand(newCmdShow(f))
 	cmd.AddCommand(newCmdDomains(f))
 	cmd.AddCommand(newCmdUpsert(f))
+	cmd.AddCommand(newCmdReenrich(f))
+	cmd.AddCommand(newCmdStats(f))
 
 	return cmd
+}
+
+// enrichmentState classifies a common third party's position in the
+// enrichment lifecycle for display. A row is "enriched" once it carries
+// an enrichment payload; there is no enriched_at column.
+func enrichmentState(p *coredata.CommonThirdParty) string {
+	switch {
+	case p.EnrichmentRequestedAt != nil:
+		return "queued"
+	case len(p.Enrichment) > 0:
+		return "enriched"
+	default:
+		return "unenriched"
+	}
+}
+
+// enrichmentStatus returns the run-level status recorded in the
+// enrichment payload (done, partial, failed), or an empty string when
+// the row has never been enriched or the payload is malformed.
+func enrichmentStatus(p *coredata.CommonThirdParty) string {
+	if len(p.Enrichment) == 0 {
+		return ""
+	}
+
+	var meta struct {
+		Status string `json:"status"`
+	}
+
+	if err := json.Unmarshal(p.Enrichment, &meta); err != nil {
+		return ""
+	}
+
+	return meta.Status
+}
+
+// parseEnrichmentState maps the --state flag to a coredata enrichment
+// state.
+func parseEnrichmentState(value string) (coredata.CommonThirdPartyEnrichmentState, error) {
+	switch value {
+	case "queued":
+		return coredata.CommonThirdPartyEnrichmentStateQueued, nil
+	case "enriched":
+		return coredata.CommonThirdPartyEnrichmentStateEnriched, nil
+	case "unenriched":
+		return coredata.CommonThirdPartyEnrichmentStateUnenriched, nil
+	default:
+		return "", fmt.Errorf("invalid --state value %q: valid values are queued, enriched, unenriched", value)
+	}
+}
+
+// validEnrichmentStatuses are the run-level statuses the enrichment
+// worker records in the payload.
+var validEnrichmentStatuses = map[string]struct{}{
+	"done":    {},
+	"partial": {},
+	"failed":  {},
+}
+
+// resolveCommonThirdPartyID accepts either a common third party GID or a
+// slug and returns the corresponding id.
+func resolveCommonThirdPartyID(ctx context.Context, conn pg.Querier, value string) (gid.GID, error) {
+	if id, err := gid.ParseGID(value); err == nil {
+		return id, nil
+	}
+
+	var party coredata.CommonThirdParty
+	if err := party.LoadBySlug(ctx, conn, value); err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return gid.GID{}, fmt.Errorf("no common third party found for %q (pass a slug or GID)", value)
+		}
+
+		return gid.GID{}, fmt.Errorf("cannot resolve common third party %q: %w", value, err)
+	}
+
+	return party.ID, nil
 }
 
 // resolveCommonThirdParty loads a common third party by GID or slug.

--- a/pkg/proboctl/commonthirdparty/list.go
+++ b/pkg/proboctl/commonthirdparty/list.go
@@ -31,6 +31,8 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 		flagName     string
 		flagCategory string
 		flagKeyword  string
+		flagState    string
+		flagStatus   string
 		flagSort     string
 		flagOrder    string
 	)
@@ -46,6 +48,8 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagName, "name", "", "Filter by name substring")
 	cmd.Flags().StringVar(&flagCategory, "category", "", "Filter by category")
 	cmd.Flags().StringVar(&flagKeyword, "keyword", "", "Filter by name/slug substring")
+	cmd.Flags().StringVar(&flagState, "state", "", "Filter by enrichment state (queued, enriched, unenriched)")
+	cmd.Flags().StringVar(&flagStatus, "status", "", "Filter by last enrichment status (done, partial, failed)")
 	cmd.Flags().StringVar(&flagSort, "sort", "name", "Sort field: name, created, updated")
 	cmd.Flags().StringVar(&flagOrder, "order", "", "Sort order: asc, desc (default depends on field)")
 
@@ -79,6 +83,23 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 
 		if flagKeyword != "" {
 			filter.WithKeyword(&flagKeyword)
+		}
+
+		if flagState != "" {
+			st, err := parseEnrichmentState(flagState)
+			if err != nil {
+				return err
+			}
+
+			filter.WithState(&st)
+		}
+
+		if flagStatus != "" {
+			if _, ok := validEnrichmentStatuses[flagStatus]; !ok {
+				return fmt.Errorf("invalid --status value %q: valid values are done, partial, failed", flagStatus)
+			}
+
+			filter.WithEnrichmentStatus(&flagStatus)
 		}
 
 		pgClient, err := f.PgClient()
@@ -128,14 +149,15 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 			return nil
 		}
 
-		table := clicmdutil.NewTable("ID", "NAME", "SLUG", "CATEGORY", "CREATED", "UPDATED")
+		table := clicmdutil.NewTable("ID", "NAME", "SLUG", "CATEGORY", "STATE", "STATUS", "UPDATED")
 		for _, p := range parties {
 			table.Row(
 				p.ID.String(),
 				p.Name,
 				p.Slug,
 				string(p.Category),
-				p.CreatedAt.Format("2006-01-02 15:04:05"),
+				enrichmentState(p),
+				enrichmentStatus(p),
 				p.UpdatedAt.Format("2006-01-02 15:04:05"),
 			)
 		}

--- a/pkg/proboctl/commonthirdparty/reenrich.go
+++ b/pkg/proboctl/commonthirdparty/reenrich.go
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package commonthirdparty
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/proboctl/cmdutil"
+)
+
+func newCmdReenrich(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagIDs      []string
+		flagSlugs    []string
+		flagCategory string
+		flagKeyword  string
+		flagState    string
+		flagStatus   string
+		flagDryRun   bool
+		flagYes      bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "reenrich",
+		Short: "Re-enrich common third parties via the enrichment worker",
+		Long: "Re-arm the async common-third-party enrichment worker for selected " +
+			"catalog rows. The worker re-resolves company profile, compliance " +
+			"documents, owned domains, and the logo, merging results over prior " +
+			"per-field provenance so curated seed data and human edits are never " +
+			"overwritten. Already-enriched rows are re-processed. Enrichment is " +
+			"expensive (LLM + browser per row), so a non-empty selection requires " +
+			"--yes; use --dry-run to preview.",
+		Args: cobra.NoArgs,
+	}
+
+	cmd.Flags().StringSliceVar(&flagIDs, "id", nil, "Common third party GID(s) to re-enrich (repeatable)")
+	cmd.Flags().StringSliceVar(&flagSlugs, "slug", nil, "Common third party slug(s) to re-enrich (repeatable)")
+	cmd.Flags().StringVar(&flagCategory, "category", "", "Select rows by category")
+	cmd.Flags().StringVar(&flagKeyword, "keyword", "", "Select rows by a name/slug substring")
+	cmd.Flags().StringVar(&flagState, "state", "", "Select rows by enrichment state (queued, enriched, unenriched)")
+	cmd.Flags().StringVar(&flagStatus, "status", "", "Select rows by last enrichment status (done, partial, failed)")
+	cmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "Print the selected rows without enriching")
+	cmd.Flags().BoolVar(&flagYes, "yes", false, "Skip confirmation")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		pgClient, err := f.PgClient()
+		if err != nil {
+			return err
+		}
+
+		ids, err := resolveReenrichIDs(
+			ctx,
+			pgClient,
+			flagIDs,
+			flagSlugs,
+			flagCategory,
+			flagKeyword,
+			flagState,
+			flagStatus,
+		)
+		if err != nil {
+			return err
+		}
+
+		out := f.IOStreams.Out
+
+		if len(ids) == 0 {
+			_, _ = fmt.Fprintln(out, "No common third parties matched the selection.")
+			return nil
+		}
+
+		if flagDryRun {
+			_, _ = fmt.Fprintf(out, "Would re-enrich %d common third party(ies).\n", len(ids))
+			printSample(out, ids)
+
+			return nil
+		}
+
+		if !flagYes {
+			return fmt.Errorf("about to re-enrich %d common third party(ies); pass --yes to proceed or --dry-run to preview", len(ids))
+		}
+
+		var requeued int64
+
+		if err := pgClient.WithTx(
+			ctx,
+			func(ctx context.Context, tx pg.Tx) error {
+				var parties coredata.CommonThirdParties
+
+				requeued, err = parties.RequestEnrichmentByIDs(ctx, tx, ids)
+
+				return err
+			},
+		); err != nil {
+			return fmt.Errorf("cannot enqueue enrichment: %w", err)
+		}
+
+		_, _ = fmt.Fprintf(out, "Queued %d common third party(ies) for the enrichment worker.\n", requeued)
+
+		return nil
+	}
+
+	return cmd
+}
+
+// resolveReenrichIDs turns the selection flags into the set of common
+// third party IDs to re-enrich. Explicit selection (--id and/or --slug)
+// is used verbatim and the filtering flags do not apply. With no
+// explicit selection the filtering flags (--category, --keyword,
+// --state, --status) select across the whole catalog.
+func resolveReenrichIDs(
+	ctx context.Context,
+	pgClient *pg.Client,
+	rawIDs, rawSlugs []string,
+	category, keyword, state, status string,
+) ([]gid.GID, error) {
+	explicit := len(rawIDs) > 0 || len(rawSlugs) > 0
+	filtered := category != "" || keyword != "" || state != "" || status != ""
+
+	if explicit && filtered {
+		return nil, fmt.Errorf("--id/--slug cannot be combined with --category, --keyword, --state, or --status")
+	}
+
+	if explicit {
+		return resolveExplicitIDs(ctx, pgClient, rawIDs, rawSlugs)
+	}
+
+	filter, err := buildReenrichFilter(category, keyword, state, status)
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []gid.GID
+
+	err = pgClient.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var parties coredata.CommonThirdParties
+
+			ids, err = parties.LoadAllIDs(ctx, conn, filter)
+
+			return err
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
+// resolveExplicitIDs parses the --id GIDs and resolves the --slug values,
+// preserving order and de-duplicating the combined set.
+func resolveExplicitIDs(
+	ctx context.Context,
+	pgClient *pg.Client,
+	rawIDs, rawSlugs []string,
+) ([]gid.GID, error) {
+	seen := make(map[gid.GID]struct{}, len(rawIDs)+len(rawSlugs))
+	ids := make([]gid.GID, 0, len(rawIDs)+len(rawSlugs))
+
+	add := func(id gid.GID) {
+		if _, ok := seen[id]; ok {
+			return
+		}
+
+		seen[id] = struct{}{}
+
+		ids = append(ids, id)
+	}
+
+	for _, raw := range rawIDs {
+		id, err := gid.ParseGID(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --id value %q: %w", raw, err)
+		}
+
+		add(id)
+	}
+
+	if len(rawSlugs) > 0 {
+		if err := pgClient.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				for _, slug := range rawSlugs {
+					id, err := resolveCommonThirdPartyID(ctx, conn, slug)
+					if err != nil {
+						return err
+					}
+
+					add(id)
+				}
+
+				return nil
+			},
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	return ids, nil
+}
+
+func buildReenrichFilter(category, keyword, state, status string) (*coredata.CommonThirdPartyFilter, error) {
+	filter := coredata.NewCommonThirdPartyFilter(nil)
+
+	if category != "" {
+		cat := coredata.ThirdPartyCategory(category)
+		if !cat.IsValid() {
+			return nil, fmt.Errorf("invalid --category value %q", category)
+		}
+
+		filter.WithCategory(&cat)
+	}
+
+	if keyword != "" {
+		filter.WithKeyword(&keyword)
+	}
+
+	if state != "" {
+		st, err := parseEnrichmentState(state)
+		if err != nil {
+			return nil, err
+		}
+
+		filter.WithState(&st)
+	}
+
+	if status != "" {
+		if _, ok := validEnrichmentStatuses[status]; !ok {
+			return nil, fmt.Errorf("invalid --status value %q: valid values are done, partial, failed", status)
+		}
+
+		filter.WithEnrichmentStatus(&status)
+	}
+
+	return filter, nil
+}
+
+func printSample(out io.Writer, ids []gid.GID) {
+	const sampleSize = 10
+
+	for i, id := range ids {
+		if i >= sampleSize {
+			_, _ = fmt.Fprintf(out, "  ... and %d more\n", len(ids)-sampleSize)
+			break
+		}
+
+		_, _ = fmt.Fprintf(out, "  %s\n", id.String())
+	}
+}

--- a/pkg/proboctl/commonthirdparty/show.go
+++ b/pkg/proboctl/commonthirdparty/show.go
@@ -16,8 +16,12 @@ package commonthirdparty
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
@@ -26,6 +30,31 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/proboctl/cmdutil"
 )
+
+// enrichmentMetadataView mirrors the subset of the enrichment payload
+// (written by the common-third-party enrichment worker) that show
+// renders. It is decoded locally to avoid a dependency on the thirdparty
+// package.
+type enrichmentMetadataView struct {
+	Model       string                             `json:"model"`
+	AttemptedAt time.Time                          `json:"attempted_at"`
+	Status      string                             `json:"status"`
+	Error       string                             `json:"error"`
+	Fields      map[string]enrichmentFieldMetaView `json:"fields"`
+	Domains     []enrichmentDomainMetaView         `json:"domains"`
+}
+
+type enrichmentFieldMetaView struct {
+	Confidence float64 `json:"confidence"`
+	SourceURL  string  `json:"source_url"`
+	Status     string  `json:"status"`
+	Source     string  `json:"source"`
+}
+
+type enrichmentDomainMetaView struct {
+	Domain     string  `json:"domain"`
+	Confidence float64 `json:"confidence"`
+}
 
 func newCmdShow(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
@@ -115,8 +144,81 @@ func newCmdShow(f *cmdutil.Factory) *cobra.Command {
 		row("Created:", party.CreatedAt.Format("2006-01-02 15:04:05"))
 		row("Updated:", party.UpdatedAt.Format("2006-01-02 15:04:05"))
 
+		row("Enrichment state:", enrichmentState(&party))
+		row("Enrichment attempts:", fmt.Sprintf("%d", party.EnrichmentAttempts))
+
+		if party.EnrichmentRequestedAt != nil {
+			row("Queued at:", party.EnrichmentRequestedAt.Format("2006-01-02 15:04:05"))
+		}
+
+		printEnrichmentDetails(out, label, party)
+
 		return nil
 	}
 
 	return cmd
+}
+
+// printEnrichmentDetails renders the run-level status and per-field
+// provenance recorded in the enrichment payload, when present.
+func printEnrichmentDetails(out io.Writer, label lipgloss.Style, party coredata.CommonThirdParty) {
+	if len(party.Enrichment) == 0 {
+		return
+	}
+
+	var meta enrichmentMetadataView
+	if err := json.Unmarshal(party.Enrichment, &meta); err != nil {
+		return
+	}
+
+	row := func(name, value string) {
+		_, _ = fmt.Fprintf(out, "%s%s\n", label.Render(name), value)
+	}
+
+	if meta.Status != "" {
+		row("Last run status:", meta.Status)
+	}
+
+	if !meta.AttemptedAt.IsZero() {
+		row("Last attempt:", meta.AttemptedAt.Format("2006-01-02 15:04:05"))
+	}
+
+	if meta.Model != "" {
+		row("Enrichment model:", meta.Model)
+	}
+
+	if meta.Error != "" {
+		row("Last error:", meta.Error)
+	}
+
+	if len(meta.Fields) > 0 {
+		names := make([]string, 0, len(meta.Fields))
+		for name := range meta.Fields {
+			names = append(names, name)
+		}
+
+		sort.Strings(names)
+
+		_, _ = fmt.Fprintln(out)
+
+		table := clicmdutil.NewTable("FIELD", "STATUS", "SOURCE", "CONF")
+
+		for _, name := range names {
+			fm := meta.Fields[name]
+			table.Row(name, fm.Status, fm.Source, fmt.Sprintf("%.2f", fm.Confidence))
+		}
+
+		_, _ = fmt.Fprintln(out, table.Render())
+	}
+
+	if len(meta.Domains) > 0 {
+		_, _ = fmt.Fprintln(out)
+
+		table := clicmdutil.NewTable("DISCOVERED DOMAIN", "CONF")
+		for _, d := range meta.Domains {
+			table.Row(d.Domain, fmt.Sprintf("%.2f", d.Confidence))
+		}
+
+		_, _ = fmt.Fprintln(out, table.Render())
+	}
 }

--- a/pkg/proboctl/commonthirdparty/stats.go
+++ b/pkg/proboctl/commonthirdparty/stats.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package commonthirdparty
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.gearno.de/kit/pg"
+	clicmdutil "go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/proboctl/cmdutil"
+)
+
+func newCmdStats(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stats",
+		Short: "Summarize the common third party catalog by enrichment state and status",
+		Args:  cobra.NoArgs,
+	}
+
+	output := clicmdutil.AddOutputFlag(cmd)
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := clicmdutil.ValidateOutputFlag(output); err != nil {
+			return err
+		}
+
+		pgClient, err := f.PgClient()
+		if err != nil {
+			return err
+		}
+
+		stats := map[string]int{}
+
+		if err := pgClient.WithConn(
+			cmd.Context(),
+			func(ctx context.Context, conn pg.Querier) error {
+				counts := []struct {
+					key    string
+					filter *coredata.CommonThirdPartyFilter
+				}{
+					{"total", coredata.NewCommonThirdPartyFilter(nil)},
+					{"queued", coredata.NewCommonThirdPartyFilter(nil).WithState(new(coredata.CommonThirdPartyEnrichmentStateQueued))},
+					{"enriched", coredata.NewCommonThirdPartyFilter(nil).WithState(new(coredata.CommonThirdPartyEnrichmentStateEnriched))},
+					{"unenriched", coredata.NewCommonThirdPartyFilter(nil).WithState(new(coredata.CommonThirdPartyEnrichmentStateUnenriched))},
+					{"status: done", coredata.NewCommonThirdPartyFilter(nil).WithEnrichmentStatus(new("done"))},
+					{"status: partial", coredata.NewCommonThirdPartyFilter(nil).WithEnrichmentStatus(new("partial"))},
+					{"status: failed", coredata.NewCommonThirdPartyFilter(nil).WithEnrichmentStatus(new("failed"))},
+				}
+
+				for _, c := range counts {
+					var parties coredata.CommonThirdParties
+
+					n, err := parties.CountAll(ctx, conn, c.filter)
+					if err != nil {
+						return err
+					}
+
+					stats[c.key] = n
+				}
+
+				return nil
+			},
+		); err != nil {
+			return err
+		}
+
+		order := []string{"total", "queued", "enriched", "unenriched", "status: done", "status: partial", "status: failed"}
+
+		if *output == clicmdutil.OutputJSON {
+			return clicmdutil.PrintJSON(f.IOStreams.Out, stats)
+		}
+
+		table := clicmdutil.NewTable("METRIC", "COUNT")
+		for _, key := range order {
+			table.Row(key, fmt.Sprintf("%d", stats[key]))
+		}
+
+		_, _ = fmt.Fprintln(f.IOStreams.Out, table.Render())
+
+		return nil
+	}
+
+	return cmd
+}

--- a/pkg/probod/aliases.go
+++ b/pkg/probod/aliases.go
@@ -43,8 +43,9 @@ type (
 	ThirdPartyVettingWorkerConfig = probodconfig.ThirdPartyVettingWorkerConfig
 	AgentsConfig                  = probodconfig.AgentsConfig
 
-	TrackerMappingWorkerConfig          = probodconfig.TrackerMappingWorkerConfig
-	CommonPatternEnrichmentWorkerConfig = probodconfig.CommonPatternEnrichmentWorkerConfig
+	TrackerMappingWorkerConfig             = probodconfig.TrackerMappingWorkerConfig
+	CommonPatternEnrichmentWorkerConfig    = probodconfig.CommonPatternEnrichmentWorkerConfig
+	CommonThirdPartyEnrichmentWorkerConfig = probodconfig.CommonThirdPartyEnrichmentWorkerConfig
 
 	MailerConfig        = probodconfig.MailerConfig
 	SMTPConfig          = probodconfig.SMTPConfig

--- a/pkg/probod/common_third_party_enrichment.go
+++ b/pkg/probod/common_third_party_enrichment.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probod
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.gearno.de/kit/log"
+	"go.opentelemetry.io/otel/trace"
+	"go.probo.inc/probo/pkg/filemanager"
+	"go.probo.inc/probo/pkg/thirdparty"
+)
+
+// buildCommonThirdPartyEnrichmentConfig wires the common-third-party
+// enrichment worker config: the LLM client for its two agents plus the
+// worker tuning, browser endpoint, and logo-storage dependencies. It is
+// opt-in: a deployment that does not set
+// `llm.common-third-party-enrichment.provider` gets a zero config (nil
+// LLM client), so the worker runs as a no-op and the caller skips
+// registration.
+func (impl *Implm) buildCommonThirdPartyEnrichmentConfig(
+	l *log.Logger,
+	tp trace.TracerProvider,
+	r prometheus.Registerer,
+	fileManager *filemanager.Service,
+) (thirdparty.EnrichmentConfig, error) {
+	if impl.cfg.Agents.CommonThirdPartyEnrichment.Provider == "" {
+		return thirdparty.EnrichmentConfig{}, nil
+	}
+
+	agentCfg, llmClient, err := impl.resolveAgentClient(
+		"common-third-party-enrichment",
+		impl.cfg.Agents.CommonThirdPartyEnrichment,
+		l,
+		tp,
+		r,
+	)
+	if err != nil {
+		return thirdparty.EnrichmentConfig{}, fmt.Errorf("cannot resolve common third party enrichment agent client: %w", err)
+	}
+
+	workerCfg := impl.cfg.CommonThirdPartyEnrichmentWorker
+
+	return thirdparty.EnrichmentConfig{
+		LLMClient:           llmClient,
+		Model:               agentCfg.ModelName,
+		MaxTokens:           agentCfg.MaxTokens,
+		Temperature:         agentCfg.Temperature,
+		FirecrawlAPIKey:     impl.cfg.Agents.Tools.FirecrawlAPIKey,
+		ChromeAddr:          impl.cfg.ChromeDPAddr,
+		AgentTimeout:        time.Duration(workerCfg.AgentTimeout) * time.Second,
+		MaxTurns:            workerCfg.AgentMaxTurns,
+		ConfidenceThreshold: workerCfg.ConfidenceThreshold,
+		StaleAfter:          time.Duration(workerCfg.StaleAfter) * time.Second,
+		MaxAttempts:         workerCfg.MaxAttempts,
+		FileManager:         fileManager,
+		Bucket:              impl.cfg.AWS.Bucket,
+	}, nil
+}

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -181,6 +181,15 @@ func New() *Implm {
 				StaleAfter:     1500,
 				MaxConcurrency: 1,
 			},
+			CommonThirdPartyEnrichmentWorker: CommonThirdPartyEnrichmentWorkerConfig{
+				Interval:            10,
+				MaxConcurrency:      1,
+				StaleAfter:          900,
+				AgentTimeout:        90,
+				AgentMaxTurns:       12,
+				ConfidenceThreshold: 0.7,
+				MaxAttempts:         3,
+			},
 		},
 	}
 }
@@ -327,6 +336,11 @@ func (impl *Implm) Run(
 	}
 
 	fileManagerService := filemanager.NewService(pgClient, baseURL, s3Client)
+
+	commonThirdPartyEnrichmentCfg, err := impl.buildCommonThirdPartyEnrichmentConfig(l, tp, r, fileManagerService)
+	if err != nil {
+		return err
+	}
 
 	var (
 		samlCert *x509.Certificate
@@ -819,6 +833,34 @@ func (impl *Implm) Run(
 		)
 	}
 
+	// The common-third-party enrichment worker fills catalog metadata
+	// (URLs, address, certifications, logo) via two agents plus a
+	// deterministic logo step. It needs an LLM client, so it is only
+	// started when its agent config is present.
+	stopCommonThirdPartyEnrichmentWorker := func() {}
+
+	if commonThirdPartyEnrichmentCfg.LLMClient != nil {
+		commonThirdPartyEnrichmentWorker := thirdparty.NewCommonThirdPartyEnrichmentWorker(
+			pgClient,
+			l.Named("common-third-party-enrichment-worker"),
+			commonThirdPartyEnrichmentCfg,
+			worker.WithInterval(time.Duration(impl.cfg.CommonThirdPartyEnrichmentWorker.Interval)*time.Second),
+			worker.WithMaxConcurrency(impl.cfg.CommonThirdPartyEnrichmentWorker.MaxConcurrency),
+		)
+
+		var commonThirdPartyEnrichmentWorkerCtx context.Context
+
+		commonThirdPartyEnrichmentWorkerCtx, stopCommonThirdPartyEnrichmentWorker = context.WithCancel(context.Background())
+
+		wg.Go(
+			func() {
+				if err := commonThirdPartyEnrichmentWorker.Run(commonThirdPartyEnrichmentWorkerCtx); err != nil {
+					cancel(fmt.Errorf("common third party enrichment worker crashed: %w", err))
+				}
+			},
+		)
+	}
+
 	mailingListWorker := mailman.NewMailingListWorker(mailmanService, pgClient, l.Named("mailing-list-worker"))
 	mailingListWorkerCtx, stopMailingListWorker := context.WithCancel(context.Background())
 
@@ -910,6 +952,7 @@ func (impl *Implm) Run(
 	stopTrackerPolicyWorker()
 	stopTrackerMappingWorker()
 	stopCommonPatternEnrichmentWorker()
+	stopCommonThirdPartyEnrichmentWorker()
 	stopMailingListWorker()
 	stopVettingWorker()
 	stopEvidenceDescriptionWorker()

--- a/pkg/probodconfig/config.go
+++ b/pkg/probodconfig/config.go
@@ -62,8 +62,9 @@ type (
 		EvidenceDescriber EvidenceDescriberConfig       `json:"evidence-describer"`
 		ThirdPartyVetting ThirdPartyVettingWorkerConfig `json:"third-party-vetting-worker"`
 
-		TrackerMappingWorker          TrackerMappingWorkerConfig          `json:"tracker-mapping-worker"`
-		CommonPatternEnrichmentWorker CommonPatternEnrichmentWorkerConfig `json:"common-pattern-enrichment-worker"`
+		TrackerMappingWorker             TrackerMappingWorkerConfig             `json:"tracker-mapping-worker"`
+		CommonPatternEnrichmentWorker    CommonPatternEnrichmentWorkerConfig    `json:"common-pattern-enrichment-worker"`
+		CommonThirdPartyEnrichmentWorker CommonThirdPartyEnrichmentWorkerConfig `json:"common-third-party-enrichment-worker"`
 
 		ChromeDPAddr  string              `json:"chrome-dp-addr"`
 		CustomDomains CustomDomainsConfig `json:"custom-domains"`

--- a/pkg/probodconfig/llm_config.go
+++ b/pkg/probodconfig/llm_config.go
@@ -76,6 +76,22 @@ type (
 		AgentMaxTurns  int `json:"agent-max-turns"`
 	}
 
+	// CommonThirdPartyEnrichmentWorkerConfig holds worker-side tuning for
+	// the common-third-party enrichment background worker. LLM parameters
+	// for its agents live under AgentsConfig.CommonThirdPartyEnrichment.
+	// ConfidenceThreshold is the floor a resolved value must clear before
+	// it is written to its column; MaxAttempts caps stale-recovery
+	// retries.
+	CommonThirdPartyEnrichmentWorkerConfig struct {
+		Interval            int     `json:"interval"` // seconds between polls
+		MaxConcurrency      int     `json:"max-concurrency"`
+		StaleAfter          int     `json:"stale-after"`   // seconds before a claim is recycled
+		AgentTimeout        int     `json:"agent-timeout"` // seconds, single agent run
+		AgentMaxTurns       int     `json:"agent-max-turns"`
+		ConfidenceThreshold float64 `json:"confidence-threshold"`
+		MaxAttempts         int     `json:"max-attempts"`
+	}
+
 	// AgentToolsConfig holds API keys and settings for external tools
 	// that agents can use (web search, scraping, etc.).
 	AgentToolsConfig struct {
@@ -86,15 +102,16 @@ type (
 	// settings. Default is used as a fallback when an agent-specific field
 	// is zero-valued.
 	AgentsConfig struct {
-		Providers                map[string]LLMProviderConfig `json:"providers"`
-		Default                  LLMAgentConfig               `json:"defaults"`
-		Probo                    LLMAgentConfig               `json:"probo"`
-		EvidenceDescriber        LLMAgentConfig               `json:"evidence-describer"`
-		ThirdPartyVetter         LLMAgentConfig               `json:"third-party-vetter"`
-		ThirdPartyDisambiguation LLMAgentConfig               `json:"third-party-disambiguation"`
-		TrackerMapping           LLMAgentConfig               `json:"tracker-mapping"`
-		TrackerEnrichment        LLMAgentConfig               `json:"tracker-enrichment"`
-		Tools                    AgentToolsConfig             `json:"tools"`
+		Providers                  map[string]LLMProviderConfig `json:"providers"`
+		Default                    LLMAgentConfig               `json:"defaults"`
+		Probo                      LLMAgentConfig               `json:"probo"`
+		EvidenceDescriber          LLMAgentConfig               `json:"evidence-describer"`
+		ThirdPartyVetter           LLMAgentConfig               `json:"third-party-vetter"`
+		ThirdPartyDisambiguation   LLMAgentConfig               `json:"third-party-disambiguation"`
+		TrackerMapping             LLMAgentConfig               `json:"tracker-mapping"`
+		TrackerEnrichment          LLMAgentConfig               `json:"tracker-enrichment"`
+		CommonThirdPartyEnrichment LLMAgentConfig               `json:"common-third-party-enrichment"`
+		Tools                      AgentToolsConfig             `json:"tools"`
 	}
 )
 

--- a/pkg/stringsx/stringsx.go
+++ b/pkg/stringsx/stringsx.go
@@ -12,37 +12,24 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package strutil_test
+// Package stringsx holds small, dependency-free string helpers shared
+// across packages.
+package stringsx
 
-import (
-	"testing"
+import "strings"
 
-	"github.com/stretchr/testify/assert"
-	"go.probo.inc/probo/pkg/strutil"
-)
+// NormalizeAlnum lowercases s and keeps only ASCII letters and digits, so
+// vendor names and domains can be compared free of spacing, punctuation,
+// and casing differences (e.g. "Letaido" and "letaido.com" both reduce to
+// a comparable form).
+func NormalizeAlnum(s string) string {
+	var b strings.Builder
 
-func TestNormalizeAlnum(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{name: "letters lowercased", input: "Letaido", expected: "letaido"},
-		{name: "strips punctuation and spaces", input: "letaido.com - Inc", expected: "letaidocominc"},
-		{name: "keeps digits", input: "auth0", expected: "auth0"},
-		{name: "empty", input: "", expected: ""},
-		{name: "only punctuation", input: "-_.:", expected: ""},
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
 	}
 
-	for _, tt := range tests {
-		t.Run(
-			tt.name,
-			func(t *testing.T) {
-				t.Parallel()
-				assert.Equal(t, tt.expected, strutil.NormalizeAlnum(tt.input))
-			},
-		)
-	}
+	return b.String()
 }

--- a/pkg/stringsx/stringsx_test.go
+++ b/pkg/stringsx/stringsx_test.go
@@ -12,24 +12,37 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-// Package strutil holds small, dependency-free string helpers shared
-// across packages.
-package strutil
+package stringsx_test
 
-import "strings"
+import (
+	"testing"
 
-// NormalizeAlnum lowercases s and keeps only ASCII letters and digits, so
-// vendor names and domains can be compared free of spacing, punctuation,
-// and casing differences (e.g. "Letaido" and "letaido.com" both reduce to
-// a comparable form).
-func NormalizeAlnum(s string) string {
-	var b strings.Builder
+	"github.com/stretchr/testify/assert"
+	"go.probo.inc/probo/pkg/stringsx"
+)
 
-	for _, r := range strings.ToLower(s) {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
-			b.WriteRune(r)
-		}
+func TestNormalizeAlnum(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "letters lowercased", input: "Letaido", expected: "letaido"},
+		{name: "strips punctuation and spaces", input: "letaido.com - Inc", expected: "letaidocominc"},
+		{name: "keeps digits", input: "auth0", expected: "auth0"},
+		{name: "empty", input: "", expected: ""},
+		{name: "only punctuation", input: "-_.:", expected: ""},
 	}
 
-	return b.String()
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tt.expected, stringsx.NormalizeAlnum(tt.input))
+			},
+		)
+	}
 }

--- a/pkg/strutil/strutil.go
+++ b/pkg/strutil/strutil.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+// Package strutil holds small, dependency-free string helpers shared
+// across packages.
+package strutil
+
+import "strings"
+
+// NormalizeAlnum lowercases s and keeps only ASCII letters and digits, so
+// vendor names and domains can be compared free of spacing, punctuation,
+// and casing differences (e.g. "Letaido" and "letaido.com" both reduce to
+// a comparable form).
+func NormalizeAlnum(s string) string {
+	var b strings.Builder
+
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+
+	return b.String()
+}

--- a/pkg/strutil/strutil_test.go
+++ b/pkg/strutil/strutil_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package strutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.probo.inc/probo/pkg/strutil"
+)
+
+func TestNormalizeAlnum(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "letters lowercased", input: "Letaido", expected: "letaido"},
+		{name: "strips punctuation and spaces", input: "letaido.com - Inc", expected: "letaidocominc"},
+		{name: "keeps digits", input: "auth0", expected: "auth0"},
+		{name: "empty", input: "", expected: ""},
+		{name: "only punctuation", input: "-_.:", expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tt.expected, strutil.NormalizeAlnum(tt.input))
+			},
+		)
+	}
+}

--- a/pkg/thirdparty/common_third_party_company_profile_agent.go
+++ b/pkg/thirdparty/common_third_party_company_profile_agent.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/agent"
+	"go.probo.inc/probo/pkg/agent/tools/search"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+//go:embed prompts/common_third_party_company_profile.txt.tmpl
+var companyProfilePrompt string
+
+// CompanyProfileResult is the structured output of the company-profile
+// agent (Agent A): the vendor's identity facts. website_url is the key
+// signal the compliance-docs agent and the logo step depend on, so it is
+// resolved here first.
+type CompanyProfileResult struct {
+	LegalName          EnrichedField `json:"legal_name" jsonschema:"The vendor's full legal company name including the entity suffix (e.g. 'Acme Technologies, Inc.')."`
+	HeadquarterAddress EnrichedField `json:"headquarter_address" jsonschema:"The vendor's headquarters postal address (street, city, region, country)."`
+	WebsiteURL         EnrichedField `json:"website_url" jsonschema:"The vendor's canonical primary marketing website URL (https scheme, no tracking query parameters, no trailing path)."`
+}
+
+func buildCompanyProfileAgent(
+	cfg EnrichmentConfig,
+	logger *log.Logger,
+) *agent.Agent {
+	var tools []agent.Tool
+
+	if cfg.FirecrawlAPIKey != "" {
+		tools = append(tools, search.FirecrawlSearchTool(cfg.FirecrawlAPIKey))
+	}
+
+	outputType, err := agent.NewOutputType[CompanyProfileResult]("common_third_party_company_profile")
+	if err != nil {
+		panic(fmt.Sprintf("thirdparty: cannot build company profile output type: %s", err))
+	}
+
+	opts := []agent.Option{
+		agent.WithInstructions(companyProfilePrompt),
+		agent.WithModel(cfg.Model),
+		agent.WithOutputType(outputType),
+		agent.WithMaxTurns(resolveEnrichmentMaxTurns(cfg.MaxTurns)),
+		agent.WithMaxTokens(resolveEnrichmentMaxTokens(cfg.MaxTokens)),
+		agent.WithLogger(logger),
+	}
+
+	if len(tools) > 0 {
+		opts = append(opts, agent.WithTools(tools...))
+	}
+
+	if cfg.Temperature != nil {
+		opts = append(opts, agent.WithTemperature(*cfg.Temperature))
+	}
+
+	return agent.New("common-third-party-company-profile", cfg.LLMClient, opts...)
+}
+
+// buildCompanyProfilePrompt renders the per-row input for Agent A. Any
+// values already on the row are passed as hints so the agent confirms or
+// corrects them rather than starting cold.
+func buildCompanyProfilePrompt(party coredata.CommonThirdParty) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "Research this company and return its profile.\n\n")
+	fmt.Fprintf(&b, "<name> %s </name>\n", party.Name)
+
+	if party.WebsiteURL != nil && strings.TrimSpace(*party.WebsiteURL) != "" {
+		fmt.Fprintf(&b, "<known_website> %s </known_website>\n", *party.WebsiteURL)
+	}
+
+	if party.LegalName != nil && strings.TrimSpace(*party.LegalName) != "" {
+		fmt.Fprintf(&b, "<known_legal_name> %s </known_legal_name>\n", *party.LegalName)
+	}
+
+	return b.String()
+}

--- a/pkg/thirdparty/common_third_party_company_profile_agent.go
+++ b/pkg/thirdparty/common_third_party_company_profile_agent.go
@@ -38,11 +38,17 @@ type CompanyProfileResult struct {
 	WebsiteURL         EnrichedField `json:"website_url" jsonschema:"The vendor's canonical primary marketing website URL (https scheme, no tracking query parameters, no trailing path)."`
 }
 
+// buildCompanyProfileAgent builds Agent A. extraTools carries the
+// browser read-only toolset when a headless Chrome endpoint is
+// configured; it is empty otherwise, in which case the agent relies on
+// web_search alone. The browser lets it read footer/imprint/about/legal
+// pages where the legal name and headquarters address live.
 func buildCompanyProfileAgent(
 	cfg EnrichmentConfig,
 	logger *log.Logger,
+	extraTools []agent.Tool,
 ) *agent.Agent {
-	var tools []agent.Tool
+	tools := append([]agent.Tool{}, extraTools...)
 
 	if cfg.FirecrawlAPIKey != "" {
 		tools = append(tools, search.FirecrawlSearchTool(cfg.FirecrawlAPIKey))

--- a/pkg/thirdparty/common_third_party_compliance_docs_agent.go
+++ b/pkg/thirdparty/common_third_party_compliance_docs_agent.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/agent"
+	"go.probo.inc/probo/pkg/agent/tools/search"
+)
+
+//go:embed prompts/common_third_party_compliance_docs.txt.tmpl
+var complianceDocsPrompt string
+
+// ComplianceDocsResult is the structured output of the compliance-docs
+// agent (Agent B): the legal-document URLs, trust/security/status pages,
+// and certifications. These all live in the same source ecosystem (the
+// vendor footer and trust portal), so one agent resolves them together.
+type ComplianceDocsResult struct {
+	PrivacyPolicyURL              EnrichedField       `json:"privacy_policy_url" jsonschema:"URL of the vendor's privacy policy."`
+	TermsOfServiceURL             EnrichedField       `json:"terms_of_service_url" jsonschema:"URL of the vendor's terms of service / terms of use."`
+	ServiceLevelAgreementURL      EnrichedField       `json:"service_level_agreement_url" jsonschema:"URL of the vendor's public service level agreement (SLA). Often gated behind sales; return empty when not public."`
+	ServiceSoftwareAgreementURL   EnrichedField       `json:"service_software_agreement_url" jsonschema:"URL of the vendor's master software/subscription agreement (MSA). Often gated or identical to the terms of service; return empty when not public."`
+	DataProcessingAgreementURL    EnrichedField       `json:"data_processing_agreement_url" jsonschema:"URL of the vendor's data processing agreement (DPA). Often a PDF; return empty when only available on request."`
+	BusinessAssociateAgreementURL EnrichedField       `json:"business_associate_agreement_url" jsonschema:"URL of the vendor's HIPAA business associate agreement (BAA). Almost always gated behind sales; return empty when not public."`
+	SubprocessorsListURL          EnrichedField       `json:"subprocessors_list_url" jsonschema:"URL of the vendor's sub-processors list page."`
+	StatusPageURL                 EnrichedField       `json:"status_page_url" jsonschema:"URL of the vendor's uptime/status page (e.g. status.vendor.com)."`
+	SecurityPageURL               EnrichedField       `json:"security_page_url" jsonschema:"URL of the vendor's security page or security overview."`
+	TrustPageURL                  EnrichedField       `json:"trust_page_url" jsonschema:"URL of the vendor's trust center / trust portal (e.g. Vanta, SafeBase, Drata hosted)."`
+	Certifications                CertificationsField `json:"certifications" jsonschema:"Certifications and compliance frameworks the vendor publicly claims."`
+}
+
+// buildComplianceDocsAgent builds Agent B. extraTools carries the browser
+// read-only toolset when a headless Chrome endpoint is configured; it is
+// empty otherwise, in which case the agent relies on web_search alone.
+func buildComplianceDocsAgent(
+	cfg EnrichmentConfig,
+	logger *log.Logger,
+	extraTools []agent.Tool,
+) *agent.Agent {
+	tools := append([]agent.Tool{}, extraTools...)
+
+	if cfg.FirecrawlAPIKey != "" {
+		tools = append(tools, search.FirecrawlSearchTool(cfg.FirecrawlAPIKey))
+	}
+
+	outputType, err := agent.NewOutputType[ComplianceDocsResult]("common_third_party_compliance_docs")
+	if err != nil {
+		panic(fmt.Sprintf("thirdparty: cannot build compliance docs output type: %s", err))
+	}
+
+	opts := []agent.Option{
+		agent.WithInstructions(complianceDocsPrompt),
+		agent.WithModel(cfg.Model),
+		agent.WithOutputType(outputType),
+		agent.WithMaxTurns(resolveEnrichmentMaxTurns(cfg.MaxTurns)),
+		agent.WithMaxTokens(resolveEnrichmentMaxTokens(cfg.MaxTokens)),
+		agent.WithLogger(logger),
+	}
+
+	if len(tools) > 0 {
+		opts = append(opts, agent.WithTools(tools...))
+	}
+
+	if cfg.Temperature != nil {
+		opts = append(opts, agent.WithTemperature(*cfg.Temperature))
+	}
+
+	return agent.New("common-third-party-compliance-docs", cfg.LLMClient, opts...)
+}
+
+// buildComplianceDocsPrompt renders the per-row input for Agent B,
+// seeding it with the vendor name and the website/legal name resolved by
+// Agent A so it can scope its search to the vendor's own domain.
+func buildComplianceDocsPrompt(name, websiteURL, legalName string) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "Find the compliance documents and trust pages for this vendor.\n\n")
+	fmt.Fprintf(&b, "<name> %s </name>\n", name)
+
+	if w := strings.TrimSpace(websiteURL); w != "" {
+		fmt.Fprintf(&b, "<website> %s </website>\n", w)
+	}
+
+	if l := strings.TrimSpace(legalName); l != "" {
+		fmt.Fprintf(&b, "<legal_name> %s </legal_name>\n", l)
+	}
+
+	return b.String()
+}

--- a/pkg/thirdparty/common_third_party_domains_agent.go
+++ b/pkg/thirdparty/common_third_party_domains_agent.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/agent"
+	"go.probo.inc/probo/pkg/agent/tools/search"
+)
+
+//go:embed prompts/common_third_party_domains.txt.tmpl
+var domainsPrompt string
+
+// DomainsResult is the structured output of the domain-discovery agent
+// (Agent C): the registrable domains the vendor itself owns and operates,
+// including the marketing site, app, public API hosts, and CDN/asset
+// hosts. The worker reduces these to eTLD+1, applies an ownership gate,
+// and writes the survivors to common_third_party_domains so the
+// tracker-mapping domain step can attribute trackers to this vendor.
+type (
+	DomainsResult struct {
+		Domains []DomainCandidate `json:"domains" jsonschema:"The domains the vendor owns and operates. Empty when none can be confirmed."`
+	}
+
+	DomainCandidate struct {
+		Domain     string  `json:"domain" jsonschema:"A domain the vendor owns and operates (a registrable domain such as 'intercomcdn.com' or a full host such as 'api.vendor.com'). Never a third-party or shared-infrastructure host the vendor does not own."`
+		Confidence float64 `json:"confidence" jsonschema:"Confidence from 0.0 to 1.0 that the vendor owns this domain. Use 0 when ownership is not confirmed."`
+		SourceURL  string  `json:"source_url" jsonschema:"The URL where the vendor's ownership of this domain was observed, or an empty string."`
+	}
+)
+
+// buildCommonThirdPartyDomainsAgent builds Agent C. extraTools carries
+// the browser read-only toolset when a headless Chrome endpoint is
+// configured; it is empty otherwise, in which case the agent relies on
+// web_search alone.
+func buildCommonThirdPartyDomainsAgent(
+	cfg EnrichmentConfig,
+	logger *log.Logger,
+	extraTools []agent.Tool,
+) *agent.Agent {
+	tools := append([]agent.Tool{}, extraTools...)
+
+	if cfg.FirecrawlAPIKey != "" {
+		tools = append(tools, search.FirecrawlSearchTool(cfg.FirecrawlAPIKey))
+	}
+
+	outputType, err := agent.NewOutputType[DomainsResult]("common_third_party_domains")
+	if err != nil {
+		panic(fmt.Sprintf("thirdparty: cannot build domains output type: %s", err))
+	}
+
+	opts := []agent.Option{
+		agent.WithInstructions(domainsPrompt),
+		agent.WithModel(cfg.Model),
+		agent.WithOutputType(outputType),
+		agent.WithMaxTurns(resolveEnrichmentMaxTurns(cfg.MaxTurns)),
+		agent.WithMaxTokens(resolveEnrichmentMaxTokens(cfg.MaxTokens)),
+		agent.WithLogger(logger),
+	}
+
+	if len(tools) > 0 {
+		opts = append(opts, agent.WithTools(tools...))
+	}
+
+	if cfg.Temperature != nil {
+		opts = append(opts, agent.WithTemperature(*cfg.Temperature))
+	}
+
+	return agent.New("common-third-party-domains", cfg.LLMClient, opts...)
+}
+
+// buildCommonThirdPartyDomainsPrompt renders the per-row input for Agent
+// C, seeding it with the vendor name and the website resolved by Agent A
+// so it can anchor ownership to the vendor's own domain.
+func buildCommonThirdPartyDomainsPrompt(name, websiteURL string) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "Find the domains owned and operated by this vendor.\n\n")
+	fmt.Fprintf(&b, "<name> %s </name>\n", name)
+
+	if w := strings.TrimSpace(websiteURL); w != "" {
+		fmt.Fprintf(&b, "<website> %s </website>\n", w)
+	}
+
+	return b.String()
+}

--- a/pkg/thirdparty/common_third_party_enrichment.go
+++ b/pkg/thirdparty/common_third_party_enrichment.go
@@ -248,6 +248,7 @@ func normalizeCertifications(values []string) []string {
 		}
 
 		seen[key] = struct{}{}
+
 		out = append(out, v)
 	}
 

--- a/pkg/thirdparty/common_third_party_enrichment.go
+++ b/pkg/thirdparty/common_third_party_enrichment.go
@@ -30,10 +30,11 @@ const (
 	enrichmentSourceEnrichment = "enrichment"
 	enrichmentSourceExternal   = "external"
 
-	enrichmentFieldStatusFound         = "found"
-	enrichmentFieldStatusNotFound      = "not_found"
-	enrichmentFieldStatusLowConfidence = "low_confidence"
-	enrichmentFieldStatusExternal      = "exists_external"
+	enrichmentFieldStatusFound               = "found"
+	enrichmentFieldStatusNotFound            = "not_found"
+	enrichmentFieldStatusLowConfidence       = "low_confidence"
+	enrichmentFieldStatusExternal            = "exists_external"
+	enrichmentFieldStatusFallbackDisplayName = "fallback_display_name"
 
 	// Run-level status recorded at the top of the enrichment payload.
 	enrichmentStatusDone    = "done"
@@ -227,6 +228,35 @@ func applyCertifications(
 		Status:     status,
 		Source:     enrichmentSourceEnrichment,
 		UpdatedAt:  now,
+	}
+}
+
+// applyLegalNameFallback fills legal_name with the catalog display name
+// when the merge left the column empty, so it is never blank. A real
+// value (agent-resolved or external) already on the row is left
+// untouched. The fallback is recorded as enrichment-owned so a later run
+// that resolves the real legal entity overwrites it.
+func applyLegalNameFallback(
+	party *coredata.CommonThirdParty,
+	meta map[string]EnrichmentFieldMeta,
+	now time.Time,
+) {
+	const name = "legal_name"
+
+	if party.LegalName != nil && strings.TrimSpace(*party.LegalName) != "" {
+		return
+	}
+
+	displayName := strings.TrimSpace(party.Name)
+	if displayName == "" {
+		return
+	}
+
+	party.LegalName = &displayName
+	meta[name] = EnrichmentFieldMeta{
+		Status:    enrichmentFieldStatusFallbackDisplayName,
+		Source:    enrichmentSourceEnrichment,
+		UpdatedAt: now,
 	}
 }
 

--- a/pkg/thirdparty/common_third_party_enrichment.go
+++ b/pkg/thirdparty/common_third_party_enrichment.go
@@ -71,6 +71,16 @@ type (
 		UpdatedAt  time.Time `json:"updated_at"`
 	}
 
+	// EnrichmentDomainMeta is the provenance of one domain written to
+	// common_third_party_domains during a run, recorded in the enrichment
+	// payload so the discovered domain set is auditable.
+	EnrichmentDomainMeta struct {
+		Domain     string    `json:"domain"`
+		Confidence float64   `json:"confidence"`
+		SourceURL  string    `json:"source_url,omitempty"`
+		UpdatedAt  time.Time `json:"updated_at"`
+	}
+
 	// EnrichmentMetadata is the full payload stored in the enrichment
 	// JSON column: run-level bookkeeping plus per-field provenance keyed
 	// by the column name.
@@ -80,6 +90,7 @@ type (
 		Status      string                         `json:"status"`
 		Error       string                         `json:"error,omitempty"`
 		Fields      map[string]EnrichmentFieldMeta `json:"fields"`
+		Domains     []EnrichmentDomainMeta         `json:"domains,omitempty"`
 	}
 )
 

--- a/pkg/thirdparty/common_third_party_enrichment.go
+++ b/pkg/thirdparty/common_third_party_enrichment.go
@@ -1,0 +1,345 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+// Provenance sources and per-field statuses recorded in the enrichment
+// JSON. The "source" distinguishes values written by this enricher from
+// values owned externally (curated seed data or a human edit), which the
+// enricher must never overwrite.
+const (
+	enrichmentSourceEnrichment = "enrichment"
+	enrichmentSourceExternal   = "external"
+
+	enrichmentFieldStatusFound         = "found"
+	enrichmentFieldStatusNotFound      = "not_found"
+	enrichmentFieldStatusLowConfidence = "low_confidence"
+	enrichmentFieldStatusExternal      = "exists_external"
+
+	// Run-level status recorded at the top of the enrichment payload.
+	enrichmentStatusDone    = "done"
+	enrichmentStatusPartial = "partial"
+	enrichmentStatusFailed  = "failed"
+)
+
+type (
+	// EnrichedField is the per-field unit the enrichment agents return:
+	// the resolved value plus a self-assessed confidence and the source
+	// URL where it was verified. The worker applies a confidence
+	// threshold before writing the value to its column.
+	EnrichedField struct {
+		Value      string  `json:"value" jsonschema:"The resolved value, or an empty string when not confidently found. Never guess."`
+		Confidence float64 `json:"confidence" jsonschema:"Confidence from 0.0 to 1.0 that the value is correct. Use 0 when the value was not found."`
+		SourceURL  string  `json:"source_url" jsonschema:"The URL where this value was verified, or an empty string."`
+	}
+
+	// CertificationsField is the list-valued counterpart of EnrichedField
+	// used for the certifications array.
+	CertificationsField struct {
+		Values     []string `json:"values" jsonschema:"Certification or compliance framework names the vendor publicly claims (e.g. 'SOC 2 Type II', 'ISO 27001', 'HIPAA'). Empty when none are found."`
+		Confidence float64  `json:"confidence" jsonschema:"Confidence from 0.0 to 1.0 in the certifications list. Use 0 when none are found."`
+		SourceURL  string   `json:"source_url" jsonschema:"The URL where the certifications were found (trust or security page), or an empty string."`
+	}
+
+	// EnrichmentFieldMeta is the per-field provenance recorded in the
+	// common_third_parties.enrichment JSON column.
+	EnrichmentFieldMeta struct {
+		Confidence float64   `json:"confidence"`
+		SourceURL  string    `json:"source_url,omitempty"`
+		Status     string    `json:"status"`
+		Source     string    `json:"source"`
+		UpdatedAt  time.Time `json:"updated_at"`
+	}
+
+	// EnrichmentMetadata is the full payload stored in the enrichment
+	// JSON column: run-level bookkeeping plus per-field provenance keyed
+	// by the column name.
+	EnrichmentMetadata struct {
+		Model       string                         `json:"model,omitempty"`
+		AttemptedAt time.Time                      `json:"attempted_at"`
+		Status      string                         `json:"status"`
+		Error       string                         `json:"error,omitempty"`
+		Fields      map[string]EnrichmentFieldMeta `json:"fields"`
+	}
+)
+
+// scalarField describes one *string column the enricher can fill,
+// pairing the agent's resolved value with accessors into the receiver.
+type scalarField struct {
+	name   string
+	get    func(*coredata.CommonThirdParty) *string
+	set    func(*coredata.CommonThirdParty, *string)
+	result EnrichedField
+}
+
+// parseEnrichmentFields extracts the prior per-field provenance from a
+// row's enrichment payload. A missing or malformed payload yields an
+// empty map, which the merge treats as "no field is enrichment-owned".
+func parseEnrichmentFields(raw json.RawMessage) map[string]EnrichmentFieldMeta {
+	if len(raw) == 0 {
+		return map[string]EnrichmentFieldMeta{}
+	}
+
+	var meta EnrichmentMetadata
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return map[string]EnrichmentFieldMeta{}
+	}
+
+	if meta.Fields == nil {
+		return map[string]EnrichmentFieldMeta{}
+	}
+
+	return meta.Fields
+}
+
+// applyScalarField merges one resolved scalar field into party, honoring
+// the confidence threshold and prior provenance, and records the
+// resulting per-field metadata. A value already present that this
+// enricher did not write (curated seed data or a human edit) is left
+// untouched. The column is written only when the value clears the
+// threshold; below it the column keeps its prior value and the metadata
+// records why nothing was written.
+func applyScalarField(
+	party *coredata.CommonThirdParty,
+	meta map[string]EnrichmentFieldMeta,
+	prior map[string]EnrichmentFieldMeta,
+	field scalarField,
+	threshold float64,
+	now time.Time,
+) {
+	value := strings.TrimSpace(field.result.Value)
+	sourceURL := strings.TrimSpace(field.result.SourceURL)
+
+	existing := field.get(party)
+	hasExisting := existing != nil && strings.TrimSpace(*existing) != ""
+
+	priorMeta, hadPrior := prior[field.name]
+	enrichmentOwned := hadPrior && priorMeta.Source == enrichmentSourceEnrichment
+
+	if hasExisting && !enrichmentOwned {
+		meta[field.name] = EnrichmentFieldMeta{
+			Status:    enrichmentFieldStatusExternal,
+			Source:    enrichmentSourceExternal,
+			UpdatedAt: now,
+		}
+
+		return
+	}
+
+	if value != "" && field.result.Confidence >= threshold {
+		v := value
+		field.set(party, &v)
+		meta[field.name] = EnrichmentFieldMeta{
+			Confidence: field.result.Confidence,
+			SourceURL:  sourceURL,
+			Status:     enrichmentFieldStatusFound,
+			Source:     enrichmentSourceEnrichment,
+			UpdatedAt:  now,
+		}
+
+		return
+	}
+
+	status := enrichmentFieldStatusNotFound
+	if value != "" {
+		status = enrichmentFieldStatusLowConfidence
+	}
+
+	meta[field.name] = EnrichmentFieldMeta{
+		Confidence: field.result.Confidence,
+		SourceURL:  sourceURL,
+		Status:     status,
+		Source:     enrichmentSourceEnrichment,
+		UpdatedAt:  now,
+	}
+}
+
+// applyCertifications is the list-valued counterpart of
+// applyScalarField for the certifications column.
+func applyCertifications(
+	party *coredata.CommonThirdParty,
+	meta map[string]EnrichmentFieldMeta,
+	prior map[string]EnrichmentFieldMeta,
+	result CertificationsField,
+	threshold float64,
+	now time.Time,
+) {
+	const name = "certifications"
+
+	values := normalizeCertifications(result.Values)
+	sourceURL := strings.TrimSpace(result.SourceURL)
+
+	hasExisting := len(party.Certifications) > 0
+
+	priorMeta, hadPrior := prior[name]
+	enrichmentOwned := hadPrior && priorMeta.Source == enrichmentSourceEnrichment
+
+	if hasExisting && !enrichmentOwned {
+		meta[name] = EnrichmentFieldMeta{
+			Status:    enrichmentFieldStatusExternal,
+			Source:    enrichmentSourceExternal,
+			UpdatedAt: now,
+		}
+
+		return
+	}
+
+	if len(values) > 0 && result.Confidence >= threshold {
+		party.Certifications = values
+		meta[name] = EnrichmentFieldMeta{
+			Confidence: result.Confidence,
+			SourceURL:  sourceURL,
+			Status:     enrichmentFieldStatusFound,
+			Source:     enrichmentSourceEnrichment,
+			UpdatedAt:  now,
+		}
+
+		return
+	}
+
+	status := enrichmentFieldStatusNotFound
+	if len(values) > 0 {
+		status = enrichmentFieldStatusLowConfidence
+	}
+
+	meta[name] = EnrichmentFieldMeta{
+		Confidence: result.Confidence,
+		SourceURL:  sourceURL,
+		Status:     status,
+		Source:     enrichmentSourceEnrichment,
+		UpdatedAt:  now,
+	}
+}
+
+// normalizeCertifications trims, drops blanks, and de-duplicates the
+// certification names returned by the agent, preserving order.
+func normalizeCertifications(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+
+		key := strings.ToLower(v)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+
+		seen[key] = struct{}{}
+		out = append(out, v)
+	}
+
+	return out
+}
+
+// scalarFields returns the descriptor list pairing each *string column
+// with the resolved value from the two agents. website_url comes from
+// the company-profile agent; the document and page URLs come from the
+// compliance-docs agent.
+func scalarFields(
+	company CompanyProfileResult,
+	compliance ComplianceDocsResult,
+) []scalarField {
+	return []scalarField{
+		{
+			name:   "legal_name",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.LegalName },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.LegalName = v },
+			result: company.LegalName,
+		},
+		{
+			name:   "headquarter_address",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.HeadquarterAddress },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.HeadquarterAddress = v },
+			result: company.HeadquarterAddress,
+		},
+		{
+			name:   "website_url",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.WebsiteURL },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.WebsiteURL = v },
+			result: company.WebsiteURL,
+		},
+		{
+			name:   "privacy_policy_url",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.PrivacyPolicyURL },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.PrivacyPolicyURL = v },
+			result: compliance.PrivacyPolicyURL,
+		},
+		{
+			name:   "terms_of_service_url",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.TermsOfServiceURL },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.TermsOfServiceURL = v },
+			result: compliance.TermsOfServiceURL,
+		},
+		{
+			name:   "service_level_agreement_url",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.ServiceLevelAgreementURL },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.ServiceLevelAgreementURL = v },
+			result: compliance.ServiceLevelAgreementURL,
+		},
+		{
+			name:   "service_software_agreement_url",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.ServiceSoftwareAgreementURL },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.ServiceSoftwareAgreementURL = v },
+			result: compliance.ServiceSoftwareAgreementURL,
+		},
+		{
+			name:   "data_processing_agreement_url",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.DataProcessingAgreementURL },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.DataProcessingAgreementURL = v },
+			result: compliance.DataProcessingAgreementURL,
+		},
+		{
+			name:   "business_associate_agreement_url",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.BusinessAssociateAgreementURL },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.BusinessAssociateAgreementURL = v },
+			result: compliance.BusinessAssociateAgreementURL,
+		},
+		{
+			name:   "subprocessors_list_url",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.SubprocessorsListURL },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.SubprocessorsListURL = v },
+			result: compliance.SubprocessorsListURL,
+		},
+		{
+			name:   "status_page_url",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.StatusPageURL },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.StatusPageURL = v },
+			result: compliance.StatusPageURL,
+		},
+		{
+			name:   "security_page_url",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.SecurityPageURL },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.SecurityPageURL = v },
+			result: compliance.SecurityPageURL,
+		},
+		{
+			name:   "trust_page_url",
+			get:    func(p *coredata.CommonThirdParty) *string { return p.TrustPageURL },
+			set:    func(p *coredata.CommonThirdParty, v *string) { p.TrustPageURL = v },
+			result: compliance.TrustPageURL,
+		},
+	}
+}

--- a/pkg/thirdparty/common_third_party_enrichment_worker.go
+++ b/pkg/thirdparty/common_third_party_enrichment_worker.go
@@ -56,6 +56,13 @@ const (
 	// recorded in the enrichment metadata but not promoted.
 	defaultEnrichmentConfidenceThreshold = 0.7
 
+	// defaultEnrichmentDomainConfidenceThreshold is the ownership-confidence
+	// floor a discovered domain must clear before it is written to
+	// common_third_party_domains. It is stricter than the field threshold
+	// because a domain feeds cross-tenant tracker attribution: a wrong
+	// domain mis-attributes every tracker served from it.
+	defaultEnrichmentDomainConfidenceThreshold = 0.85
+
 	// defaultEnrichmentStaleAfter is the idle window after which a
 	// claimed-but-unfinished enrichment is re-armed.
 	defaultEnrichmentStaleAfter = 15 * time.Minute
@@ -236,13 +243,15 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 
 		runErrors = append(runErrors, "website_url unresolved: skipped compliance docs")
 
-		return h.persist(ctx, party, EnrichmentMetadata{
+		payload := EnrichmentMetadata{
 			Model:       h.cfg.Model,
 			AttemptedAt: now,
 			Status:      enrichmentStatusFailed,
 			Error:       strings.Join(runErrors, "; "),
 			Fields:      meta,
-		}, nil, now)
+		}
+
+		return h.persist(ctx, party, payload, nil, nil, now)
 	}
 
 	legalName := effectiveLegalName(party, company, h.cfg.ConfidenceThreshold)
@@ -256,6 +265,19 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 		anySuccess = true
 	}
 
+	// Agent C: domains the vendor owns and operates. Anchored on the
+	// resolved website, so it runs only on this website-resolved path.
+	var owned []ownedDomain
+
+	domainsResult, err := h.runDomains(ctx, party.Name, website)
+	if err != nil {
+		h.logger.WarnCtx(ctx, "domains agent failed", log.Error(err), log.String("common_third_party_id", party.ID.String()))
+		runErrors = append(runErrors, "domains: "+err.Error())
+	} else {
+		anySuccess = true
+		owned = resolveOwnedDomains(party.Name, website, domainsResult, defaultEnrichmentDomainConfidenceThreshold)
+	}
+
 	// Deterministic logo step (no LLM). Uploads to S3 outside the final
 	// transaction; the File row is inserted below.
 	logoFile := h.prepareLogo(ctx, party, website)
@@ -266,6 +288,26 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 
 	applyCertifications(&party, meta, prior, compliance.Certifications, h.cfg.ConfidenceThreshold, now)
 	applyLegalNameFallback(&party, meta, now)
+
+	domainRows := make([]coredata.CommonThirdPartyDomain, 0, len(owned))
+	domainMeta := make([]EnrichmentDomainMeta, 0, len(owned))
+
+	for _, d := range owned {
+		domainRows = append(domainRows, coredata.CommonThirdPartyDomain{
+			ID:                 gid.New(gid.NilTenant, coredata.CommonThirdPartyDomainEntityType),
+			CommonThirdPartyID: party.ID,
+			Domain:             d.Domain,
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		})
+
+		domainMeta = append(domainMeta, EnrichmentDomainMeta{
+			Domain:     d.Domain,
+			Confidence: d.Confidence,
+			SourceURL:  d.SourceURL,
+			UpdatedAt:  now,
+		})
+	}
 
 	status := enrichmentStatusDone
 
@@ -282,20 +324,25 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 		Status:      status,
 		Error:       strings.Join(runErrors, "; "),
 		Fields:      meta,
+		Domains:     domainMeta,
 	}
 
-	return h.persist(ctx, party, payload, logoFile, now)
+	return h.persist(ctx, party, payload, logoFile, domainRows, now)
 }
 
 // persist marshals the enrichment payload onto the row and writes it in a
 // single transaction, inserting the logo File row and linking it when one
-// was prepared. It always writes an enrichment payload, even on a
-// no-result run, so stale recovery does not re-queue the row.
+// was prepared and upserting the discovered owned domains. It always
+// writes an enrichment payload, even on a no-result run, so stale
+// recovery does not re-queue the row. Domain upserts are idempotent
+// against the (common_third_party_id, domain) unique index, so re-runs
+// are safe and never conflict with curated seed rows.
 func (h *enrichmentHandler) persist(
 	ctx context.Context,
 	party coredata.CommonThirdParty,
 	payload EnrichmentMetadata,
 	logoFile *coredata.File,
+	domains []coredata.CommonThirdPartyDomain,
 	now time.Time,
 ) error {
 	raw, err := json.Marshal(payload)
@@ -325,6 +372,12 @@ func (h *enrichmentHandler) persist(
 				return fmt.Errorf("cannot persist common third party enrichment: %w", err)
 			}
 
+			for i := range domains {
+				if _, err := domains[i].Upsert(ctx, tx); err != nil {
+					return fmt.Errorf("cannot upsert common third party domain: %w", err)
+				}
+			}
+
 			h.logger.InfoCtx(
 				ctx,
 				"enriched common third party",
@@ -332,6 +385,7 @@ func (h *enrichmentHandler) persist(
 				log.String("name", party.Name),
 				log.String("status", payload.Status),
 				log.Bool("logo_stored", logoFile != nil),
+				log.Int("domains_stored", len(domains)),
 			)
 
 			return nil
@@ -437,6 +491,49 @@ func (h *enrichmentHandler) runComplianceDocs(
 	)
 	if err != nil {
 		return ComplianceDocsResult{}, fmt.Errorf("compliance docs agent run failed: %w", err)
+	}
+
+	return result.Output, nil
+}
+
+// runDomains builds Agent C with a per-run browser when a Chrome endpoint
+// is configured, then runs it. The browser is closed when the run
+// returns. It is not pinned to the vendor domain so the agent can follow
+// links to the vendor's other owned domains; SSRF protection still blocks
+// non-public hosts.
+func (h *enrichmentHandler) runDomains(
+	ctx context.Context,
+	name string,
+	website string,
+) (DomainsResult, error) {
+	var browserTools []agent.Tool
+
+	if h.cfg.ChromeAddr != "" {
+		webBrowser := browser.NewBrowser(ctx, h.cfg.ChromeAddr)
+		defer webBrowser.Close()
+
+		browserTools = browser.NewReadOnlyToolset(webBrowser).Tools()
+	}
+
+	domainsAgent := buildCommonThirdPartyDomainsAgent(h.cfg, h.logger, browserTools)
+
+	prompt := buildCommonThirdPartyDomainsPrompt(name, website)
+
+	agentCtx, cancel := context.WithTimeout(ctx, h.cfg.AgentTimeout)
+	defer cancel()
+
+	result, err := agent.RunTyped[DomainsResult](
+		agentCtx,
+		domainsAgent,
+		[]llm.Message{
+			{
+				Role:  llm.RoleUser,
+				Parts: []llm.Part{llm.TextPart{Text: prompt}},
+			},
+		},
+	)
+	if err != nil {
+		return DomainsResult{}, fmt.Errorf("domains agent run failed: %w", err)
 	}
 
 	return result.Output, nil

--- a/pkg/thirdparty/common_third_party_enrichment_worker.go
+++ b/pkg/thirdparty/common_third_party_enrichment_worker.go
@@ -303,16 +303,19 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 
 	go func() {
 		defer wg.Done()
+
 		compliance, complianceErr = h.runComplianceDocs(ctx, party.Name, website, legalName)
 	}()
 
 	go func() {
 		defer wg.Done()
+
 		domainsResult, domainsErr = h.runDomains(ctx, party.Name, website)
 	}()
 
 	go func() {
 		defer wg.Done()
+
 		logoFile = h.prepareLogo(ctx, party, website)
 	}()
 

--- a/pkg/thirdparty/common_third_party_enrichment_worker.go
+++ b/pkg/thirdparty/common_third_party_enrichment_worker.go
@@ -132,11 +132,10 @@ func resolveEnrichmentMaxTokens(configured *int) int {
 }
 
 type enrichmentHandler struct {
-	pg           *pg.Client
-	logger       *log.Logger
-	cfg          EnrichmentConfig
-	companyAgent *agent.Agent
-	httpClient   *http.Client
+	pg         *pg.Client
+	logger     *log.Logger
+	cfg        EnrichmentConfig
+	httpClient *http.Client
 }
 
 // NewCommonThirdPartyEnrichmentWorker builds the worker that enriches
@@ -156,13 +155,6 @@ func NewCommonThirdPartyEnrichmentWorker(
 		logger:     logger,
 		cfg:        cfg,
 		httpClient: newEnrichmentHTTPClient(),
-	}
-
-	// Agent A has no browser, so it is built once and reused. Agent B is
-	// built per Process because it needs a per-run browser bound to the
-	// process context.
-	if cfg.LLMClient != nil {
-		h.companyAgent = buildCompanyProfileAgent(cfg, logger)
 	}
 
 	return worker.New(
@@ -203,7 +195,7 @@ func (h *enrichmentHandler) Claim(ctx context.Context) (coredata.CommonThirdPart
 // transaction. Process always writes an enrichment payload, even on a
 // no-result run, so stale recovery does not re-queue the row.
 func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonThirdParty) error {
-	if h.companyAgent == nil {
+	if h.cfg.LLMClient == nil {
 		return nil
 	}
 
@@ -226,6 +218,33 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 	}
 
 	website := effectiveWebsiteURL(party, company, h.cfg.ConfidenceThreshold)
+
+	meta := make(map[string]EnrichmentFieldMeta)
+
+	// Website is the hard precondition: Agent B and the logo step both
+	// depend on it, and an Agent B run without a domain scope produces
+	// inconsistent cross-domain results. When no website is resolved,
+	// persist what Agent A found and stop here rather than running Agent
+	// B blind.
+	if website == "" {
+		for _, field := range scalarFields(company, ComplianceDocsResult{}) {
+			applyScalarField(&party, meta, prior, field, h.cfg.ConfidenceThreshold, now)
+		}
+
+		applyCertifications(&party, meta, prior, CertificationsField{}, h.cfg.ConfidenceThreshold, now)
+		applyLegalNameFallback(&party, meta, now)
+
+		runErrors = append(runErrors, "website_url unresolved: skipped compliance docs")
+
+		return h.persist(ctx, party, EnrichmentMetadata{
+			Model:       h.cfg.Model,
+			AttemptedAt: now,
+			Status:      enrichmentStatusFailed,
+			Error:       strings.Join(runErrors, "; "),
+			Fields:      meta,
+		}, nil, now)
+	}
+
 	legalName := effectiveLegalName(party, company, h.cfg.ConfidenceThreshold)
 
 	// Agent B: compliance documents and trust pages.
@@ -241,13 +260,12 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 	// transaction; the File row is inserted below.
 	logoFile := h.prepareLogo(ctx, party, website)
 
-	meta := make(map[string]EnrichmentFieldMeta)
-
 	for _, field := range scalarFields(company, compliance) {
 		applyScalarField(&party, meta, prior, field, h.cfg.ConfidenceThreshold, now)
 	}
 
 	applyCertifications(&party, meta, prior, compliance.Certifications, h.cfg.ConfidenceThreshold, now)
+	applyLegalNameFallback(&party, meta, now)
 
 	status := enrichmentStatusDone
 
@@ -266,6 +284,20 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 		Fields:      meta,
 	}
 
+	return h.persist(ctx, party, payload, logoFile, now)
+}
+
+// persist marshals the enrichment payload onto the row and writes it in a
+// single transaction, inserting the logo File row and linking it when one
+// was prepared. It always writes an enrichment payload, even on a
+// no-result run, so stale recovery does not re-queue the row.
+func (h *enrichmentHandler) persist(
+	ctx context.Context,
+	party coredata.CommonThirdParty,
+	payload EnrichmentMetadata,
+	logoFile *coredata.File,
+	now time.Time,
+) error {
 	raw, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("cannot marshal enrichment metadata: %w", err)
@@ -298,7 +330,7 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 				"enriched common third party",
 				log.String("common_third_party_id", party.ID.String()),
 				log.String("name", party.Name),
-				log.String("status", status),
+				log.String("status", payload.Status),
 				log.Bool("logo_stored", logoFile != nil),
 			)
 
@@ -323,10 +355,27 @@ func (h *enrichmentHandler) RecoverStale(ctx context.Context) error {
 	)
 }
 
+// runCompanyProfile builds Agent A with a per-run browser when a Chrome
+// endpoint is configured, then runs it. The browser is closed when the
+// run returns. It is not pinned to a domain so the agent can follow a
+// product site to the legal entity's corporate domain (where the legal
+// name and headquarters address live); SSRF protection still blocks
+// non-public hosts.
 func (h *enrichmentHandler) runCompanyProfile(
 	ctx context.Context,
 	party coredata.CommonThirdParty,
 ) (CompanyProfileResult, error) {
+	var browserTools []agent.Tool
+
+	if h.cfg.ChromeAddr != "" {
+		webBrowser := browser.NewBrowser(ctx, h.cfg.ChromeAddr)
+		defer webBrowser.Close()
+
+		browserTools = browser.NewReadOnlyToolset(webBrowser).Tools()
+	}
+
+	companyAgent := buildCompanyProfileAgent(h.cfg, h.logger, browserTools)
+
 	prompt := buildCompanyProfilePrompt(party)
 
 	agentCtx, cancel := context.WithTimeout(ctx, h.cfg.AgentTimeout)
@@ -334,7 +383,7 @@ func (h *enrichmentHandler) runCompanyProfile(
 
 	result, err := agent.RunTyped[CompanyProfileResult](
 		agentCtx,
-		h.companyAgent,
+		companyAgent,
 		[]llm.Message{
 			{
 				Role:  llm.RoleUser,

--- a/pkg/thirdparty/common_third_party_enrichment_worker.go
+++ b/pkg/thirdparty/common_third_party_enrichment_worker.go
@@ -299,25 +299,17 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 
 	var wg sync.WaitGroup
 
-	wg.Add(3)
-
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		compliance, complianceErr = h.runComplianceDocs(ctx, party.Name, website, legalName)
-	}()
+	})
 
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		domainsResult, domainsErr = h.runDomains(ctx, party.Name, website)
-	}()
+	})
 
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		logoFile = h.prepareLogo(ctx, party, website)
-	}()
+	})
 
 	wg.Wait()
 

--- a/pkg/thirdparty/common_third_party_enrichment_worker.go
+++ b/pkg/thirdparty/common_third_party_enrichment_worker.go
@@ -372,10 +372,37 @@ func (h *enrichmentHandler) persist(
 				return fmt.Errorf("cannot persist common third party enrichment: %w", err)
 			}
 
+			var (
+				newDomains []string
+				remapped   int64
+			)
+
 			for i := range domains {
-				if _, err := domains[i].Upsert(ctx, tx); err != nil {
+				inserted, err := domains[i].Upsert(ctx, tx)
+				if err != nil {
 					return fmt.Errorf("cannot upsert common third party domain: %w", err)
 				}
+
+				if inserted {
+					newDomains = append(newDomains, domains[i].Domain)
+				}
+			}
+
+			// A newly-discovered owned domain can resolve org tracker
+			// patterns that were detected and left unmapped before the
+			// domain was known. Re-arm those still-unmapped patterns so
+			// the mapping worker re-resolves them via its domain-overlap
+			// signal. Only newly-inserted domains trigger this: a re-run
+			// that rediscovers existing domains cascaded them already.
+			if len(newDomains) > 0 {
+				var patterns coredata.TrackerPatterns
+
+				n, err := patterns.RequestMappingForUnmappedByInitiatorDomains(ctx, tx, newDomains)
+				if err != nil {
+					return fmt.Errorf("cannot re-arm mapping for unmapped tracker patterns: %w", err)
+				}
+
+				remapped = n
 			}
 
 			h.logger.InfoCtx(
@@ -386,6 +413,8 @@ func (h *enrichmentHandler) persist(
 				log.String("status", payload.Status),
 				log.Bool("logo_stored", logoFile != nil),
 				log.Int("domains_stored", len(domains)),
+				log.Int("domains_new", len(newDomains)),
+				log.Int64("tracker_patterns_remapped", remapped),
 			)
 
 			return nil

--- a/pkg/thirdparty/common_third_party_enrichment_worker.go
+++ b/pkg/thirdparty/common_third_party_enrichment_worker.go
@@ -250,6 +250,7 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 	applyCertifications(&party, meta, prior, compliance.Certifications, h.cfg.ConfidenceThreshold, now)
 
 	status := enrichmentStatusDone
+
 	switch {
 	case !anySuccess:
 		status = enrichmentStatusFailed

--- a/pkg/thirdparty/common_third_party_enrichment_worker.go
+++ b/pkg/thirdparty/common_third_party_enrichment_worker.go
@@ -1,0 +1,456 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.gearno.de/kit/httpclient"
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.gearno.de/kit/worker"
+	"go.probo.inc/probo/pkg/agent"
+	"go.probo.inc/probo/pkg/agent/tools/browser"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/filemanager"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/llm"
+)
+
+const (
+	// defaultEnrichmentAgentTimeout caps a single enrichment agent run.
+	// It is generous because Agent B browses several pages on top of the
+	// LLM round-trips.
+	defaultEnrichmentAgentTimeout = 90 * time.Second
+
+	// defaultEnrichmentMaxTurns bounds an agent's reasoning loop (LLM
+	// call plus tool round-trips). Agent B may navigate the site footer
+	// and trust portal across several turns before synthesizing.
+	defaultEnrichmentMaxTurns = 12
+
+	// defaultEnrichmentMaxTokens caps agent output. The structured
+	// output is moderate; the budget leaves headroom for reasoning
+	// models whose reasoning tokens count against max_tokens.
+	defaultEnrichmentMaxTokens = 8192
+
+	// defaultEnrichmentConfidenceThreshold is the floor a resolved value
+	// must clear before it is written to its column. Values below it are
+	// recorded in the enrichment metadata but not promoted.
+	defaultEnrichmentConfidenceThreshold = 0.7
+
+	// defaultEnrichmentStaleAfter is the idle window after which a
+	// claimed-but-unfinished enrichment is re-armed.
+	defaultEnrichmentStaleAfter = 15 * time.Minute
+
+	// defaultEnrichmentMaxAttempts caps how many times a row is retried
+	// before stale recovery leaves it alone, so a permanently failing
+	// row does not loop forever.
+	defaultEnrichmentMaxAttempts = 3
+
+	enrichmentLogoUserAgent = "Probo-Enricher/1.0"
+)
+
+// EnrichmentConfig configures the common-third-party enrichment worker
+// and the two agents it runs. The worker no-ops when LLMClient is nil;
+// callers gate registration on config presence. Browser tools for Agent
+// B are enabled only when ChromeAddr is set; otherwise it relies on
+// web_search alone. Logo storage is enabled only when FileManager and
+// Bucket are both set.
+type EnrichmentConfig struct {
+	LLMClient           *llm.Client
+	Model               string
+	MaxTokens           *int
+	Temperature         *float64
+	FirecrawlAPIKey     string
+	ChromeAddr          string
+	AgentTimeout        time.Duration
+	MaxTurns            int
+	ConfidenceThreshold float64
+	StaleAfter          time.Duration
+	MaxAttempts         int
+
+	FileManager *filemanager.Service
+	Bucket      string
+}
+
+func (c EnrichmentConfig) withDefaults() EnrichmentConfig {
+	if c.AgentTimeout <= 0 {
+		c.AgentTimeout = defaultEnrichmentAgentTimeout
+	}
+
+	if c.MaxTurns < 1 {
+		c.MaxTurns = defaultEnrichmentMaxTurns
+	}
+
+	if c.ConfidenceThreshold <= 0 {
+		c.ConfidenceThreshold = defaultEnrichmentConfidenceThreshold
+	}
+
+	if c.StaleAfter <= 0 {
+		c.StaleAfter = defaultEnrichmentStaleAfter
+	}
+
+	if c.MaxAttempts < 1 {
+		c.MaxAttempts = defaultEnrichmentMaxAttempts
+	}
+
+	return c
+}
+
+func resolveEnrichmentMaxTurns(configured int) int {
+	if configured > 0 {
+		return configured
+	}
+
+	return defaultEnrichmentMaxTurns
+}
+
+func resolveEnrichmentMaxTokens(configured *int) int {
+	if configured != nil && *configured > 0 {
+		return *configured
+	}
+
+	return defaultEnrichmentMaxTokens
+}
+
+type enrichmentHandler struct {
+	pg           *pg.Client
+	logger       *log.Logger
+	cfg          EnrichmentConfig
+	companyAgent *agent.Agent
+	httpClient   *http.Client
+}
+
+// NewCommonThirdPartyEnrichmentWorker builds the worker that enriches
+// global common_third_parties rows. It is a system worker: the catalog
+// is not tenant-scoped, so a single enrichment benefits all tenants. The
+// worker no-ops when no LLM client is configured.
+func NewCommonThirdPartyEnrichmentWorker(
+	pgClient *pg.Client,
+	logger *log.Logger,
+	cfg EnrichmentConfig,
+	opts ...worker.Option,
+) *worker.Worker[coredata.CommonThirdParty] {
+	cfg = cfg.withDefaults()
+
+	h := &enrichmentHandler{
+		pg:         pgClient,
+		logger:     logger,
+		cfg:        cfg,
+		httpClient: newEnrichmentHTTPClient(),
+	}
+
+	// Agent A has no browser, so it is built once and reused. Agent B is
+	// built per Process because it needs a per-run browser bound to the
+	// process context.
+	if cfg.LLMClient != nil {
+		h.companyAgent = buildCompanyProfileAgent(cfg, logger)
+	}
+
+	return worker.New(
+		"common-third-party-enrichment-worker",
+		h,
+		logger,
+		opts...,
+	)
+}
+
+func (h *enrichmentHandler) Claim(ctx context.Context) (coredata.CommonThirdParty, error) {
+	var party coredata.CommonThirdParty
+
+	if err := h.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			if err := party.LoadNextForEnrichmentForUpdateSkipLocked(ctx, tx); err != nil {
+				return err
+			}
+
+			return party.ClearEnrichmentRequestedAt(ctx, tx)
+		},
+	); err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return coredata.CommonThirdParty{}, worker.ErrNoTask
+		}
+
+		return coredata.CommonThirdParty{}, fmt.Errorf("cannot claim common third party enrichment task: %w", err)
+	}
+
+	return party, nil
+}
+
+// Process runs the enrichment pipeline for one catalog row: Agent A
+// (company profile) first, then Agent B (compliance docs) and the
+// deterministic logo step, all outside any transaction. The merged
+// result and per-field provenance are persisted in a single final
+// transaction. Process always writes an enrichment payload, even on a
+// no-result run, so stale recovery does not re-queue the row.
+func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonThirdParty) error {
+	if h.companyAgent == nil {
+		return nil
+	}
+
+	now := time.Now()
+	prior := parseEnrichmentFields(party.Enrichment)
+
+	var (
+		runErrors  []string
+		anySuccess bool
+	)
+
+	// Agent A first: it resolves website_url, which Agent B and the logo
+	// step depend on.
+	company, err := h.runCompanyProfile(ctx, party)
+	if err != nil {
+		h.logger.WarnCtx(ctx, "company profile agent failed", log.Error(err), log.String("common_third_party_id", party.ID.String()))
+		runErrors = append(runErrors, "company_profile: "+err.Error())
+	} else {
+		anySuccess = true
+	}
+
+	website := effectiveWebsiteURL(party, company, h.cfg.ConfidenceThreshold)
+	legalName := effectiveLegalName(party, company, h.cfg.ConfidenceThreshold)
+
+	// Agent B: compliance documents and trust pages.
+	compliance, err := h.runComplianceDocs(ctx, party.Name, website, legalName)
+	if err != nil {
+		h.logger.WarnCtx(ctx, "compliance docs agent failed", log.Error(err), log.String("common_third_party_id", party.ID.String()))
+		runErrors = append(runErrors, "compliance_docs: "+err.Error())
+	} else {
+		anySuccess = true
+	}
+
+	// Deterministic logo step (no LLM). Uploads to S3 outside the final
+	// transaction; the File row is inserted below.
+	logoFile := h.prepareLogo(ctx, party, website)
+
+	meta := make(map[string]EnrichmentFieldMeta)
+
+	for _, field := range scalarFields(company, compliance) {
+		applyScalarField(&party, meta, prior, field, h.cfg.ConfidenceThreshold, now)
+	}
+
+	applyCertifications(&party, meta, prior, compliance.Certifications, h.cfg.ConfidenceThreshold, now)
+
+	status := enrichmentStatusDone
+	switch {
+	case !anySuccess:
+		status = enrichmentStatusFailed
+	case len(runErrors) > 0:
+		status = enrichmentStatusPartial
+	}
+
+	payload := EnrichmentMetadata{
+		Model:       h.cfg.Model,
+		AttemptedAt: now,
+		Status:      status,
+		Error:       strings.Join(runErrors, "; "),
+		Fields:      meta,
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("cannot marshal enrichment metadata: %w", err)
+	}
+
+	party.Enrichment = raw
+	party.UpdatedAt = now
+
+	return h.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			if logoFile != nil {
+				if err := logoFile.Insert(ctx, tx, coredata.NewScope(gid.NilTenant)); err != nil {
+					return fmt.Errorf("cannot insert common third party logo file: %w", err)
+				}
+
+				party.LogoFileID = &logoFile.ID
+
+				if err := party.UpdateLogoFileID(ctx, tx); err != nil {
+					return fmt.Errorf("cannot update common third party logo: %w", err)
+				}
+			}
+
+			if err := party.UpdateEnrichment(ctx, tx); err != nil {
+				return fmt.Errorf("cannot persist common third party enrichment: %w", err)
+			}
+
+			h.logger.InfoCtx(
+				ctx,
+				"enriched common third party",
+				log.String("common_third_party_id", party.ID.String()),
+				log.String("name", party.Name),
+				log.String("status", status),
+				log.Bool("logo_stored", logoFile != nil),
+			)
+
+			return nil
+		},
+	)
+}
+
+// RecoverStale re-arms enrichment for rows whose run was claimed but
+// never finished. Claim clears enrichment_requested_at up front, so a
+// crash between phases would otherwise strand the row.
+func (h *enrichmentHandler) RecoverStale(ctx context.Context) error {
+	return h.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := coredata.ResetStaleCommonThirdPartyEnrichments(ctx, conn, h.cfg.StaleAfter, h.cfg.MaxAttempts); err != nil {
+				return fmt.Errorf("cannot reset stale common third party enrichments: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+func (h *enrichmentHandler) runCompanyProfile(
+	ctx context.Context,
+	party coredata.CommonThirdParty,
+) (CompanyProfileResult, error) {
+	prompt := buildCompanyProfilePrompt(party)
+
+	agentCtx, cancel := context.WithTimeout(ctx, h.cfg.AgentTimeout)
+	defer cancel()
+
+	result, err := agent.RunTyped[CompanyProfileResult](
+		agentCtx,
+		h.companyAgent,
+		[]llm.Message{
+			{
+				Role:  llm.RoleUser,
+				Parts: []llm.Part{llm.TextPart{Text: prompt}},
+			},
+		},
+	)
+	if err != nil {
+		return CompanyProfileResult{}, fmt.Errorf("company profile agent run failed: %w", err)
+	}
+
+	return result.Output, nil
+}
+
+// runComplianceDocs builds Agent B with a per-run browser when a Chrome
+// endpoint is configured, then runs it. The browser is closed when the
+// run returns. The browser is intentionally not pinned to the vendor
+// domain so the agent can follow links to hosted trust portals (Vanta,
+// SafeBase, etc.); SSRF protection still blocks non-public hosts.
+func (h *enrichmentHandler) runComplianceDocs(
+	ctx context.Context,
+	name string,
+	website string,
+	legalName string,
+) (ComplianceDocsResult, error) {
+	var browserTools []agent.Tool
+
+	if h.cfg.ChromeAddr != "" {
+		webBrowser := browser.NewBrowser(ctx, h.cfg.ChromeAddr)
+		defer webBrowser.Close()
+
+		browserTools = browser.NewReadOnlyToolset(webBrowser).Tools()
+	}
+
+	complianceAgent := buildComplianceDocsAgent(h.cfg, h.logger, browserTools)
+
+	prompt := buildComplianceDocsPrompt(name, website, legalName)
+
+	agentCtx, cancel := context.WithTimeout(ctx, h.cfg.AgentTimeout)
+	defer cancel()
+
+	result, err := agent.RunTyped[ComplianceDocsResult](
+		agentCtx,
+		complianceAgent,
+		[]llm.Message{
+			{
+				Role:  llm.RoleUser,
+				Parts: []llm.Part{llm.TextPart{Text: prompt}},
+			},
+		},
+	)
+	if err != nil {
+		return ComplianceDocsResult{}, fmt.Errorf("compliance docs agent run failed: %w", err)
+	}
+
+	return result.Output, nil
+}
+
+// effectiveWebsiteURL is the website passed to Agent B and the logo step.
+// A curated value already on the row wins (seed data and human edits are
+// trusted); otherwise Agent A's value is used when it clears the
+// confidence threshold.
+func effectiveWebsiteURL(
+	party coredata.CommonThirdParty,
+	company CompanyProfileResult,
+	threshold float64,
+) string {
+	if party.WebsiteURL != nil {
+		if v := strings.TrimSpace(*party.WebsiteURL); v != "" {
+			return v
+		}
+	}
+
+	if v := strings.TrimSpace(company.WebsiteURL.Value); v != "" && company.WebsiteURL.Confidence >= threshold {
+		return v
+	}
+
+	return ""
+}
+
+// effectiveLegalName is the legal name hint passed to Agent B, resolved
+// the same way as effectiveWebsiteURL.
+func effectiveLegalName(
+	party coredata.CommonThirdParty,
+	company CompanyProfileResult,
+	threshold float64,
+) string {
+	if party.LegalName != nil {
+		if v := strings.TrimSpace(*party.LegalName); v != "" {
+			return v
+		}
+	}
+
+	if v := strings.TrimSpace(company.LegalName.Value); v != "" && company.LegalName.Confidence >= threshold {
+		return v
+	}
+
+	return ""
+}
+
+type userAgentRoundTripper struct {
+	next http.RoundTripper
+}
+
+func (t *userAgentRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r2 := r.Clone(r.Context())
+	r2.Header.Set("User-Agent", enrichmentLogoUserAgent)
+
+	return t.next.RoundTrip(r2)
+}
+
+// newEnrichmentHTTPClient builds the SSRF-protected client used by the
+// deterministic logo step.
+func newEnrichmentHTTPClient() *http.Client {
+	client := httpclient.DefaultPooledClient(httpclient.WithSSRFProtection())
+	client.Timeout = 20 * time.Second
+	client.Transport = &userAgentRoundTripper{next: client.Transport}
+
+	return client
+}

--- a/pkg/thirdparty/common_third_party_enrichment_worker.go
+++ b/pkg/thirdparty/common_third_party_enrichment_worker.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"go.gearno.de/kit/httpclient"
@@ -215,11 +216,13 @@ func (h *enrichmentHandler) Claim(ctx context.Context) (coredata.CommonThirdPart
 }
 
 // Process runs the enrichment pipeline for one catalog row: Agent A
-// (company profile) first, then Agent B (compliance docs) and the
-// deterministic logo step, all outside any transaction. The merged
-// result and per-field provenance are persisted in a single final
-// transaction. Process always writes an enrichment payload, even on a
-// no-result run, so stale recovery does not re-queue the row.
+// (company profile) first, then Agent B (compliance docs), Agent C
+// (owned domains), and the deterministic logo step concurrently, all
+// outside any transaction. Agent A runs first because the others depend
+// on the website it resolves. The merged result and per-field provenance
+// are persisted in a single final transaction. Process always writes an
+// enrichment payload, even on a no-result run, so stale recovery does not
+// re-queue the row.
 func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonThirdParty) error {
 	if h.cfg.LLMClient == nil {
 		return nil
@@ -275,11 +278,50 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 
 	legalName := effectiveLegalName(party, company, h.cfg.ConfidenceThreshold)
 
+	// Agent B (compliance docs), Agent C (owned domains), and the
+	// deterministic logo step all depend only on the resolved website
+	// (Agent B also on the legal name) and are independent of each other.
+	// Run them concurrently so wall time is the slowest of the three
+	// rather than their sum. Each builds its own per-run browser and
+	// writes only into its own locals; the shared LLM/HTTP/FileManager
+	// clients are safe for concurrent use and the database is not touched
+	// until persist below. Results are merged after Wait in a fixed order
+	// to keep runErrors and log output deterministic.
+	var (
+		compliance    ComplianceDocsResult
+		complianceErr error
+
+		domainsResult DomainsResult
+		domainsErr    error
+
+		logoFile *coredata.File
+	)
+
+	var wg sync.WaitGroup
+
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		compliance, complianceErr = h.runComplianceDocs(ctx, party.Name, website, legalName)
+	}()
+
+	go func() {
+		defer wg.Done()
+		domainsResult, domainsErr = h.runDomains(ctx, party.Name, website)
+	}()
+
+	go func() {
+		defer wg.Done()
+		logoFile = h.prepareLogo(ctx, party, website)
+	}()
+
+	wg.Wait()
+
 	// Agent B: compliance documents and trust pages.
-	compliance, err := h.runComplianceDocs(ctx, party.Name, website, legalName)
-	if err != nil {
-		h.logger.WarnCtx(ctx, "compliance docs agent failed", log.Error(err), log.String("common_third_party_id", party.ID.String()))
-		runErrors = append(runErrors, "compliance_docs: "+sanitizeAgentError(err))
+	if complianceErr != nil {
+		h.logger.WarnCtx(ctx, "compliance docs agent failed", log.Error(complianceErr), log.String("common_third_party_id", party.ID.String()))
+		runErrors = append(runErrors, "compliance_docs: "+sanitizeAgentError(complianceErr))
 	} else {
 		anySuccess = true
 	}
@@ -288,18 +330,13 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 	// resolved website, so it runs only on this website-resolved path.
 	var owned []ownedDomain
 
-	domainsResult, err := h.runDomains(ctx, party.Name, website)
-	if err != nil {
-		h.logger.WarnCtx(ctx, "domains agent failed", log.Error(err), log.String("common_third_party_id", party.ID.String()))
-		runErrors = append(runErrors, "domains: "+sanitizeAgentError(err))
+	if domainsErr != nil {
+		h.logger.WarnCtx(ctx, "domains agent failed", log.Error(domainsErr), log.String("common_third_party_id", party.ID.String()))
+		runErrors = append(runErrors, "domains: "+sanitizeAgentError(domainsErr))
 	} else {
 		anySuccess = true
 		owned = resolveOwnedDomains(party.Name, website, domainsResult, defaultEnrichmentDomainConfidenceThreshold)
 	}
-
-	// Deterministic logo step (no LLM). Uploads to S3 outside the final
-	// transaction; the File row is inserted below.
-	logoFile := h.prepareLogo(ctx, party, website)
 
 	for _, field := range scalarFields(company, compliance) {
 		applyScalarField(&party, meta, prior, field, h.cfg.ConfidenceThreshold, now)

--- a/pkg/thirdparty/common_third_party_enrichment_worker.go
+++ b/pkg/thirdparty/common_third_party_enrichment_worker.go
@@ -73,7 +73,26 @@ const (
 	defaultEnrichmentMaxAttempts = 3
 
 	enrichmentLogoUserAgent = "Probo-Enricher/1.0"
+
+	// maxEnrichmentErrorLen bounds the per-agent error text persisted in
+	// enrichment metadata so a verbose or hostile agent/tool error cannot
+	// leak unbounded internal detail into the column.
+	maxEnrichmentErrorLen = 500
 )
+
+// sanitizeAgentError reduces a raw agent or tool error to a single bounded
+// line safe to persist in enrichment metadata: whitespace runs (including
+// embedded newlines) collapse to single spaces and the result is truncated
+// to maxEnrichmentErrorLen runes.
+func sanitizeAgentError(err error) string {
+	msg := strings.Join(strings.Fields(err.Error()), " ")
+
+	if runes := []rune(msg); len(runes) > maxEnrichmentErrorLen {
+		msg = string(runes[:maxEnrichmentErrorLen]) + "…"
+	}
+
+	return msg
+}
 
 // EnrichmentConfig configures the common-third-party enrichment worker
 // and the two agents it runs. The worker no-ops when LLMClient is nil;
@@ -219,7 +238,7 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 	company, err := h.runCompanyProfile(ctx, party)
 	if err != nil {
 		h.logger.WarnCtx(ctx, "company profile agent failed", log.Error(err), log.String("common_third_party_id", party.ID.String()))
-		runErrors = append(runErrors, "company_profile: "+err.Error())
+		runErrors = append(runErrors, "company_profile: "+sanitizeAgentError(err))
 	} else {
 		anySuccess = true
 	}
@@ -260,7 +279,7 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 	compliance, err := h.runComplianceDocs(ctx, party.Name, website, legalName)
 	if err != nil {
 		h.logger.WarnCtx(ctx, "compliance docs agent failed", log.Error(err), log.String("common_third_party_id", party.ID.String()))
-		runErrors = append(runErrors, "compliance_docs: "+err.Error())
+		runErrors = append(runErrors, "compliance_docs: "+sanitizeAgentError(err))
 	} else {
 		anySuccess = true
 	}
@@ -272,7 +291,7 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 	domainsResult, err := h.runDomains(ctx, party.Name, website)
 	if err != nil {
 		h.logger.WarnCtx(ctx, "domains agent failed", log.Error(err), log.String("common_third_party_id", party.ID.String()))
-		runErrors = append(runErrors, "domains: "+err.Error())
+		runErrors = append(runErrors, "domains: "+sanitizeAgentError(err))
 	} else {
 		anySuccess = true
 		owned = resolveOwnedDomains(party.Name, website, domainsResult, defaultEnrichmentDomainConfidenceThreshold)

--- a/pkg/thirdparty/common_third_party_logo.go
+++ b/pkg/thirdparty/common_third_party_logo.go
@@ -196,9 +196,13 @@ func downloadImage(
 		return nil, "", fmt.Errorf("logo response is not an image: %q", contentType)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLogoSize))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLogoSize+1))
 	if err != nil {
 		return nil, "", fmt.Errorf("cannot read logo body: %w", err)
+	}
+
+	if len(body) > maxLogoSize {
+		return nil, "", fmt.Errorf("logo response exceeds max size %d bytes", maxLogoSize)
 	}
 
 	if len(body) == 0 {

--- a/pkg/thirdparty/common_third_party_logo.go
+++ b/pkg/thirdparty/common_third_party_logo.go
@@ -178,6 +178,7 @@ func downloadImage(
 	if err != nil {
 		return nil, "", fmt.Errorf("cannot fetch logo: %w", err)
 	}
+
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
@@ -188,6 +189,7 @@ func downloadImage(
 	if idx := strings.Index(contentType, ";"); idx != -1 {
 		contentType = contentType[:idx]
 	}
+
 	contentType = strings.TrimSpace(contentType)
 
 	if !strings.HasPrefix(contentType, "image/") {

--- a/pkg/thirdparty/common_third_party_logo.go
+++ b/pkg/thirdparty/common_third_party_logo.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"go.gearno.de/crypto/uuid"
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/webinspect"
+)
+
+// maxLogoSize caps a downloaded logo image. Logos are small; the cap
+// guards against an oversized or malicious response.
+const maxLogoSize = 5 << 20 // 5 MiB
+
+// prepareLogo discovers and uploads a vendor logo to S3, returning a
+// fully-populated (but not yet inserted) File record for the caller to
+// persist in its transaction. It is deterministic and best-effort: any
+// failure logs and returns (nil, nil) so a missing logo never fails the
+// enrichment run.
+//
+// It no-ops when the row already has a logo, when logo storage is not
+// configured, or when no website is known. The S3 upload happens here,
+// outside any transaction; the caller inserts the File row and links it
+// via UpdateLogoFileID.
+func (h *enrichmentHandler) prepareLogo(
+	ctx context.Context,
+	party coredata.CommonThirdParty,
+	websiteURL string,
+) *coredata.File {
+	if party.LogoFileID != nil {
+		return nil
+	}
+
+	if h.cfg.FileManager == nil || h.cfg.Bucket == "" {
+		return nil
+	}
+
+	website := strings.TrimSpace(websiteURL)
+	if website == "" {
+		return nil
+	}
+
+	data, contentType, err := fetchCommonThirdPartyLogo(ctx, h.httpClient, website)
+	if err != nil {
+		h.logger.InfoCtx(
+			ctx,
+			"could not fetch common third party logo",
+			log.String("common_third_party_id", party.ID.String()),
+			log.Error(err),
+		)
+
+		return nil
+	}
+
+	objectKey, err := uuid.NewV7()
+	if err != nil {
+		h.logger.WarnCtx(ctx, "cannot generate logo object key", log.Error(err))
+
+		return nil
+	}
+
+	now := time.Now()
+	fileRecord := &coredata.File{
+		ID:             gid.New(gid.NilTenant, coredata.FileEntityType),
+		OrganizationID: gid.Nil,
+		BucketName:     h.cfg.Bucket,
+		MimeType:       contentType,
+		FileName:       party.Name + "-logo" + webinspect.ExtensionForMIME(contentType),
+		FileKey:        objectKey.String(),
+		FileSize:       int64(len(data)),
+		Visibility:     coredata.FileVisibilityPublic,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	size, err := h.cfg.FileManager.PutFile(
+		ctx,
+		fileRecord,
+		bytes.NewReader(data),
+		map[string]string{
+			"type":                  "common-third-party-logo",
+			"common-third-party-id": party.ID.String(),
+		},
+	)
+	if err != nil {
+		h.logger.WarnCtx(
+			ctx,
+			"cannot upload common third party logo",
+			log.String("common_third_party_id", party.ID.String()),
+			log.Error(err),
+		)
+
+		return nil
+	}
+
+	fileRecord.FileSize = size
+
+	return fileRecord
+}
+
+// fetchCommonThirdPartyLogo finds the best logo for a website and
+// downloads it. It first parses the page's <head> for icon links
+// (webinspect), then falls back to well-known icon paths on the same
+// host. The supplied client must enforce SSRF protection.
+func fetchCommonThirdPartyLogo(
+	ctx context.Context,
+	client *http.Client,
+	websiteURL string,
+) (data []byte, contentType string, err error) {
+	candidates := make([]string, 0, 3)
+
+	pageInfo, parseErr := webinspect.Parse(ctx, client, websiteURL)
+	if parseErr == nil {
+		if logoURL, logoErr := webinspect.FindLogoURL(pageInfo); logoErr == nil {
+			candidates = append(candidates, logoURL)
+		}
+	}
+
+	if parsed, parseURLErr := url.Parse(websiteURL); parseURLErr == nil && parsed.Host != "" {
+		base := url.URL{Scheme: parsed.Scheme, Host: parsed.Host}
+		if base.Scheme == "" {
+			base.Scheme = "https"
+		}
+
+		candidates = append(
+			candidates,
+			base.ResolveReference(&url.URL{Path: "/apple-touch-icon.png"}).String(),
+			base.ResolveReference(&url.URL{Path: "/favicon.ico"}).String(),
+		)
+	}
+
+	for _, candidate := range candidates {
+		data, contentType, err = downloadImage(ctx, client, candidate)
+		if err == nil {
+			return data, contentType, nil
+		}
+	}
+
+	return nil, "", fmt.Errorf("cannot fetch logo for %s", websiteURL)
+}
+
+// downloadImage fetches a single candidate URL and returns its bytes when
+// the response is a non-empty image within the size cap.
+func downloadImage(
+	ctx context.Context,
+	client *http.Client,
+	rawURL string,
+) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot create logo request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot fetch logo: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("cannot fetch logo: status %d", resp.StatusCode)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if idx := strings.Index(contentType, ";"); idx != -1 {
+		contentType = contentType[:idx]
+	}
+	contentType = strings.TrimSpace(contentType)
+
+	if !strings.HasPrefix(contentType, "image/") {
+		return nil, "", fmt.Errorf("logo response is not an image: %q", contentType)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxLogoSize))
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot read logo body: %w", err)
+	}
+
+	if len(body) == 0 {
+		return nil, "", fmt.Errorf("logo response is empty")
+	}
+
+	return body, contentType, nil
+}

--- a/pkg/thirdparty/common_third_party_owned_domains.go
+++ b/pkg/thirdparty/common_third_party_owned_domains.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"strings"
+
+	"go.probo.inc/probo/pkg/uri"
+)
+
+// minLabelOverlap is the shortest label length allowed for a substring
+// ownership match. Shorter labels (e.g. "id", "go") match too many
+// unrelated domains to be a trustworthy ownership signal, so they only
+// match on exact equality.
+const minLabelOverlap = 4
+
+// ownedDomain is a vendor-owned eTLD+1 that cleared the ownership gate,
+// carrying the provenance the worker records in the enrichment payload.
+type ownedDomain struct {
+	Domain     string
+	Confidence float64
+	SourceURL  string
+}
+
+// resolveOwnedDomains reduces the domain-discovery agent's candidates to
+// the eTLD+1 domains the vendor demonstrably owns, ready to write to
+// common_third_party_domains. The vendor's own website eTLD+1 is always
+// included. Every other candidate must clear the confidence threshold and
+// be ownership-related to the vendor by a label match against the website
+// label or the normalized vendor name.
+//
+// Shared tracker-delivery / CDN infrastructure (uri.FilterSharedInfra...)
+// is dropped only when it is NOT owned: a generic provider domain cannot
+// be attributed to an unrelated vendor, but when the vendor itself is
+// that provider (e.g. enriching Cloudflare or Fastly) its own domain
+// passes a stricter exact-label match and is kept. Results are
+// deduplicated with insertion order preserved.
+func resolveOwnedDomains(
+	name string,
+	website string,
+	result DomainsResult,
+	threshold float64,
+) []ownedDomain {
+	vendorLabels := vendorLabels(name, website)
+
+	var (
+		owned []ownedDomain
+		seen  = make(map[string]struct{})
+	)
+
+	add := func(domain string, confidence float64, sourceURL string) {
+		domain = strings.ToLower(strings.TrimSpace(domain))
+		if domain == "" {
+			return
+		}
+
+		if _, ok := seen[domain]; ok {
+			return
+		}
+
+		seen[domain] = struct{}{}
+
+		owned = append(owned, ownedDomain{
+			Domain:     domain,
+			Confidence: confidence,
+			SourceURL:  sourceURL,
+		})
+	}
+
+	// The vendor's own website domain is owned by definition.
+	if site := normalizeToETLD1(website); site != "" {
+		add(site, 1.0, strings.TrimSpace(website))
+	}
+
+	for _, candidate := range result.Domains {
+		domain := normalizeToETLD1(candidate.Domain)
+		if domain == "" {
+			continue
+		}
+
+		if !isVendorOwnedDomain(domain, candidate.Confidence, threshold, vendorLabels) {
+			continue
+		}
+
+		add(domain, candidate.Confidence, strings.TrimSpace(candidate.SourceURL))
+	}
+
+	return owned
+}
+
+// isVendorOwnedDomain reports whether an eTLD+1 candidate clears the
+// confidence threshold and is owned by the vendor. Shared-infrastructure
+// domains require an exact label match (the vendor must be that provider);
+// all other domains accept a substring label overlap.
+func isVendorOwnedDomain(
+	domain string,
+	confidence float64,
+	threshold float64,
+	vendorLabels []string,
+) bool {
+	if confidence < threshold {
+		return false
+	}
+
+	label := uri.DomainLabel(domain)
+	if label == "" {
+		return false
+	}
+
+	if isSharedInfrastructureDomain(domain) {
+		return exactLabelMatch(label, vendorLabels)
+	}
+
+	return relatedLabelMatch(label, vendorLabels)
+}
+
+// isSharedInfrastructureDomain reports whether an eTLD+1 belongs to the
+// shared tracker-delivery / CDN infrastructure list, reusing the curated
+// set maintained in the uri package.
+func isSharedInfrastructureDomain(domain string) bool {
+	return len(uri.FilterSharedInfrastructureDomains([]string{domain})) == 0
+}
+
+// vendorLabels returns the lowercase ownership labels for a vendor: the
+// registrable label of its website and its name reduced to alphanumerics.
+func vendorLabels(name, website string) []string {
+	var (
+		labels []string
+		seen   = make(map[string]struct{})
+	)
+
+	add := func(label string) {
+		if label == "" {
+			return
+		}
+
+		if _, ok := seen[label]; ok {
+			return
+		}
+
+		seen[label] = struct{}{}
+
+		labels = append(labels, label)
+	}
+
+	add(uri.DomainLabel(website))
+	add(normalizeAlnum(name))
+
+	return labels
+}
+
+// exactLabelMatch reports whether label equals any vendor label.
+func exactLabelMatch(label string, vendorLabels []string) bool {
+	for _, vl := range vendorLabels {
+		if label == vl {
+			return true
+		}
+	}
+
+	return false
+}
+
+// relatedLabelMatch reports whether label is the same as, contains, or is
+// contained by any vendor label. Substring matches require the shorter
+// string to be at least minLabelOverlap characters to avoid spurious hits
+// on very short labels.
+func relatedLabelMatch(label string, vendorLabels []string) bool {
+	for _, vl := range vendorLabels {
+		if label == vl {
+			return true
+		}
+
+		shorter, longer := label, vl
+		if len(longer) < len(shorter) {
+			shorter, longer = longer, shorter
+		}
+
+		if len(shorter) >= minLabelOverlap && strings.Contains(longer, shorter) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// normalizeToETLD1 reduces a bare domain or full URL to its eTLD+1,
+// tolerating candidates the agent returns without a scheme.
+func normalizeToETLD1(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+
+	return uri.ExtractDomain(raw)
+}
+
+// normalizeAlnum lowercases a string and drops every non-alphanumeric
+// rune, so "Dark Reader" and "DarkReader, Inc." both reduce to a
+// comparable label root.
+func normalizeAlnum(s string) string {
+	var b strings.Builder
+
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+
+	return b.String()
+}

--- a/pkg/thirdparty/common_third_party_owned_domains.go
+++ b/pkg/thirdparty/common_third_party_owned_domains.go
@@ -15,6 +15,7 @@
 package thirdparty
 
 import (
+	"slices"
 	"strings"
 
 	"go.probo.inc/probo/pkg/uri"
@@ -163,13 +164,7 @@ func vendorLabels(name, website string) []string {
 
 // exactLabelMatch reports whether label equals any vendor label.
 func exactLabelMatch(label string, vendorLabels []string) bool {
-	for _, vl := range vendorLabels {
-		if label == vl {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(vendorLabels, label)
 }
 
 // relatedLabelMatch reports whether label is the same as, contains, or is

--- a/pkg/thirdparty/common_third_party_owned_domains.go
+++ b/pkg/thirdparty/common_third_party_owned_domains.go
@@ -167,10 +167,11 @@ func exactLabelMatch(label string, vendorLabels []string) bool {
 	return slices.Contains(vendorLabels, label)
 }
 
-// relatedLabelMatch reports whether label is the same as, contains, or is
-// contained by any vendor label. Substring matches require the shorter
-// string to be at least minLabelOverlap characters to avoid spurious hits
-// on very short labels.
+// relatedLabelMatch reports whether label is the same as, or shares a
+// dominant root with, any vendor label. A substring match requires the
+// shorter label to be at least minLabelOverlap characters AND to cover at
+// least half of the longer label, so a short root (e.g. "meta") no longer
+// attributes an unrelated domain (e.g. "metallica") to the vendor.
 func relatedLabelMatch(label string, vendorLabels []string) bool {
 	for _, vl := range vendorLabels {
 		if label == vl {
@@ -182,7 +183,15 @@ func relatedLabelMatch(label string, vendorLabels []string) bool {
 			shorter, longer = longer, shorter
 		}
 
-		if len(shorter) >= minLabelOverlap && strings.Contains(longer, shorter) {
+		if len(shorter) < minLabelOverlap {
+			continue
+		}
+
+		if len(shorter)*2 < len(longer) {
+			continue
+		}
+
+		if strings.Contains(longer, shorter) {
 			return true
 		}
 	}

--- a/pkg/thirdparty/common_third_party_owned_domains.go
+++ b/pkg/thirdparty/common_third_party_owned_domains.go
@@ -18,7 +18,7 @@ import (
 	"slices"
 	"strings"
 
-	"go.probo.inc/probo/pkg/strutil"
+	"go.probo.inc/probo/pkg/stringsx"
 	"go.probo.inc/probo/pkg/uri"
 )
 
@@ -158,7 +158,7 @@ func vendorLabels(name, website string) []string {
 	}
 
 	add(uri.DomainLabel(website))
-	add(strutil.NormalizeAlnum(name))
+	add(stringsx.NormalizeAlnum(name))
 
 	return labels
 }

--- a/pkg/thirdparty/common_third_party_owned_domains.go
+++ b/pkg/thirdparty/common_third_party_owned_domains.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"strings"
 
+	"go.probo.inc/probo/pkg/strutil"
 	"go.probo.inc/probo/pkg/uri"
 )
 
@@ -157,7 +158,7 @@ func vendorLabels(name, website string) []string {
 	}
 
 	add(uri.DomainLabel(website))
-	add(normalizeAlnum(name))
+	add(strutil.NormalizeAlnum(name))
 
 	return labels
 }
@@ -212,19 +213,4 @@ func normalizeToETLD1(raw string) string {
 	}
 
 	return uri.ExtractDomain(raw)
-}
-
-// normalizeAlnum lowercases a string and drops every non-alphanumeric
-// rune, so "Dark Reader" and "DarkReader, Inc." both reduce to a
-// comparable label root.
-func normalizeAlnum(s string) string {
-	var b strings.Builder
-
-	for _, r := range strings.ToLower(s) {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
-			b.WriteRune(r)
-		}
-	}
-
-	return b.String()
 }

--- a/pkg/thirdparty/common_third_party_owned_domains_test.go
+++ b/pkg/thirdparty/common_third_party_owned_domains_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveOwnedDomains(t *testing.T) {
+	t.Parallel()
+
+	const threshold = 0.85
+
+	domainsOf := func(owned []ownedDomain) []string {
+		out := make([]string, len(owned))
+		for i, d := range owned {
+			out[i] = d.Domain
+		}
+
+		return out
+	}
+
+	t.Run(
+		"keeps website and brand-related domains, drops unrelated and generic",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveOwnedDomains(
+				"Dark Reader",
+				"https://darkreader.org",
+				DomainsResult{
+					Domains: []DomainCandidate{
+						{Domain: "darkreader.org", Confidence: 0.95},
+						{Domain: "darkreader.ltd", Confidence: 0.9},
+						{Domain: "https://api.darkreader.org/v1", Confidence: 0.9},
+						{Domain: "cloudflare.com", Confidence: 0.9},
+						{Domain: "googleapis.com", Confidence: 0.95},
+					},
+				},
+				threshold,
+			)
+
+			assert.Equal(t, []string{"darkreader.org", "darkreader.ltd"}, domainsOf(got))
+		},
+	)
+
+	t.Run(
+		"always includes the website domain even when absent from candidates",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveOwnedDomains(
+				"Dark Reader",
+				"https://darkreader.org",
+				DomainsResult{},
+				threshold,
+			)
+
+			assert.Equal(t, []string{"darkreader.org"}, domainsOf(got))
+			assert.Equal(t, 1.0, got[0].Confidence)
+			assert.Equal(t, "https://darkreader.org", got[0].SourceURL)
+		},
+	)
+
+	t.Run(
+		"drops candidates below the confidence threshold",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveOwnedDomains(
+				"Dark Reader",
+				"https://darkreader.org",
+				DomainsResult{
+					Domains: []DomainCandidate{
+						{Domain: "darkreader.io", Confidence: 0.5},
+					},
+				},
+				threshold,
+			)
+
+			assert.Equal(t, []string{"darkreader.org"}, domainsOf(got))
+		},
+	)
+
+	t.Run(
+		"keeps a separate brand CDN domain",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveOwnedDomains(
+				"Intercom",
+				"https://intercom.com",
+				DomainsResult{
+					Domains: []DomainCandidate{
+						{Domain: "intercomcdn.com", Confidence: 0.9},
+					},
+				},
+				threshold,
+			)
+
+			assert.Equal(t, []string{"intercom.com", "intercomcdn.com"}, domainsOf(got))
+		},
+	)
+
+	t.Run(
+		"keeps the vendor's own shared-infrastructure domain when the vendor is that provider",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveOwnedDomains(
+				"Fastly",
+				"https://fastly.com",
+				DomainsResult{
+					Domains: []DomainCandidate{
+						{Domain: "fastly.net", Confidence: 0.95},
+					},
+				},
+				threshold,
+			)
+
+			assert.Equal(t, []string{"fastly.com", "fastly.net"}, domainsOf(got))
+		},
+	)
+
+	t.Run(
+		"drops shared-infrastructure domains for an unrelated vendor even at high confidence",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveOwnedDomains(
+				"Dark Reader",
+				"https://darkreader.org",
+				DomainsResult{
+					Domains: []DomainCandidate{
+						{Domain: "amazonaws.com", Confidence: 0.99},
+						{Domain: "fastly.net", Confidence: 0.99},
+					},
+				},
+				threshold,
+			)
+
+			assert.Equal(t, []string{"darkreader.org"}, domainsOf(got))
+		},
+	)
+}

--- a/pkg/thirdparty/prompts/common_third_party_company_profile.txt.tmpl
+++ b/pkg/thirdparty/prompts/common_third_party_company_profile.txt.tmpl
@@ -1,0 +1,33 @@
+You are a research agent that builds a factual company profile for a software
+vendor or service provider. You are given the vendor's name (and sometimes a
+known website). Return only verifiable identity facts.
+
+Resolve these fields:
+
+- legal_name: the full legal entity name, including the suffix (Inc., Ltd.,
+  GmbH, S.A.S., etc.). Prefer the name as it appears in the vendor's own legal
+  documents (privacy policy footer, terms of service) or an official business
+  registry.
+- headquarter_address: the postal address of the company's headquarters.
+- website_url: the canonical primary marketing website. Use the https scheme,
+  drop tracking query parameters and trailing paths, and prefer the apex or
+  www host the vendor uses for its homepage.
+
+Method:
+
+- Use the web_search tool when it is available to confirm facts. Prefer the
+  vendor's own website and official registries over third-party aggregators.
+- The website_url is the most important field: downstream steps depend on it.
+  Resolve it carefully and with high confidence when the vendor clearly owns a
+  primary domain.
+
+Rules:
+
+- Never guess. If you cannot verify a field, return an empty string with a
+  confidence of 0.
+- confidence is your own 0.0-1.0 estimate that the value is correct. Reserve
+  values above 0.8 for facts you verified from the vendor's own site or an
+  official registry.
+- source_url is the page where you verified the value. Leave it empty when the
+  value was not found.
+- Do not include commentary; return only the structured fields.

--- a/pkg/thirdparty/prompts/common_third_party_company_profile.txt.tmpl
+++ b/pkg/thirdparty/prompts/common_third_party_company_profile.txt.tmpl
@@ -22,7 +22,13 @@ Each field carries a value, a 0.0-1.0 confidence, and the source_url where you v
 
 4. Use the web_search tool to confirm facts and to find the corporate domain or an official business registry. Prefer the vendor's own website and official registries over third-party aggregators.
 
-5. Never guess. If you cannot verify a field, return an empty string with a confidence of 0. confidence is your own 0.0-1.0 estimate that the value is correct; reserve values above 0.8 for facts you verified on the vendor's own site or an official registry.
+5. Never guess. If you cannot verify a field, return an empty string with a confidence of 0. confidence is your own calibrated 0.0-1.0 estimate that the value is correct — it measures how sure you are, not how hard you looked. Aim for it to be well-calibrated: across many vendors, the facts you tag around 0.9 should turn out correct roughly nine times in ten. Anchor your estimate on the strength of the evidence:
+   - 0.9-1.0: verified on the vendor's own site (footer, imprint/impressum, about, legal) or an official business registry, with no conflicting evidence.
+   - 0.7-0.9: found on the vendor's own site but with minor ambiguity (for example a parent or brand name you could not fully disambiguate), or the same value corroborated across two independent reputable sources.
+   - 0.4-0.7: drawn from a single third-party aggregator, or an inference you could not confirm against an authoritative source.
+   - 0.1-0.4: a weak or partial signal you are mostly guessing from.
+   - 0: not found, or you cannot verify it at all.
+   A downstream step only persists a field when its confidence clears a threshold, so calibrate honestly: do not inflate a value to push it over the bar, and do not deflate a fact you genuinely verified.
 
 6. source_url is the page where you verified the value. Leave it empty when the value was not found.
 

--- a/pkg/thirdparty/prompts/common_third_party_company_profile.txt.tmpl
+++ b/pkg/thirdparty/prompts/common_third_party_company_profile.txt.tmpl
@@ -1,33 +1,30 @@
-You are a research agent that builds a factual company profile for a software
-vendor or service provider. You are given the vendor's name (and sometimes a
-known website). Return only verifiable identity facts.
+<role>
+You are a research agent that builds a factual company profile for a software vendor or service provider. You are given the vendor's name and sometimes a known website. You return only verifiable identity facts.
+</role>
 
-Resolve these fields:
+<task>
+Resolve these fields for the vendor:
+- legal_name: the full legal entity name, including the suffix (Inc., Ltd., GmbH, S.A.S., etc.).
+- headquarter_address: the postal address of the company's headquarters (street, city, region, country).
+- website_url: the canonical primary marketing website. Use the https scheme, drop tracking query parameters and trailing paths, and prefer the apex or www host the vendor uses for its homepage.
 
-- legal_name: the full legal entity name, including the suffix (Inc., Ltd.,
-  GmbH, S.A.S., etc.). Prefer the name as it appears in the vendor's own legal
-  documents (privacy policy footer, terms of service) or an official business
-  registry.
-- headquarter_address: the postal address of the company's headquarters.
-- website_url: the canonical primary marketing website. Use the https scheme,
-  drop tracking query parameters and trailing paths, and prefer the apex or
-  www host the vendor uses for its homepage.
+Each field carries a value, a 0.0-1.0 confidence, and the source_url where you verified it.
+</task>
 
-Method:
+<instructions>
+0. Work within a tight tool budget. You have a limited number of turns, so do not exhaust them browsing exhaustively. Read the homepage and the one or two pages most likely to carry identity facts (footer, imprint/impressum, about, legal, contact), then produce the structured output. Leaving a field empty is acceptable; running out of turns before producing the structured output is not.
 
-- Use the web_search tool when it is available to confirm facts. Prefer the
-  vendor's own website and official registries over third-party aggregators.
-- The website_url is the most important field: downstream steps depend on it.
-  Resolve it carefully and with high confidence when the vendor clearly owns a
-  primary domain.
+1. website_url is the gating field: downstream steps (compliance-document discovery, logo) only run when it is resolved. Resolve one canonical primary marketing domain with high confidence. If you cannot confidently identify the vendor's own primary domain, return an empty website_url with confidence 0 rather than guessing.
 
-Rules:
+2. When the browser tools (navigate, extract_links, find_links_matching) are available, use them to read the vendor's own site. The legal name and headquarters address usually live in the footer, imprint/impressum, about, legal, or contact pages, not on the homepage.
 
-- Never guess. If you cannot verify a field, return an empty string with a
-  confidence of 0.
-- confidence is your own 0.0-1.0 estimate that the value is correct. Reserve
-  values above 0.8 for facts you verified from the vendor's own site or an
-  official registry.
-- source_url is the page where you verified the value. Leave it empty when the
-  value was not found.
-- Do not include commentary; return only the structured fields.
+3. The legal entity often lives on a different domain from the product or marketing site. A product site (for example a .org or .io) frequently links to a corporate domain (for example a .ltd or .com) in its footer, imprint, or terms. Follow those links to the corporate domain to confirm the legal_name and headquarter_address.
+
+4. Use the web_search tool to confirm facts and to find the corporate domain or an official business registry. Prefer the vendor's own website and official registries over third-party aggregators.
+
+5. Never guess. If you cannot verify a field, return an empty string with a confidence of 0. confidence is your own 0.0-1.0 estimate that the value is correct; reserve values above 0.8 for facts you verified on the vendor's own site or an official registry.
+
+6. source_url is the page where you verified the value. Leave it empty when the value was not found.
+
+7. Do not include commentary; return only the structured fields.
+</instructions>

--- a/pkg/thirdparty/prompts/common_third_party_compliance_docs.txt.tmpl
+++ b/pkg/thirdparty/prompts/common_third_party_compliance_docs.txt.tmpl
@@ -1,0 +1,51 @@
+You are a research agent that locates a software vendor's public compliance
+documents and trust pages. You are given the vendor's name and, usually, its
+website. Return canonical URLs for each document, plus the certifications the
+vendor publicly claims.
+
+Resolve these fields (each is a single URL unless noted):
+
+- privacy_policy_url: the privacy policy.
+- terms_of_service_url: the terms of service / terms of use.
+- service_level_agreement_url: the public SLA. Frequently gated behind sales.
+- service_software_agreement_url: the master software/subscription agreement
+  (MSA). Often gated, or the same document as the terms of service.
+- data_processing_agreement_url: the DPA. Often a downloadable PDF; sometimes
+  only available on request.
+- business_associate_agreement_url: the HIPAA BAA. Almost always gated behind
+  sales or an enterprise plan.
+- subprocessors_list_url: the sub-processors list page.
+- status_page_url: the uptime/status page (commonly status.<domain> or a
+  hosted statuspage.io / instatus / better-uptime page).
+- security_page_url: the security overview page.
+- trust_page_url: the trust center / trust portal. Many vendors host this on
+  Vanta, SafeBase, Drata, Conveyor, or a /trust path.
+- certifications: the compliance frameworks and certifications the vendor
+  publicly claims (e.g. SOC 2 Type II, ISO 27001, ISO 27701, PCI DSS, HIPAA,
+  GDPR, FedRAMP). Read these from the trust or security page.
+
+Method:
+
+- Start from the vendor's <website> when provided. Use the browser tools
+  (navigate, extract_links, find_links_matching) to inspect the site footer
+  and the trust/security pages, which is where these links normally live.
+- Use web_search to fill gaps with site-scoped queries (for example
+  "site:<domain> data processing agreement"). Prefer the vendor's own domain
+  and its hosted trust portal over third-party aggregators.
+- Finding the trust center first usually yields the security page and the
+  certifications in one place.
+
+Rules:
+
+- Return the most specific canonical URL. Prefer a direct document/page URL
+  over a generic legal-index page.
+- Never guess or fabricate a URL. If a document is gated, only available on
+  request, or you cannot find it, return an empty string with confidence 0.
+  Several of these (SLA, MSA, BAA) are commonly non-public; leaving them empty
+  is the correct outcome.
+- confidence is your own 0.0-1.0 estimate that the URL is correct and current.
+  Reserve values above 0.8 for URLs you actually reached on the vendor's own
+  domain or hosted trust portal.
+- source_url is the page where you found the link (for certifications, the
+  page you read them from). Leave it empty when nothing was found.
+- Do not include commentary; return only the structured fields.

--- a/pkg/thirdparty/prompts/common_third_party_compliance_docs.txt.tmpl
+++ b/pkg/thirdparty/prompts/common_third_party_compliance_docs.txt.tmpl
@@ -32,7 +32,13 @@ Each field carries a value, a 0.0-1.0 confidence, and the source_url where you f
 
 5. Never guess or fabricate a URL. If a document is gated, only available on request, or you cannot find it, return an empty string with confidence 0. Several of these (SLA, MSA, BAA) are commonly non-public; leaving them empty is the correct outcome.
 
-6. confidence is your own 0.0-1.0 estimate that the URL is correct and current. Reserve values above 0.8 for URLs you actually reached on the vendor's own domain or hosted trust portal.
+6. confidence is your own calibrated 0.0-1.0 estimate that the URL is correct and current — it measures how sure you are, not how hard you looked. Aim for it to be well-calibrated: across many vendors, the URLs you tag around 0.9 should turn out correct roughly nine times in ten. Anchor your estimate on the strength of the evidence:
+   - 0.9-1.0: a URL you actually reached and that loaded the expected document on the vendor's own domain or hosted trust portal.
+   - 0.7-0.9: a URL you found linked from the vendor's own site or trust portal but did not fully open or verify, or one with minor ambiguity about whether it is the current canonical version.
+   - 0.4-0.7: a URL from a single third-party source or search result you could not confirm on the vendor's own domain.
+   - 0.1-0.4: a weak guess, for example a path you assume exists by convention but never reached.
+   - 0: not found, gated, or you cannot verify it at all.
+   A downstream step only persists a field when its confidence clears a threshold, so calibrate honestly: do not inflate a value to push it over the bar, and do not deflate a URL you genuinely reached.
 
 7. source_url is the page where you found the link (for certifications, the page you read them from). Leave it empty when nothing was found.
 

--- a/pkg/thirdparty/prompts/common_third_party_compliance_docs.txt.tmpl
+++ b/pkg/thirdparty/prompts/common_third_party_compliance_docs.txt.tmpl
@@ -1,51 +1,40 @@
-You are a research agent that locates a software vendor's public compliance
-documents and trust pages. You are given the vendor's name and, usually, its
-website. Return canonical URLs for each document, plus the certifications the
-vendor publicly claims.
+<role>
+You are a research agent that locates a software vendor's public compliance documents and trust pages. You are given the vendor's name and, usually, its website. You return canonical URLs for each document, plus the certifications the vendor publicly claims.
+</role>
 
+<task>
 Resolve these fields (each is a single URL unless noted):
-
 - privacy_policy_url: the privacy policy.
 - terms_of_service_url: the terms of service / terms of use.
 - service_level_agreement_url: the public SLA. Frequently gated behind sales.
-- service_software_agreement_url: the master software/subscription agreement
-  (MSA). Often gated, or the same document as the terms of service.
-- data_processing_agreement_url: the DPA. Often a downloadable PDF; sometimes
-  only available on request.
-- business_associate_agreement_url: the HIPAA BAA. Almost always gated behind
-  sales or an enterprise plan.
+- service_software_agreement_url: the master software/subscription agreement (MSA). Often gated, or the same document as the terms of service.
+- data_processing_agreement_url: the DPA. Often a downloadable PDF; sometimes only available on request.
+- business_associate_agreement_url: the HIPAA BAA. Almost always gated behind sales or an enterprise plan.
 - subprocessors_list_url: the sub-processors list page.
-- status_page_url: the uptime/status page (commonly status.<domain> or a
-  hosted statuspage.io / instatus / better-uptime page).
+- status_page_url: the uptime/status page (commonly status.<domain> or a hosted statuspage.io / instatus / better-uptime page).
 - security_page_url: the security overview page.
-- trust_page_url: the trust center / trust portal. Many vendors host this on
-  Vanta, SafeBase, Drata, Conveyor, or a /trust path.
-- certifications: the compliance frameworks and certifications the vendor
-  publicly claims (e.g. SOC 2 Type II, ISO 27001, ISO 27701, PCI DSS, HIPAA,
-  GDPR, FedRAMP). Read these from the trust or security page.
+- trust_page_url: the trust center / trust portal. Many vendors host this on Vanta, SafeBase, Drata, Conveyor, or a /trust path.
+- certifications: the compliance frameworks and certifications the vendor publicly claims (e.g. SOC 2 Type II, ISO 27001, ISO 27701, PCI DSS, HIPAA, GDPR, FedRAMP). Read these from the trust or security page.
 
-Method:
+Each field carries a value, a 0.0-1.0 confidence, and the source_url where you found it.
+</task>
 
-- Start from the vendor's <website> when provided. Use the browser tools
-  (navigate, extract_links, find_links_matching) to inspect the site footer
-  and the trust/security pages, which is where these links normally live.
-- Use web_search to fill gaps with site-scoped queries (for example
-  "site:<domain> data processing agreement"). Prefer the vendor's own domain
-  and its hosted trust portal over third-party aggregators.
-- Finding the trust center first usually yields the security page and the
-  certifications in one place.
+<instructions>
+0. Work within a tight tool budget. You have a limited number of turns, so do not exhaust them browsing exhaustively. Prefer extract_links / find_links_matching over navigating many pages one at a time, fetch the footer and trust/security pages first, and stop as soon as you have the core documents. Leaving a field empty is acceptable; running out of turns before producing the structured output is not. Once you have what you can reasonably find, produce the final structured output instead of continuing to search.
 
-Rules:
+1. Start from the vendor's <website> when provided. Use the browser tools (navigate, extract_links, find_links_matching) to inspect the site footer and the trust/security pages, which is where these links normally live. Finding the trust center first usually yields the security page and the certifications in one place.
 
-- Return the most specific canonical URL. Prefer a direct document/page URL
-  over a generic legal-index page.
-- Never guess or fabricate a URL. If a document is gated, only available on
-  request, or you cannot find it, return an empty string with confidence 0.
-  Several of these (SLA, MSA, BAA) are commonly non-public; leaving them empty
-  is the correct outcome.
-- confidence is your own 0.0-1.0 estimate that the URL is correct and current.
-  Reserve values above 0.8 for URLs you actually reached on the vendor's own
-  domain or hosted trust portal.
-- source_url is the page where you found the link (for certifications, the
-  page you read them from). Leave it empty when nothing was found.
-- Do not include commentary; return only the structured fields.
+2. Use web_search to fill gaps with site-scoped queries (for example "site:<domain> data processing agreement"). Prefer the vendor's own domain and its hosted trust portal over third-party aggregators.
+
+3. Keep document URLs on the primary <website> host. A vendor may operate several linked domains (for example a product site and a corporate site); when the same document is reachable on more than one of them, choose the one served from the <website> host and verify it loads. Do not mix hosts across fields when one canonical host serves them all.
+
+4. Return the most specific canonical URL. Prefer a direct document/page URL over a generic legal-index page.
+
+5. Never guess or fabricate a URL. If a document is gated, only available on request, or you cannot find it, return an empty string with confidence 0. Several of these (SLA, MSA, BAA) are commonly non-public; leaving them empty is the correct outcome.
+
+6. confidence is your own 0.0-1.0 estimate that the URL is correct and current. Reserve values above 0.8 for URLs you actually reached on the vendor's own domain or hosted trust portal.
+
+7. source_url is the page where you found the link (for certifications, the page you read them from). Leave it empty when nothing was found.
+
+8. Do not include commentary; return only the structured fields.
+</instructions>

--- a/pkg/thirdparty/prompts/common_third_party_domains.txt.tmpl
+++ b/pkg/thirdparty/prompts/common_third_party_domains.txt.tmpl
@@ -29,7 +29,13 @@ Each entry carries the domain, a 0.0-1.0 confidence that the vendor owns it, and
 
 4. Return registrable domains or full hosts; do not invent subdomains you have not seen. Never guess ownership: if you cannot confirm the vendor owns a domain, leave it out or give it a confidence of 0.
 
-5. confidence is your own 0.0-1.0 estimate that the vendor owns the domain. Reserve values above 0.85 for domains whose ownership you confirmed from the vendor's own site, its documentation, or an authoritative source.
+5. confidence is your own calibrated 0.0-1.0 estimate that the vendor owns the domain — it measures how sure you are about ownership, not how hard you looked. Aim for it to be well-calibrated: across many domains, the ones you tag around 0.9 should genuinely be vendor-owned roughly nine times in ten. Anchor your estimate on the strength of the ownership evidence:
+   - 0.9-1.0: ownership confirmed from the vendor's own site, its documentation, sub-processors/trust pages, or another authoritative source that names the domain as theirs.
+   - 0.7-0.9: strong but indirect evidence, for example a domain consistently serving the vendor's assets or linked as a product/brand from its own site, without an explicit ownership statement.
+   - 0.4-0.7: a plausible association (similar branding or naming) you could not confirm the vendor controls.
+   - 0.1-0.4: a weak guess.
+   - 0: ownership not confirmed, or the domain is shared/third-party infrastructure.
+   A downstream step only keeps a domain when its confidence clears a threshold, so calibrate honestly: do not inflate a value to push it over the bar, and do not deflate a domain whose ownership you genuinely confirmed.
 
 6. source_url is the page where you confirmed ownership. Leave it empty when nothing was found.
 

--- a/pkg/thirdparty/prompts/common_third_party_domains.txt.tmpl
+++ b/pkg/thirdparty/prompts/common_third_party_domains.txt.tmpl
@@ -1,0 +1,37 @@
+<role>
+You are a research agent that maps the domains a software vendor owns and operates. You are given the vendor's name and its primary website. You return the registrable domains the vendor itself controls, so they can be used to attribute web traffic and trackers to this vendor.
+</role>
+
+<task>
+Return the registrable domains (eTLD+1) the vendor owns and operates. Subdomains collapse to their registrable domain (api.acme.com and cdn.acme.com are both acme.com), so the goal is to find every DISTINCT registrable domain, not every subdomain. Cover all of these when they exist:
+- the primary marketing website domain, including its country and regional variants (for example acme.co.uk, acme.de);
+- product and sub-brand domains: a distinct registrable domain for each product, service, or brand the vendor owns or operates, including products shipped under their own name and brands the company has acquired (for example a parent vendor that runs several differently-named products, each on its own domain);
+- application, login, dashboard, and console domains when on a distinct registrable domain;
+- public API host domains (for example api.<vendor>) when on a distinct registrable domain;
+- developer, documentation, and status domains on a distinct registrable domain;
+- CDN, static-asset, media, and file/upload domains the vendor serves content from, including separate registrable domains used for this (for example a distinct CDN brand such as intercomcdn.com for Intercom);
+- corporate / legal-entity domains the operating company uses (for example a .ltd or country domain).
+
+Each entry carries the domain, a 0.0-1.0 confidence that the vendor owns it, and the source_url where ownership was observed.
+</task>
+
+<instructions>
+0. Work within a tight tool budget. Aim for breadth of DISTINCT registrable domains, not exhaustive subdomain crawling: visiting more pages on a domain you already have adds nothing, since they share its eTLD+1. Spend each turn on a source likely to reveal a NEW registrable domain, then produce the structured output. Returning fewer well-verified domains is better than running out of turns.
+
+1. Anchor on the <website>, then work through the highest-yield ownership sources in order, stopping early once they stop revealing new registrable domains:
+   - the asset/script hosts the homepage and app load (these surface CDN and API domains), and the footer / "our products" / brand-portfolio links;
+   - the vendor's own pages that list its domains explicitly: the sub-processors list, security / trust page, and a privacy policy or "cookies" page (these often enumerate owned domains);
+   - targeted web_search, for example "<vendor> products", "domains owned by <vendor>", "<vendor> api domain", "<vendor> cdn domain", "<vendor> subprocessors".
+
+2. Return only domains the vendor itself owns and operates. Exclude shared or third-party infrastructure the vendor merely uses but does not own: tag managers, analytics, font providers, and generic CDN / cloud / hosting providers such as Google, Cloudflare, Fastly, Akamai, AWS / CloudFront, jsDelivr, unpkg. Those belong to other vendors.
+
+3. Exception: when the vendor itself IS such a provider (for example the vendor is Cloudflare, Fastly, or Akamai), then its own infrastructure domains ARE owned by it and you should include them. Judge ownership by whether the domain belongs to this specific vendor, not by whether it looks like infrastructure.
+
+4. Return registrable domains or full hosts; do not invent subdomains you have not seen. Never guess ownership: if you cannot confirm the vendor owns a domain, leave it out or give it a confidence of 0.
+
+5. confidence is your own 0.0-1.0 estimate that the vendor owns the domain. Reserve values above 0.85 for domains whose ownership you confirmed from the vendor's own site, its documentation, or an authoritative source.
+
+6. source_url is the page where you confirmed ownership. Leave it empty when nothing was found.
+
+7. Do not include commentary; return only the structured fields.
+</instructions>

--- a/pkg/thirdparty/resolver.go
+++ b/pkg/thirdparty/resolver.go
@@ -70,8 +70,14 @@ func ResolveOrCreateCommonThirdParty(
 		Slug:           partySlug,
 		Category:       category,
 		Certifications: []string{},
-		CreatedAt:      now,
-		UpdatedAt:      now,
+		// Request enrichment at creation: a freshly resolved catalog row
+		// carries only name/slug/category, so the enrichment worker fills
+		// the rest (URLs, address, certifications, logo). Curated seed
+		// rows are inserted via Upsert without this flag, so a full
+		// re-seed does not trigger an enrichment storm.
+		EnrichmentRequestedAt: &now,
+		CreatedAt:             now,
+		UpdatedAt:             now,
 	}
 
 	// Insert inside a savepoint so a concurrent transaction that created

--- a/pkg/webinspect/logo.go
+++ b/pkg/webinspect/logo.go
@@ -39,6 +39,7 @@ func FindLogoURL(info *PageInfo) (string, error) {
 
 	for _, n := range findAllIn(head, "link") {
 		rel := strings.ToLower(attrVal(n, "rel"))
+
 		href := attrVal(n, "href")
 		if href == "" {
 			continue
@@ -64,6 +65,7 @@ func FindLogoURL(info *PageInfo) (string, error) {
 
 	for _, n := range findAllIn(head, "meta") {
 		name := strings.ToLower(attrVal(n, "name"))
+
 		content := attrVal(n, "content")
 		if name == "msapplication-tileimage" && content != "" {
 			msTileImage = content
@@ -92,8 +94,10 @@ func parseSizeAttr(sizes string) int {
 	}
 
 	best := 0
+
 	for token := range strings.FieldsSeq(sizes) {
 		token = strings.ToLower(token)
+
 		parts := strings.SplitN(token, "x", 2)
 		if len(parts) != 2 {
 			continue
@@ -117,6 +121,7 @@ func ExtensionForMIME(contentType string) string {
 	if idx := strings.Index(ct, ";"); idx != -1 {
 		ct = ct[:idx]
 	}
+
 	ct = strings.TrimSpace(ct)
 
 	switch ct {
@@ -146,6 +151,7 @@ func (p *PageInfo) HeadLinks(rel string) []*html.Node {
 	}
 
 	rel = strings.ToLower(rel)
+
 	var matches []*html.Node
 
 	for _, n := range findAllIn(head, "link") {

--- a/pkg/webinspect/logo.go
+++ b/pkg/webinspect/logo.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package webinspect
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+func FindLogoURL(info *PageInfo) (string, error) {
+	head := findElement(info.Root, "head")
+	if head == nil {
+		return "", fmt.Errorf("cannot find logo: no head element")
+	}
+
+	var (
+		svgIcon        string
+		appleTouchIcon string
+		appleTouchSize int
+		largestIcon    string
+		largestSize    int
+		msTileImage    string
+	)
+
+	for _, n := range findAllIn(head, "link") {
+		rel := strings.ToLower(attrVal(n, "rel"))
+		href := attrVal(n, "href")
+		if href == "" {
+			continue
+		}
+
+		switch {
+		case strings.Contains(rel, "icon") && !strings.Contains(rel, "apple-touch-icon") && attrVal(n, "type") == "image/svg+xml":
+			svgIcon = href
+		case strings.Contains(rel, "apple-touch-icon"):
+			size := parseSizeAttr(attrVal(n, "sizes"))
+			if appleTouchIcon == "" || size > appleTouchSize {
+				appleTouchIcon = href
+				appleTouchSize = size
+			}
+		case strings.Contains(rel, "icon") && !strings.Contains(rel, "apple-touch-icon"):
+			size := parseSizeAttr(attrVal(n, "sizes"))
+			if largestIcon == "" || size > largestSize {
+				largestIcon = href
+				largestSize = size
+			}
+		}
+	}
+
+	for _, n := range findAllIn(head, "meta") {
+		name := strings.ToLower(attrVal(n, "name"))
+		content := attrVal(n, "content")
+		if name == "msapplication-tileimage" && content != "" {
+			msTileImage = content
+		}
+	}
+
+	candidates := []string{
+		svgIcon,
+		appleTouchIcon,
+		largestIcon,
+		msTileImage,
+	}
+
+	for _, href := range candidates {
+		if href != "" {
+			return info.ResolveHref(href), nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot find logo")
+}
+
+func parseSizeAttr(sizes string) int {
+	if sizes == "" || strings.EqualFold(sizes, "any") {
+		return 0
+	}
+
+	best := 0
+	for token := range strings.FieldsSeq(sizes) {
+		token = strings.ToLower(token)
+		parts := strings.SplitN(token, "x", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		w, err := strconv.Atoi(parts[0])
+		if err != nil {
+			continue
+		}
+
+		if w > best {
+			best = w
+		}
+	}
+
+	return best
+}
+
+func ExtensionForMIME(contentType string) string {
+	ct := strings.ToLower(contentType)
+	if idx := strings.Index(ct, ";"); idx != -1 {
+		ct = ct[:idx]
+	}
+	ct = strings.TrimSpace(ct)
+
+	switch ct {
+	case "image/svg+xml":
+		return ".svg"
+	case "image/png":
+		return ".png"
+	case "image/jpeg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	case "image/x-icon", "image/vnd.microsoft.icon":
+		return ".ico"
+	default:
+		return ".png"
+	}
+}
+
+// HeadLinks returns all <link> nodes from <head> whose rel attribute
+// contains the given value (case-insensitive partial match).
+func (p *PageInfo) HeadLinks(rel string) []*html.Node {
+	head := findElement(p.Root, "head")
+	if head == nil {
+		return nil
+	}
+
+	rel = strings.ToLower(rel)
+	var matches []*html.Node
+
+	for _, n := range findAllIn(head, "link") {
+		if strings.Contains(strings.ToLower(attrVal(n, "rel")), rel) {
+			matches = append(matches, n)
+		}
+	}
+
+	return matches
+}
+
+// HeadMeta returns the content attribute of the first <meta> tag in <head>
+// whose name attribute matches (case-insensitive).
+func (p *PageInfo) HeadMeta(name string) (string, bool) {
+	head := findElement(p.Root, "head")
+	if head == nil {
+		return "", false
+	}
+
+	name = strings.ToLower(name)
+
+	for _, n := range findAllIn(head, "meta") {
+		if strings.EqualFold(attrVal(n, "name"), name) {
+			content := attrVal(n, "content")
+			if content != "" {
+				return content, true
+			}
+		}
+	}
+
+	return "", false
+}

--- a/pkg/webinspect/logo_test.go
+++ b/pkg/webinspect/logo_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package webinspect_test
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/webinspect"
+)
+
+func parseTestHTML(t *testing.T, rawURL string, body string) *webinspect.PageInfo {
+	t.Helper()
+
+	u, err := url.Parse(rawURL)
+	require.NoError(t, err)
+
+	info, err := webinspect.ParseHTML(u, strings.NewReader(body))
+	require.NoError(t, err)
+
+	return info
+}
+
+func TestFindLogoURL_SVGPreferred(t *testing.T) {
+	t.Parallel()
+
+	info := parseTestHTML(t, "https://example.com", `<html><head>
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+		<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+		<link rel="icon" sizes="192x192" href="/icon-192.png">
+	</head><body></body></html>`)
+
+	got, err := webinspect.FindLogoURL(info)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/favicon.svg", got)
+}
+
+func TestFindLogoURL_AppleTouchIconSecond(t *testing.T) {
+	t.Parallel()
+
+	info := parseTestHTML(t, "https://example.com", `<html><head>
+		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+		<link rel="icon" sizes="32x32" href="/favicon-32.png">
+	</head><body></body></html>`)
+
+	got, err := webinspect.FindLogoURL(info)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/apple-touch-icon.png", got)
+}
+
+func TestFindLogoURL_AppleTouchIconLargest(t *testing.T) {
+	t.Parallel()
+
+	info := parseTestHTML(t, "https://example.com", `<html><head>
+		<link rel="apple-touch-icon" sizes="120x120" href="/touch-120.png">
+		<link rel="apple-touch-icon" sizes="180x180" href="/touch-180.png">
+		<link rel="apple-touch-icon" sizes="152x152" href="/touch-152.png">
+	</head><body></body></html>`)
+
+	got, err := webinspect.FindLogoURL(info)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/touch-180.png", got)
+}
+
+func TestFindLogoURL_LargestIcon(t *testing.T) {
+	t.Parallel()
+
+	info := parseTestHTML(t, "https://example.com", `<html><head>
+		<link rel="icon" sizes="32x32" href="/icon-32.png">
+		<link rel="icon" sizes="192x192" href="/icon-192.png">
+		<link rel="icon" sizes="16x16" href="/icon-16.png">
+	</head><body></body></html>`)
+
+	got, err := webinspect.FindLogoURL(info)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/icon-192.png", got)
+}
+
+func TestFindLogoURL_MsTileImage(t *testing.T) {
+	t.Parallel()
+
+	info := parseTestHTML(t, "https://example.com", `<html><head>
+		<meta name="msapplication-TileImage" content="/mstile-144.png">
+	</head><body></body></html>`)
+
+	got, err := webinspect.FindLogoURL(info)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/mstile-144.png", got)
+}
+
+func TestFindLogoURL_RelativeHrefResolved(t *testing.T) {
+	t.Parallel()
+
+	info := parseTestHTML(t, "https://cdn.example.com/app/", `<html><head>
+		<link rel="icon" type="image/svg+xml" href="../assets/logo.svg">
+	</head><body></body></html>`)
+
+	got, err := webinspect.FindLogoURL(info)
+	require.NoError(t, err)
+	assert.Equal(t, "https://cdn.example.com/assets/logo.svg", got)
+}
+
+func TestFindLogoURL_NoHead(t *testing.T) {
+	t.Parallel()
+
+	info := parseTestHTML(t, "https://example.com", `<html><body><p>no head</p></body></html>`)
+
+	_, err := webinspect.FindLogoURL(info)
+	assert.Error(t, err)
+}
+
+func TestFindLogoURL_NothingFound(t *testing.T) {
+	t.Parallel()
+
+	info := parseTestHTML(t, "https://example.com", `<html><head></head><body></body></html>`)
+
+	_, err := webinspect.FindLogoURL(info)
+	assert.Error(t, err)
+}
+
+func TestExtensionForMIME(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		contentType string
+		expected    string
+	}{
+		{"image/svg+xml", ".svg"},
+		{"image/png", ".png"},
+		{"image/jpeg", ".jpg"},
+		{"image/gif", ".gif"},
+		{"image/webp", ".webp"},
+		{"image/x-icon", ".ico"},
+		{"image/vnd.microsoft.icon", ".ico"},
+		{"image/png; charset=utf-8", ".png"},
+		{"application/octet-stream", ".png"},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.contentType,
+			func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tt.expected, webinspect.ExtensionForMIME(tt.contentType))
+			},
+		)
+	}
+}

--- a/pkg/webinspect/parse.go
+++ b/pkg/webinspect/parse.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+// Package webinspect parses a web page's static HTML to extract metadata
+// from its <head> (icons/logos, meta tags, link relations). It is a pure,
+// deterministic helper: callers supply an http.Client (e.g. one with SSRF
+// protection) so the package itself makes no policy decisions about which
+// hosts are reachable. The logo discovery is reused by the common
+// third-party enricher to populate logo_file_id without an LLM.
+package webinspect
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/html"
+)
+
+type PageInfo struct {
+	URL  *url.URL
+	Root *html.Node
+}
+
+func Parse(ctx context.Context, client *http.Client, websiteURL string) (*PageInfo, error) {
+	parsed, err := url.Parse(websiteURL)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse website URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, websiteURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot fetch page: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cannot fetch page: status %d", resp.StatusCode)
+	}
+
+	const maxHTMLSize = 10 << 20 // 10 MiB
+	return ParseHTML(parsed, io.LimitReader(resp.Body, maxHTMLSize))
+}
+
+func ParseHTML(baseURL *url.URL, r io.Reader) (*PageInfo, error) {
+	root, err := html.Parse(r)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse HTML: %w", err)
+	}
+
+	return &PageInfo{URL: baseURL, Root: root}, nil
+}
+
+func (p *PageInfo) ResolveHref(href string) string {
+	ref, err := url.Parse(href)
+	if err != nil {
+		return href
+	}
+
+	return p.URL.ResolveReference(ref).String()
+}
+
+func findElement(n *html.Node, tag string) *html.Node {
+	if n.Type == html.ElementNode && n.Data == tag {
+		return n
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if found := findElement(c, tag); found != nil {
+			return found
+		}
+	}
+
+	return nil
+}
+
+func findAllIn(parent *html.Node, tag string) []*html.Node {
+	var nodes []*html.Node
+
+	for c := parent.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && c.Data == tag {
+			nodes = append(nodes, c)
+		}
+
+		nodes = append(nodes, findAllIn(c, tag)...)
+	}
+
+	return nodes
+}
+
+func attrVal(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+
+	return ""
+}

--- a/pkg/webinspect/parse.go
+++ b/pkg/webinspect/parse.go
@@ -50,6 +50,7 @@ func Parse(ctx context.Context, client *http.Client, websiteURL string) (*PageIn
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch page: %w", err)
 	}
+
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
@@ -57,6 +58,7 @@ func Parse(ctx context.Context, client *http.Client, websiteURL string) (*PageIn
 	}
 
 	const maxHTMLSize = 10 << 20 // 10 MiB
+
 	return ParseHTML(parsed, io.LimitReader(resp.Body, maxHTMLSize))
 }
 


### PR DESCRIPTION
Closes ENG-403

This PR adds a poll-based background worker that enriches common third-party records by browsing the web with LLM agents, resolving company profiles, compliance documents, owned domains, and logos while respecting externally-owned values and a per-field confidence threshold. It wires the worker into `probod` behind opt-in config, adds web-inspection helpers for logo/HTML parsing, and exposes `proboctl` commands to inspect, re-enrich, and report stats on enrichment.

### Service **`+2377`** **`-18`**

Adds the enrichment engine in `pkg/thirdparty`: the `common_third_party_enrichment_worker.go` poll loop plus the company-profile, compliance-docs, and domains agents, owned-domain resolution, logo handling, and the provenance/confidence model in `common_third_party_enrichment.go` (sources, per-field statuses, and run-level done/partial/failed states) with their prompt templates. Adds `pkg/webinspect` (`logo.go`, `parse.go`) for HTML parsing and logo extraction. Wires the worker into `pkg/probod` via opt-in `buildCommonThirdPartyEnrichmentConfig` (a deployment without `llm.common-third-party-enrichment.provider` runs it as a no-op), with the matching config in `pkg/probodconfig` and `pkg/bootstrap`, plus small touch-ups to `pkg/agent` and the third-party resolver.

### proboctl **`+577`** **`-5`**

Extends the `commonthirdparty` command group with `reenrich.go` (force re-enrichment), `stats.go` (enrichment reporting), and an expanded `show.go`, plus list/command wiring updates to surface enrichment state.

### Coredata **`+551`** **`-6`**

Adds enrichment persistence for common third parties (`common_third_party.go`, filter updates in `common_third_party_filter.go`), tracker-pattern helpers in `tracker_pattern.go`, and migration `20260609T120000Z.sql`.

### Tests **`+534`** **`-0`**

Adds unit coverage for owned-domain resolution, web-inspect logo extraction, tracker patterns, and the bootstrap builder.

### Agents **`+104`** **`-0`**

Adds a prompt-style guide (`contrib/claude/prompt-style.md`) and the corresponding `.cursor/rules/prompt-style.mdc` documenting the agent prompt template structure.

### Other **`+92`** **`-0`**

Adds Helm chart plumbing for the new worker (`deployment.yaml`, `values.yaml`, `values-production.yaml.example`) and an `AGENTS.md` reference.
