### PR TITLE
Notify only for the latest document version

### DIFF
--- a/pkg/coredata/document_version_approval_decision.go
+++ b/pkg/coredata/document_version_approval_decision.go
@@ -436,6 +436,13 @@ WITH next_group AS (
 			WHERE q.id = document_version_approval_decisions.quorum_id
 				AND doc.deleted_at IS NULL
 				AND doc.archived_at IS NULL
+				AND dv.id = (
+					SELECT latest.id
+					FROM document_versions latest
+					WHERE latest.document_id = dv.document_id
+					ORDER BY latest.major DESC, latest.minor DESC
+					LIMIT 1
+				)
 		)
 		AND EXISTS (
 			SELECT 1
@@ -479,6 +486,13 @@ WHERE
 		WHERE q.id = d.quorum_id
 			AND doc.deleted_at IS NULL
 			AND doc.archived_at IS NULL
+			AND dv.id = (
+				SELECT latest.id
+				FROM document_versions latest
+				WHERE latest.document_id = dv.document_id
+				ORDER BY latest.major DESC, latest.minor DESC
+				LIMIT 1
+			)
 	)
 ORDER BY
 	d.quorum_id

--- a/pkg/coredata/document_version_signature.go
+++ b/pkg/coredata/document_version_signature.go
@@ -460,6 +460,8 @@ WITH next_group AS (
 			WHERE dv.id = document_version_signatures.document_version_id
 				AND doc.deleted_at IS NULL
 				AND doc.archived_at IS NULL
+				AND doc.current_published_major IS NOT NULL
+				AND dv.major = doc.current_published_major
 		)
 		AND EXISTS (
 			SELECT 1
@@ -502,6 +504,8 @@ WHERE
 		WHERE dv.id = s.document_version_id
 			AND doc.deleted_at IS NULL
 			AND doc.archived_at IS NULL
+			AND doc.current_published_major IS NOT NULL
+			AND dv.major = doc.current_published_major
 	)
 ORDER BY
 	s.document_version_id


### PR DESCRIPTION
Scope the signature and approval notification queries to the document's current version so the worker ignores requests left on superseded versions: signatures must belong to the current published major, and pending approval decisions must target the document's latest version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope notifications to the latest document version to stop alerts for superseded versions. Signatures must match the current published major; approval decisions only consider the latest version ID.

### Coredata **`+18`** **`-0`**
- document_version_approval_decision: Added filter to ensure `dv.id` equals the document’s latest version (by major/minor desc) in both query paths.
- document_version_signature: Consider signatures only when `doc.current_published_major` is set and `dv.major` equals it.

<sup>Written for commit 49cacef44c2114e733eaec90fa1631780747dee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

