### PR TITLE
Allow signature requests only on current published version

### DIFF
--- a/apps/console/src/pages/organizations/documents/signatures/_components/DocumentSignaturePlaceholder.tsx
+++ b/apps/console/src/pages/organizations/documents/signatures/_components/DocumentSignaturePlaceholder.tsx
@@ -42,6 +42,12 @@ const versionFragment = graphql`
   fragment DocumentSignaturePlaceholder_versionFragment on DocumentVersion {
     id
     status
+    major
+    minor
+    document {
+      currentPublishedMajor
+      currentPublishedMinor
+    }
   }
 `;
 
@@ -81,6 +87,11 @@ export function DocumentSignaturePlaceholder(props: {
   const person = useFragment<DocumentSignaturePlaceholder_personFragment$key>(personFragment, personFragmentRef);
   const version = useFragment<DocumentSignaturePlaceholder_versionFragment$key>(versionFragment, versionFragmentRef);
 
+  const isCurrentPublishedVersion
+    = version.status === "PUBLISHED"
+      && version.document.currentPublishedMajor === version.major
+      && version.document.currentPublishedMinor === version.minor;
+
   const [requestSignature, isSendingRequest] = useMutationWithToasts(
     requestSignatureMutation,
     {
@@ -99,7 +110,7 @@ export function DocumentSignaturePlaceholder(props: {
           {person.emailAddress}
         </div>
       </div>
-      {version.status === "PUBLISHED" && canRequestSignature && (
+      {isCurrentPublishedVersion && canRequestSignature && (
         <Button
           variant="secondary"
           className="ml-auto"

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -68,6 +68,9 @@ type (
 	ErrDocumentVersionNotPublished struct {
 	}
 
+	ErrDocumentVersionNotCurrent struct {
+	}
+
 	ErrDocumentVersionPendingApproval struct {
 	}
 
@@ -268,6 +271,10 @@ func (e ErrDocumentVersionNotDraft) Error() string {
 
 func (e ErrDocumentVersionNotPublished) Error() string {
 	return "document version is not published"
+}
+
+func (e ErrDocumentVersionNotCurrent) Error() string {
+	return "document version is not the current published version"
 }
 
 func (e ErrDocumentVersionPendingApproval) Error() string {
@@ -1102,6 +1109,13 @@ func (s *DocumentService) RequestSignature(
 
 			if documentVersion.Status != coredata.DocumentVersionStatusPublished {
 				return &ErrDocumentVersionNotPublished{}
+			}
+
+			if document.CurrentPublishedMajor == nil ||
+				document.CurrentPublishedMinor == nil ||
+				documentVersion.Major != *document.CurrentPublishedMajor ||
+				documentVersion.Minor != *document.CurrentPublishedMinor {
+				return &ErrDocumentVersionNotCurrent{}
 			}
 
 			profile := &coredata.MembershipProfile{}

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -1337,6 +1337,10 @@ func (r *mutationResolver) RequestSignature(ctx context.Context, input types.Req
 			return nil, gqlutils.Conflict(ctx, errNotPublished)
 		}
 
+		if errNotCurrent, ok := errors.AsType[*probo.ErrDocumentVersionNotCurrent](err); ok {
+			return nil, gqlutils.Conflict(ctx, errNotCurrent)
+		}
+
 		if errContractEnded, ok := errors.AsType[*probo.ErrProfileContractEnded](err); ok {
 			return nil, gqlutils.Conflict(ctx, errContractEnded)
 		}

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2456,6 +2456,10 @@ func (r *Resolver) RequestDocumentVersionSignatureTool(ctx context.Context, req 
 		},
 	)
 	if err != nil {
+		if _, ok := errors.AsType[*probo.ErrDocumentVersionNotCurrent](err); ok {
+			return nil, types.RequestDocumentVersionSignatureOutput{}, fmt.Errorf("cannot request signature: %w", err)
+		}
+
 		panic(fmt.Errorf("cannot request signature: %w", err))
 	}
 


### PR DESCRIPTION
Requesting a signature only validated that the version was PUBLISHED, so a signature could be requested on a superseded (older) published version. Reject versions that are not the document's current published major/minor, and hide the request button in the console for non-current versions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts signature requests to only the current published document version. Blocks requests on superseded versions and hides the button when the version isn’t current.

### Service **`+14`** **`-0`**
- Added `ErrDocumentVersionNotCurrent`.
- `RequestSignature` now requires `version.major/minor` to match `document.currentPublishedMajor/minor` (both non-nil), otherwise returns the new error.

### GraphQL API **`+4`** **`-0`**
- Maps `ErrDocumentVersionNotCurrent` to a 409 Conflict in the console API.

### MCP **`+4`** **`-0`**
- In the signature tool, detects `ErrDocumentVersionNotCurrent` and returns a clear error instead of panicking.

### App: console **`+12`** **`-1`**
- Extends the version fragment with `major`, `minor`, and the document’s `currentPublishedMajor`/`currentPublishedMinor`.
- Shows the Request Signature button only for the current published version.

<sup>Written for commit a8e8e3e0e7b27c425b632af219e94fbfeab2e4f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

