### PR TITLE
Fix dangling release guide link in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,6 @@ Detailed guides for specific subsystems live in `contrib/claude/`:
 - [`contrib/claude/prompt-style.md`](contrib/claude/prompt-style.md) — Agent prompt template structure (role/task/instructions XML style)
 - [`contrib/claude/commit.md`](contrib/claude/commit.md) — Commit message conventions
 - [`contrib/claude/license.md`](contrib/claude/license.md) — ISC license header (all file types)
-- [`contrib/claude/release.md`](contrib/claude/release.md) — Release process (version bump, changelog, tag, push)
+- [`contrib/claude/release/README.md`](contrib/claude/release/README.md) — Release process (per-track version bump, changelog, tag, push)
 - [`contrib/claude/sandbox.md`](contrib/claude/sandbox.md) — Lima sandbox environments (create, manage, access services)
 - [`contrib/claude/n8n.md`](contrib/claude/n8n.md) — n8n community node (resources, operations, GraphQL helpers)


### PR DESCRIPTION
The release guide was refactored from a single contrib/claude/release.md into a contrib/claude/release/ directory with a README index and per-track guides, but the AGENTS.md link was never updated and pointed at a missing file. Repoint it to release/README.md. CLAUDE.md is a symlink to AGENTS.md, so it inherits the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken release guide link in `AGENTS.md` by pointing to the new `contrib/claude/release/README.md`. This removes the 404 and ensures `CLAUDE.md` (symlink) resolves correctly.

### Other **`+1`** **`-1`**
- Update link from `contrib/claude/release.md` to `contrib/claude/release/README.md` (per-track guide index).
- `CLAUDE.md` inherits the fix via symlink.

<sup>Written for commit 50658a42a430f6e61dca6351d3f1bc4207b0e620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

