### PR TITLE
Expose role on MCP listUsers and getUser

### DIFF
--- a/e2e/mcp/user_test.go
+++ b/e2e/mcp/user_test.go
@@ -48,22 +48,35 @@ func TestMCP_User_CRUD(t *testing.T) {
 	// Get
 	var getResult struct {
 		User struct {
-			ID string `json:"id"`
+			ID   string `json:"id"`
+			Role string `json:"role"`
 		} `json:"user"`
 	}
 	mc.CallToolInto("getUser", map[string]any{
 		"id": createResult.User.ID,
 	}, &getResult)
 	assert.Equal(t, createResult.User.ID, getResult.User.ID)
+	assert.Equal(t, "EMPLOYEE", getResult.User.Role)
 
 	// List
 	var listResult struct {
 		Users []struct {
-			ID string `json:"id"`
+			ID   string `json:"id"`
+			Role string `json:"role"`
 		} `json:"users"`
 	}
 	mc.CallToolInto("listUsers", map[string]any{
 		"organizationId": orgID,
 	}, &listResult)
-	assert.NotEmpty(t, listResult.Users)
+	require.NotEmpty(t, listResult.Users)
+
+	var foundRole bool
+	for _, user := range listResult.Users {
+		if user.Role != "" {
+			foundRole = true
+			break
+		}
+	}
+
+	assert.True(t, foundRole)
 }

--- a/pkg/coredata/membership.go
+++ b/pkg/coredata/membership.go
@@ -419,3 +419,55 @@ LIMIT 1
 
 	return nil
 }
+
+func (ms *Memberships) LoadByIdentityIDsAndOrganizationID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	organizationID gid.GID,
+	identityIDs []gid.GID,
+) error {
+	if len(identityIDs) == 0 {
+		*ms = nil
+
+		return nil
+	}
+
+	q := `
+SELECT
+    id,
+    identity_id,
+    organization_id,
+    role,
+    created_at,
+    updated_at
+FROM
+    iam_memberships
+WHERE
+    organization_id = @organization_id
+    AND identity_id = ANY(@identity_ids)
+    AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"organization_id": organizationID,
+		"identity_ids":    identityIDs,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query memberships: %w", err)
+	}
+
+	memberships, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[Membership])
+	if err != nil {
+		return fmt.Errorf("cannot collect memberships: %w", err)
+	}
+
+	*ms = memberships
+
+	return nil
+}

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1306,6 +1306,48 @@ func (s *OrganizationService) ListProfiles(
 	return page.NewPage(profiles, cursor), nil
 }
 
+func (s *OrganizationService) GetMembershipRolesByIdentityIDs(
+	ctx context.Context,
+	organizationID gid.GID,
+	identityIDs []gid.GID,
+) (map[gid.GID]coredata.MembershipRole, error) {
+	if len(identityIDs) == 0 {
+		return map[gid.GID]coredata.MembershipRole{}, nil
+	}
+
+	var (
+		scope       = coredata.NewScopeFromObjectID(organizationID)
+		memberships coredata.Memberships
+	)
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := memberships.LoadByIdentityIDsAndOrganizationID(
+				ctx,
+				conn,
+				scope,
+				organizationID,
+				identityIDs,
+			); err != nil {
+				return fmt.Errorf("cannot load memberships: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	roles := make(map[gid.GID]coredata.MembershipRole, len(memberships))
+	for _, membership := range memberships {
+		roles[membership.IdentityID] = membership.Role
+	}
+
+	return roles, nil
+}
+
 func (s OrganizationService) CountProfiles(
 	ctx context.Context,
 	organizationID gid.GID,

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2774,9 +2774,24 @@ func (r *Resolver) ListUsersTool(ctx context.Context, req *mcp.CallToolRequest, 
 		return nil, types.ListUsersOutput{}, fmt.Errorf("list users: %w", err)
 	}
 
+	identityIDs := make([]gid.GID, 0, len(pageResult.Data))
+	for _, p := range pageResult.Data {
+		identityIDs = append(identityIDs, p.IdentityID)
+	}
+
+	roles, err := r.iamSvc.OrganizationService.GetMembershipRolesByIdentityIDs(ctx, input.OrganizationID, identityIDs)
+	if err != nil {
+		return nil, types.ListUsersOutput{}, fmt.Errorf("list user roles: %w", err)
+	}
+
 	users := make([]*types.Profile, 0, len(pageResult.Data))
 	for _, p := range pageResult.Data {
-		users = append(users, types.NewProfile(p))
+		var role *coredata.MembershipRole
+		if r, ok := roles[p.IdentityID]; ok {
+			role = &r
+		}
+
+		users = append(users, types.NewProfile(p, role))
 	}
 
 	var nextCursor *page.CursorKey
@@ -2806,7 +2821,18 @@ func (r *Resolver) GetUserTool(ctx context.Context, req *mcp.CallToolRequest, in
 		return nil, types.GetUserOutput{}, err
 	}
 
-	return nil, types.GetUserOutput{User: types.NewProfile(profile)}, nil
+	var role *coredata.MembershipRole
+
+	membership, err := r.iamSvc.AccountService.GetMembershipForOrganization(ctx, profile.IdentityID, profile.OrganizationID)
+	if err != nil {
+		if !errors.Is(err, coredata.ErrResourceNotFound) {
+			return nil, types.GetUserOutput{}, fmt.Errorf("get user role: %w", err)
+		}
+	} else {
+		role = &membership.Role
+	}
+
+	return nil, types.GetUserOutput{User: types.NewProfile(profile, role)}, nil
 }
 
 func (r *Resolver) CreateUserTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateUserInput) (*mcp.CallToolResult, types.CreateUserOutput, error) {
@@ -2842,7 +2868,7 @@ func (r *Resolver) CreateUserTool(ctx context.Context, req *mcp.CallToolRequest,
 		return nil, types.CreateUserOutput{}, fmt.Errorf("create user: %w", err)
 	}
 
-	return nil, types.CreateUserOutput{User: types.NewProfile(profile)}, nil
+	return nil, types.CreateUserOutput{User: types.NewProfile(profile, nil)}, nil
 }
 
 func (r *Resolver) InviteUserTool(ctx context.Context, req *mcp.CallToolRequest, input *types.InviteUserInput) (*mcp.CallToolResult, types.InviteUserOutput, error) {
@@ -2906,7 +2932,7 @@ func (r *Resolver) UpdateUserTool(ctx context.Context, req *mcp.CallToolRequest,
 		return nil, types.UpdateUserOutput{}, fmt.Errorf("update user: %w", err)
 	}
 
-	return nil, types.UpdateUserOutput{User: types.NewProfile(profile)}, nil
+	return nil, types.UpdateUserOutput{User: types.NewProfile(profile, nil)}, nil
 }
 
 func (r *Resolver) UpdateMembershipTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateMembershipInput) (*mcp.CallToolResult, types.UpdateMembershipOutput, error) {

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -537,6 +537,11 @@ components:
             - "null"
           format: date-time
           description: Contract end date
+        role:
+          anyOf:
+            - $ref: "#/components/schemas/MembershipRole"
+            - type: "null"
+          description: Membership role in the organization
         created_at:
           type: string
           format: date-time

--- a/pkg/server/api/mcp/v1/types/profile.go
+++ b/pkg/server/api/mcp/v1/types/profile.go
@@ -16,7 +16,7 @@ package types
 
 import "go.probo.inc/probo/pkg/coredata"
 
-func NewProfile(p *coredata.MembershipProfile) *Profile {
+func NewProfile(p *coredata.MembershipProfile, role *coredata.MembershipRole) *Profile {
 	return &Profile{
 		ID:                       p.ID,
 		OrganizationID:           p.OrganizationID,
@@ -29,6 +29,7 @@ func NewProfile(p *coredata.MembershipProfile) *Profile {
 		Position:                 p.Position,
 		ContractStartDate:        p.ContractStartDate,
 		ContractEndDate:          p.ContractEndDate,
+		Role:                     role,
 		CreatedAt:                p.CreatedAt,
 		UpdatedAt:                p.UpdatedAt,
 	}


### PR DESCRIPTION
## Summary

- Add a nullable `role` field (`MembershipRole`) to the MCP `Profile` schema
- Populate `role` in `listUsers` via a batch membership lookup by identity ID
- Populate `role` in `getUser` via `GetMembershipForOrganization` (`null` when no membership)
- Add `Memberships.LoadByIdentityIDsAndOrganizationID` and `OrganizationService.GetMembershipRolesByIdentityIDs` to avoid N+1 queries on list

## Test plan

- [ ] `go generate ./pkg/server/api/mcp/v1`
- [ ] `go test ./pkg/coredata/... ./pkg/iam/... ./pkg/server/api/mcp/v1/...`
- [ ] `go test ./e2e/mcp/... -run TestMCP_User_CRUD`
- [ ] Call `getUser` on a user created with `role: EMPLOYEE` and confirm `role` is returned
- [ ] Call `listUsers` and confirm each user includes a `role`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose membership role on MCP `listUsers` and `getUser` responses. Adds a nullable `role` to the Profile schema and batches role lookups to avoid N+1 queries.

### MCP **`+37`** **`-5`**
- Add nullable `role` to Profile in `specification.yaml` and wire it through `types.NewProfile(p, role)`.
- `listUsers`: batch fetch roles via `OrganizationService.GetMembershipRolesByIdentityIDs` and attach by `IdentityID`.
- `getUser`: fetch role via `AccountService.GetMembershipForOrganization`; return null when not found.
- Update create/update user paths to pass `nil` role.

### Service **`+42`** **`-0`**
- Add `OrganizationService.GetMembershipRolesByIdentityIDs` to return a `map[IdentityID]MembershipRole` for an org using a single query.

### Coredata **`+52`** **`-0`**
- Add `Memberships.LoadByIdentityIDsAndOrganizationID` to load memberships for an org and a set of identity IDs, respecting scope.

### Tests **`+16`** **`-3`**
- Extend `TestMCP_User_CRUD` to assert `getUser` returns `role: EMPLOYEE`.
- Verify `listUsers` includes at least one user with a non-empty role and use `require.NotEmpty` for the list.

<sup>Written for commit 133e0108837c9701aaeb89dd66c942b43e295559. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

