### PR TITLE
Fix n8n Organization Get Many failing on pending invitations

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/organization/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/organization/getAll.operation.ts
@@ -56,9 +56,9 @@ export async function execute(
 	const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
 
 	const query = `
-		query GetOrganizations($first: Int, $after: CursorKey) {
+		query GetOrganizations($first: Int, $after: CursorKey, $filter: ProfileFilter) {
 			viewer {
-				profiles(first: $first, after: $after) {
+				profiles(first: $first, after: $after, filter: $filter) {
 					edges {
 						node {
 							organization {
@@ -95,7 +95,7 @@ export async function execute(
 	const memberships = await proboConnectApiRequestAllItems.call(
 		this,
 		query,
-		{},
+		{ filter: { state: 'ACTIVE' } },
 		(response: IDataObject) => {
 			const data = response?.data as IDataObject | undefined;
 			const viewer = data?.viewer as IDataObject | undefined;


### PR DESCRIPTION
The Organization "Get Many" operation listed all viewer profiles without filtering by state, then selected each profile's nested organization field. Inactive profiles (e.g. unaccepted invitations) have no active membership, so the per-org iam:organization:get authorization check failed and the whole operation errored.

Filter profiles to ACTIVE state, matching the `prb org list` CLI behavior, so only organizations the identity is an active member of are fetched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes n8n Organization “Get Many” failing when the user has pending invitations by filtering profiles to ACTIVE. Matches `prb org list` and avoids auth errors on inactive memberships.

### Package: `n8n-node` **`+3`** **`-3`**
- Added `ProfileFilter` to `viewer.profiles` and passed `{ state: 'ACTIVE' }`.
- Prevents per-org `iam:organization:get` failures from inactive profiles (pending invites).

<sup>Written for commit 0bf36f74db1f2b304c57c0bee104cc9126026220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

