### PR TITLE
Fix third party assessment header

### DIFF
--- a/apps/console/src/pages/organizations/third-parties/ThirdPartiesPage.tsx
+++ b/apps/console/src/pages/organizations/third-parties/ThirdPartiesPage.tsx
@@ -139,7 +139,7 @@ export default function ThirdPartiesPage(props: Props) {
         <Thead>
           <Tr>
             <SortableTh field="NAME">{__("Third party")}</SortableTh>
-            <Th>{__("Accessed At")}</Th>
+            <Th>{__("Assessed At")}</Th>
             <Th>{__("Data Risk")}</Th>
             <Th>{__("Business Risk")}</Th>
             {hasAnyAction && <Th></Th>}

--- a/apps/console/src/pages/organizations/third-parties/third-parties/ThirdPartyThirdPartiesPage.tsx
+++ b/apps/console/src/pages/organizations/third-parties/third-parties/ThirdPartyThirdPartiesPage.tsx
@@ -199,7 +199,7 @@ export default function ThirdPartyThirdPartiesPage({ queryRef }: Props) {
         <Thead>
           <Tr>
             <SortableTh field="NAME">{__("Third party")}</SortableTh>
-            <Th>{__("Accessed At")}</Th>
+            <Th>{__("Assessed At")}</Th>
             <Th>{__("Data Risk")}</Th>
             <Th>{__("Business Risk")}</Th>
             <Th />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update the Third parties table assessment date header to say "Assessed At".
- Apply the same copy fix to the nested third-party relations table.

## Verification
- `rg "Accessed At" apps/console/src` (no matches)
- `rg "Assessed At" apps/console/src` (shows the two updated headers)
- `make go-fmt`
- `npm -w @probo/console run check` (fails: existing missing generated Relay modules and related TypeScript errors; no errors attributable to this copy-only change)

Linear: ENG-528
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-528](https://linear.app/probo/issue/ENG-528/third-party-tab-column-says-accessed-at-instead-of-assessed-at)

<div><a href="https://cursor.com/agents/bc-405bb7ed-4401-4892-964e-b6de82207fcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-405bb7ed-4401-4892-964e-b6de82207fcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Third parties assessment date column to show “Assessed At” in both the main and nested tables. Aligns with Linear ENG-528.

### App: console **`+2`** **`-2`**
- Updated the column header in ThirdPartiesPage and nested ThirdPartyThirdPartiesPage.
- Copy-only change; no logic or data updates.

<sup>Written for commit 002c91ba11bd5cc387b28bdeb1659232fbf36d5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

