### PR TITLE
Add profile ID to duplicate user error

### DIFF
--- a/pkg/iam/errors.go
+++ b/pkg/iam/errors.go
@@ -318,14 +318,24 @@ func (e ErrSessionExpired) Error() string {
 type ErrUserAlreadyExists struct {
 	IdentityID     gid.GID
 	OrganizationID gid.GID
+	ProfileID      gid.GID
 }
 
-func NewUserAlreadyExistsError(identityID gid.GID, organizationID gid.GID) error {
-	return &ErrUserAlreadyExists{IdentityID: identityID, OrganizationID: organizationID}
+func NewUserAlreadyExistsError(identityID gid.GID, organizationID gid.GID, profileID gid.GID) error {
+	return &ErrUserAlreadyExists{
+		IdentityID:     identityID,
+		OrganizationID: organizationID,
+		ProfileID:      profileID,
+	}
 }
 
 func (e ErrUserAlreadyExists) Error() string {
-	return fmt.Sprintf("user already exists for identity %q in organization %q", e.IdentityID, e.OrganizationID)
+	return fmt.Sprintf(
+		"user already exists for identity %q in organization %q with profile %q",
+		e.IdentityID,
+		e.OrganizationID,
+		e.ProfileID,
+	)
 }
 
 type ErrSAMLConfigurationNotFound struct{ ConfigID gid.GID }

--- a/pkg/iam/errors_test.go
+++ b/pkg/iam/errors_test.go
@@ -30,6 +30,8 @@ func TestAuthorizeRelatedErrors_Error(t *testing.T) {
 	identityID := gid.New(gid.NilTenant, coredata.IdentityEntityType)
 	resourceID := gid.New(tenantID, coredata.FrameworkEntityType)
 	membershipID := gid.New(tenantID, coredata.MembershipEntityType)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+	profileID := gid.New(tenantID, coredata.MembershipProfileEntityType)
 	sessionID := gid.New(gid.NilTenant, coredata.SessionEntityType)
 	action := iam.Action("core:framework:get")
 	mixedOrgIDs := []string{
@@ -100,6 +102,16 @@ func TestAuthorizeRelatedErrors_Error(t *testing.T) {
 			name: "session expired",
 			err:  iam.NewSessionExpiredError(sessionID),
 			want: fmt.Sprintf("session %q expired", sessionID),
+		},
+		{
+			name: "user already exists",
+			err:  iam.NewUserAlreadyExistsError(identityID, organizationID, profileID),
+			want: fmt.Sprintf(
+				"user already exists for identity %q in organization %q with profile %q",
+				identityID,
+				organizationID,
+				profileID,
+			),
 		},
 	}
 

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1014,6 +1014,23 @@ func (s *OrganizationService) CreateUser(ctx context.Context, req *CreateUserReq
 				if err := identity.Insert(ctx, conn); err != nil {
 					return fmt.Errorf("cannot insert identity: %w", err)
 				}
+			} else {
+				existingProfile := &coredata.MembershipProfile{}
+
+				err := existingProfile.LoadByIdentityIDAndOrganizationID(
+					ctx,
+					conn,
+					scope,
+					identity.ID,
+					req.OrganizationID,
+				)
+				if err == nil {
+					return NewUserAlreadyExistsError(identity.ID, req.OrganizationID, existingProfile.ID)
+				}
+
+				if !errors.Is(err, coredata.ErrResourceNotFound) {
+					return fmt.Errorf("cannot load existing profile: %w", err)
+				}
 			}
 
 			profile = &coredata.MembershipProfile{
@@ -1042,7 +1059,7 @@ func (s *OrganizationService) CreateUser(ctx context.Context, req *CreateUserReq
 
 			if err := profile.Insert(ctx, conn); err != nil {
 				if errors.Is(err, coredata.ErrResourceAlreadyExists) {
-					return NewUserAlreadyExistsError(identity.ID, req.OrganizationID)
+					return NewUserAlreadyExistsError(identity.ID, req.OrganizationID, gid.Nil)
 				}
 
 				return fmt.Errorf("cannot insert profile: %w", err)
@@ -1068,6 +1085,30 @@ func (s *OrganizationService) CreateUser(ctx context.Context, req *CreateUserReq
 		},
 	)
 	if err != nil {
+		if errAlreadyExists, ok := errors.AsType[*ErrUserAlreadyExists](err); ok && errAlreadyExists.ProfileID == gid.Nil {
+			existingProfile := &coredata.MembershipProfile{}
+
+			loadErr := s.pg.WithConn(
+				ctx,
+				func(ctx context.Context, conn pg.Querier) error {
+					return existingProfile.LoadByIdentityIDAndOrganizationID(
+						ctx,
+						conn,
+						scope,
+						errAlreadyExists.IdentityID,
+						errAlreadyExists.OrganizationID,
+					)
+				},
+			)
+			if loadErr == nil {
+				return nil, NewUserAlreadyExistsError(
+					errAlreadyExists.IdentityID,
+					errAlreadyExists.OrganizationID,
+					existingProfile.ID,
+				)
+			}
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Include membership profile ID on `ErrUserAlreadyExists`
- Load the existing profile during duplicate user creation so API errors expose the profile ID
- Cover the updated duplicate-user error string
- Fix Go lint whitespace around the duplicate-profile lookup

## Testing
- `make go-fmt`
- `go test ./pkg/iam` (passed after temporary local email template placeholders; this checkout lacks `packages/emails/dist`)
- `golangci-lint run ./pkg/iam` (not run locally: `golangci-lint` is not installed in this environment)
- `go test ./pkg/server/api/connect/v1 ./pkg/server/api/mcp/v1` (blocked by missing generated GraphQL/MCP types in this checkout)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-512](https://linear.app/probo/issue/ENG-512/add-profile-id-to-existing-user-error-message)

<div><a href="https://cursor.com/agents/bc-57322581-200c-4678-a2ea-9e2c149a3582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57322581-200c-4678-a2ea-9e2c149a3582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the membership profile ID to duplicate user errors and returns it from `CreateUser` so clients can link to the existing profile. Addresses Linear ENG-512 by enriching `ErrUserAlreadyExists` and loading the profile when duplicates are detected.

### Service **`+55`** **`-4`**
- Add `ProfileID` to `ErrUserAlreadyExists`, update `NewUserAlreadyExistsError`, and include it in the error message.
- In `CreateUser`, load the existing `MembershipProfile` on duplicate and return the enriched error; add a post-transaction fallback when `ProfileID` is `gid.Nil`.

### Tests **`+12`** **`-0`**
- Assert the updated error string includes the profile ID.

<sup>Written for commit cc93340fef459055050ffb3c964058e2884f23af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

