### PR TITLE
Fix trust center file creation in console

### DIFF
--- a/pkg/coredata/migrations/20260612T074402Z.sql
+++ b/pkg/coredata/migrations/20260612T074402Z.sql
@@ -1,0 +1,23 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+-- Backfill organization_id on compliance page file uploads that were inserted
+-- with the nil GID. Before the fix in TrustCenterFileService.uploadFile, the
+-- OrganizationID field was omitted from the File struct.
+
+UPDATE files
+SET organization_id = o.id
+FROM organizations o
+WHERE files.organization_id = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+  AND files.tenant_id = o.tenant_id;

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -2212,15 +2212,16 @@ func (s *DocumentService) BuildAndUploadExport(ctx context.Context, scope coreda
 			now := time.Now()
 
 			file := coredata.File{
-				ID:         gid.New(exportJob.ID.TenantID(), coredata.FileEntityType),
-				BucketName: s.svc.bucket,
-				MimeType:   "application/zip",
-				FileName:   fmt.Sprintf("Documents Export %s.zip", now.Format("2006-01-02")),
-				FileKey:    uuid.String(),
-				FileSize:   fileInfo.Size(),
-				Visibility: coredata.FileVisibilityPrivate,
-				CreatedAt:  now,
-				UpdatedAt:  now,
+				ID:             gid.New(exportJob.ID.TenantID(), coredata.FileEntityType),
+				OrganizationID: organizationID,
+				BucketName:     s.svc.bucket,
+				MimeType:       "application/zip",
+				FileName:       fmt.Sprintf("Documents Export %s.zip", now.Format("2006-01-02")),
+				FileKey:        uuid.String(),
+				FileSize:       fileInfo.Size(),
+				Visibility:     coredata.FileVisibilityPrivate,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 			}
 
 			if err := file.Insert(ctx, tx, scope); err != nil {

--- a/pkg/probo/framework_service.go
+++ b/pkg/probo/framework_service.go
@@ -802,15 +802,16 @@ func (s *FrameworkService) BuildAndUploadExport(ctx context.Context, scope cored
 			now := time.Now()
 
 			file := coredata.File{
-				ID:         gid.New(exportJob.ID.TenantID(), coredata.FileEntityType),
-				BucketName: s.svc.bucket,
-				MimeType:   "application/zip",
-				FileName:   fmt.Sprintf("Framework Export %s.zip", now.Format("2006-01-02")),
-				FileKey:    uuid.String(),
-				FileSize:   fileInfo.Size(),
-				Visibility: coredata.FileVisibilityPrivate,
-				CreatedAt:  now,
-				UpdatedAt:  now,
+				ID:             gid.New(exportJob.ID.TenantID(), coredata.FileEntityType),
+				OrganizationID: framework.OrganizationID,
+				BucketName:     s.svc.bucket,
+				MimeType:       "application/zip",
+				FileName:       fmt.Sprintf("Framework Export %s.zip", now.Format("2006-01-02")),
+				FileKey:        uuid.String(),
+				FileSize:       fileInfo.Size(),
+				Visibility:     coredata.FileVisibilityPrivate,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 			}
 
 			if err := file.Insert(ctx, tx, scope); err != nil {

--- a/pkg/probo/third_party_business_associate_agreement_service.go
+++ b/pkg/probo/third_party_business_associate_agreement_service.go
@@ -156,15 +156,16 @@ func (s ThirdPartyBusinessAssociateAgreementService) Upload(
 			thirdPartyBusinessAssociateAgreementID := gid.New(scope.GetTenantID(), coredata.ThirdPartyBusinessAssociateAgreementEntityType)
 
 			file = &coredata.File{
-				ID:         fileID,
-				BucketName: s.svc.bucket,
-				MimeType:   mimeType,
-				FileName:   req.FileName,
-				FileKey:    objectKey.String(),
-				FileSize:   *headOutput.ContentLength,
-				Visibility: coredata.FileVisibilityPrivate,
-				CreatedAt:  now,
-				UpdatedAt:  now,
+				ID:             fileID,
+				OrganizationID: thirdParty.OrganizationID,
+				BucketName:     s.svc.bucket,
+				MimeType:       mimeType,
+				FileName:       req.FileName,
+				FileKey:        objectKey.String(),
+				FileSize:       *headOutput.ContentLength,
+				Visibility:     coredata.FileVisibilityPrivate,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 			}
 
 			thirdPartyBusinessAssociateAgreement = &coredata.ThirdPartyBusinessAssociateAgreement{

--- a/pkg/probo/third_party_data_privacy_agreement_service.go
+++ b/pkg/probo/third_party_data_privacy_agreement_service.go
@@ -156,15 +156,16 @@ func (s ThirdPartyDataPrivacyAgreementService) Upload(
 			fileID := gid.New(scope.GetTenantID(), coredata.FileEntityType)
 			thirdPartyDataPrivacyAgreementID := gid.New(scope.GetTenantID(), coredata.ThirdPartyDataPrivacyAgreementEntityType)
 			file = &coredata.File{
-				ID:         fileID,
-				BucketName: s.svc.bucket,
-				MimeType:   mimeType,
-				FileName:   req.FileName,
-				FileKey:    objectKey.String(),
-				FileSize:   *headOutput.ContentLength,
-				Visibility: coredata.FileVisibilityPrivate,
-				CreatedAt:  now,
-				UpdatedAt:  now,
+				ID:             fileID,
+				OrganizationID: thirdParty.OrganizationID,
+				BucketName:     s.svc.bucket,
+				MimeType:       mimeType,
+				FileName:       req.FileName,
+				FileKey:        objectKey.String(),
+				FileSize:       *headOutput.ContentLength,
+				Visibility:     coredata.FileVisibilityPrivate,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 			}
 
 			thirdPartyDataPrivacyAgreement = &coredata.ThirdPartyDataPrivacyAgreement{

--- a/pkg/probo/trust_center_file_service.go
+++ b/pkg/probo/trust_center_file_service.go
@@ -400,15 +400,16 @@ func (s TrustCenterFileService) uploadFile(
 	}
 
 	fileRecord := &coredata.File{
-		ID:         fileID,
-		BucketName: s.svc.bucket,
-		MimeType:   contentType,
-		FileName:   filename,
-		FileKey:    objectKey.String(),
-		FileSize:   fileSize,
-		Visibility: coredata.FileVisibilityPrivate,
-		CreatedAt:  now,
-		UpdatedAt:  now,
+		ID:             fileID,
+		OrganizationID: organizationID,
+		BucketName:     s.svc.bucket,
+		MimeType:       contentType,
+		FileName:       filename,
+		FileKey:        objectKey.String(),
+		FileSize:       fileSize,
+		Visibility:     coredata.FileVisibilityPrivate,
+		CreatedAt:      now,
+		UpdatedAt:      now,
 	}
 
 	if err := fileRecord.Insert(ctx, tx, scope); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Trust Center file creation in the console and related uploads/exports by setting the correct organization on new `coredata.File` records and backfilling older rows. Restores proper scoping so files appear under the right org.

### Coredata **`+23`** **`-0`**
Adds a migration to backfill `files.organization_id` for rows with the nil GID by joining on tenant to `organizations`, correcting historical uploads for proper org scoping.

### Service **`+50`** **`-45`**
Sets `OrganizationID` on `coredata.File` creation across `trust_center_file_service`, `document_service`, `framework_service`, `third_party_business_associate_agreement_service`, and `third_party_data_privacy_agreement_service`, ensuring all new uploads/exports are saved under the correct org.

<sup>Written for commit 8dbfa35382c4dd404f9a10963757aad3b9289e6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

