### PR TITLE
Fix S3 filename header escaping

### DIFF
--- a/pkg/filemanager/s3.go
+++ b/pkg/filemanager/s3.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -118,11 +119,10 @@ func (s *Service) GeneratePresignedURL(
 ) (string, error) {
 	presignClient := s3.NewPresignClient(s.s3Client)
 
-	encodedFilename := url.QueryEscape(file.FileName)
 	contentDisposition := fmt.Sprintf(
 		"attachment; filename=%q; filename*=UTF-8''%s",
-		encodedFilename,
-		encodedFilename,
+		asciiFilename(file.FileName),
+		url.PathEscape(file.FileName),
 	)
 
 	presignedReq, err := presignClient.PresignGetObject(
@@ -143,6 +143,22 @@ func (s *Service) GeneratePresignedURL(
 	}
 
 	return presignedReq.URL, nil
+}
+
+func asciiFilename(filename string) string {
+	var b strings.Builder
+	b.Grow(len(filename))
+
+	for _, r := range filename {
+		if r < 0x20 || r > 0x7e {
+			b.WriteByte('_')
+			continue
+		}
+
+		b.WriteRune(r)
+	}
+
+	return b.String()
 }
 
 // GetFileSize determines the byte size of a seekable io.Reader by seeking to

--- a/pkg/filemanager/url_test.go
+++ b/pkg/filemanager/url_test.go
@@ -15,9 +15,16 @@
 package filemanager_test
 
 import (
+	"context"
+	"net/url"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/filemanager"
@@ -63,5 +70,35 @@ func TestGenerateFileURL_PrivateFile(t *testing.T) {
 		t,
 		"https://app.example.com/api/files/v1/"+file.ID.String(),
 		svc.GenerateFileURL(file),
+	)
+}
+
+func TestGeneratePresignedFileURL_EscapesContentDispositionFilename(t *testing.T) {
+	t.Parallel()
+
+	s3Client := awss3.NewFromConfig(
+		aws.Config{
+			Region:      "us-east-1",
+			Credentials: credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
+		},
+	)
+	svc := filemanager.NewService(nil, nil, s3Client)
+	file := &coredata.File{
+		BucketName: "uploads",
+		FileKey:    "tenant/file",
+		FileName:   `report "Q2"/résumé 100%.pdf`,
+		MimeType:   "application/pdf",
+	}
+
+	rawURL, err := svc.GeneratePresignedFileURL(context.Background(), file, time.Hour)
+	require.NoError(t, err)
+
+	parsedURL, err := url.Parse(rawURL)
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		`attachment; filename="report \"Q2\"/r_sum_ 100%.pdf"; filename*=UTF-8''report%20%22Q2%22%2Fr%C3%A9sum%C3%A9%20100%25.pdf`,
+		parsedURL.Query().Get("response-content-disposition"),
 	)
 }

--- a/pkg/filemanager/url_test.go
+++ b/pkg/filemanager/url_test.go
@@ -73,7 +73,7 @@ func TestGenerateFileURL_PrivateFile(t *testing.T) {
 	)
 }
 
-func TestGeneratePresignedFileURL_EscapesContentDispositionFilename(t *testing.T) {
+func TestGeneratePresignedURL_EscapesContentDispositionFilename(t *testing.T) {
 	t.Parallel()
 
 	s3Client := awss3.NewFromConfig(
@@ -90,7 +90,7 @@ func TestGeneratePresignedFileURL_EscapesContentDispositionFilename(t *testing.T
 		MimeType:   "application/pdf",
 	}
 
-	rawURL, err := svc.GeneratePresignedFileURL(context.Background(), file, time.Hour)
+	rawURL, err := svc.GeneratePresignedURL(context.Background(), file, time.Hour)
 	require.NoError(t, err)
 
 	parsedURL, err := url.Parse(rawURL)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add RFC 5987 `filename*` escaping with `url.PathEscape` for filemanager presigned S3 URLs
- Add an ASCII-only quoted fallback for the legacy `filename` parameter
- Cover the presigned URL `response-content-disposition` value with a regression test

## Verification
- Red state observed: `go test ./pkg/filemanager` failed on the new encoding assertion before the production change
- `go test ./pkg/filemanager` passed
- Code-review subagent reran `go test ./pkg/filemanager` and `go test ./pkg/filemanager -run TestGeneratePresignedFileURL_EscapesContentDispositionFilename -count=1`; both passed
- `go test ./pkg/...` was attempted but is blocked in this workspace by missing generated/embed artifacts (`packages/emails dist`, `apps/trust dist`, `apps/console dist`, and generated GraphQL/MCP type symbols)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-491](https://linear.app/probo/issue/ENG-491/fix-content-disposition-escaping-in-s3-upload-service)

<div><a href="https://cursor.com/agents/bc-51e2b765-910c-47ce-90e4-8bef858c30ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51e2b765-910c-47ce-90e4-8bef858c30ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Content-Disposition filename escaping for presigned S3 download URLs (ENG-491). Uses RFC 5987 `filename*` with `url.PathEscape` and an ASCII-only quoted `filename` fallback so spaces and Unicode filenames work across browsers.

### Service **`+19`** **`-3`**
- Build header as: attachment; filename="<ascii>"; filename*=UTF-8''<path-escaped>.
- Replace `url.QueryEscape` with `url.PathEscape` for `filename*`.

### Tests **`+37`** **`-0`**
- Add regression test for `response-content-disposition` (quotes, slashes, Unicode, `%`) using the split service method.

<sup>Written for commit 6c74a9fe6eae035e5507c6d99ff553d764ec5740. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

