### PR TITLE
Redirect to the org SAML login on SSO-required assume

### DIFF
--- a/apps/console/src/pages/iam/organizations/AssumePage.tsx
+++ b/apps/console/src/pages/iam/organizations/AssumePage.tsx
@@ -16,7 +16,7 @@ import { useTranslate } from "@probo/i18n";
 import { UnAuthenticatedError } from "@probo/relay";
 import { useEffect } from "react";
 import { type PreloadedQuery, useMutation, usePreloadedQuery } from "react-relay";
-import { useNavigate, useSearchParams } from "react-router";
+import { useNavigate } from "react-router";
 import { graphql } from "relay-runtime";
 
 import type { AssumePageMutation } from "#/__generated__/iam/AssumePageMutation.graphql";
@@ -38,6 +38,7 @@ const assumeMutation = graphql`
         }
         ... on SAMLAuthenticationRequired {
           reason
+          ssoLoginURL
         }
       }
     }
@@ -48,9 +49,6 @@ export const assumePageQuery = graphql`
   query AssumePageQuery {
     viewer @required(action: THROW) {
       __typename
-      ... on Identity {
-        ssoLoginURL
-      }
     }
   }
 `;
@@ -60,12 +58,11 @@ export function AssumePage(props: { queryRef: PreloadedQuery<AssumePageQuery> })
 
   const organizationId = useOrganizationId();
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const { __ } = useTranslate();
 
   const safeContinueUrl = useSafeContinueUrl(`/organizations/${organizationId}`);
 
-  const { viewer } = usePreloadedQuery<AssumePageQuery>(assumePageQuery, queryRef);
+  usePreloadedQuery<AssumePageQuery>(assumePageQuery, queryRef);
   const [assumeOrganizationSession] = useMutation<AssumePageMutation>(assumeMutation);
 
   useEffect(() => {
@@ -91,7 +88,6 @@ export function AssumePage(props: { queryRef: PreloadedQuery<AssumePageQuery> })
 
         const { result } = assumeOrganizationSession;
         const search = new URLSearchParams();
-        let samlSSOLoginURL: URL;
 
         switch (result.__typename) {
           case "PasswordRequired":
@@ -100,21 +96,19 @@ export function AssumePage(props: { queryRef: PreloadedQuery<AssumePageQuery> })
 
             void navigate({ pathname: "/auth/login", search: "?" + search.toString() });
             break;
-          case "SAMLAuthenticationRequired":
-            if (!viewer.ssoLoginURL) {
-              throw new Error("missing SSO login URL for user email");
-            }
-            samlSSOLoginURL = new URL(viewer.ssoLoginURL);
-            samlSSOLoginURL.search = "?" + searchParams.toString();
+          case "SAMLAuthenticationRequired": {
+            const samlSSOLoginURL = new URL(result.ssoLoginURL);
+            samlSSOLoginURL.searchParams.set("continue", safeContinueUrl.toString());
 
             window.location.href = samlSSOLoginURL.toString();
             break;
+          }
           default:
             window.location.href = safeContinueUrl.toString();
         }
       },
     });
-  }, [organizationId, navigate, assumeOrganizationSession, safeContinueUrl, searchParams, viewer.ssoLoginURL]);
+  }, [organizationId, navigate, assumeOrganizationSession, safeContinueUrl]);
 
   return (
     <AuthLayout>

--- a/pkg/iam/errors.go
+++ b/pkg/iam/errors.go
@@ -404,11 +404,12 @@ func (e *ErrPasswordAuthenticationRequired) Error() string {
 }
 
 type ErrSAMLAuthenticationRequired struct {
-	Reason string
+	Reason              string
+	SAMLConfigurationID gid.GID
 }
 
-func NewSAMLAuthenticationRequiredError(reason string) *ErrSAMLAuthenticationRequired {
-	return &ErrSAMLAuthenticationRequired{Reason: reason}
+func NewSAMLAuthenticationRequiredError(reason string, samlConfigurationID gid.GID) *ErrSAMLAuthenticationRequired {
+	return &ErrSAMLAuthenticationRequired{Reason: reason, SAMLConfigurationID: samlConfigurationID}
 }
 
 func (e *ErrSAMLAuthenticationRequired) Error() string {

--- a/pkg/iam/session_service.go
+++ b/pkg/iam/session_service.go
@@ -581,7 +581,7 @@ func (s SessionService) AssumeOrganizationSession(
 				switch samlConfig.EnforcementPolicy {
 				case coredata.SAMLEnforcementPolicyRequired:
 					if rootSession.AuthMethod != coredata.AuthMethodSAML {
-						return NewSAMLAuthenticationRequiredError("policy_requirement")
+						return NewSAMLAuthenticationRequiredError("policy_requirement", samlConfig.ID)
 					}
 				case coredata.SAMLEnforcementPolicyOptional:
 					// SAML is optional: any password-equivalent (PASSWORD, OIDC,

--- a/pkg/server/api/connect/v1/graphql/session.graphql
+++ b/pkg/server/api/connect/v1/graphql/session.graphql
@@ -176,6 +176,7 @@ type PasswordRequired {
 
 type SAMLAuthenticationRequired {
   reason: ReauthenticationReason!
+  ssoLoginURL: String!
 }
 
 type AssumeOrganizationSessionPayload {

--- a/pkg/server/api/connect/v1/session_resolvers.go
+++ b/pkg/server/api/connect/v1/session_resolvers.go
@@ -396,7 +396,8 @@ func (r *mutationResolver) AssumeOrganizationSession(ctx context.Context, input 
 		if errSAMLAuthenticationRequired, ok := errors.AsType[*iam.ErrSAMLAuthenticationRequired](err); ok {
 			return &types.AssumeOrganizationSessionPayload{
 				Result: types.SAMLAuthenticationRequired{
-					Reason: types.ReauthenticationReason(errSAMLAuthenticationRequired.Reason),
+					Reason:      types.ReauthenticationReason(errSAMLAuthenticationRequired.Reason),
+					SsoLoginURL: r.SSOLoginURL(errSAMLAuthenticationRequired.SAMLConfigurationID),
 				},
 			}, nil
 		}


### PR DESCRIPTION
When assuming an organization with a REQUIRED SAML policy, a non-SAML
session must re-authenticate through that org's IdP. The console derived
the SAML URL from the viewer's email domain (viewer.ssoLoginURL), which
errors for domains with zero or multiple SAML configs, so the assume
page threw and bounced the user to the email/password screen.

Now ErrSAMLAuthenticationRequired carries the org's SAML configuration
ID, the resolver returns the org-specific ssoLoginURL in the
SAMLAuthenticationRequired result, and the console redirects straight to
it. SAML enforcement stays strict: only the org's own SAML session
satisfies a REQUIRED policy.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect users to the organization’s SAML login when assuming an org with SAML set to REQUIRED. Uses the org-specific SSO URL to avoid domain-based failures and ensure only the org’s SAML session satisfies the policy.

### Service **`+5`** **`-4`**
Add SAML configuration ID to `ErrSAMLAuthenticationRequired` and update `NewSAMLAuthenticationRequiredError`. In `AssumeOrganizationSession`, when SAML is REQUIRED and the root session isn’t SAML, return this error with the org’s config ID to force reauth via the org IdP.

### GraphQL API **`+3`** **`-1`**
Expose `ssoLoginURL` on `SAMLAuthenticationRequired` and resolve it using the carried config ID.

### App: console **`+8`** **`-14`**
Assume page redirects using `result.ssoLoginURL` and attaches a continue param. Remove `viewer.ssoLoginURL` and query-string reliance to prevent redirect errors.

<sup>Written for commit a0a71f46493c777242790266e2da6d0f51a1c201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



