### PR TITLE
Skip notifications for inactive users

### DIFF
--- a/pkg/coredata/document_version_approval_decision.go
+++ b/pkg/coredata/document_version_approval_decision.go
@@ -437,6 +437,13 @@ WITH next_group AS (
 				AND doc.deleted_at IS NULL
 				AND doc.archived_at IS NULL
 		)
+		AND EXISTS (
+			SELECT 1
+			FROM iam_membership_profiles p
+			WHERE p.id = document_version_approval_decisions.approver_id
+				AND p.state = @recipient_state::membership_state
+				AND (p.contract_end_date IS NULL OR p.contract_end_date >= @now::date)
+		)
 	GROUP BY
 		organization_id,
 		approver_id
@@ -479,6 +486,7 @@ ORDER BY
 
 	args := pgx.StrictNamedArgs{
 		"state":                     DocumentVersionApprovalDecisionStatePending,
+		"recipient_state":           ProfileStateActive,
 		"max_notifications":         documentNotificationMaxCount,
 		"now":                       now,
 		"debounce_before":           debounceBefore,

--- a/pkg/coredata/document_version_signature.go
+++ b/pkg/coredata/document_version_signature.go
@@ -461,6 +461,13 @@ WITH next_group AS (
 				AND doc.deleted_at IS NULL
 				AND doc.archived_at IS NULL
 		)
+		AND EXISTS (
+			SELECT 1
+			FROM iam_membership_profiles p
+			WHERE p.id = document_version_signatures.signed_by_profile_id
+				AND p.state = @recipient_state::membership_state
+				AND (p.contract_end_date IS NULL OR p.contract_end_date >= @now::date)
+		)
 	GROUP BY
 		organization_id,
 		signed_by_profile_id
@@ -502,6 +509,7 @@ ORDER BY
 
 	args := pgx.StrictNamedArgs{
 		"state":                     DocumentVersionSignatureStateRequested,
+		"recipient_state":           ProfileStateActive,
 		"max_notifications":         documentNotificationMaxCount,
 		"now":                       now,
 		"debounce_before":           debounceBefore,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop sending document approval and signature notifications to inactive or expired users. Only active profiles with valid contracts now receive reminders.

### Coredata **`+16`** **`-0`**
- Filter recipients to active profiles with non-expired contracts in approval and signature queries.
- Add `recipient_state` arg defaulting to `ProfileStateActive`; compare `contract_end_date` to `@now::date`.

<sup>Written for commit fdf51887070279eb3d91cca15357e692d11eed23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

