### PR TITLE
Redirect employee to tab list for missing documents

### DIFF
--- a/apps/console/src/pages/organizations/documents/approve/DocumentApprovePage.tsx
+++ b/apps/console/src/pages/organizations/documents/approve/DocumentApprovePage.tsx
@@ -38,7 +38,7 @@ import {
   useMutation,
   usePreloadedQuery,
 } from "react-relay";
-import { useNavigate } from "react-router";
+import { Navigate, useNavigate } from "react-router";
 import { graphql } from "relay-runtime";
 import { useWindowSize } from "usehooks-ts";
 
@@ -142,6 +142,7 @@ export function DocumentApprovePage(props: {
   queryRef: PreloadedQuery<DocumentApprovePageQuery>;
 }) {
   const { queryRef } = props;
+  const organizationId = useOrganizationId();
   const data = usePreloadedQuery<DocumentApprovePageQuery>(
     documentApprovePageQuery,
     queryRef,
@@ -150,9 +151,10 @@ export function DocumentApprovePage(props: {
   const document = data.viewer.approvableDocument;
   if (!document) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <Spinner />
-      </div>
+      <Navigate
+        to={`/organizations/${organizationId}/employee/approvals`}
+        replace
+      />
     );
   }
 
@@ -496,6 +498,15 @@ function DocumentApproveContent({
       pdfUrlRef.current = null;
     };
   }, [selectedVersion?.id, exportPDF, toast, __]);
+
+  if (versions.length === 0) {
+    return (
+      <Navigate
+        to={`/organizations/${organizationId}/employee/approvals`}
+        replace
+      />
+    );
+  }
 
   return (
     <div className="fixed inset-0 top-12 bg-level-2 flex flex-col">

--- a/apps/console/src/pages/organizations/employee/EmployeeDocumentSignaturePage.tsx
+++ b/apps/console/src/pages/organizations/employee/EmployeeDocumentSignaturePage.tsx
@@ -15,7 +15,7 @@
 import { formatError } from "@probo/helpers";
 import { usePageTitle } from "@probo/hooks";
 import { useTranslate } from "@probo/i18n";
-import { Card, Spinner, useToast } from "@probo/ui";
+import { Card, useToast } from "@probo/ui";
 import { useEffect, useRef, useState } from "react";
 import {
   type PreloadedQuery,
@@ -24,7 +24,7 @@ import {
   usePreloadedQuery,
 } from "react-relay";
 import { graphql } from "react-relay";
-import { useNavigate } from "react-router";
+import { Navigate, useNavigate } from "react-router";
 import { useWindowSize } from "usehooks-ts";
 
 import type { EmployeeDocumentSignaturePageDocumentFragment$key } from "#/__generated__/core/EmployeeDocumentSignaturePageDocumentFragment.graphql";
@@ -94,6 +94,7 @@ export function EmployeeDocumentSignaturePage(props: {
   queryRef: PreloadedQuery<EmployeeDocumentSignaturePageQuery>;
 }) {
   const { queryRef } = props;
+  const organizationId = useOrganizationId();
   const { viewer } = usePreloadedQuery<EmployeeDocumentSignaturePageQuery>(
     employeeDocumentSignaturePageQuery,
     queryRef,
@@ -102,9 +103,10 @@ export function EmployeeDocumentSignaturePage(props: {
 
   if (!document) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <Spinner />
-      </div>
+      <Navigate
+        to={`/organizations/${organizationId}/employee/signatures`}
+        replace
+      />
     );
   }
 
@@ -231,6 +233,15 @@ function DocumentSignatureContent({
       pdfUrlRef.current = null;
     };
   }, [selectedVersion?.id, exportEmployeeDocumentVersionPDF, toast, __]);
+
+  if (versions.length === 0) {
+    return (
+      <Navigate
+        to={`/organizations/${organizationId}/employee/signatures`}
+        replace
+      />
+    );
+  }
 
   return (
     <div


### PR DESCRIPTION
When an email link points to an employee signature or approval document that has been deleted or is no longer accessible to the user, the detail pages rendered an infinite spinner. Redirect to the signatures/approvals tab list instead, both when the document resolves to null and when it has no accessible versions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect employees to the approvals or signatures list when a linked document is missing or has no accessible versions. This removes the infinite spinner and fixes broken deep-links.

### App: console **`+31`** **`-9`**
- Approvals and Signatures: replace spinner fallback with `Navigate` to the employee tab when the document is null or `versions.length === 0`; added `useOrganizationId` for URL paths.

<sup>Written for commit 45b434dd996da7b5314c59b28e295c6aafcd5550. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

