### PR TITLE
Add latest published document version ID node

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/document/getLatestPublishedVersionId.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/getLatestPublishedVersionId.operation.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Document ID',
+		name: 'documentId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['document'],
+				operation: ['getLatestPublishedVersionId'],
+			},
+		},
+		default: '',
+		description: 'The ID of the document whose latest published version ID should be returned',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const documentId = this.getNodeParameter('documentId', itemIndex) as string;
+
+	const query = `
+		query GetLatestPublishedDocumentVersionId($documentId: ID!) {
+			node(id: $documentId) {
+				... on Document {
+					versions(first: 1, orderBy: { field: CREATED_AT, direction: DESC }, filter: { statuses: [PUBLISHED] }) {
+						edges {
+							node {
+								id
+							}
+						}
+					}
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { documentId });
+	const data = responseData.data as IDataObject | undefined;
+	const node = data?.node as IDataObject | undefined;
+	const versions = node?.versions as IDataObject | undefined;
+	const edges = versions?.edges as Array<{ node?: IDataObject }> | undefined;
+
+	return {
+		json: {
+			documentVersionId: edges?.[0]?.node?.id ?? null,
+		},
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/document/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/index.ts
@@ -21,6 +21,7 @@ import * as deleteOp from './delete.operation';
 import * as archiveOp from './archive.operation';
 import * as unarchiveOp from './unarchive.operation';
 import * as getVersionOp from './getVersion.operation';
+import * as getLatestPublishedVersionIdOp from './getLatestPublishedVersionId.operation';
 import * as getAllVersionsOp from './getAllVersions.operation';
 import * as createDraftVersionOp from './createDraftVersion.operation';
 import * as updateVersionOp from './updateVersion.operation';
@@ -101,6 +102,12 @@ export const description: INodeProperties[] = [
 				value: 'getApprovalQuorum',
 				description: 'Get an approval quorum',
 				action: 'Get an approval quorum',
+			},
+			{
+				name: 'Get Latest Published Version ID',
+				value: 'getLatestPublishedVersionId',
+				description: 'Get the latest published document version ID',
+				action: 'Get the latest published document version ID',
 			},
 			{
 				name: 'Get Many',
@@ -191,6 +198,7 @@ export const description: INodeProperties[] = [
 	...archiveOp.description,
 	...unarchiveOp.description,
 	...getVersionOp.description,
+	...getLatestPublishedVersionIdOp.description,
 	...getAllVersionsOp.description,
 	...createDraftVersionOp.description,
 	...updateVersionOp.description,
@@ -216,6 +224,7 @@ export {
 	archiveOp as archive,
 	unarchiveOp as unarchive,
 	getVersionOp as getVersion,
+	getLatestPublishedVersionIdOp as getLatestPublishedVersionId,
 	getAllVersionsOp as getAllVersions,
 	createDraftVersionOp as createDraftVersion,
 	updateVersionOp as updateVersion,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a Document operation for getting the latest published document version ID in the n8n node
- Register the operation as `getLatestPublishedVersionId`
- Query published document versions by newest creation time and expose `documentVersionId` for downstream workflow steps

## Testing
- `npm -w @probo/n8n-nodes-probo run lint`
- `npm -w @probo/n8n-nodes-probo run build`

## Notes
- `npm ci` was needed in this cloud workspace before validation because dependencies were not installed. The install emitted engine warnings because the image has Node v22.14.0/npm 10.9.7 while the repo declares Node ^24/npm ^11.8.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-552](https://linear.app/probo/issue/ENG-552/in-n8n-add-a-node-get-latest-document-version-id)

<div><a href="https://cursor.com/agents/bc-ba07b2c8-ab63-4e0f-9449-134d69391336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba07b2c8-ab63-4e0f-9449-134d69391336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Document operation in `packages/n8n-node` to fetch the latest published document version ID and output it as `documentVersionId`. Addresses ENG-552 so workflows can reference the most recent published content.

### Package: `n8n-node` **`+78`** **`-0`**
- Add `getLatestPublishedVersionId.operation.ts`: takes `documentId`, queries newest PUBLISHED version (`CREATED_AT DESC`), returns `{ documentVersionId }`.
- Register operation in `document/index.ts` (name, description, action, export).

<sup>Written for commit 972d68d937b4fbf0be5e3f337aa09a881325787d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

