### PR TITLE
Return conflict when removing a referenced person

### DIFF
--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
 	"go.probo.inc/probo/e2e/internal/testutil"
 )
 
@@ -322,6 +323,67 @@ func TestUser_RemoveUser(t *testing.T) {
 	}
 
 	assert.False(t, removedUserFound, "Should not find removed user")
+}
+
+func TestUser_RemoveUser_ProfileInUse(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	profileID := factory.CreateUser(owner)
+
+	const createAssetMutation = `
+		mutation($input: CreateAssetInput!) {
+			createAsset(input: $input) {
+				assetEdge {
+					node {
+						id
+					}
+				}
+			}
+		}
+	`
+
+	var createAssetResult struct {
+		CreateAsset struct {
+			AssetEdge struct {
+				Node struct {
+					ID string `json:"id"`
+				} `json:"node"`
+			} `json:"assetEdge"`
+		} `json:"createAsset"`
+	}
+
+	err := owner.Execute(createAssetMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId":  owner.GetOrganizationID().String(),
+			"name":            "Production Database Server",
+			"amount":          1,
+			"ownerId":         profileID,
+			"assetType":       "VIRTUAL",
+			"dataTypesStored": "Customer PII",
+		},
+	}, &createAssetResult)
+	require.NoError(t, err)
+	require.NotEmpty(t, createAssetResult.CreateAsset.AssetEdge.Node.ID)
+
+	const removeUserMutation = `
+		mutation($input: RemoveUserInput!) {
+			removeUser(input: $input) {
+				deletedProfileId
+			}
+		}
+	`
+
+	err = owner.ExecuteConnect(removeUserMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"profileId":      profileID,
+		},
+	}, nil)
+	testutil.RequireErrorCode(t, err, "CONFLICT")
+
+	var gqlErrors testutil.GraphQLErrors
+	require.ErrorAs(t, err, &gqlErrors)
+	assert.Contains(t, gqlErrors[0].Message, "referenced by other resources")
 }
 
 func TestUser_ArchiveUser(t *testing.T) {

--- a/pkg/coredata/connector.go
+++ b/pkg/coredata/connector.go
@@ -323,7 +323,7 @@ WHERE %s AND id = @id
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
-			if pgErr.Code == "23503" {
+			if pgErr.Code == "23503" || pgErr.Code == "23001" {
 				return ErrResourceInUse
 			}
 		}

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -1263,7 +1263,7 @@ WHERE
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
-			if pgErr.Code == "23503" {
+			if pgErr.Code == "23503" || pgErr.Code == "23001" {
 				return ErrResourceInUse
 			}
 		}

--- a/pkg/iam/errors.go
+++ b/pkg/iam/errors.go
@@ -180,6 +180,18 @@ func (e ErrLastActiveOwner) Error() string {
 	return fmt.Sprintf("cannot remove profile %q: last active owner of the organization", e.MembershipID)
 }
 
+type ErrProfileInUse struct {
+	ProfileID gid.GID
+}
+
+func NewProfileInUseError(profileID gid.GID) error {
+	return &ErrProfileInUse{ProfileID: profileID}
+}
+
+func (e ErrProfileInUse) Error() string {
+	return fmt.Sprintf("cannot remove profile %q: referenced by other resources", e.ProfileID)
+}
+
 type ErrOrganizationNotFound struct{ OrganizationID gid.GID }
 
 func NewOrganizationNotFoundError(organizationID gid.GID) error {

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -354,6 +354,10 @@ func (s *OrganizationService) RemoveUser(
 			}
 
 			if err := profile.Delete(ctx, tx, scope, profileID); err != nil {
+				if errors.Is(err, coredata.ErrResourceInUse) {
+					return NewProfileInUseError(profileID)
+				}
+
 				return fmt.Errorf("cannot delete profile: %w", err)
 			}
 

--- a/pkg/server/api/connect/v1/profile_resolvers.go
+++ b/pkg/server/api/connect/v1/profile_resolvers.go
@@ -145,6 +145,10 @@ func (r *mutationResolver) RemoveUser(ctx context.Context, input types.RemoveUse
 			return nil, gqlutils.Conflictf(ctx, "cannot remove last active owner")
 		}
 
+		if _, ok := errors.AsType[*iam.ErrProfileInUse](err); ok {
+			return nil, gqlutils.Conflictf(ctx, "cannot remove person: referenced by other resources")
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot remove user from organization", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2954,6 +2954,10 @@ func (r *Resolver) RemoveUserTool(ctx context.Context, req *mcp.CallToolRequest,
 			return nil, types.RemoveUserOutput{}, fmt.Errorf("cannot remove last active owner: %w", err)
 		}
 
+		if _, ok := errors.AsType[*iam.ErrProfileInUse](err); ok {
+			return nil, types.RemoveUserOutput{}, fmt.Errorf("cannot remove person: referenced by other resources: %w", err)
+		}
+
 		return nil, types.RemoveUserOutput{}, fmt.Errorf("remove user: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Map PostgreSQL `23001` (restrict violation) alongside `23503` in `MembershipProfile.Delete` so `ON DELETE RESTRICT` FK blocks become `ErrResourceInUse`
- Promote `ErrResourceInUse` to `iam.ErrProfileInUse` in `OrganizationService.RemoveUser`
- Return a user-facing `CONFLICT` from connect `removeUser` and MCP `RemoveUserTool`
- Add `TestUser_RemoveUser_ProfileInUse` (person owns an asset → removal blocked)

## Context

Removing a person who is still referenced (e.g. `assets.owner_profile_id`) failed with an internal server error. The DELETE hit `assets_owner_profile_id_fkey`, but the SQL layer only handled SQLSTATE `23503`. PostgreSQL reports RESTRICT violations as **`23001`**, so the error was wrapped and the resolver fell through to `gqlutils.Internal`.

Error flow after this change:

1. `membership_profile.Delete` → `ErrResourceInUse`
2. `OrganizationService.RemoveUser` → `ErrProfileInUse`
3. GraphQL/MCP → `CONFLICT`: `cannot remove person: referenced by other resources`

The console toast surfaces this via existing `formatError` handling (no frontend change).

## Test plan

- [x] `go test ./pkg/coredata/... ./pkg/iam/...`
- [x] `make test-e2e` — `TestUser_RemoveUser_ProfileInUse`
- [x] Manually remove a person who owns an asset; confirm conflict toast instead of internal error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return a clear CONFLICT when removing a person who is still referenced (e.g., as an asset owner). Maps PostgreSQL `23001` (RESTRICT) to surface `ErrProfileInUse` through Connect and MCP instead of an internal error.

### Tests **`+62`** **`-0`**
- Add `TestUser_RemoveUser_ProfileInUse` that creates an owned asset, attempts removal, and asserts `CONFLICT` with the expected message.

### Coredata **`+2`** **`-2`**
- Map SQLSTATE `23001` (along with `23503`) to `ErrResourceInUse` in delete paths (`connector`, `membership_profile`).

### GraphQL API **`+4`** **`-0`**
- Connect `removeUser` translates `iam.ErrProfileInUse` into `CONFLICT`: "cannot remove person: referenced by other resources".

### MCP **`+4`** **`-0`**
- `RemoveUserTool` returns an error with the same message when the profile is referenced.

### Service **`+16`** **`-0`**
- Introduce `iam.ErrProfileInUse` and return it from `OrganizationService.RemoveUser` when profile deletion hits `coredata.ErrResourceInUse`.

<sup>Written for commit 888fa4d63a2de246cbc592e2f67ff936fdea9cf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

