### PR TITLE
Add cache headers to files static API

### DIFF
--- a/pkg/brand/brand.go
+++ b/pkg/brand/brand.go
@@ -9,17 +9,10 @@ var (
 	//go:embed assets
 	staticAssets embed.FS
 
-	Assets fs.FS
-
 	DefaultPoweredByLogoPath     string = "/api/files/v1/static/probo-gray-small.png"
 	DefaultSenderCompanyLogoPath string = "/api/files/v1/static/probo.png"
 )
 
-func init() {
-	var err error
-
-	Assets, err = fs.Sub(staticAssets, "assets")
-	if err != nil {
-		panic(err)
-	}
+func NewAssets() (fs.FS, error) {
+	return fs.Sub(staticAssets, "assets")
 }

--- a/pkg/brand/brand_test.go
+++ b/pkg/brand/brand_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package brand
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAssetsReturnsEmbeddedAssets(t *testing.T) {
+	t.Parallel()
+
+	assets, err := NewAssets()
+	require.NoError(t, err)
+
+	content, err := fs.ReadFile(assets, "probo.png")
+	require.NoError(t, err)
+	require.NotEmpty(t, content)
+}

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -172,18 +172,6 @@ func NewServer(cfg Config) (*Server, error) {
 		)
 	}))
 
-	filesHandler, err := files_v1.NewMux(
-		cfg.Logger.Named("files.v1"),
-		cfg.File,
-		cfg.Probo,
-		cfg.IAM,
-		cfg.Cookie,
-		cfg.TokenSecret,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("cannot create files handler: %w", err)
-	}
-
 	return &Server{
 		cfg:  cfg,
 		csrf: csrf,
@@ -222,7 +210,14 @@ func NewServer(cfg Config) (*Server, error) {
 			cfg.CookieBanner,
 			cfg.Geoloc,
 		),
-		filesHandler: filesHandler,
+		filesHandler: files_v1.NewMux(
+			cfg.Logger.Named("files.v1"),
+			cfg.File,
+			cfg.Probo,
+			cfg.IAM,
+			cfg.Cookie,
+			cfg.TokenSecret,
+		),
 		mcpHandler: mcp_v1.NewMux(
 			cfg.Logger.Named("mcp.v1"),
 			cfg.Probo,

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -28,6 +28,7 @@ import (
 	"go.probo.inc/probo/pkg/accessreview"
 	"go.probo.inc/probo/pkg/agentrun"
 	"go.probo.inc/probo/pkg/baseurl"
+	"go.probo.inc/probo/pkg/brand"
 	"go.probo.inc/probo/pkg/connector"
 	"go.probo.inc/probo/pkg/connector/provider"
 	"go.probo.inc/probo/pkg/cookiebanner"
@@ -172,6 +173,11 @@ func NewServer(cfg Config) (*Server, error) {
 		)
 	}))
 
+	staticFiles, err := files_v1.NewStaticFileServer(brand.Assets)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create files static server: %w", err)
+	}
+
 	return &Server{
 		cfg:  cfg,
 		csrf: csrf,
@@ -215,6 +221,7 @@ func NewServer(cfg Config) (*Server, error) {
 			cfg.File,
 			cfg.Probo,
 			cfg.IAM,
+			staticFiles,
 			cfg.Cookie,
 			cfg.TokenSecret,
 		),

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -28,7 +28,6 @@ import (
 	"go.probo.inc/probo/pkg/accessreview"
 	"go.probo.inc/probo/pkg/agentrun"
 	"go.probo.inc/probo/pkg/baseurl"
-	"go.probo.inc/probo/pkg/brand"
 	"go.probo.inc/probo/pkg/connector"
 	"go.probo.inc/probo/pkg/connector/provider"
 	"go.probo.inc/probo/pkg/cookiebanner"
@@ -173,9 +172,16 @@ func NewServer(cfg Config) (*Server, error) {
 		)
 	}))
 
-	staticFiles, err := files_v1.NewStaticFileServer(brand.Assets)
+	filesHandler, err := files_v1.NewMux(
+		cfg.Logger.Named("files.v1"),
+		cfg.File,
+		cfg.Probo,
+		cfg.IAM,
+		cfg.Cookie,
+		cfg.TokenSecret,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create files static server: %w", err)
+		return nil, fmt.Errorf("cannot create files handler: %w", err)
 	}
 
 	return &Server{
@@ -216,15 +222,7 @@ func NewServer(cfg Config) (*Server, error) {
 			cfg.CookieBanner,
 			cfg.Geoloc,
 		),
-		filesHandler: files_v1.NewMux(
-			cfg.Logger.Named("files.v1"),
-			cfg.File,
-			cfg.Probo,
-			cfg.IAM,
-			staticFiles,
-			cfg.Cookie,
-			cfg.TokenSecret,
-		),
+		filesHandler: filesHandler,
 		mcpHandler: mcp_v1.NewMux(
 			cfg.Logger.Named("mcp.v1"),
 			cfg.Probo,

--- a/pkg/server/api/files/v1/handler.go
+++ b/pkg/server/api/files/v1/handler.go
@@ -50,15 +50,15 @@ func NewMux(
 	iamSvc *iam.Service,
 	cookieConfig securecookie.Config,
 	tokenSecret string,
-) (*chi.Mux, error) {
+) *chi.Mux {
 	assets, err := brand.NewAssets()
 	if err != nil {
-		return nil, fmt.Errorf("cannot create brand assets: %w", err)
+		panic(fmt.Errorf("cannot create brand assets: %w", err))
 	}
 
 	staticFiles, err := newStaticFileServer(assets)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create static file server: %w", err)
+		panic(fmt.Errorf("cannot create static file server: %w", err))
 	}
 
 	h := &Handler{
@@ -82,7 +82,7 @@ func NewMux(
 		r.Get("/{fileID}", h.handleGetFile)
 	})
 
-	return r, nil
+	return r
 }
 
 func (h *Handler) handleGetStaticFile(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/api/files/v1/handler.go
+++ b/pkg/server/api/files/v1/handler.go
@@ -76,6 +76,7 @@ func NewMux(
 
 func (h *Handler) handleGetStaticFile(w http.ResponseWriter, r *http.Request) {
 	file := chi.URLParam(r, "file")
+
 	staticFiles := h.staticFiles
 	if staticFiles == nil {
 		staticFiles = defaultStaticFileServer

--- a/pkg/server/api/files/v1/handler.go
+++ b/pkg/server/api/files/v1/handler.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/brand"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/filemanager"
 	"go.probo.inc/probo/pkg/gid"
@@ -39,7 +40,7 @@ type Handler struct {
 	fileSvc     *filemanager.Service
 	probo       *probo.Service
 	iamSvc      *iam.Service
-	staticFiles *StaticFileServer
+	staticFiles *staticFileServer
 }
 
 func NewMux(
@@ -47,10 +48,14 @@ func NewMux(
 	fileSvc *filemanager.Service,
 	proboSvc *probo.Service,
 	iamSvc *iam.Service,
-	staticFiles *StaticFileServer,
 	cookieConfig securecookie.Config,
 	tokenSecret string,
-) *chi.Mux {
+) (*chi.Mux, error) {
+	staticFiles, err := newStaticFileServer(brand.Assets)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create static file server: %w", err)
+	}
+
 	h := &Handler{
 		logger:      logger,
 		fileSvc:     fileSvc,
@@ -72,7 +77,7 @@ func NewMux(
 		r.Get("/{fileID}", h.handleGetFile)
 	})
 
-	return r
+	return r, nil
 }
 
 func (h *Handler) handleGetStaticFile(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/api/files/v1/handler.go
+++ b/pkg/server/api/files/v1/handler.go
@@ -17,13 +17,11 @@ package files_v1
 import (
 	"errors"
 	"fmt"
-	"io/fs"
 	"net/http"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"go.gearno.de/kit/log"
-	"go.probo.inc/probo/pkg/brand"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/filemanager"
 	"go.probo.inc/probo/pkg/gid"
@@ -37,10 +35,11 @@ import (
 const presignedURLExpiry = 1 * time.Hour
 
 type Handler struct {
-	logger  *log.Logger
-	fileSvc *filemanager.Service
-	probo   *probo.Service
-	iamSvc  *iam.Service
+	logger      *log.Logger
+	fileSvc     *filemanager.Service
+	probo       *probo.Service
+	iamSvc      *iam.Service
+	staticFiles *staticFileServer
 }
 
 func NewMux(
@@ -52,10 +51,11 @@ func NewMux(
 	tokenSecret string,
 ) *chi.Mux {
 	h := &Handler{
-		logger:  logger,
-		fileSvc: fileSvc,
-		probo:   proboSvc,
-		iamSvc:  iamSvc,
+		logger:      logger,
+		fileSvc:     fileSvc,
+		probo:       proboSvc,
+		iamSvc:      iamSvc,
+		staticFiles: defaultStaticFileServer,
 	}
 
 	r := chi.NewRouter()
@@ -76,9 +76,12 @@ func NewMux(
 
 func (h *Handler) handleGetStaticFile(w http.ResponseWriter, r *http.Request) {
 	file := chi.URLParam(r, "file")
+	staticFiles := h.staticFiles
+	if staticFiles == nil {
+		staticFiles = defaultStaticFileServer
+	}
 
-	if _, statErr := fs.Stat(brand.Assets, file); statErr == nil {
-		http.ServeFileFS(w, r, brand.Assets, file)
+	if staticFiles.ServeHTTP(w, r, file) {
 		return
 	}
 

--- a/pkg/server/api/files/v1/handler.go
+++ b/pkg/server/api/files/v1/handler.go
@@ -51,7 +51,12 @@ func NewMux(
 	cookieConfig securecookie.Config,
 	tokenSecret string,
 ) (*chi.Mux, error) {
-	staticFiles, err := newStaticFileServer(brand.Assets)
+	assets, err := brand.NewAssets()
+	if err != nil {
+		return nil, fmt.Errorf("cannot create brand assets: %w", err)
+	}
+
+	staticFiles, err := newStaticFileServer(assets)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create static file server: %w", err)
 	}

--- a/pkg/server/api/files/v1/handler.go
+++ b/pkg/server/api/files/v1/handler.go
@@ -39,7 +39,7 @@ type Handler struct {
 	fileSvc     *filemanager.Service
 	probo       *probo.Service
 	iamSvc      *iam.Service
-	staticFiles *staticFileServer
+	staticFiles *StaticFileServer
 }
 
 func NewMux(
@@ -47,6 +47,7 @@ func NewMux(
 	fileSvc *filemanager.Service,
 	proboSvc *probo.Service,
 	iamSvc *iam.Service,
+	staticFiles *StaticFileServer,
 	cookieConfig securecookie.Config,
 	tokenSecret string,
 ) *chi.Mux {
@@ -55,7 +56,7 @@ func NewMux(
 		fileSvc:     fileSvc,
 		probo:       proboSvc,
 		iamSvc:      iamSvc,
-		staticFiles: defaultStaticFileServer,
+		staticFiles: staticFiles,
 	}
 
 	r := chi.NewRouter()
@@ -77,12 +78,7 @@ func NewMux(
 func (h *Handler) handleGetStaticFile(w http.ResponseWriter, r *http.Request) {
 	file := chi.URLParam(r, "file")
 
-	staticFiles := h.staticFiles
-	if staticFiles == nil {
-		staticFiles = defaultStaticFileServer
-	}
-
-	if staticFiles.ServeHTTP(w, r, file) {
+	if h.staticFiles.ServeHTTP(w, r, file) {
 		return
 	}
 

--- a/pkg/server/api/files/v1/handler_test.go
+++ b/pkg/server/api/files/v1/handler_test.go
@@ -266,7 +266,7 @@ func TestHandleGetFile_UnauthenticatedReturns401(t *testing.T) {
 
 	// NewMux with nil services — safe because auth middleware returns 401
 	// before any service is called when no credentials are present.
-	mux, err := NewMux(
+	mux := NewMux(
 		log.NewLogger(log.WithOutput(io.Discard)),
 		nil, // fileSvc — not reached
 		nil, // proboSvc — not reached
@@ -274,7 +274,6 @@ func TestHandleGetFile_UnauthenticatedReturns401(t *testing.T) {
 		securecookie.Config{},
 		"test-secret",
 	)
-	require.NoError(t, err)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/some-valid-looking-id", nil)

--- a/pkg/server/api/files/v1/handler_test.go
+++ b/pkg/server/api/files/v1/handler_test.go
@@ -36,7 +36,9 @@ import (
 func testHandler(t *testing.T) *Handler {
 	t.Helper()
 
-	staticFiles, err := newStaticFileServer(brand.Assets)
+	assets := testBrandAssets(t)
+
+	staticFiles, err := newStaticFileServer(assets)
 	require.NoError(t, err)
 
 	return &Handler{
@@ -54,10 +56,19 @@ func newStaticFileRequest(file string) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 }
 
+func testBrandAssets(t *testing.T) fs.FS {
+	t.Helper()
+
+	assets, err := brand.NewAssets()
+	require.NoError(t, err)
+
+	return assets
+}
+
 func readBrandAsset(t *testing.T, file string) []byte {
 	t.Helper()
 
-	content, err := fs.ReadFile(brand.Assets, file)
+	content, err := fs.ReadFile(testBrandAssets(t), file)
 	require.NoError(t, err)
 
 	return content

--- a/pkg/server/api/files/v1/handler_test.go
+++ b/pkg/server/api/files/v1/handler_test.go
@@ -166,6 +166,7 @@ func TestHandleGetStaticFile_CompressesGzipResponses(t *testing.T) {
 
 	gz, err := gzip.NewReader(rec.Body)
 	require.NoError(t, err)
+
 	defer func() { _ = gz.Close() }()
 
 	decompressed, err := io.ReadAll(gz)

--- a/pkg/server/api/files/v1/handler_test.go
+++ b/pkg/server/api/files/v1/handler_test.go
@@ -15,15 +15,21 @@
 package files_v1
 
 import (
+	"compress/gzip"
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/brand"
 	"go.probo.inc/probo/pkg/securecookie"
 )
 
@@ -31,6 +37,176 @@ func testHandler() *Handler {
 	return &Handler{
 		logger: log.NewLogger(log.WithOutput(io.Discard)),
 	}
+}
+
+func newStaticFileRequest(file string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/static/"+file, nil)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("file", file)
+
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+func readBrandAsset(t *testing.T, file string) []byte {
+	t.Helper()
+
+	content, err := fs.ReadFile(brand.Assets, file)
+	require.NoError(t, err)
+
+	return content
+}
+
+func etagForContent(content []byte) string {
+	hash := md5.Sum(content)
+
+	return `"` + hex.EncodeToString(hash[:]) + `"`
+}
+
+func TestHandleGetStaticFile_SetsCachingHeaders(t *testing.T) {
+	t.Parallel()
+
+	h := testHandler()
+	content := readBrandAsset(t, "probo.png")
+
+	rec := httptest.NewRecorder()
+	req := newStaticFileRequest("probo.png")
+
+	h.handleGetStaticFile(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "image/png", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "public, max-age=31536000, immutable", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "Accept-Encoding", rec.Header().Get("Vary"))
+	assert.Equal(t, etagForContent(content), rec.Header().Get("ETag"))
+	assert.Empty(t, rec.Header().Get("Content-Encoding"))
+	assert.Equal(t, content, rec.Body.Bytes())
+}
+
+func TestHandleGetStaticFile_ReturnsNotModifiedForMatchingETag(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"exact match",
+		func(t *testing.T) {
+			t.Parallel()
+
+			h := testHandler()
+			content := readBrandAsset(t, "probo.png")
+
+			rec := httptest.NewRecorder()
+			req := newStaticFileRequest("probo.png")
+			req.Header.Set("If-None-Match", etagForContent(content))
+
+			h.handleGetStaticFile(rec, req)
+
+			assert.Equal(t, http.StatusNotModified, rec.Code)
+			assert.Equal(t, "public, max-age=31536000, immutable", rec.Header().Get("Cache-Control"))
+			assert.Equal(t, etagForContent(content), rec.Header().Get("ETag"))
+			assert.Empty(t, rec.Body.String())
+		},
+	)
+
+	t.Run(
+		"gzip request with etag list",
+		func(t *testing.T) {
+			t.Parallel()
+
+			h := testHandler()
+			content := readBrandAsset(t, "probo.png")
+
+			rec := httptest.NewRecorder()
+			req := newStaticFileRequest("probo.png")
+			req.Header.Set("Accept-Encoding", "gzip")
+			req.Header.Set("If-None-Match", `"other", `+etagForContent(content))
+
+			h.handleGetStaticFile(rec, req)
+
+			assert.Equal(t, http.StatusNotModified, rec.Code)
+			assert.Equal(t, etagForContent(content), rec.Header().Get("ETag"))
+			assert.Empty(t, rec.Header().Get("Content-Encoding"))
+			assert.Empty(t, rec.Body.String())
+		},
+	)
+
+	t.Run(
+		"gzip request with weak etag",
+		func(t *testing.T) {
+			t.Parallel()
+
+			h := testHandler()
+			content := readBrandAsset(t, "probo.png")
+
+			rec := httptest.NewRecorder()
+			req := newStaticFileRequest("probo.png")
+			req.Header.Set("Accept-Encoding", "gzip")
+			req.Header.Set("If-None-Match", "W/"+etagForContent(content))
+
+			h.handleGetStaticFile(rec, req)
+
+			assert.Equal(t, http.StatusNotModified, rec.Code)
+			assert.Equal(t, etagForContent(content), rec.Header().Get("ETag"))
+			assert.Empty(t, rec.Header().Get("Content-Encoding"))
+			assert.Empty(t, rec.Body.String())
+		},
+	)
+}
+
+func TestHandleGetStaticFile_CompressesGzipResponses(t *testing.T) {
+	t.Parallel()
+
+	h := testHandler()
+	content := readBrandAsset(t, "probo.png")
+
+	rec := httptest.NewRecorder()
+	req := newStaticFileRequest("probo.png")
+	req.Header.Set("Accept-Encoding", "br, GZip;q=0.5")
+
+	h.handleGetStaticFile(rec, req)
+
+	gz, err := gzip.NewReader(rec.Body)
+	require.NoError(t, err)
+	defer func() { _ = gz.Close() }()
+
+	decompressed, err := io.ReadAll(gz)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "gzip", rec.Header().Get("Content-Encoding"))
+	assert.Equal(t, "Accept-Encoding", rec.Header().Get("Vary"))
+	assert.Equal(t, etagForContent(content), rec.Header().Get("ETag"))
+	assert.Equal(t, content, decompressed)
+}
+
+func TestHandleGetStaticFile_DoesNotCompressWhenGzipIsRefused(t *testing.T) {
+	t.Parallel()
+
+	h := testHandler()
+	content := readBrandAsset(t, "probo.png")
+
+	rec := httptest.NewRecorder()
+	req := newStaticFileRequest("probo.png")
+	req.Header.Set("Accept-Encoding", "br, gzip;q=0, *;q=1")
+
+	h.handleGetStaticFile(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get("Content-Encoding"))
+	assert.Equal(t, content, rec.Body.Bytes())
+}
+
+func TestHandleGetStaticFile_NotFound(t *testing.T) {
+	t.Parallel()
+
+	h := testHandler()
+
+	rec := httptest.NewRecorder()
+	req := newStaticFileRequest("missing.png")
+
+	h.handleGetStaticFile(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "file not found")
 }
 
 func TestHandleGetPublicFile_InvalidGID(t *testing.T) {

--- a/pkg/server/api/files/v1/handler_test.go
+++ b/pkg/server/api/files/v1/handler_test.go
@@ -36,7 +36,7 @@ import (
 func testHandler(t *testing.T) *Handler {
 	t.Helper()
 
-	staticFiles, err := NewStaticFileServer(brand.Assets)
+	staticFiles, err := newStaticFileServer(brand.Assets)
 	require.NoError(t, err)
 
 	return &Handler{
@@ -255,15 +255,15 @@ func TestHandleGetFile_UnauthenticatedReturns401(t *testing.T) {
 
 	// NewMux with nil services — safe because auth middleware returns 401
 	// before any service is called when no credentials are present.
-	mux := NewMux(
+	mux, err := NewMux(
 		log.NewLogger(log.WithOutput(io.Discard)),
 		nil, // fileSvc — not reached
 		nil, // proboSvc — not reached
 		nil, // iamSvc — not reached when no token/cookie present
-		nil, // staticFiles — not reached
 		securecookie.Config{},
 		"test-secret",
 	)
+	require.NoError(t, err)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/some-valid-looking-id", nil)

--- a/pkg/server/api/files/v1/handler_test.go
+++ b/pkg/server/api/files/v1/handler_test.go
@@ -33,9 +33,15 @@ import (
 	"go.probo.inc/probo/pkg/securecookie"
 )
 
-func testHandler() *Handler {
+func testHandler(t *testing.T) *Handler {
+	t.Helper()
+
+	staticFiles, err := NewStaticFileServer(brand.Assets)
+	require.NoError(t, err)
+
 	return &Handler{
-		logger: log.NewLogger(log.WithOutput(io.Discard)),
+		logger:      log.NewLogger(log.WithOutput(io.Discard)),
+		staticFiles: staticFiles,
 	}
 }
 
@@ -66,7 +72,7 @@ func etagForContent(content []byte) string {
 func TestHandleGetStaticFile_SetsCachingHeaders(t *testing.T) {
 	t.Parallel()
 
-	h := testHandler()
+	h := testHandler(t)
 	content := readBrandAsset(t, "probo.png")
 
 	rec := httptest.NewRecorder()
@@ -91,7 +97,7 @@ func TestHandleGetStaticFile_ReturnsNotModifiedForMatchingETag(t *testing.T) {
 		func(t *testing.T) {
 			t.Parallel()
 
-			h := testHandler()
+			h := testHandler(t)
 			content := readBrandAsset(t, "probo.png")
 
 			rec := httptest.NewRecorder()
@@ -112,7 +118,7 @@ func TestHandleGetStaticFile_ReturnsNotModifiedForMatchingETag(t *testing.T) {
 		func(t *testing.T) {
 			t.Parallel()
 
-			h := testHandler()
+			h := testHandler(t)
 			content := readBrandAsset(t, "probo.png")
 
 			rec := httptest.NewRecorder()
@@ -134,7 +140,7 @@ func TestHandleGetStaticFile_ReturnsNotModifiedForMatchingETag(t *testing.T) {
 		func(t *testing.T) {
 			t.Parallel()
 
-			h := testHandler()
+			h := testHandler(t)
 			content := readBrandAsset(t, "probo.png")
 
 			rec := httptest.NewRecorder()
@@ -155,7 +161,7 @@ func TestHandleGetStaticFile_ReturnsNotModifiedForMatchingETag(t *testing.T) {
 func TestHandleGetStaticFile_CompressesGzipResponses(t *testing.T) {
 	t.Parallel()
 
-	h := testHandler()
+	h := testHandler(t)
 	content := readBrandAsset(t, "probo.png")
 
 	rec := httptest.NewRecorder()
@@ -182,7 +188,7 @@ func TestHandleGetStaticFile_CompressesGzipResponses(t *testing.T) {
 func TestHandleGetStaticFile_DoesNotCompressWhenGzipIsRefused(t *testing.T) {
 	t.Parallel()
 
-	h := testHandler()
+	h := testHandler(t)
 	content := readBrandAsset(t, "probo.png")
 
 	rec := httptest.NewRecorder()
@@ -199,7 +205,7 @@ func TestHandleGetStaticFile_DoesNotCompressWhenGzipIsRefused(t *testing.T) {
 func TestHandleGetStaticFile_NotFound(t *testing.T) {
 	t.Parallel()
 
-	h := testHandler()
+	h := testHandler(t)
 
 	rec := httptest.NewRecorder()
 	req := newStaticFileRequest("missing.png")
@@ -213,7 +219,7 @@ func TestHandleGetStaticFile_NotFound(t *testing.T) {
 func TestHandleGetPublicFile_InvalidGID(t *testing.T) {
 	t.Parallel()
 
-	h := testHandler()
+	h := testHandler(t)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/public/not-a-valid-gid", nil)
@@ -230,7 +236,7 @@ func TestHandleGetPublicFile_InvalidGID(t *testing.T) {
 func TestHandleGetFile_InvalidGID(t *testing.T) {
 	t.Parallel()
 
-	h := testHandler()
+	h := testHandler(t)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/not-a-valid-gid", nil)
@@ -254,6 +260,7 @@ func TestHandleGetFile_UnauthenticatedReturns401(t *testing.T) {
 		nil, // fileSvc — not reached
 		nil, // proboSvc — not reached
 		nil, // iamSvc — not reached when no token/cookie present
+		nil, // staticFiles — not reached
 		securecookie.Config{},
 		"test-secret",
 	)

--- a/pkg/server/api/files/v1/static_file.go
+++ b/pkg/server/api/files/v1/static_file.go
@@ -143,7 +143,7 @@ func shouldCompressStaticFile(r *http.Request) bool {
 
 	gzipQ := -1.0
 	wildcardQ := -1.0
-	for _, encoding := range strings.Split(r.Header.Get("Accept-Encoding"), ",") {
+	for encoding := range strings.SplitSeq(r.Header.Get("Accept-Encoding"), ",") {
 		encoding, q := parseAcceptEncoding(encoding)
 		switch encoding {
 		case "gzip":
@@ -181,7 +181,7 @@ func parseAcceptEncoding(encoding string) (string, float64) {
 }
 
 func ifNoneMatch(header string, etag string) bool {
-	for _, candidate := range strings.Split(header, ",") {
+	for candidate := range strings.SplitSeq(header, ",") {
 		candidate = strings.TrimSpace(candidate)
 		if candidate == "*" {
 			return true
@@ -199,7 +199,7 @@ func ifNoneMatch(header string, etag string) bool {
 
 func addVary(h http.Header, value string) {
 	for _, vary := range h.Values("Vary") {
-		for _, field := range strings.Split(vary, ",") {
+		for field := range strings.SplitSeq(vary, ",") {
 			if strings.EqualFold(strings.TrimSpace(field), value) {
 				return
 			}

--- a/pkg/server/api/files/v1/static_file.go
+++ b/pkg/server/api/files/v1/static_file.go
@@ -80,6 +80,7 @@ func newStaticFileServer(files fs.FS) (*staticFileServer, error) {
 			}
 
 			hash := md5.Sum(content)
+
 			contentType := mime.TypeByExtension(filepath.Ext(path))
 			if contentType == "" {
 				contentType = http.DetectContentType(content)
@@ -143,6 +144,7 @@ func shouldCompressStaticFile(r *http.Request) bool {
 
 	gzipQ := -1.0
 	wildcardQ := -1.0
+
 	for encoding := range strings.SplitSeq(r.Header.Get("Accept-Encoding"), ",") {
 		encoding, q := parseAcceptEncoding(encoding)
 		switch encoding {
@@ -189,6 +191,7 @@ func ifNoneMatch(header string, etag string) bool {
 
 		candidate = strings.TrimPrefix(candidate, "W/")
 		candidate = strings.TrimPrefix(candidate, "w/")
+
 		if candidate == etag {
 			return true
 		}

--- a/pkg/server/api/files/v1/static_file.go
+++ b/pkg/server/api/files/v1/static_file.go
@@ -32,7 +32,7 @@ import (
 const staticFileCacheControl = "public, max-age=31536000, immutable"
 
 type (
-	StaticFileServer struct {
+	staticFileServer struct {
 		files map[string]staticFile
 	}
 
@@ -44,8 +44,8 @@ type (
 	}
 )
 
-func NewStaticFileServer(files fs.FS) (*StaticFileServer, error) {
-	server := &StaticFileServer{
+func newStaticFileServer(files fs.FS) (*staticFileServer, error) {
+	server := &staticFileServer{
 		files: make(map[string]staticFile),
 	}
 
@@ -90,7 +90,7 @@ func NewStaticFileServer(files fs.FS) (*StaticFileServer, error) {
 	return server, nil
 }
 
-func (s *StaticFileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, file string) bool {
+func (s *staticFileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, file string) bool {
 	asset, ok := s.files[file]
 	if !ok {
 		return false

--- a/pkg/server/api/files/v1/static_file.go
+++ b/pkg/server/api/files/v1/static_file.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package files_v1
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"mime"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.probo.inc/probo/pkg/brand"
+)
+
+const staticFileCacheControl = "public, max-age=31536000, immutable"
+
+type (
+	staticFileServer struct {
+		files map[string]staticFile
+	}
+
+	staticFile struct {
+		content     []byte
+		contentType string
+		etag        string
+		name        string
+	}
+)
+
+var defaultStaticFileServer = mustNewStaticFileServer(brand.Assets)
+
+func mustNewStaticFileServer(files fs.FS) *staticFileServer {
+	server, err := newStaticFileServer(files)
+	if err != nil {
+		panic(err)
+	}
+
+	return server
+}
+
+func newStaticFileServer(files fs.FS) (*staticFileServer, error) {
+	server := &staticFileServer{
+		files: make(map[string]staticFile),
+	}
+
+	err := fs.WalkDir(
+		files,
+		".",
+		func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return fmt.Errorf("cannot walk static file: %w", err)
+			}
+
+			if d.IsDir() {
+				return nil
+			}
+
+			content, err := fs.ReadFile(files, path)
+			if err != nil {
+				return fmt.Errorf("cannot read static file: %w", err)
+			}
+
+			hash := md5.Sum(content)
+			contentType := mime.TypeByExtension(filepath.Ext(path))
+			if contentType == "" {
+				contentType = http.DetectContentType(content)
+			}
+
+			server.files[path] = staticFile{
+				content:     content,
+				contentType: contentType,
+				etag:        `"` + hex.EncodeToString(hash[:]) + `"`,
+				name:        path,
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot index static files: %w", err)
+	}
+
+	return server, nil
+}
+
+func (s *staticFileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, file string) bool {
+	asset, ok := s.files[file]
+	if !ok {
+		return false
+	}
+
+	h := w.Header()
+	h.Set("Cache-Control", staticFileCacheControl)
+	h.Set("Content-Type", asset.contentType)
+	h.Set("ETag", asset.etag)
+	addVary(h, "Accept-Encoding")
+
+	if ifNoneMatch(r.Header.Get("If-None-Match"), asset.etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return true
+	}
+
+	if shouldCompressStaticFile(r) {
+		h.Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusOK)
+
+		gz := gzip.NewWriter(w)
+		defer func() { _ = gz.Close() }()
+
+		_, _ = gz.Write(asset.content)
+
+		return true
+	}
+
+	http.ServeContent(w, r, asset.name, time.Time{}, bytes.NewReader(asset.content))
+
+	return true
+}
+
+func shouldCompressStaticFile(r *http.Request) bool {
+	if r.Header.Get("Range") != "" {
+		return false
+	}
+
+	gzipQ := -1.0
+	wildcardQ := -1.0
+	for _, encoding := range strings.Split(r.Header.Get("Accept-Encoding"), ",") {
+		encoding, q := parseAcceptEncoding(encoding)
+		switch encoding {
+		case "gzip":
+			gzipQ = q
+		case "*":
+			wildcardQ = q
+		}
+	}
+
+	if gzipQ >= 0 {
+		return gzipQ > 0
+	}
+
+	return wildcardQ > 0
+}
+
+func parseAcceptEncoding(encoding string) (string, float64) {
+	parts := strings.Split(encoding, ";")
+	token := strings.ToLower(strings.TrimSpace(parts[0]))
+	q := 1.0
+
+	for _, param := range parts[1:] {
+		key, value, ok := strings.Cut(strings.TrimSpace(param), "=")
+		if !ok || !strings.EqualFold(key, "q") {
+			continue
+		}
+
+		parsedQ, err := strconv.ParseFloat(value, 64)
+		if err == nil {
+			q = parsedQ
+		}
+	}
+
+	return token, q
+}
+
+func ifNoneMatch(header string, etag string) bool {
+	for _, candidate := range strings.Split(header, ",") {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "*" {
+			return true
+		}
+
+		candidate = strings.TrimPrefix(candidate, "W/")
+		candidate = strings.TrimPrefix(candidate, "w/")
+		if candidate == etag {
+			return true
+		}
+	}
+
+	return false
+}
+
+func addVary(h http.Header, value string) {
+	for _, vary := range h.Values("Vary") {
+		for _, field := range strings.Split(vary, ",") {
+			if strings.EqualFold(strings.TrimSpace(field), value) {
+				return
+			}
+		}
+	}
+
+	if h.Get("Vary") == "" {
+		h.Set("Vary", value)
+		return
+	}
+
+	h.Add("Vary", value)
+}

--- a/pkg/server/api/files/v1/static_file.go
+++ b/pkg/server/api/files/v1/static_file.go
@@ -27,14 +27,12 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"go.probo.inc/probo/pkg/brand"
 )
 
 const staticFileCacheControl = "public, max-age=31536000, immutable"
 
 type (
-	staticFileServer struct {
+	StaticFileServer struct {
 		files map[string]staticFile
 	}
 
@@ -46,19 +44,8 @@ type (
 	}
 )
 
-var defaultStaticFileServer = mustNewStaticFileServer(brand.Assets)
-
-func mustNewStaticFileServer(files fs.FS) *staticFileServer {
-	server, err := newStaticFileServer(files)
-	if err != nil {
-		panic(err)
-	}
-
-	return server
-}
-
-func newStaticFileServer(files fs.FS) (*staticFileServer, error) {
-	server := &staticFileServer{
+func NewStaticFileServer(files fs.FS) (*StaticFileServer, error) {
+	server := &StaticFileServer{
 		files: make(map[string]staticFile),
 	}
 
@@ -103,7 +90,7 @@ func newStaticFileServer(files fs.FS) (*staticFileServer, error) {
 	return server, nil
 }
 
-func (s *staticFileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, file string) bool {
+func (s *StaticFileServer) ServeHTTP(w http.ResponseWriter, r *http.Request, file string) bool {
 	asset, ok := s.files[file]
 	if !ok {
 		return false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Serve files API static assets through an indexed embedded asset server
- Add immutable cache headers, stable ETags, conditional 304 handling, and gzip negotiation
- Cover cache, ETag, gzip, refused gzip, and 404 behavior with focused tests
- Apply the Go 1.26 `go fix` iterator rewrite required by lint-go
- Satisfy `wsl_v5` whitespace lint around the new static asset code

## Verification
- `go test ./pkg/server/api/files/v1`
- `make go-fmt`
- `make test MODULE=./pkg/server/api/files/v1`
- `CGO_ENABLED=0 GOOS= go fix -omitzero=false ./pkg/server/api/files/v1`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-484](https://linear.app/probo/issue/ENG-484/rework-the-filesv1staticxxx-to-set-the-full-needed-headers-and)

<div><a href="https://cursor.com/agents/bc-909d1777-c128-4e65-b516-f2d3c3d6a7b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-909d1777-c128-4e65-b516-f2d3c3d6a7b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve `pkg/server/api/files/v1` static assets via an indexed embedded server with immutable cache headers, stable ETags, conditional 304s, and gzip; adds `Vary: Accept-Encoding` and Go 1.26 iterator parsing. Built in the files mux from `brand.NewAssets()` with panics on init failure; meets ENG-484.

### GraphQL API **`+226`** **`-11`**
Added `static_file.go` indexed server that sets `Cache-Control`, `ETag`, and `Vary: Accept-Encoding`, supports gzip and `If-None-Match` 304s, and uses `strings.SplitSeq`; satisfies `wsl_v5`. Updated `handler.go` to construct the server from `brand.NewAssets()` in `NewMux`, store it on the handler, and delegate `handleGetStaticFile`.

### Tests **`+231`** **`-4`**
Added focused tests for cache headers, ETag matching (exact, weak, list), gzip negotiation/refusal, and 404. Added `pkg/brand/brand_test.go` to confirm embedded assets.

### Service **`+2`** **`-9`**
Replaced global `brand.Assets` with `brand.NewAssets()` and removed `init` panic-based setup.

<sup>Written for commit 89cf80404eabe4f0a9bcfd0cc86f50f7213d56e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

