### PR TITLE
Add npm allowScripts policy for dependency install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,14 @@
     "form-data": "^4.0.6",
     "js-yaml": "^4.2.0"
   },
+  "allowScripts": {
+    "esbuild": true,
+    "fsevents": true,
+    "unrs-resolver": true,
+    "core-js": false,
+    "isolated-vm": false,
+    "eslint-plugin-n8n-nodes-base": false
+  },
   "license": "MIT",
   "packageManager": "npm@11.8.0",
   "dependencies": {


### PR DESCRIPTION
Allow install scripts for the packages we actually need (esbuild for Vite builds, fsevents for dev file watching, unrs-resolver for n8n linting) and deny the rest (core-js, isolated-vm,
eslint-plugin-n8n-nodes-base) so npm 11's install-script warning is covered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an npm `allowScripts` policy to control dependency install scripts. We allow the few we need and block the rest to silence npm 11 warnings and reduce risk.

### Other **`+8`** **`-0`**
- Added `allowScripts` to `package.json` to whitelist needed install scripts.
- Allowed: `esbuild`, `fsevents`, `unrs-resolver`.
- Denied: `core-js`, `isolated-vm`, `eslint-plugin-n8n-nodes-base`.

<sup>Written for commit 9c399c29bdc3da22c53e27eaa05ba78dbb869431. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

