### PR TITLE
Coalesce nil additional emails to empty array

### DIFF
--- a/pkg/server/api/mcp/v1/types/profile.go
+++ b/pkg/server/api/mcp/v1/types/profile.go
@@ -14,15 +14,23 @@
 
 package types
 
-import "go.probo.inc/probo/pkg/coredata"
+import (
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/mail"
+)
 
 func NewProfile(p *coredata.MembershipProfile) *Profile {
+	additionalEmailAddresses := p.AdditionalEmailAddresses
+	if additionalEmailAddresses == nil {
+		additionalEmailAddresses = mail.Addrs{}
+	}
+
 	return &Profile{
 		ID:                       p.ID,
 		OrganizationID:           p.OrganizationID,
 		FullName:                 p.FullName,
 		EmailAddress:             p.EmailAddress,
-		AdditionalEmailAddresses: p.AdditionalEmailAddresses,
+		AdditionalEmailAddresses: additionalEmailAddresses,
 		Kind:                     p.Kind,
 		Source:                   p.Source,
 		State:                    p.State,


### PR DESCRIPTION
The MCP Profile schema declares additional_email_addresses as a required, non-nullable array, but NewProfile passed the mail.Addrs value through unchanged. A profile with no extra emails has a nil slice, which marshals to JSON null and fails tool output validation with "type: null, want array".

Default the nil slice to an empty mail.Addrs so the marshalled output always honors the strict array schema.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix MCP Profile serialization by defaulting nil additional emails to an empty array. This aligns with the non-nullable schema and stops “type: null, want array” validation errors.

### MCP **`+10`** **`-2`**
- Default `AdditionalEmailAddresses` to `mail.Addrs{}` when nil in `NewProfile`.
- Added `go.probo.inc/probo/pkg/mail` import; behavior unchanged when addresses exist.

<sup>Written for commit de26b889ffad95e319468f6f9ea24149081bf2d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

