### PR TITLE
Stop source-name loop on Google 403

### DIFF
--- a/pkg/accessreview/drivers/google_workspace_test.go
+++ b/pkg/accessreview/drivers/google_workspace_test.go
@@ -16,6 +16,8 @@ package drivers
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -39,4 +41,65 @@ func TestGoogleWorkspaceDriver(t *testing.T) {
 	assert.NotEmpty(t, r.FullName)
 	assert.NotEmpty(t, r.ExternalID)
 	assert.NotEmpty(t, r.Roles)
+}
+
+func TestGoogleWorkspaceNameResolver(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		status  int
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "200 returns customer domain",
+			status: http.StatusOK,
+			body:   `{"kind":"admin#directory#customer","customerDomain":"example.com"}`,
+			want:   "example.com",
+		},
+		{
+			name:   "403 is terminal (no error, no name)",
+			status: http.StatusForbidden,
+			body:   `{"error":{"code":403,"message":"Not Authorized to access this resource/api","status":"FORBIDDEN"}}`,
+			want:   "",
+		},
+		{
+			name:    "500 is retryable",
+			status:  http.StatusInternalServerError,
+			body:    `{"error":{"code":500,"message":"Internal Server Error","status":"INTERNAL"}}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(
+				http.HandlerFunc(
+					func(w http.ResponseWriter, r *http.Request) {
+						assert.Equal(t, http.MethodGet, r.Method)
+						assert.Equal(t, "/admin/directory/v1/customers/my_customer", r.URL.Path)
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(tc.status)
+						_, _ = w.Write([]byte(tc.body))
+					},
+				),
+			)
+			defer srv.Close()
+
+			client := &http.Client{Transport: &hostRewriter{target: srv.URL}}
+
+			got, err := NewGoogleWorkspaceNameResolver(client).ResolveInstanceName(t.Context())
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/pkg/accessreview/drivers/name_resolver.go
+++ b/pkg/accessreview/drivers/name_resolver.go
@@ -18,12 +18,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 
 	"go.probo.inc/probo/pkg/connector"
 	admin "google.golang.org/api/admin/directory/v1"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -87,6 +89,11 @@ func (r *googleWorkspaceNameResolver) ResolveInstanceName(ctx context.Context) (
 
 	customer, err := adminService.Customers.Get("my_customer").Context(ctx).Do()
 	if err != nil {
+		var gerr *googleapi.Error
+		if errors.As(err, &gerr) && gerr.Code == http.StatusForbidden {
+			return "", nil
+		}
+
 		return "", fmt.Errorf("cannot fetch google workspace customer: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Treat Google Workspace `Customers.Get` 403 as terminal in the name resolver so the source-name worker marks the source synced instead of retrying forever
- Add resolver tests in `google_workspace_test.go` for success, forbidden, and retryable server errors

## Test plan
- [x] `go test ./pkg/accessreview/drivers/ -run TestGoogleWorkspaceNameResolver`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops infinite retries when Google Workspace returns 403 for `Customers.Get` by treating it as a terminal case in the name resolver. Adds targeted tests for 200, 403, and 500 responses.

### Tests **`+63`** **`-0`**
- Added table-driven tests for success, forbidden (terminal), and server error (retryable).
- Used `httptest` to validate request method/path and response handling.

### Service **`+7`** **`-0`**
- Treat 403 from Google `Customers.Get` as non-retryable: return empty name with no error.
- Prevents source-name worker from looping when the token lacks `admin.directory.customer.readonly`.

<sup>Written for commit 83db67711ceb0b25272708b30f6f0ad6f126ada6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

