### PR TITLE
Cancel incomplete signatures and quorums on archive

### DIFF
--- a/e2e/console/document_version_test.go
+++ b/e2e/console/document_version_test.go
@@ -2281,3 +2281,134 @@ func TestDocumentVersion_SignArchivedDocumentFails(t *testing.T) {
 		},
 	})
 }
+
+// archiveTestDocument archives the given document.
+func archiveTestDocument(t *testing.T, owner *testutil.Client, docID string) {
+	t.Helper()
+
+	_, err := owner.Do(`
+		mutation($input: ArchiveDocumentInput!) {
+			archiveDocument(input: $input) {
+				document { id status }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"documentId": docID,
+		},
+	})
+	require.NoError(t, err)
+}
+
+// TestDocumentVersion_ArchiveCancelsPendingSignature verifies that archiving a
+// document deletes every still-pending signature request on it.
+func TestDocumentVersion_ArchiveCancelsPendingSignature(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	docID, _ := createTestDocument(t, owner)
+	approveTestDocument(t, owner, docID)
+
+	publishedVersionID := latestDocumentVersionID(t, owner, docID)
+	requestDocumentSignature(t, owner, publishedVersionID, getOwnerProfileID(t, owner))
+
+	before := requestedSignatureVersions(t, owner, publishedVersionID)
+	require.Len(t, before, 1)
+
+	archiveTestDocument(t, owner, docID)
+
+	after := requestedSignatureVersions(t, owner, publishedVersionID)
+	assert.Empty(t, after)
+}
+
+// TestDocumentVersion_ArchiveVoidsPendingApproval verifies that archiving a
+// document voids its pending approval quorum and every still-pending decision.
+func TestDocumentVersion_ArchiveVoidsPendingApproval(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	docID, _ := createTestDocument(t, owner)
+	requestDocumentApproval(t, owner, docID, []string{getOwnerProfileID(t, owner)})
+
+	versionID := latestDocumentVersionID(t, owner, docID)
+
+	var before struct {
+		Node struct {
+			Status          string `json:"status"`
+			ApprovalQuorums struct {
+				Edges []struct {
+					Node struct {
+						Status string `json:"status"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"approvalQuorums"`
+		} `json:"node"`
+	}
+
+	err := owner.Execute(`
+		query($id: ID!) {
+			node(id: $id) {
+				... on DocumentVersion {
+					status
+					approvalQuorums(first: 1, orderBy: { field: CREATED_AT, direction: DESC }) {
+						edges { node { status } }
+					}
+				}
+			}
+		}
+	`, map[string]any{"id": versionID}, &before)
+	require.NoError(t, err)
+	assert.Equal(t, "PENDING_APPROVAL", before.Node.Status)
+	require.NotEmpty(t, before.Node.ApprovalQuorums.Edges)
+	assert.Equal(t, "PENDING", before.Node.ApprovalQuorums.Edges[0].Node.Status)
+
+	archiveTestDocument(t, owner, docID)
+
+	var after struct {
+		Node struct {
+			Status          string `json:"status"`
+			ApprovalQuorums struct {
+				Edges []struct {
+					Node struct {
+						Status    string `json:"status"`
+						Decisions struct {
+							Edges []struct {
+								Node struct {
+									State string `json:"state"`
+								} `json:"node"`
+							} `json:"edges"`
+						} `json:"decisions"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"approvalQuorums"`
+		} `json:"node"`
+	}
+
+	err = owner.Execute(`
+		query($id: ID!) {
+			node(id: $id) {
+				... on DocumentVersion {
+					status
+					approvalQuorums(first: 1, orderBy: { field: CREATED_AT, direction: DESC }) {
+						edges {
+							node {
+								status
+								decisions(first: 100) {
+									edges { node { state } }
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	`, map[string]any{"id": versionID}, &after)
+	require.NoError(t, err)
+	assert.Equal(t, "DRAFT", after.Node.Status)
+	require.NotEmpty(t, after.Node.ApprovalQuorums.Edges)
+	assert.Equal(t, "VOIDED", after.Node.ApprovalQuorums.Edges[0].Node.Status)
+
+	for _, edge := range after.Node.ApprovalQuorums.Edges[0].Node.Decisions.Edges {
+		assert.Equal(t, "VOIDED", edge.Node.State)
+	}
+}

--- a/pkg/coredata/document_version_signature.go
+++ b/pkg/coredata/document_version_signature.go
@@ -769,6 +769,76 @@ WHERE
 	return nil
 }
 
+func (pvss *DocumentVersionSignatures) DeleteRequestedByDocumentID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	documentID gid.GID,
+) error {
+	q := `
+DELETE FROM document_version_signatures
+WHERE
+	%s
+	AND state = @state
+	AND document_version_id IN (
+		SELECT id
+		FROM document_versions
+		WHERE document_id = @document_id
+	)
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"document_id": documentID,
+		"state":       DocumentVersionSignatureStateRequested,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	if _, err := conn.Exec(ctx, q, args); err != nil {
+		return fmt.Errorf("cannot delete requested document version signatures: %w", err)
+	}
+
+	return nil
+}
+
+func (pvss *DocumentVersionSignatures) DeleteRequestedByDocumentIDs(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	documentIDs []gid.GID,
+) error {
+	if len(documentIDs) == 0 {
+		return nil
+	}
+
+	q := `
+DELETE FROM document_version_signatures
+WHERE
+	%s
+	AND state = @state
+	AND document_version_id IN (
+		SELECT id
+		FROM document_versions
+		WHERE document_id = ANY(@document_ids)
+	)
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"document_ids": documentIDs,
+		"state":        DocumentVersionSignatureStateRequested,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	if _, err := conn.Exec(ctx, q, args); err != nil {
+		return fmt.Errorf("cannot delete requested document version signatures: %w", err)
+	}
+
+	return nil
+}
+
 func (pvss *DocumentVersionSignatures) DeleteRequestedByDocumentIDBelowMajor(
 	ctx context.Context,
 	conn pg.Tx,

--- a/pkg/probo/document_approval_service.go
+++ b/pkg/probo/document_approval_service.go
@@ -498,42 +498,15 @@ func (s *DocumentApprovalService) VoidApproval(
 				return &ErrDocumentVersionNotPendingApproval{}
 			}
 
-			quorum = &coredata.DocumentVersionApprovalQuorum{}
-			if err := quorum.LoadLastByDocumentVersionID(ctx, tx, scope, documentVersionID); err != nil {
-				return fmt.Errorf("cannot load approval quorum: %w", err)
+			var err error
+
+			quorum, err = s.voidPendingApprovalInTx(ctx, scope, tx, document, documentVersion)
+			if err != nil {
+				return err
 			}
 
-			if quorum.Status != coredata.DocumentVersionApprovalQuorumStatusPending {
+			if quorum == nil {
 				return &ErrDocumentVersionNotPendingApproval{}
-			}
-
-			now := time.Now()
-
-			quorum.Status = coredata.DocumentVersionApprovalQuorumStatusVoided
-			quorum.UpdatedAt = now
-
-			if err := quorum.Update(ctx, tx, scope); err != nil {
-				return fmt.Errorf("cannot update approval quorum: %w", err)
-			}
-
-			decisions := &coredata.DocumentVersionApprovalDecisions{}
-			if err := decisions.VoidPendingByQuorumID(ctx, tx, scope, quorum.ID, now); err != nil {
-				return fmt.Errorf("cannot void pending decisions: %w", err)
-			}
-
-			documentVersion.Status = coredata.DocumentVersionStatusDraft
-			if document.CurrentPublishedMajor != nil {
-				documentVersion.Major = *document.CurrentPublishedMajor
-				documentVersion.Minor = *document.CurrentPublishedMinor + 1
-			} else {
-				documentVersion.Major = 0
-				documentVersion.Minor = 1
-			}
-
-			documentVersion.UpdatedAt = now
-
-			if err := documentVersion.Update(ctx, tx, scope); err != nil {
-				return fmt.Errorf("cannot update document version status: %w", err)
 			}
 
 			return nil
@@ -544,6 +517,86 @@ func (s *DocumentApprovalService) VoidApproval(
 	}
 
 	return quorum, documentVersion, nil
+}
+
+// voidPendingApprovalInTx voids the pending approval quorum on documentVersion
+// when one exists. It returns nil quorum when the version is not pending approval
+// or its last quorum is no longer pending. Used by VoidApproval and document
+// archive to cancel incomplete approval workflows.
+func (s *DocumentApprovalService) voidPendingApprovalInTx(
+	ctx context.Context, scope coredata.Scoper,
+	tx pg.Tx,
+	document *coredata.Document,
+	documentVersion *coredata.DocumentVersion,
+) (*coredata.DocumentVersionApprovalQuorum, error) {
+	if documentVersion.Status != coredata.DocumentVersionStatusPendingApproval {
+		return nil, nil
+	}
+
+	quorum := &coredata.DocumentVersionApprovalQuorum{}
+	if err := quorum.LoadLastByDocumentVersionID(ctx, tx, scope, documentVersion.ID); err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("cannot load approval quorum: %w", err)
+	}
+
+	if quorum.Status != coredata.DocumentVersionApprovalQuorumStatusPending {
+		return nil, nil
+	}
+
+	now := time.Now()
+
+	quorum.Status = coredata.DocumentVersionApprovalQuorumStatusVoided
+	quorum.UpdatedAt = now
+
+	if err := quorum.Update(ctx, tx, scope); err != nil {
+		return nil, fmt.Errorf("cannot update approval quorum: %w", err)
+	}
+
+	decisions := &coredata.DocumentVersionApprovalDecisions{}
+	if err := decisions.VoidPendingByQuorumID(ctx, tx, scope, quorum.ID, now); err != nil {
+		return nil, fmt.Errorf("cannot void pending decisions: %w", err)
+	}
+
+	documentVersion.Status = coredata.DocumentVersionStatusDraft
+	if document.CurrentPublishedMajor != nil {
+		documentVersion.Major = *document.CurrentPublishedMajor
+		documentVersion.Minor = *document.CurrentPublishedMinor + 1
+	} else {
+		documentVersion.Major = 0
+		documentVersion.Minor = 1
+	}
+
+	documentVersion.UpdatedAt = now
+
+	if err := documentVersion.Update(ctx, tx, scope); err != nil {
+		return nil, fmt.Errorf("cannot update document version status: %w", err)
+	}
+
+	return quorum, nil
+}
+
+func (s *DocumentApprovalService) voidPendingApprovalForDocumentInTx(
+	ctx context.Context, scope coredata.Scoper,
+	tx pg.Tx,
+	document *coredata.Document,
+) error {
+	documentVersion := &coredata.DocumentVersion{}
+	if err := documentVersion.LoadLatestVersion(ctx, tx, scope, document.ID); err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return nil
+		}
+
+		return fmt.Errorf("cannot load latest document version: %w", err)
+	}
+
+	if _, err := s.voidPendingApprovalInTx(ctx, scope, tx, document, documentVersion); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *DocumentApprovalService) GetQuorum(

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -1312,6 +1312,10 @@ func (s *DocumentService) BulkArchive(
 				return err
 			}
 
+			if err := s.cancelIncompleteWorkflowsForDocumentsInTx(ctx, scope, tx, documentIDs); err != nil {
+				return err
+			}
+
 			return documents.BulkArchive(ctx, tx, scope)
 		},
 	)
@@ -2001,6 +2005,10 @@ func (s *DocumentService) Archive(
 			}
 
 			if err := s.clearDocumentReferences(ctx, scope, tx, []gid.GID{documentID}); err != nil {
+				return err
+			}
+
+			if err := s.cancelIncompleteWorkflowsInTx(ctx, scope, tx, document); err != nil {
 				return err
 			}
 
@@ -2845,6 +2853,54 @@ func (s *DocumentService) publishMajorVersionInTx(
 	}
 
 	return document, documentVersion, nil
+}
+
+// cancelIncompleteWorkflowsInTx removes every still-pending signature request
+// and voids any pending approval quorum on the document. SIGNED signatures and
+// completed approvals are left untouched to preserve the audit trail.
+func (s *DocumentService) cancelIncompleteWorkflowsInTx(
+	ctx context.Context, scope coredata.Scoper,
+	tx pg.Tx,
+	document *coredata.Document,
+) error {
+	signatures := &coredata.DocumentVersionSignatures{}
+	if err := signatures.DeleteRequestedByDocumentID(ctx, tx, scope, document.ID); err != nil {
+		return fmt.Errorf("cannot cancel signature requests: %w", err)
+	}
+
+	if err := s.svc.DocumentApprovals.voidPendingApprovalForDocumentInTx(ctx, scope, tx, document); err != nil {
+		return fmt.Errorf("cannot cancel pending approval quorum: %w", err)
+	}
+
+	return nil
+}
+
+func (s *DocumentService) cancelIncompleteWorkflowsForDocumentsInTx(
+	ctx context.Context, scope coredata.Scoper,
+	tx pg.Tx,
+	documentIDs []gid.GID,
+) error {
+	signatures := &coredata.DocumentVersionSignatures{}
+	if err := signatures.DeleteRequestedByDocumentIDs(ctx, tx, scope, documentIDs); err != nil {
+		return fmt.Errorf("cannot cancel signature requests: %w", err)
+	}
+
+	for _, documentID := range documentIDs {
+		document := &coredata.Document{}
+		if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
+			return fmt.Errorf("cannot load document %q: %w", documentID, err)
+		}
+
+		if document.ArchivedAt != nil {
+			continue
+		}
+
+		if err := s.svc.DocumentApprovals.voidPendingApprovalForDocumentInTx(ctx, scope, tx, document); err != nil {
+			return fmt.Errorf("cannot cancel pending approval quorum for %q: %w", documentID, err)
+		}
+	}
+
+	return nil
 }
 
 // cancelPreviousMajorSignatureRequestsInTx cancels every still-pending


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Archiving a document now cancels incomplete workflow items in the same transaction:

- **Signatures**: deletes every `REQUESTED` signature request on any version of the document (same semantics as manual cancel and major publish).
- **Approval quorums**: voids a pending quorum, voids its pending decisions, and reverts the version to `DRAFT` (same semantics as `voidDocumentVersionApproval`).

This applies to both `archiveDocument` and `bulkArchiveDocuments`. Completed signatures and finished approvals are left untouched.

## Test plan

- [x] Added `TestDocumentVersion_ArchiveCancelsPendingSignature`
- [x] Added `TestDocumentVersion_ArchiveVoidsPendingApproval`
- [ ] Run e2e console document version tests in CI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1898-169e-7030-aee5-b8a27d8e08d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1898-169e-7030-aee5-b8a27d8e08d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Archiving a document now cancels incomplete workflows. We delete pending signature requests and void pending approval quorums for both `archiveDocument` and `bulkArchiveDocuments`, without touching completed records.

### Tests **`+131`** **`-0`**
- Added e2e coverage for cancelling pending signatures and voiding pending approvals on archive.
- Verified version reverts to DRAFT and quorum/decisions are VOIDED.

### Coredata **`+70`** **`-0`**
- Added methods to delete `REQUESTED` signatures by document ID or IDs in one query.

### Service **`+140`** **`-31`**
- On single and bulk archive, remove pending signature requests and void the latest pending approval quorum in the same transaction.
- Extracted shared logic to void quorums and revert the version to DRAFT with updated major/minor.

<sup>Written for commit 794de680391d3e76584bb3e564bc083222fced0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

