### PR TITLE
Retry DNS TXT lookup over TCP on truncated UDP response

### DIFF
--- a/pkg/iam/saml_domain_verifier.go
+++ b/pkg/iam/saml_domain_verifier.go
@@ -168,7 +168,7 @@ func (v *SAMLDomainVerifier) tryVerifyDomain(ctx context.Context, configID gid.G
 
 			expectedValue := txtRecordValuePrefix + *config.DomainVerificationToken
 
-			if err := v.checkDNSTXTRecord(config.EmailDomain, expectedValue); err != nil {
+			if err := v.checkDNSTXTRecord(ctx, config.EmailDomain, expectedValue); err != nil {
 				return err
 			}
 
@@ -194,20 +194,21 @@ func (v *SAMLDomainVerifier) tryVerifyDomain(ctx context.Context, configID gid.G
 	)
 }
 
-func (v *SAMLDomainVerifier) checkDNSTXTRecord(emailDomain string, expectedValue string) error {
-	fqdn := emailDomain
-	if !strings.HasSuffix(fqdn, ".") {
-		fqdn = fqdn + "."
-	}
-
-	msg := &dns.Msg{MsgHeader: dns.MsgHeader{ID: dns.ID(), RecursionDesired: true}}
-	msg.Question = []dns.RR{&dns.TXT{Hdr: dns.Header{Name: fqdn, Class: dns.ClassINET}}}
+func (v *SAMLDomainVerifier) checkDNSTXTRecord(ctx context.Context, emailDomain string, expectedValue string) error {
+	msg := dns.NewMsg(emailDomain, dns.TypeTXT)
 
 	client := dns.NewClient()
 
-	resp, _, err := client.Exchange(context.Background(), msg, "udp", v.resolverAddr)
+	resp, _, err := client.Exchange(ctx, msg, "udp", v.resolverAddr)
 	if err != nil {
 		return fmt.Errorf("cannot query TXT record for %q: %w", emailDomain, err)
+	}
+
+	if resp.Truncated {
+		resp, _, err = client.Exchange(ctx, msg, "tcp", v.resolverAddr)
+		if err != nil {
+			return fmt.Errorf("cannot query TXT record for %q over TCP: %w", emailDomain, err)
+		}
 	}
 
 	if resp.Rcode != dns.RcodeSuccess {
@@ -224,9 +225,7 @@ func (v *SAMLDomainVerifier) checkDNSTXTRecord(emailDomain string, expectedValue
 			continue
 		}
 
-		value := strings.Join(txt.Txt, "")
-
-		if value == expectedValue {
+		if strings.Join(txt.Txt, "") == expectedValue {
 			return nil
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #1335

- DNS TXT queries use UDP by default (512-byte limit). When a domain has multiple TXT records (SPF, DKIM, Google Search Console, etc.), the DNS server sets the TC (Truncated) bit and omits records that don't fit.
- The verifier was not checking `resp.Truncated`, so any response truncated before the `probo-verification=…` record would silently fail as a mismatch.
- Fix: check `resp.Truncated` after the UDP exchange and retry the query over TCP, which has no size limit.

Also fixes two minor issues in the same function: `context.Background()` was used instead of the caller's `ctx`, and message construction is simplified with `dns.NewMsg`.

## Test plan

- [ ] Verify that a domain with many TXT records (e.g. SPF + DKIM + Google + probo) completes domain verification successfully
- [ ] Verify that a domain with no matching TXT record still returns `errDomainTXTRecordMismatch`
- [ ] Verify that a domain with no TXT records at all still returns `errDomainTXTRecordNotFound`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry DNS TXT lookups over TCP when the UDP response is truncated to prevent false “record mismatch” during domain verification. Also passes the caller’s context and simplifies DNS query construction.

### Service **`+12`** **`-13`**
- Detect `resp.Truncated` after UDP and retry the TXT query over TCP.
- Use `ctx` in `dns.Client.Exchange` instead of `context.Background`.
- Build the query with `dns.NewMsg(emailDomain, dns.TypeTXT)` and inline TXT join for comparison.

<sup>Written for commit 95a12d338bf18905002d96234227fb6aee898d10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

