### PR TITLE
Fix activate login path

### DIFF
--- a/apps/console/src/pages/iam/auth/ActivateAccountPage.tsx
+++ b/apps/console/src/pages/iam/auth/ActivateAccountPage.tsx
@@ -113,7 +113,7 @@ export default function ActivateAccountPage() {
 
         const search = new URLSearchParams([["continue", safeContinueUrl.toString()]]);
         void navigate({
-          pathname: "/auth/password-login",
+          pathname: "/auth/login",
           search: "?" + search.toString(),
         }, { replace: true });
       },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the post-activation redirect to point to the correct login route. After activation, users now land on /auth/login with the continue parameter preserved.

### App: console **`+1`** **`-1`**
Update ActivateAccountPage redirect from /auth/password-login to /auth/login, preserving the continue query param to prevent a broken redirect.

<sup>Written for commit 99d568d07d88e989dbe31a03c8bca31783e07bc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

