### PR TITLE
Expose signature document version ID

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/document/getSignature.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/getSignature.operation.ts
@@ -43,6 +43,9 @@ export async function execute(
 			node(id: $signatureId) {
 				... on DocumentVersionSignature {
 					id
+					documentVersion {
+						id
+					}
 					state
 					signedAt
 					requestedAt


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Include the associated document version ID in the n8n Document > Get Signature response.

## Testing
- `npm -w @probo/n8n-nodes-probo run lint`
- `npm -w @probo/n8n-nodes-probo run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-556](https://linear.app/probo/issue/ENG-556/add-document-version-id-to-get-signature-output)

<div><a href="https://cursor.com/agents/bc-d2b6ea83-b600-42e6-8e74-17d6cba054b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2b6ea83-b600-42e6-8e74-17d6cba054b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the signature’s document version ID in the `n8n-node` Document > Get Signature response so workflows can link signatures to the exact version. Fulfills Linear ENG-556.

### Package: n8n-node **`+3`** **`-0`**
- Added `documentVersion { id }` to the GraphQL selection for `DocumentVersionSignature` in `getSignature.operation.ts`.
- Response now includes `documentVersion.id`; no breaking changes.

<sup>Written for commit bbfd8a18b6597856a1e27bdeab845a3af193e83a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

