### PR TITLE
Trackers misc improvements

### DIFF
--- a/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordPage.tsx
@@ -49,6 +49,7 @@ export const cookieBannerConsentRecordPageQuery = graphql`
             kind
             cookies {
               name
+              trackerType
               maxAgeSeconds
               description
             }
@@ -235,7 +236,7 @@ export default function CookieBannerConsentRecordPage({
                                     {cookie.name}
                                   </td>
                                   <td className="py-1 pr-4 text-txt-secondary">
-                                    {humanizeSeconds(cookie.maxAgeSeconds ?? null)}
+                                    {humanizeSeconds(cookie.maxAgeSeconds ?? null, cookie.trackerType)}
                                   </td>
                                   <td className="py-1 text-txt-secondary">
                                     {cookie.description}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/display/_components/CategorySection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/display/_components/CategorySection.tsx
@@ -795,7 +795,7 @@ export function CategorySection({ categoryKey, connectionId }: CategorySectionPr
                       })()}
                     </Td>
                     <Td className="text-sm text-muted-foreground">
-                      {humanizeSeconds(pattern.maxAgeSeconds ?? null)}
+                      {humanizeSeconds(pattern.maxAgeSeconds ?? null, pattern.trackerType)}
                     </Td>
                     <Td>
                       <div className="flex items-center gap-1">

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
@@ -244,6 +244,7 @@ export default function CookieBannerTrackersPage({
           <Option value="ALL">{__("All sources")}</Option>
           <Option value="SCRIPT">{__("Script")}</Option>
           <Option value="PRE_EXISTING">{__("Pre-existing")}</Option>
+          <Option value="HTTP">{__("HTTP")}</Option>
           <Option value="EXTENSION">{__("Extension")}</Option>
         </Select>
         <Select

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
@@ -12,15 +12,19 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { getTrackerSourceBadge, getTrackerTypeBadge, humanizeSeconds } from "@probo/helpers";
+import { formatError, getTrackerSourceBadge, getTrackerTypeBadge, type GraphQLError, humanizeSeconds } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import { Badge, Card, IconSquareBehindSquare2, PropertyRow, useToast } from "@probo/ui";
-import { graphql, useFragment } from "react-relay";
+import { graphql, useFragment, useMutation } from "react-relay";
 
 import type { TrackerPatternPropertiesSection_trackerPattern$key } from "#/__generated__/core/TrackerPatternPropertiesSection_trackerPattern.graphql";
+import type { TrackerPatternPropertiesSectionMoveMutation } from "#/__generated__/core/TrackerPatternPropertiesSectionMoveMutation.graphql";
+
+import { MoveToCategorySelect } from "./MoveToCategorySelect";
 
 const trackerPatternPropertiesSectionFragment = graphql`
   fragment TrackerPatternPropertiesSection_trackerPattern on TrackerPattern {
+    id
     pattern
     matchType
     trackerType
@@ -32,13 +36,40 @@ const trackerPatternPropertiesSectionFragment = graphql`
     lastMatchedAt
     commonTrackerPatternId
     cookieCategory {
+      id
       name
+      kind
     }
     thirdParty {
       name
     }
     commonThirdParty {
       name
+    }
+  }
+`;
+
+const movePatternMutation = graphql`
+  mutation TrackerPatternPropertiesSectionMoveMutation(
+    $input: MoveTrackerPatternToCategoryInput!
+  ) {
+    moveTrackerPatternToCategory(input: $input) {
+      trackerPattern {
+        id
+        cookieCategory {
+          id
+          name
+          kind
+        }
+      }
+      cookieBanner {
+        id
+        latestVersion {
+          id
+          version
+          state
+        }
+      }
     }
   }
 `;
@@ -56,6 +87,33 @@ export function TrackerPatternPropertiesSection({
     trackerPatternPropertiesSectionFragment,
     trackerPatternKey,
   );
+
+  const [movePattern]
+    = useMutation<TrackerPatternPropertiesSectionMoveMutation>(movePatternMutation);
+
+  const handleMove = (targetCategoryId: string) => {
+    if (targetCategoryId === pattern.cookieCategory?.id) {
+      return;
+    }
+    movePattern({
+      variables: {
+        input: {
+          trackerPatternId: pattern.id,
+          targetCookieCategoryId: targetCategoryId,
+        },
+      },
+      onCompleted(_, errors) {
+        if (errors?.length) {
+          toast({ title: __("Error"), description: errors[0].message, variant: "error" });
+          return;
+        }
+        toast({ title: __("Success"), description: __("Cookie moved"), variant: "success" });
+      },
+      onError(error) {
+        toast({ title: __("Error"), description: formatError(__("Failed to move cookie"), error as GraphQLError), variant: "error" });
+      },
+    });
+  };
 
   const typeBadge = getTrackerTypeBadge(pattern.trackerType, __);
 
@@ -78,9 +136,12 @@ export function TrackerPatternPropertiesSection({
         </PropertyRow>
       )}
       <PropertyRow label={__("Category")}>
-        <span className="text-sm">
-          {pattern.cookieCategory?.name ?? "-"}
-        </span>
+        <MoveToCategorySelect
+          currentCategoryId={pattern.cookieCategory?.id}
+          currentCategoryName={pattern.cookieCategory?.name}
+          highlight={!!pattern.cookieCategory && pattern.cookieCategory.kind !== "UNCATEGORISED"}
+          onSelect={handleMove}
+        />
       </PropertyRow>
       <PropertyRow label={__("Third party")}>
         {pattern.thirdParty

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
@@ -161,7 +161,7 @@ export function TrackerPatternPropertiesSection({
       </PropertyRow>
       <PropertyRow label={__("Max Age")}>
         <span className="text-sm">
-          {humanizeSeconds(pattern.maxAgeSeconds ?? null)}
+          {humanizeSeconds(pattern.maxAgeSeconds ?? null, pattern.trackerType)}
         </span>
       </PropertyRow>
       {pattern.description && (

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
@@ -28,7 +28,6 @@ import {
 } from "@probo/ui";
 import { useState } from "react";
 import { graphql, useFragment, useMutation } from "react-relay";
-import { ConnectionHandler } from "relay-runtime";
 
 import type { TrackerPatternRowDeleteMutation } from "#/__generated__/core/TrackerPatternRowDeleteMutation.graphql";
 import type { TrackerPatternRowFragment$key } from "#/__generated__/core/TrackerPatternRowFragment.graphql";
@@ -94,6 +93,8 @@ const movePatternMutation = graphql`
         id
         cookieCategory {
           id
+          name
+          kind
         }
       }
       cookieBanner {
@@ -213,17 +214,6 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
           trackerPatternId: pattern.id,
           targetCookieCategoryId: targetCategoryId,
         },
-      },
-      updater(store) {
-        const payload = store.getRootField("moveTrackerPatternToCategory");
-        if (!payload?.getLinkedRecord("trackerPattern")) {
-          return;
-        }
-
-        const conn = store.get(connectionId);
-        if (conn) {
-          ConnectionHandler.deleteNode(conn, pattern.id);
-        }
       },
       onCompleted(_, errors) {
         if (errors?.length) {
@@ -392,7 +382,7 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
         </div>
       </Td>
       <Td>
-        <span className="pl-2">{humanizeSeconds(pattern.maxAgeSeconds ?? null)}</span>
+        <span className="pl-2">{humanizeSeconds(pattern.maxAgeSeconds ?? null, pattern.trackerType)}</span>
       </Td>
       <Td>
         {pattern.lastMatchedAt

--- a/packages/cookie-banner/src/components/cookie-list.ts
+++ b/packages/cookie-banner/src/components/cookie-list.ts
@@ -52,8 +52,8 @@ export class ProboCookieList extends ProboElement {
     if (!this.template) return;
 
     const duration = cookie.max_age_seconds != null
-      ? humanizeDuration(cookie.max_age_seconds, lang)
-      : humanizeDuration(0, lang);
+      ? humanizeDuration(cookie.max_age_seconds, lang, cookie.tracker_type)
+      : humanizeDuration(0, lang, cookie.tracker_type);
 
     const type = getTrackerTypeLabel(cookie.tracker_type);
 

--- a/packages/cookie-banner/src/cookie-utils.ts
+++ b/packages/cookie-banner/src/cookie-utils.ts
@@ -13,6 +13,16 @@
 // PERFORMANCE OF THIS SOFTWARE.
 
 import { interpolate } from "./i18n";
+import type { TrackerType } from "./types";
+
+// Tracker types whose data persists until explicitly cleared. When such a
+// tracker has no max-age, its lifetime is "persistent" rather than "session"
+// (cookies and session storage are cleared when the session/tab ends).
+const PERSISTENT_TRACKER_TYPES: ReadonlySet<TrackerType> = new Set([
+  "LOCAL_STORAGE",
+  "INDEXED_DB",
+  "CACHE_STORAGE",
+]);
 
 interface DurationTexts {
   [key: string]: string;
@@ -35,6 +45,7 @@ const durationTextsByLanguage: Record<string, DurationTexts> = {
     duration_second_one: "{{count}} second",
     duration_second_other: "{{count}} seconds",
     duration_session: "session",
+    duration_persistent: "persistent",
   },
   fr: {
     duration_year_one: "{{count}} an",
@@ -52,6 +63,7 @@ const durationTextsByLanguage: Record<string, DurationTexts> = {
     duration_second_one: "{{count}} seconde",
     duration_second_other: "{{count}} secondes",
     duration_session: "session",
+    duration_persistent: "persistant",
   },
   de: {
     duration_year_one: "{{count}} Jahr",
@@ -69,6 +81,7 @@ const durationTextsByLanguage: Record<string, DurationTexts> = {
     duration_second_one: "{{count}} Sekunde",
     duration_second_other: "{{count}} Sekunden",
     duration_session: "Sitzung",
+    duration_persistent: "dauerhaft",
   },
   es: {
     duration_year_one: "{{count}} año",
@@ -86,6 +99,7 @@ const durationTextsByLanguage: Record<string, DurationTexts> = {
     duration_second_one: "{{count}} segundo",
     duration_second_other: "{{count}} segundos",
     duration_session: "sesión",
+    duration_persistent: "persistente",
   },
 };
 
@@ -107,9 +121,17 @@ const DURATION_UNITS: [number, string, number][] = [
   [1, "duration_second", 0],
 ];
 
-export function humanizeDuration(seconds: number, lang?: string): string {
+export function humanizeDuration(
+  seconds: number,
+  lang?: string,
+  trackerType?: TrackerType,
+): string {
   const texts = getDurationTexts(lang);
-  if (seconds <= 0) return texts.duration_session;
+  if (seconds <= 0) {
+    return trackerType && PERSISTENT_TRACKER_TYPES.has(trackerType)
+      ? texts.duration_persistent
+      : texts.duration_session;
+  }
 
   let remaining = seconds;
   const parts: string[] = [];

--- a/packages/helpers/src/duration.ts
+++ b/packages/helpers/src/duration.ts
@@ -22,8 +22,24 @@ export const DURATION_UNITS: { value: string; label: string; singular: string; s
   { value: "years", label: "years", singular: "year", seconds: 31536000, snap: 21 * 24 *  3600 },
 ] as const;
 
-export function humanizeSeconds(seconds: number | null): string {
-  if (seconds === null || seconds <= 0) return "session";
+// Tracker types whose data persists until explicitly cleared. When such a
+// tracker has no max-age, its lifetime is "persistent" rather than "session"
+// (cookies and session storage are cleared when the session/tab ends).
+const PERSISTENT_TRACKER_TYPES = new Set([
+  "LOCAL_STORAGE",
+  "INDEXED_DB",
+  "CACHE_STORAGE",
+]);
+
+export function humanizeSeconds(
+  seconds: number | null,
+  trackerType?: string | null,
+): string {
+  if (seconds === null || seconds <= 0) {
+    return trackerType && PERSISTENT_TRACKER_TYPES.has(trackerType)
+      ? "persistent"
+      : "session";
+  }
 
   let remaining = seconds;
   const parts: string[] = [];

--- a/packages/helpers/src/tracker.ts
+++ b/packages/helpers/src/tracker.ts
@@ -43,6 +43,7 @@ export function getTrackerSourceBadge(source: string, __: Translator): Badge {
     case "SCRIPT": return { label: __("Script"), variant: "info" };
     case "PRE_EXISTING": return { label: __("Pre-existing"), variant: "outline" };
     case "HTTP": return { label: __("HTTP"), variant: "neutral" };
+    case "EXTENSION": return { label: __("Extension"), variant: "warning" };
     default: return { label: source, variant: "neutral" };
   }
 }

--- a/pkg/cookiebanner/pattern_analysis_worker.go
+++ b/pkg/cookiebanner/pattern_analysis_worker.go
@@ -704,11 +704,15 @@ func globMatch(pattern, name string) bool {
 }
 
 // sourceRank converts a CookieSource into a comparable rank that
-// reflects signal strength: SCRIPT > EXTENSION > PRE_EXISTING. HTTP
-// and nil collapse into the PRE_EXISTING rank because bestSource
-// already normalises them; if a future caller hands us either, the
-// ranking still produces a sane "no promotion" outcome against
-// PRE_EXISTING/EXTENSION/SCRIPT existing values.
+// reflects signal strength: SCRIPT > HTTP > EXTENSION > PRE_EXISTING.
+// SCRIPT is a real page tracker observed being written by page JS;
+// HTTP is a real server-set cookie (a Set-Cookie response header),
+// which is page evidence just like SCRIPT and so must outrank both
+// browser-extension state and the PRE_EXISTING catch-all — otherwise a
+// cookie first enumerated as PRE_EXISTING and later re-observed only
+// via Set-Cookie would stay PRE_EXISTING and remain agent-skipped.
+// EXTENSION is high-confidence extension state; PRE_EXISTING (and nil)
+// is the low-signal catch-all.
 func sourceRank(s *coredata.CookieSource) int {
 	if s == nil {
 		return 0
@@ -716,6 +720,8 @@ func sourceRank(s *coredata.CookieSource) int {
 
 	switch *s {
 	case coredata.CookieSourceScript:
+		return 3
+	case coredata.CookieSourceHTTP:
 		return 2
 	case coredata.CookieSourceExtension:
 		return 1
@@ -733,17 +739,19 @@ func shouldPromoteSource(existing, candidate *coredata.CookieSource) bool {
 }
 
 // bestSource rolls up the source values of a group of exact patterns
-// being merged into a single glob. Precedence is SCRIPT > EXTENSION
-// > PRE_EXISTING, mirroring both the page-script-wins rule in
-// detected_trackers and the asymmetric signal strength of each
-// bucket: SCRIPT is high-confidence page evidence (a real page
-// tracker), EXTENSION is high-confidence extension evidence, and
-// PRE_EXISTING is the catch-all that may include extension state
-// injected before SDK load. HTTP and nil collapse into PRE_EXISTING
-// here, preserving the original two-value rollup behaviour for
-// non-script values.
+// being merged into a single glob. Precedence is SCRIPT > HTTP >
+// EXTENSION > PRE_EXISTING, mirroring the asymmetric signal strength of
+// each bucket: SCRIPT is high-confidence page evidence (a real page
+// tracker), HTTP is a real server-set cookie (a Set-Cookie response
+// header) and is page evidence too, EXTENSION is high-confidence
+// extension state, and PRE_EXISTING is the catch-all that may include
+// extension state injected before SDK load. nil collapses into
+// PRE_EXISTING.
 func bestSource(patterns []*coredata.TrackerPattern) *coredata.CookieSource {
-	var hasExtension bool
+	var (
+		hasHTTP      bool
+		hasExtension bool
+	)
 
 	for _, p := range patterns {
 		if p.Source == nil {
@@ -753,19 +761,24 @@ func bestSource(patterns []*coredata.TrackerPattern) *coredata.CookieSource {
 		switch *p.Source {
 		case coredata.CookieSourceScript:
 			return p.Source
+		case coredata.CookieSourceHTTP:
+			hasHTTP = true
 		case coredata.CookieSourceExtension:
 			hasExtension = true
 		}
 	}
 
-	if hasExtension {
+	switch {
+	case hasHTTP:
+		src := coredata.CookieSourceHTTP
+		return &src
+	case hasExtension:
 		src := coredata.CookieSourceExtension
 		return &src
+	default:
+		src := coredata.CookieSourcePreExisting
+		return &src
 	}
-
-	src := coredata.CookieSourcePreExisting
-
-	return &src
 }
 
 // inheritedMapping rolls up the resolved org ThirdParty of a group of

--- a/pkg/cookiebanner/pattern_analysis_worker_test.go
+++ b/pkg/cookiebanner/pattern_analysis_worker_test.go
@@ -1159,15 +1159,45 @@ func TestShouldPromoteSource(t *testing.T) {
 			want:      false,
 		},
 		{
-			name:      "HTTP collapses to PRE_EXISTING rank: does not promote SCRIPT",
+			name:      "HTTP does not promote to SCRIPT (HTTP ranks below SCRIPT)",
 			existing:  &script,
 			candidate: &http,
 			want:      false,
 		},
 		{
-			name:      "HTTP collapses to PRE_EXISTING rank: equal to nil existing",
+			name:      "nil existing promotes to HTTP",
 			existing:  nil,
 			candidate: &http,
+			want:      true,
+		},
+		{
+			name:      "PRE_EXISTING promotes to HTTP",
+			existing:  &preExisting,
+			candidate: &http,
+			want:      true,
+		},
+		{
+			name:      "EXTENSION promotes to HTTP (real server cookie outranks extension state)",
+			existing:  &extension,
+			candidate: &http,
+			want:      true,
+		},
+		{
+			name:      "HTTP promotes to SCRIPT",
+			existing:  &http,
+			candidate: &script,
+			want:      true,
+		},
+		{
+			name:      "HTTP does not promote to EXTENSION",
+			existing:  &http,
+			candidate: &extension,
+			want:      false,
+		},
+		{
+			name:      "HTTP does not promote to PRE_EXISTING",
+			existing:  &http,
+			candidate: &preExisting,
 			want:      false,
 		},
 	}

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -289,7 +289,9 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 	// Phase 4: persist the pattern mapping in a short transaction. The
 	// unmatched fallback keeps catalog coverage complete even when no
 	// vendor was resolved.
-	return h.pg.WithTx(
+	mapped := true
+
+	if err := h.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			if commonPatternID == nil {
@@ -331,6 +333,8 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 						log.String("tracker_pattern_id", tp.ID.String()),
 					)
 
+					mapped = false
+
 					return nil
 				}
 
@@ -344,20 +348,39 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 				log.String("tracker_pattern_id", tp.ID.String()),
 			)
 
-			// This run newly resolved a catalog third party, so
-			// same-banner siblings that share an initiator domain but
-			// were processed earlier and left unmatched can now match
-			// against it. Re-arm their mapping so the worker revisits
-			// them; the guards keep already-mapped siblings untouched.
-			if commonThirdPartyID != nil && !det.commonThirdPartyPreexisted {
-				if err := h.reenqueueUnmappedSiblings(ctx, tx, tp, det.domains); err != nil {
-					return err
-				}
-			}
-
 			return nil
 		},
-	)
+	); err != nil {
+		return err
+	}
+
+	// Phase 5: re-arm same-banner siblings in a separate short
+	// transaction, after the mapping above has committed. This run newly
+	// resolved a catalog third party, so siblings that share an initiator
+	// domain but were processed earlier and left unmatched can now match
+	// against it. Re-arm their mapping so the worker revisits them; the
+	// guards keep already-mapped siblings untouched.
+	//
+	// The re-enqueue must not run inside the Phase 4 transaction: that
+	// transaction holds the row lock on tp, and the sibling UPDATE then
+	// takes locks on other tracker_patterns rows while holding it. Two
+	// workers mapping sibling patterns on the same banner would acquire
+	// those row locks in opposite orders and deadlock. Committing Phase 4
+	// first releases tp's lock, and RequestMappingForUnmappedSiblings
+	// takes its locks in a deterministic id order, so the two can no
+	// longer cycle.
+	if mapped && commonThirdPartyID != nil && !det.commonThirdPartyPreexisted {
+		if err := h.pg.WithTx(
+			ctx,
+			func(ctx context.Context, tx pg.Tx) error {
+				return h.reenqueueUnmappedSiblings(ctx, tx, tp, det.domains)
+			},
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // deterministicResult carries the outcome of the pure-SQL catalog

--- a/pkg/coredata/common_tracker_pattern.go
+++ b/pkg/coredata/common_tracker_pattern.go
@@ -1015,6 +1015,38 @@ WHERE
 	return result.RowsAffected(), nil
 }
 
+// ClearDescriptionByIDs blanks the researched description on the given
+// catalog rows without re-arming enrichment or touching the enrichment
+// payload. It backs the first-party verdict: a terminal non-third-party
+// row keeps no vendor link, so a description that named the (now-cleared)
+// vendor would be stale. The verdict is terminal, so rather than re-derive
+// a description - which would re-run the mapping agent and re-link a
+// vendor - the description simply returns to empty. Returns the number of
+// rows updated.
+func (ps *CommonTrackerPatterns) ClearDescriptionByIDs(
+	ctx context.Context,
+	tx pg.Tx,
+	ids []gid.GID,
+) (int64, error) {
+	q := `
+UPDATE common_tracker_patterns
+SET
+    description = '',
+    updated_at = NOW()
+WHERE
+    id = ANY(@ids)
+`
+
+	args := pgx.StrictNamedArgs{"ids": ids}
+
+	result, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return 0, fmt.Errorf("cannot clear common tracker pattern description: %w", err)
+	}
+
+	return result.RowsAffected(), nil
+}
+
 // RequestEnrichmentByIDs arms enrichment on the given common tracker
 // patterns by stamping enrichment_requested_at, which is the only column
 // the enrichment worker claims on. It resets enrichment_attempts to 0 so

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -1406,6 +1406,49 @@ WHERE
 	return result.RowsAffected(), nil
 }
 
+// ClearDescriptionForUncategorisedByCommonTrackerPatternIDs blanks the
+// description on the uncategorised org tracker patterns linked to the
+// given common tracker patterns. It pairs with the first-party verdict on
+// the catalog row: when the catalog description is cleared because its
+// vendor attribution was wrong, the descriptions fanned out to org
+// patterns named the same stale vendor and must be cleared too - the
+// mapping worker only ever copies a description into an empty org row, it
+// never clears one. Like the mapping re-arm it is a global catalog
+// operation, so it is intentionally not tenant-scoped, and it leaves
+// excluded and user-categorised patterns untouched. The cookie_categories
+// subquery is used only for filtering. Returns the number of org patterns
+// cleared.
+func (tps *TrackerPatterns) ClearDescriptionForUncategorisedByCommonTrackerPatternIDs(
+	ctx context.Context,
+	tx pg.Tx,
+	commonIDs []gid.GID,
+) (int64, error) {
+	q := `
+UPDATE tracker_patterns
+SET
+	description = '',
+	updated_at = NOW()
+WHERE
+	common_tracker_pattern_id = ANY(@common_ids)
+	AND excluded = false
+	AND cookie_category_id IN (
+		SELECT id FROM cookie_categories WHERE kind = @uncategorised_kind
+	)
+`
+
+	args := pgx.StrictNamedArgs{
+		"common_ids":         commonIDs,
+		"uncategorised_kind": CookieCategoryKindUncategorised,
+	}
+
+	result, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return 0, fmt.Errorf("cannot clear uncategorised tracker pattern descriptions: %w", err)
+	}
+
+	return result.RowsAffected(), nil
+}
+
 // RequestMappingForUnmappedByInitiatorDomains re-arms mapping on the
 // still-unmapped org tracker patterns whose detected trackers share one
 // of the given initiator domains, so the mapping worker re-resolves them

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -1286,26 +1286,37 @@ func (tps *TrackerPatterns) RequestMappingForUnmappedSiblings(
 		return 0, nil
 	}
 
+	// The target rows are locked through an ORDER BY id ... FOR UPDATE
+	// subquery so concurrent re-enqueues over overlapping sibling sets
+	// always acquire their row locks in the same ascending id order. Two
+	// workers mapping sibling patterns on the same banner would otherwise
+	// lock the shared rows in opposite orders and deadlock (40P01).
 	q := `
 UPDATE tracker_patterns
 SET
 	mapping_requested_at = NOW(),
 	updated_at = NOW()
-WHERE
-	%[1]s
-	AND cookie_banner_id = @cookie_banner_id
-	AND id != @exclude_pattern_id
-	AND third_party_id IS NULL
-	AND mapping_requested_at IS NULL
-	AND (source IS NULL OR source != @extension_source)
-	AND id IN (
-		SELECT DISTINCT tracker_pattern_id
-		FROM detected_trackers
-		WHERE %[1]s
-			AND cookie_banner_id = @cookie_banner_id
-			AND initiator_domain = ANY(@domains)
-			AND tracker_pattern_id IS NOT NULL
-	)
+WHERE id IN (
+	SELECT id
+	FROM tracker_patterns
+	WHERE
+		%[1]s
+		AND cookie_banner_id = @cookie_banner_id
+		AND id != @exclude_pattern_id
+		AND third_party_id IS NULL
+		AND mapping_requested_at IS NULL
+		AND (source IS NULL OR source != @extension_source)
+		AND id IN (
+			SELECT DISTINCT tracker_pattern_id
+			FROM detected_trackers
+			WHERE %[1]s
+				AND cookie_banner_id = @cookie_banner_id
+				AND initiator_domain = ANY(@domains)
+				AND tracker_pattern_id IS NOT NULL
+		)
+	ORDER BY id
+	FOR UPDATE
+)
 `
 
 	q = fmt.Sprintf(q, scope.SQLFragment())

--- a/pkg/proboctl/commontrackerpattern/mark_first_party.go
+++ b/pkg/proboctl/commontrackerpattern/mark_first_party.go
@@ -44,12 +44,14 @@ func newCmdMarkFirstParty(f *cmdutil.Factory) *cobra.Command {
 		Long: "Record the terminal FIRST_PARTY verdict on selected common tracker " +
 			"patterns: the artifact has no third party (it is the scanned site's own, " +
 			"a generic library/log key, or an extension key embedding the site origin). " +
-			"Any vendor link is cleared, and the uncategorised org tracker patterns " +
-			"linked to them are remapped (org third party cleared, mapping re-armed) so " +
-			"the pipeline drops the stale vendor; because the verdict is terminal the " +
-			"mapping worker leaves them unattributed. User-categorised and excluded org " +
-			"patterns are left untouched. Selection mirrors 'reenrich'. To re-attribute " +
-			"a row later, use 'link' (which returns it to THIRD_PARTY).",
+			"Any vendor link is cleared and the now-stale description - which may name " +
+			"the wrong vendor - is blanked on both the catalog row and the uncategorised " +
+			"org tracker patterns linked to it. Those org patterns are remapped (org " +
+			"third party cleared, mapping re-armed) so the pipeline drops the stale " +
+			"vendor; because the verdict is terminal the mapping worker leaves them " +
+			"unattributed. User-categorised and excluded org patterns are left " +
+			"untouched. Selection mirrors 'reenrich'. To re-attribute a row later, use " +
+			"'link' (which returns it to THIRD_PARTY).",
 		Args: cobra.NoArgs,
 	}
 
@@ -109,6 +111,7 @@ func newCmdMarkFirstParty(f *cmdutil.Factory) *cobra.Command {
 		var (
 			marked   int64
 			remapped int64
+			cleared  int64
 		)
 
 		if err := pgClient.WithTx(
@@ -121,9 +124,18 @@ func newCmdMarkFirstParty(f *cmdutil.Factory) *cobra.Command {
 					return err
 				}
 
+				if _, err = ps.ClearDescriptionByIDs(ctx, tx, ids); err != nil {
+					return err
+				}
+
 				var tps coredata.TrackerPatterns
 
 				remapped, err = tps.RequestMappingForUncategorisedByCommonTrackerPatternIDs(ctx, tx, ids)
+				if err != nil {
+					return err
+				}
+
+				cleared, err = tps.ClearDescriptionForUncategorisedByCommonTrackerPatternIDs(ctx, tx, ids)
 				if err != nil {
 					return err
 				}
@@ -136,9 +148,10 @@ func newCmdMarkFirstParty(f *cmdutil.Factory) *cobra.Command {
 
 		_, _ = fmt.Fprintf(
 			out,
-			"Marked %d pattern(s) first-party, remapped %d uncategorised org tracker pattern(s).\n",
+			"Marked %d pattern(s) first-party, remapped %d uncategorised org tracker pattern(s), cleared %d stale org description(s).\n",
 			marked,
 			remapped,
+			cleared,
 		)
 
 		return nil

--- a/pkg/proboctl/commontrackerpattern/unlink.go
+++ b/pkg/proboctl/commontrackerpattern/unlink.go
@@ -41,10 +41,15 @@ func newCmdUnlink(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unlink",
 		Short: "Unlink common tracker patterns from any common third party",
-		Long: "Detach selected common tracker patterns from their common third party. " +
-			"Unlinking only clears the catalog link: there is no new vendor to " +
-			"re-enrich a description for or to remap org patterns onto, so neither " +
-			"enrichment nor org remapping is triggered. Selection mirrors 'reenrich'.",
+		Long: "Detach selected common tracker patterns from their common third party, " +
+			"returning the verdict to UNDETERMINED so the pipeline can re-probe them. " +
+			"The now-stale description - which still names the removed vendor - is " +
+			"blanked on both the catalog row and the uncategorised org tracker patterns " +
+			"linked to it, and those org patterns are remapped (org third party cleared, " +
+			"mapping re-armed) so the pipeline drops the stale vendor and re-resolves; a " +
+			"re-resolved vendor re-arms catalog enrichment, re-deriving the description. " +
+			"User-categorised and excluded org patterns are left untouched. Selection " +
+			"mirrors 'reenrich'.",
 		Args: cobra.NoArgs,
 	}
 
@@ -101,7 +106,11 @@ func newCmdUnlink(f *cmdutil.Factory) *cobra.Command {
 			return fmt.Errorf("about to unlink %d pattern(s); pass --yes to proceed or --dry-run to preview", len(ids))
 		}
 
-		var unlinked int64
+		var (
+			unlinked int64
+			remapped int64
+			cleared  int64
+		)
 
 		if err := pgClient.WithTx(
 			ctx,
@@ -109,14 +118,39 @@ func newCmdUnlink(f *cmdutil.Factory) *cobra.Command {
 				var ps coredata.CommonTrackerPatterns
 
 				unlinked, err = ps.RelinkCommonThirdPartyByIDs(ctx, tx, ids, nil)
+				if err != nil {
+					return err
+				}
 
-				return err
+				if _, err = ps.ClearDescriptionByIDs(ctx, tx, ids); err != nil {
+					return err
+				}
+
+				var tps coredata.TrackerPatterns
+
+				remapped, err = tps.RequestMappingForUncategorisedByCommonTrackerPatternIDs(ctx, tx, ids)
+				if err != nil {
+					return err
+				}
+
+				cleared, err = tps.ClearDescriptionForUncategorisedByCommonTrackerPatternIDs(ctx, tx, ids)
+				if err != nil {
+					return err
+				}
+
+				return nil
 			},
 		); err != nil {
 			return fmt.Errorf("cannot unlink common tracker patterns: %w", err)
 		}
 
-		_, _ = fmt.Fprintf(out, "Unlinked %d pattern(s) from any common third party.\n", unlinked)
+		_, _ = fmt.Fprintf(
+			out,
+			"Unlinked %d pattern(s) from any common third party, remapped %d uncategorised org tracker pattern(s), cleared %d stale org description(s).\n",
+			unlinked,
+			remapped,
+			cleared,
+		)
 
 		return nil
 	}


### PR DESCRIPTION
Surface every CookieSource value in the console: the trackers page filter was missing the HTTP option and the source badge helper had no EXTENSION case, so HTTP-sourced rows could not be filtered and extension-sourced rows rendered the raw enum string.

On the backend, the mark-first-party verdict now blanks the stale description on both the catalog row and its uncategorised org tracker patterns. A terminal non-third-party row keeps no vendor link, so a description naming the (now-cleared) vendor would be misleading; the mapping worker only copies descriptions into empty rows and never clears them, so clearing is done explicitly here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing tracker source support, makes tracker category editable, and clears stale descriptions when marking first‑party or unlinking. Ranks `HTTP` above `PRE_EXISTING`, fixes a mapping deadlock, and shows “persistent” for local‑storage/IndexedDB/cache‑storage trackers without max‑age across console and banner.

### Coredata **`+101`** **`-15`**
- Add helpers to clear catalog descriptions by ID and clear descriptions on uncategorised org patterns linked by common IDs.
- Leave excluded and user‑categorised patterns untouched; no enrichment re‑arm.

### Service **`+69`** **`-33`**
- Rank sources as SCRIPT > `HTTP` > EXTENSION > PRE_EXISTING so `HTTP` promotes and unblocks mapping.
- Fix deadlock in concurrent mapping: re‑enqueue siblings after commit in a separate txn and lock rows in deterministic id order.

### proboctl **`+61`** **`-14`**
- `mark first-party`: clear catalog and uncategorised org descriptions, then re‑arm mapping; output shows cleared org count.
- `unlink`: match this cleanup and remap so stale vendors drop and re‑resolve; output updated.

### App: console **`+74`** **`-21`**
- Add `HTTP` to the tracker source filter.
- Make category editable on the pattern detail page via `MoveToCategorySelect` and `moveTrackerPatternToCategory` with success/error toasts.
- Show “persistent” when max‑age is missing for local‑storage/IndexedDB/cache‑storage by threading trackerType into `humanizeSeconds`; update consent records, category section, rows, and properties.

### Package: cookie-banner **`+26`** **`-4`**
- Localize “persistent” and pass tracker type into `humanizeDuration`; update cookie list rendering.

### Package: helpers **`+19`** **`-2`**
- `humanizeSeconds` accepts trackerType and returns “persistent” for local‑storage/IndexedDB/cache‑storage; add `EXTENSION` to `getTrackerSourceBadge`.

### Tests **`+32`** **`-2`**
- Add cases covering `HTTP` ranking and promotion behavior.

<sup>Written for commit f1fc2dc0e0f699e3aad8cf7e636fb9d4feaa969e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

