### PR TITLE
Handle passwordless identities during sign-in

### DIFF
--- a/apps/console/src/pages/iam/auth/ForgotPasswordPage.tsx
+++ b/apps/console/src/pages/iam/auth/ForgotPasswordPage.tsx
@@ -18,7 +18,7 @@ import { useTranslate } from "@probo/i18n";
 import { Button, Field, useToast } from "@probo/ui";
 import { useState } from "react";
 import { useMutation } from "react-relay";
-import { Link } from "react-router";
+import { Link, useSearchParams } from "react-router";
 import { graphql } from "relay-runtime";
 import { z } from "zod";
 
@@ -40,13 +40,14 @@ const schema = z.object({
 export default function ForgotPasswordPage() {
   const { toast } = useToast();
   const { __ } = useTranslate();
+  const [searchParams] = useSearchParams();
 
   usePageTitle(__("Forgot Password"));
 
   const [instructionsSent, setInstructionsSent] = useState<boolean>();
   const { register, handleSubmit, formState } = useFormWithSchema(schema, {
     defaultValues: {
-      email: "",
+      email: searchParams.get("email") ?? "",
     },
   });
 

--- a/apps/console/src/pages/iam/auth/sign-in/PasswordSignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/PasswordSignInPage.tsx
@@ -12,10 +12,10 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { formatError } from "@probo/helpers";
+import { formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import { Button, Field, IconChevronLeft, useToast } from "@probo/ui";
-import type { FormEventHandler } from "react";
+import { type FormEventHandler, useState } from "react";
 import { useMutation } from "react-relay";
 import { Link, matchPath, useLocation } from "react-router";
 import { graphql } from "relay-runtime";
@@ -33,12 +33,32 @@ const signInMutation = graphql`
   }
 `;
 
+function hasInvalidCredentialsError(
+  error: GraphQLError | GraphQLError[] | null | undefined,
+) {
+  const errors = Array.isArray(error)
+    ? error
+    : (error?.source?.errors ?? (error ? [error] : []));
+
+  return errors.some(error => error.extensions?.code === "INVALID_CREDENTIALS");
+}
+
+function forgotPasswordSearch(locationSearch: string, email: string) {
+  const searchParams = new URLSearchParams(locationSearch);
+  searchParams.set("email", email);
+
+  return `?${searchParams.toString()}`;
+}
+
 export default function PasswordSignInPage() {
   const location = useLocation();
   const safeContinueUrl = useSafeContinueUrl();
 
   const { __ } = useTranslate();
   const { toast } = useToast();
+  const [failedSignInEmail, setFailedSignInEmail] = useState<
+    string | null
+  >(null);
 
   const [signIn, isSigningIn]
     = useMutation<PasswordSignInPageMutation>(signInMutation);
@@ -50,6 +70,8 @@ export default function PasswordSignInPage() {
     const passwordValue = formData.get("password") ? (formData.get("password") as string).toString() : "";
 
     if (!emailValue || !passwordValue) return;
+
+    setFailedSignInEmail(null);
 
     const match = matchPath(
       { path: "/organizations/:organizationId", caseSensitive: false, end: false },
@@ -67,6 +89,10 @@ export default function PasswordSignInPage() {
       },
       onCompleted: (_, error) => {
         if (error) {
+          if (hasInvalidCredentialsError(error)) {
+            setFailedSignInEmail(emailValue);
+          }
+
           toast({
             title: __("Error"),
             description: formatError(
@@ -125,6 +151,29 @@ export default function PasswordSignInPage() {
           label={__("Password")}
         />
       </div>
+
+      {failedSignInEmail && (
+        <div
+          role="alert"
+          className="space-y-3 rounded-lg border border-border-low bg-subtle p-4 text-sm text-txt-secondary"
+        >
+          <p>
+            {__(
+              "Check your credentials, or set a password if you were invited and have not set one yet.",
+            )}
+          </p>
+          <Button
+            variant="secondary"
+            className="w-full h-10"
+            to={{
+              pathname: "/auth/forgot-password",
+              search: forgotPasswordSearch(location.search, failedSignInEmail),
+            }}
+          >
+            {__("Set or reset password")}
+          </Button>
+        </div>
+      )}
 
       <Button className="w-xs h-10 mx-auto mt-6" disabled={isSigningIn}>
         {isSigningIn ? __("Logging in...") : __("Login")}

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -509,6 +509,10 @@ func (s AuthService) CheckCredentials(
 				return NewInvalidCredentialsError("invalid email or password")
 			}
 
+			if identity.HashedPassword == nil {
+				return NewPasswordNotSetError()
+			}
+
 			isPasswordMatch, err := s.hp.ComparePasswordAndHash([]byte(password), identity.HashedPassword)
 			if err != nil {
 				return fmt.Errorf("cannot verify password: %w", err)

--- a/pkg/iam/errors.go
+++ b/pkg/iam/errors.go
@@ -408,6 +408,16 @@ func (e ErrInvalidCredentials) Error() string {
 	return e.message
 }
 
+type ErrPasswordNotSet struct{ message string }
+
+func NewPasswordNotSetError() error {
+	return &ErrPasswordNotSet{"password is not set for this account"}
+}
+
+func (e ErrPasswordNotSet) Error() string {
+	return e.message
+}
+
 type ErrPasswordAuthenticationRequired struct {
 	Reason string
 }

--- a/pkg/server/api/connect/v1/session_resolvers.go
+++ b/pkg/server/api/connect/v1/session_resolvers.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/server/api/authn"
@@ -27,12 +26,12 @@ func (r *mutationResolver) SignIn(ctx context.Context, input types.SignInInput) 
 		}
 
 		if _, ok := errors.AsType[*iam.ErrInvalidCredentials](err); ok {
-			return nil, &gqlerror.Error{
-				Message: err.Error(),
-				Extensions: map[string]any{
-					"code": "INVALID_CREDENTIALS",
-				},
-			}
+			return nil, gqlutils.InvalidCredentials(ctx)
+		}
+
+		if _, ok := errors.AsType[*iam.ErrPasswordNotSet](err); ok {
+			// Keep passwordless identities indistinguishable from invalid credentials.
+			return nil, gqlutils.InvalidCredentials(ctx)
 		}
 
 		r.logger.ErrorCtx(ctx, "cannot check credentials", log.Error(err))

--- a/pkg/server/gqlutils/errors.go
+++ b/pkg/server/gqlutils/errors.go
@@ -100,6 +100,16 @@ func AccountAlreadyActivated(ctx context.Context, err error) *gqlerror.Error {
 	}
 }
 
+func InvalidCredentials(ctx context.Context) *gqlerror.Error {
+	return &gqlerror.Error{
+		Message: "invalid email or password",
+		Path:    graphql.GetPath(ctx),
+		Extensions: map[string]any{
+			"code": "INVALID_CREDENTIALS",
+		},
+	}
+}
+
 func Forbidden(ctx context.Context, err error) *gqlerror.Error {
 	return &gqlerror.Error{
 		Message: err.Error(),


### PR DESCRIPTION
## Summary

- Detect identities without a stored password hash before password verification so password sign-in no longer reaches an internal hash error.
- Return the same public `INVALID_CREDENTIALS` GraphQL error for passwordless identities as for unknown users or wrong passwords, avoiding account-state enumeration.
- Show generic invalid-credentials recovery guidance in the console, with a forgot-password link that keeps the attempted email prefilled.

## Why

Invited accounts can exist without a local password hash, especially when they were created through invite or SSO-first flows. Password login for those accounts previously reached password verification with a nil hash and surfaced as an internal server error. This keeps the internal error typed while ensuring unauthenticated sign-in responses remain indistinguishable.

## Validation

- `npm ci`
- `PATH=/usr/local/go/bin:$PATH make @probo/emails`
- `PATH=/usr/local/go/bin:$PATH make relay`
- `PATH=/usr/local/go/bin:$PATH make generate`
- `/usr/local/go/bin/go test ./pkg/iam ./pkg/server/gqlutils ./pkg/server/api/connect/v1`
- `npm --workspace @probo/console run check`
- `../../node_modules/.bin/eslint --no-warn-ignored src/pages/iam/auth/sign-in/PasswordSignInPage.tsx src/pages/iam/auth/ForgotPasswordPage.tsx`
- `git diff --check`

## Notes

The commit includes the required DCO `Signed-off-by` trailer and is GPG-signed with a GitHub-verified key. The account-state enumeration review thread is addressed by commit `a6a7bdb`.