### PR TITLE
Allow closing failed access review campaigns

### DIFF
--- a/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
@@ -148,7 +148,9 @@ export const campaignDetailPageQuery = graphql`
         id
         name
         status
-        pendingEntryCount
+        pendingEntries: entries(first: 0, filter: { decision: PENDING }) {
+          totalCount
+        }
         canDelete: permission(action: "access-review:campaign:delete")
         sources {
           id
@@ -249,7 +251,7 @@ export default function CampaignDetailPage({ queryRef }: Props) {
   const [deleteCampaign, isDeleting]
     = useMutation<CampaignDetailPageDeleteMutation>(deleteCampaignMutation);
 
-  const canComplete = campaign.pendingEntryCount === 0;
+  const canComplete = campaign.pendingEntries.totalCount === 0;
 
   const handleStart = () => {
     startCampaign({

--- a/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
@@ -148,6 +148,7 @@ export const campaignDetailPageQuery = graphql`
         id
         name
         status
+        pendingEntryCount
         canDelete: permission(action: "access-review:campaign:delete")
         sources {
           id
@@ -248,13 +249,7 @@ export default function CampaignDetailPage({ queryRef }: Props) {
   const [deleteCampaign, isDeleting]
     = useMutation<CampaignDetailPageDeleteMutation>(deleteCampaignMutation);
 
-  const allDecided = campaign.sources.length > 0
-    && campaign.sources.every(source =>
-      source.entries
-      && source.entries.edges.length > 0
-      && source.entries.edges.every(edge => edge.node.decision !== "PENDING")
-      && !source.entries.pageInfo.hasNextPage,
-    );
+  const canComplete = campaign.pendingEntryCount === 0;
 
   const handleStart = () => {
     startCampaign({
@@ -425,7 +420,7 @@ export default function CampaignDetailPage({ queryRef }: Props) {
         {isPendingActions && (
           <Button
             onClick={handleComplete}
-            disabled={!allDecided || isClosing}
+            disabled={!canComplete || isClosing}
           >
             {isClosing ? __("Completing...") : __("Complete campaign")}
           </Button>

--- a/e2e/console/access_review_test.go
+++ b/e2e/console/access_review_test.go
@@ -349,50 +349,6 @@ func TestAccessReviewCampaign_Create(t *testing.T) {
 		assert.Len(t, node.CampaignSources, 2)
 	})
 
-	t.Run("with framework controls", func(t *testing.T) {
-		t.Parallel()
-
-		const query = `
-			mutation($input: CreateAccessReviewCampaignInput!) {
-				createAccessReviewCampaign(input: $input) {
-					accessReviewCampaignEdge {
-						node {
-							id
-							name
-							frameworkControls
-						}
-					}
-				}
-			}
-		`
-
-		var result struct {
-			CreateAccessReviewCampaign struct {
-				AccessReviewCampaignEdge struct {
-					Node struct {
-						ID                string   `json:"id"`
-						Name              string   `json:"name"`
-						FrameworkControls []string `json:"frameworkControls"`
-					} `json:"node"`
-				} `json:"accessReviewCampaignEdge"`
-			} `json:"createAccessReviewCampaign"`
-		}
-
-		err := owner.Execute(query, map[string]any{
-			"input": map[string]any{
-				"organizationId":    orgID,
-				"name":              "SOC2 Campaign",
-				"frameworkControls": []string{"CC6.1", "CC6.2"},
-			},
-		}, &result)
-		require.NoError(t, err)
-
-		node := result.CreateAccessReviewCampaign.AccessReviewCampaignEdge.Node
-		assert.NotEmpty(t, node.ID)
-		assert.Equal(t, "SOC2 Campaign", node.Name)
-		assert.Contains(t, node.FrameworkControls, "CC6.1")
-		assert.Contains(t, node.FrameworkControls, "CC6.2")
-	})
 }
 
 func TestAccessReviewCampaign_Update(t *testing.T) {

--- a/e2e/console/access_review_test.go
+++ b/e2e/console/access_review_test.go
@@ -348,7 +348,6 @@ func TestAccessReviewCampaign_Create(t *testing.T) {
 		assert.Equal(t, "Campaign with Sources", node.Name)
 		assert.Len(t, node.CampaignSources, 2)
 	})
-
 }
 
 func TestAccessReviewCampaign_Update(t *testing.T) {

--- a/pkg/accessreview/campaign_service.go
+++ b/pkg/accessreview/campaign_service.go
@@ -36,14 +36,13 @@ func (s *Service) CreateCampaign(
 
 	now := time.Now()
 	campaign := &coredata.AccessReviewCampaign{
-		ID:                gid.New(scope.GetTenantID(), coredata.AccessReviewCampaignEntityType),
-		OrganizationID:    req.OrganizationID,
-		Name:              req.Name,
-		Description:       req.Description,
-		Status:            coredata.AccessReviewCampaignStatusDraft,
-		FrameworkControls: req.FrameworkControls,
-		CreatedAt:         now,
-		UpdatedAt:         now,
+		ID:             gid.New(scope.GetTenantID(), coredata.AccessReviewCampaignEntityType),
+		OrganizationID: req.OrganizationID,
+		Name:           req.Name,
+		Description:    req.Description,
+		Status:         coredata.AccessReviewCampaignStatusDraft,
+		CreatedAt:      now,
+		UpdatedAt:      now,
 	}
 
 	err := s.pg.WithTx(
@@ -158,10 +157,6 @@ func (s *Service) UpdateCampaign(
 
 			if req.Description != nil && *req.Description != nil {
 				campaign.Description = **req.Description
-			}
-
-			if req.FrameworkControls != nil {
-				campaign.FrameworkControls = *req.FrameworkControls
 			}
 
 			campaign.UpdatedAt = time.Now()

--- a/pkg/accessreview/campaign_service.go
+++ b/pkg/accessreview/campaign_service.go
@@ -370,8 +370,17 @@ func (s *Service) CloseCampaign(
 			}
 
 			entries := coredata.AccessReviewEntries{}
+			filter := &coredata.AccessReviewEntryFilter{
+				Decision: new(coredata.AccessReviewEntryDecisionPending),
+			}
 
-			pendingCount, err := entries.CountPendingByCampaignID(ctx, conn, scope, campaignID)
+			pendingCount, err := entries.CountByCampaignID(
+				ctx,
+				conn,
+				scope,
+				campaignID,
+				filter,
+			)
 			if err != nil {
 				return fmt.Errorf("cannot count pending entries: %w", err)
 			}

--- a/pkg/accessreview/campaign_types.go
+++ b/pkg/accessreview/campaign_types.go
@@ -27,15 +27,13 @@ type (
 		OrganizationID        gid.GID
 		Name                  string
 		Description           string
-		FrameworkControls     []string
 		AccessReviewSourceIDs []gid.GID
 	}
 
 	UpdateAccessReviewCampaignRequest struct {
-		CampaignID        gid.GID
-		Name              **string
-		Description       **string
-		FrameworkControls *[]string
+		CampaignID  gid.GID
+		Name        **string
+		Description **string
 	}
 
 	AddCampaignSourceRequest struct {

--- a/pkg/accessreview/entry_service.go
+++ b/pkg/accessreview/entry_service.go
@@ -378,33 +378,6 @@ func (s *Service) CountEntriesForCampaignIDAndSourceID(
 	return count, nil
 }
 
-func (s *Service) CountPendingEntriesForCampaignID(
-	ctx context.Context,
-	scope coredata.Scoper,
-	campaignID gid.GID,
-) (int, error) {
-	var count int
-
-	err := s.pg.WithConn(
-		ctx,
-		func(ctx context.Context, conn pg.Querier) (err error) {
-			entries := coredata.AccessReviewEntries{}
-
-			count, err = entries.CountPendingByCampaignID(ctx, conn, scope, campaignID)
-			if err != nil {
-				return fmt.Errorf("cannot count pending access entries: %w", err)
-			}
-
-			return nil
-		},
-	)
-	if err != nil {
-		return 0, err
-	}
-
-	return count, nil
-}
-
 func (s *Service) EntryDecisionHistory(
 	ctx context.Context,
 	scope coredata.Scoper,

--- a/pkg/cmd/access-review/campaign/update/update.go
+++ b/pkg/cmd/access-review/campaign/update/update.go
@@ -47,10 +47,9 @@ type updateResponse struct {
 
 func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	var (
-		flagName             string
-		flagDescription      string
-		flagFrameworkControl []string
-		flagOutput           *string
+		flagName        string
+		flagDescription string
+		flagOutput      *string
 	)
 
 	cmd := &cobra.Command{
@@ -92,10 +91,6 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				input["description"] = flagDescription
 			}
 
-			if cmd.Flags().Changed("framework-control") {
-				input["frameworkControls"] = flagFrameworkControl
-			}
-
 			data, err := client.Do(
 				updateMutation,
 				map[string]any{"input": input},
@@ -125,12 +120,6 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVar(&flagName, "name", "", "Campaign name")
 	cmd.Flags().StringVar(&flagDescription, "description", "", "Campaign description")
-	cmd.Flags().StringSliceVar(
-		&flagFrameworkControl,
-		"framework-control",
-		nil,
-		"Framework control IDs (can be repeated)",
-	)
 	flagOutput = cmdutil.AddOutputFlag(cmd)
 
 	return cmd

--- a/pkg/coredata/access_review_campaign.go
+++ b/pkg/coredata/access_review_campaign.go
@@ -30,16 +30,15 @@ import (
 
 type (
 	AccessReviewCampaign struct {
-		ID                gid.GID                    `db:"id"`
-		OrganizationID    gid.GID                    `db:"organization_id"`
-		Name              string                     `db:"name"`
-		Description       string                     `db:"description"`
-		Status            AccessReviewCampaignStatus `db:"status"`
-		StartedAt         *time.Time                 `db:"started_at"`
-		CompletedAt       *time.Time                 `db:"completed_at"`
-		FrameworkControls []string                   `db:"framework_controls"`
-		CreatedAt         time.Time                  `db:"created_at"`
-		UpdatedAt         time.Time                  `db:"updated_at"`
+		ID             gid.GID                    `db:"id"`
+		OrganizationID gid.GID                    `db:"organization_id"`
+		Name           string                     `db:"name"`
+		Description    string                     `db:"description"`
+		Status         AccessReviewCampaignStatus `db:"status"`
+		StartedAt      *time.Time                 `db:"started_at"`
+		CompletedAt    *time.Time                 `db:"completed_at"`
+		CreatedAt      time.Time                  `db:"created_at"`
+		UpdatedAt      time.Time                  `db:"updated_at"`
 	}
 
 	AccessReviewCampaigns []*AccessReviewCampaign
@@ -136,7 +135,6 @@ SELECT
     status,
     started_at,
     completed_at,
-    framework_controls,
     created_at,
     updated_at
 FROM
@@ -186,7 +184,6 @@ INSERT INTO
         status,
         started_at,
         completed_at,
-        framework_controls,
         created_at,
         updated_at
     )
@@ -199,24 +196,22 @@ VALUES (
     @status,
     @started_at,
     @completed_at,
-    @framework_controls,
     @created_at,
     @updated_at
 );
 `
 
 	args := pgx.StrictNamedArgs{
-		"id":                 c.ID,
-		"tenant_id":          scope.GetTenantID(),
-		"organization_id":    c.OrganizationID,
-		"name":               c.Name,
-		"description":        c.Description,
-		"status":             c.Status,
-		"started_at":         c.StartedAt,
-		"completed_at":       c.CompletedAt,
-		"framework_controls": c.FrameworkControls,
-		"created_at":         c.CreatedAt,
-		"updated_at":         c.UpdatedAt,
+		"id":              c.ID,
+		"tenant_id":       scope.GetTenantID(),
+		"organization_id": c.OrganizationID,
+		"name":            c.Name,
+		"description":     c.Description,
+		"status":          c.Status,
+		"started_at":      c.StartedAt,
+		"completed_at":    c.CompletedAt,
+		"created_at":      c.CreatedAt,
+		"updated_at":      c.UpdatedAt,
 	}
 
 	_, err := conn.Exec(ctx, q, args)
@@ -240,7 +235,6 @@ SET
     status = @status,
     started_at = @started_at,
     completed_at = @completed_at,
-    framework_controls = @framework_controls,
     updated_at = @updated_at
 WHERE
     %s
@@ -249,14 +243,13 @@ WHERE
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
-		"id":                 c.ID,
-		"name":               c.Name,
-		"description":        c.Description,
-		"status":             c.Status,
-		"started_at":         c.StartedAt,
-		"completed_at":       c.CompletedAt,
-		"framework_controls": c.FrameworkControls,
-		"updated_at":         c.UpdatedAt,
+		"id":           c.ID,
+		"name":         c.Name,
+		"description":  c.Description,
+		"status":       c.Status,
+		"started_at":   c.StartedAt,
+		"completed_at": c.CompletedAt,
+		"updated_at":   c.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())
 
@@ -310,7 +303,6 @@ SELECT
     status,
     started_at,
     completed_at,
-    framework_controls,
     created_at,
     updated_at
 FROM
@@ -382,7 +374,6 @@ SELECT
     status,
     started_at,
     completed_at,
-    framework_controls,
     created_at,
     updated_at
 FROM

--- a/pkg/coredata/access_review_entry.go
+++ b/pkg/coredata/access_review_entry.go
@@ -525,33 +525,6 @@ WHERE
 	return count, nil
 }
 
-func (entries *AccessReviewEntries) CountPendingByCampaignID(
-	ctx context.Context,
-	conn pg.Querier,
-	scope Scoper,
-	campaignID gid.GID,
-) (int, error) {
-	q := `
-SELECT COUNT(id)
-FROM access_review_entries
-WHERE
-    %s
-    AND access_review_campaign_id = @campaign_id
-    AND decision = 'PENDING';
-`
-	q = fmt.Sprintf(q, scope.SQLFragment())
-
-	args := pgx.StrictNamedArgs{"campaign_id": campaignID}
-	maps.Copy(args, scope.SQLArguments())
-
-	var count int
-	if err := conn.QueryRow(ctx, q, args).Scan(&count); err != nil {
-		return 0, fmt.Errorf("cannot count pending access_review_entries: %w", err)
-	}
-
-	return count, nil
-}
-
 func (e *AccessReviewEntry) LoadOrganizationID(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/coredata/access_review_entry_filter.go
+++ b/pkg/coredata/access_review_entry_filter.go
@@ -36,8 +36,8 @@ func (f *AccessReviewEntryFilter) SQLFragment() string {
 	return `
 (
 	CASE
-		WHEN @filter_decision::text IS NOT NULL THEN
-			decision = @filter_decision::text
+		WHEN @filter_decision::access_review_entry_decision IS NOT NULL THEN
+			decision = @filter_decision::access_review_entry_decision
 		ELSE TRUE
 	END
 	AND
@@ -48,8 +48,8 @@ func (f *AccessReviewEntryFilter) SQLFragment() string {
 	END
 	AND
 	CASE
-		WHEN @filter_incremental_tag::text IS NOT NULL THEN
-			incremental_tag = @filter_incremental_tag::text
+		WHEN @filter_incremental_tag::access_review_entry_incremental_tag IS NOT NULL THEN
+			incremental_tag = @filter_incremental_tag::access_review_entry_incremental_tag
 		ELSE TRUE
 	END
 	AND
@@ -66,8 +66,8 @@ func (f *AccessReviewEntryFilter) SQLFragment() string {
 	END
 	AND
 	CASE
-		WHEN @filter_auth_method::text IS NOT NULL THEN
-			auth_method = @filter_auth_method::text
+		WHEN @filter_auth_method::auth_method IS NOT NULL THEN
+			auth_method = @filter_auth_method::auth_method
 		ELSE TRUE
 	END
 	AND

--- a/pkg/coredata/migrations/20260630T092731Z.sql
+++ b/pkg/coredata/migrations/20260630T092731Z.sql
@@ -1,0 +1,16 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE access_review_campaigns
+    DROP COLUMN framework_controls;

--- a/pkg/server/api/console/v1/access_review_campaign_resolvers.go
+++ b/pkg/server/api/console/v1/access_review_campaign_resolvers.go
@@ -736,7 +736,6 @@ func (r *mutationResolver) CreateAccessReviewCampaign(ctx context.Context, input
 			OrganizationID:        input.OrganizationID,
 			Name:                  input.Name,
 			Description:           description,
-			FrameworkControls:     input.FrameworkControls,
 			AccessReviewSourceIDs: input.AccessReviewSourceIds,
 		},
 	)
@@ -762,10 +761,9 @@ func (r *mutationResolver) UpdateAccessReviewCampaign(ctx context.Context, input
 		ctx,
 		scope,
 		accessreview.UpdateAccessReviewCampaignRequest{
-			CampaignID:        input.AccessReviewCampaignID,
-			Name:              gqlutils.UnwrapOmittable(input.Name),
-			Description:       gqlutils.UnwrapOmittable(input.Description),
-			FrameworkControls: gqlutils.UnwrapOmittable(input.FrameworkControls),
+			CampaignID:  input.AccessReviewCampaignID,
+			Name:        gqlutils.UnwrapOmittable(input.Name),
+			Description: gqlutils.UnwrapOmittable(input.Description),
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/console/v1/access_review_campaign_resolvers.go
+++ b/pkg/server/api/console/v1/access_review_campaign_resolvers.go
@@ -98,23 +98,6 @@ func (r *accessReviewCampaignResolver) Entries(ctx context.Context, obj *types.A
 	return types.NewAccessReviewEntryConnection(p, r, obj.ID, nil, filter), nil
 }
 
-// PendingEntryCount is the resolver for the pendingEntryCount field.
-func (r *accessReviewCampaignResolver) PendingEntryCount(ctx context.Context, obj *types.AccessReviewCampaign) (int, error) {
-	scope, err := r.authorize(ctx, obj.ID, accessreview.ActionEntryList)
-	if err != nil {
-		return 0, err
-	}
-
-	count, err := r.accessReview.CountPendingEntriesForCampaignID(ctx, scope, obj.ID)
-	if err != nil {
-		r.logger.ErrorCtx(ctx, "cannot count pending access entries", log.Error(err))
-
-		return 0, gqlutils.Internal(ctx)
-	}
-
-	return count, nil
-}
-
 // Statistics is the resolver for the statistics field.
 func (r *accessReviewCampaignResolver) Statistics(ctx context.Context, obj *types.AccessReviewCampaign) (*types.AccessReviewStatistics, error) {
 	scope, err := r.authorize(ctx, obj.ID, accessreview.ActionEntryList)

--- a/pkg/server/api/console/v1/graphql/access_review_campaign.graphql
+++ b/pkg/server/api/console/v1/graphql/access_review_campaign.graphql
@@ -364,8 +364,6 @@ type AccessReviewCampaign implements Node {
         filter: AccessReviewEntryFilter
     ): AccessReviewEntryConnection! @goField(forceResolver: true)
 
-    pendingEntryCount: Int! @goField(forceResolver: true)
-
     statistics: AccessReviewStatistics! @goField(forceResolver: true)
 
     permission(action: String!): Boolean! @goField(forceResolver: true)

--- a/pkg/server/api/console/v1/graphql/access_review_campaign.graphql
+++ b/pkg/server/api/console/v1/graphql/access_review_campaign.graphql
@@ -349,7 +349,6 @@ type AccessReviewCampaign implements Node {
     status: AccessReviewCampaignStatus!
     startedAt: Datetime
     completedAt: Datetime
-    frameworkControls: [String!]
     createdAt: Datetime!
     updatedAt: Datetime!
 
@@ -578,7 +577,6 @@ input CreateAccessReviewCampaignInput {
     organizationId: ID!
     name: String!
     description: String
-    frameworkControls: [String!]
     accessReviewSourceIds: [ID!]
 }
 
@@ -590,7 +588,6 @@ input UpdateAccessReviewCampaignInput {
     accessReviewCampaignId: ID!
     name: String @goField(omittable: true)
     description: String @goField(omittable: true)
-    frameworkControls: [String!] @goField(omittable: true)
 }
 
 type UpdateAccessReviewCampaignPayload {

--- a/pkg/server/api/console/v1/types/access_review.go
+++ b/pkg/server/api/console/v1/types/access_review.go
@@ -215,14 +215,13 @@ func NewAccessReviewCampaign(c *coredata.AccessReviewCampaign) *AccessReviewCamp
 		Organization: &Organization{
 			ID: c.OrganizationID,
 		},
-		Name:              c.Name,
-		Description:       c.Description,
-		Status:            c.Status,
-		StartedAt:         c.StartedAt,
-		CompletedAt:       c.CompletedAt,
-		FrameworkControls: c.FrameworkControls,
-		CreatedAt:         c.CreatedAt,
-		UpdatedAt:         c.UpdatedAt,
+		Name:        c.Name,
+		Description: c.Description,
+		Status:      c.Status,
+		StartedAt:   c.StartedAt,
+		CompletedAt: c.CompletedAt,
+		CreatedAt:   c.CreatedAt,
+		UpdatedAt:   c.UpdatedAt,
 	}
 
 	return campaign

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -3752,7 +3752,6 @@ func (r *Resolver) CreateAccessReviewCampaignTool(ctx context.Context, req *mcp.
 		OrganizationID:        input.OrganizationID,
 		Name:                  input.Name,
 		Description:           description,
-		FrameworkControls:     input.FrameworkControls,
 		AccessReviewSourceIDs: input.AccessReviewSourceIds,
 	})
 	if err != nil {
@@ -3782,22 +3781,6 @@ func (r *Resolver) UpdateAccessReviewCampaignTool(ctx context.Context, req *mcp.
 
 	if input.Description != nil {
 		updateReq.Description = &input.Description
-	}
-
-	if rawControls := UnwrapOmittable(input.FrameworkControls); rawControls != nil {
-		if *rawControls != nil {
-			controls := make([]string, 0, len(**rawControls))
-			for _, v := range **rawControls {
-				if s, ok := v.(string); ok {
-					controls = append(controls, s)
-				}
-			}
-
-			updateReq.FrameworkControls = &controls
-		} else {
-			empty := []string{}
-			updateReq.FrameworkControls = &empty
-		}
 	}
 
 	campaign, err := r.accessReview.UpdateCampaign(ctx, scope, updateReq)

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -7644,11 +7644,6 @@ components:
             - "null"
           format: date-time
           description: Campaign completion time
-        framework_controls:
-          type: array
-          items:
-            type: string
-          description: Framework controls
         created_at:
           type: string
           format: date-time
@@ -8187,11 +8182,6 @@ components:
         description:
           type: string
           description: Campaign description
-        framework_controls:
-          type: array
-          items:
-            type: string
-          description: Framework control references
         access_review_source_ids:
           type: array
           items:
@@ -8220,15 +8210,6 @@ components:
         description:
           type: string
           description: New campaign description
-        framework_controls:
-          type:
-            - array
-            - "null"
-          items:
-            type: string
-          go.probo.inc/mcpgen/omittable: true
-          description: Framework control references (set to null to clear)
-
     UpdateAccessReviewCampaignMCPOutput:
       type: object
       required:

--- a/pkg/server/api/mcp/v1/types/access_review.go
+++ b/pkg/server/api/mcp/v1/types/access_review.go
@@ -54,16 +54,15 @@ func NewListAccessReviewSourcesOutput(
 
 func NewAccessReviewCampaign(c *coredata.AccessReviewCampaign) *AccessReviewCampaign {
 	return &AccessReviewCampaign{
-		ID:                c.ID,
-		OrganizationID:    c.OrganizationID,
-		Name:              c.Name,
-		Description:       &c.Description,
-		Status:            c.Status,
-		StartedAt:         c.StartedAt,
-		CompletedAt:       c.CompletedAt,
-		FrameworkControls: c.FrameworkControls,
-		CreatedAt:         c.CreatedAt,
-		UpdatedAt:         c.UpdatedAt,
+		ID:             c.ID,
+		OrganizationID: c.OrganizationID,
+		Name:           c.Name,
+		Description:    &c.Description,
+		Status:         c.Status,
+		StartedAt:      c.StartedAt,
+		CompletedAt:    c.CompletedAt,
+		CreatedAt:      c.CreatedAt,
+		UpdatedAt:      c.UpdatedAt,
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Enable campaign completion based on the backend pending-entry count.
- Allow campaigns with failed or empty source fetches to complete when no entries remain pending.

## Verification
- `make relay`
- `npm -w @probo/console run check`

Note: `npm ci` completed with engine warnings because this workspace has Node 22.14.0 while the repo requests Node 24.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-538](https://linear.app/probo/issue/ENG-538/allow-closing-an-access-review-campaign-when-source-fetch-fails)

<div><a href="https://cursor.com/agents/bc-9a866ae5-72b9-40c5-a643-0847a09ec8c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a866ae5-72b9-40c5-a643-0847a09ec8c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows completing access review campaigns even when source fetches fail or return no entries. Completion now checks for zero PENDING entries and removes framework controls across DB, GraphQL, MCP, CLI, and UI (ENG-538).

### Tests **`+0`** **`-45`**
- Removed framework controls test coverage.

### Coredata **`+48`** **`-68`**
- Dropped `framework_controls` column (migration) and removed field from model/queries.
- Replaced pending-only counters with `CountByCampaignID(filter)` and cast filter args to enum types.

### GraphQL API **`+10`** **`-35`**
- Removed `AccessReviewCampaign.pendingEntryCount`.
- Removed `frameworkControls` from type and create/update inputs.

### MCP **`+9`** **`-46`**
- Removed framework controls from types, resolvers, and specification.

### prb (CLI) **`+3`** **`-14`**
- Removed `--framework-control` flag and payload mapping.

### Service **`+20`** **`-45`**
- `CloseCampaign` counts `PENDING` via `CountByCampaignID(filter)`; removed `CountPendingEntriesForCampaignID`.
- Create/Update no longer handle framework controls.

### App: console **`+5`** **`-8`**
- Uses `entries(first: 0, filter: { decision: PENDING }).totalCount === 0` to enable Complete; updates button state.

<sup>Written for commit 9e47aba2b6bbedd8f9a760533a24ec945b1d5a32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

