### PR TITLE
Expose document type filter in n8n

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/document/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/getAll.operation.ts
@@ -87,11 +87,11 @@ export const description: INodeProperties[] = [
 				],
 			},
 			{
-				displayName: 'Document Types',
+				displayName: 'Type',
 				name: 'documentTypes',
 				type: 'multiOptions',
 				default: [],
-				description: 'Filter by document type',
+				description: 'Filter by document type, for example Policy',
 				options: [
 					{ name: 'Governance', value: 'GOVERNANCE' },
 					{ name: 'Other', value: 'OTHER' },

--- a/packages/n8n-node/nodes/Probo/actions/document/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/getAll.operation.ts
@@ -87,6 +87,24 @@ export const description: INodeProperties[] = [
 				],
 			},
 			{
+				displayName: 'Query',
+				name: 'query',
+				type: 'string',
+				default: '',
+				description: 'Search query to filter documents',
+			},
+			{
+				displayName: 'Status',
+				name: 'status',
+				type: 'multiOptions',
+				default: [],
+				description: 'Filter by document status',
+				options: [
+					{ name: 'Active', value: 'ACTIVE' },
+					{ name: 'Archived', value: 'ARCHIVED' },
+				],
+			},
+			{
 				displayName: 'Type',
 				name: 'documentTypes',
 				type: 'multiOptions',
@@ -103,24 +121,6 @@ export const description: INodeProperties[] = [
 					{ name: 'Report', value: 'REPORT' },
 					{ name: 'Statement of Applicability', value: 'STATEMENT_OF_APPLICABILITY' },
 					{ name: 'Template', value: 'TEMPLATE' },
-				],
-			},
-			{
-				displayName: 'Query',
-				name: 'query',
-				type: 'string',
-				default: '',
-				description: 'Search query to filter documents',
-			},
-			{
-				displayName: 'Status',
-				name: 'status',
-				type: 'multiOptions',
-				default: [],
-				description: 'Filter by document status',
-				options: [
-					{ name: 'Active', value: 'ACTIVE' },
-					{ name: 'Archived', value: 'ARCHIVED' },
 				],
 			},
 			{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rename the n8n document get-many filter label to Type
- Keep the existing documentTypes parameter mapping to GraphQL DocumentFilter
- Preserve n8n collection filter sort order for lint compliance

## Testing
- `npm -w @probo/n8n-nodes-probo run lint`
- `npm -w @probo/n8n-nodes-probo run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-553](https://linear.app/probo/issue/ENG-553/add-type-filter-to-get-all-document-in-n8n)

<div><a href="https://cursor.com/agents/bc-c04b39fe-3f92-4dfe-bf2d-31733e6f932a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c04b39fe-3f92-4dfe-bf2d-31733e6f932a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a Type filter in the `n8n-node` document get-all action. Meets Linear ENG-553, keeps GraphQL behavior unchanged, and preserves filter order for lint.

### Package: `n8n-node` **`+19`** **`-19`**
- Renamed "Document Types" to "Type"; kept `documentTypes` param and GraphQL mapping
- Updated help text: "Filter by document type, for example Policy"
- Preserved filter list order for lint compliance

<sup>Written for commit 339d2d8fe363fbf2ac2057a42793a1bd25074f7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

