### PR TITLE
Add n8n trigger node for Probo webhooks

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/webhook/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/webhook/create.operation.ts
@@ -14,6 +14,7 @@
 
 import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { proboApiRequest } from '../../GenericFunctions';
+import { WEBHOOK_EVENT_OPTIONS } from './events';
 
 export const description: INodeProperties[] = [
 	{
@@ -54,20 +55,7 @@ export const description: INodeProperties[] = [
 				operation: ['create'],
 			},
 		},
-		options: [
-			{ name: 'Meeting Created', value: 'MEETING_CREATED' },
-			{ name: 'Meeting Deleted', value: 'MEETING_DELETED' },
-			{ name: 'Meeting Updated', value: 'MEETING_UPDATED' },
-			{ name: 'Obligation Created', value: 'OBLIGATION_CREATED' },
-			{ name: 'Obligation Deleted', value: 'OBLIGATION_DELETED' },
-			{ name: 'Obligation Updated', value: 'OBLIGATION_UPDATED' },
-			{ name: 'Third Party Created', value: 'THIRD_PARTY_CREATED' },
-			{ name: 'Third Party Deleted', value: 'THIRD_PARTY_DELETED' },
-			{ name: 'Third Party Updated', value: 'THIRD_PARTY_UPDATED' },
-			{ name: 'User Created', value: 'USER_CREATED' },
-			{ name: 'User Deleted', value: 'USER_DELETED' },
-			{ name: 'User Updated', value: 'USER_UPDATED' },
-		],
+		options: WEBHOOK_EVENT_OPTIONS,
 		default: [],
 		description: 'The event types to subscribe to',
 		required: true,

--- a/packages/n8n-node/nodes/Probo/actions/webhook/events.ts
+++ b/packages/n8n-node/nodes/Probo/actions/webhook/events.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,19 +12,16 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package shared
+import type { INodePropertyOptions } from 'n8n-workflow';
 
-// ValidEvents is the set of event types accepted by the webhook
-// create and update commands. Keep in sync with
-// pkg/coredata/webhook_event_type.go.
-var ValidEvents = []string{
-	"THIRD_PARTY_CREATED",
-	"THIRD_PARTY_UPDATED",
-	"THIRD_PARTY_DELETED",
-	"USER_CREATED",
-	"USER_UPDATED",
-	"USER_DELETED",
-	"OBLIGATION_CREATED",
-	"OBLIGATION_UPDATED",
-	"OBLIGATION_DELETED",
-}
+export const WEBHOOK_EVENT_OPTIONS: INodePropertyOptions[] = [
+	{ name: 'Obligation Created', value: 'OBLIGATION_CREATED' },
+	{ name: 'Obligation Deleted', value: 'OBLIGATION_DELETED' },
+	{ name: 'Obligation Updated', value: 'OBLIGATION_UPDATED' },
+	{ name: 'Third Party Created', value: 'THIRD_PARTY_CREATED' },
+	{ name: 'Third Party Deleted', value: 'THIRD_PARTY_DELETED' },
+	{ name: 'Third Party Updated', value: 'THIRD_PARTY_UPDATED' },
+	{ name: 'User Created', value: 'USER_CREATED' },
+	{ name: 'User Deleted', value: 'USER_DELETED' },
+	{ name: 'User Updated', value: 'USER_UPDATED' },
+];

--- a/packages/n8n-node/nodes/Probo/actions/webhook/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/webhook/update.operation.ts
@@ -14,6 +14,7 @@
 
 import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { proboApiRequest } from '../../GenericFunctions';
+import { WEBHOOK_EVENT_OPTIONS } from './events';
 
 export const description: INodeProperties[] = [
 	{
@@ -53,20 +54,7 @@ export const description: INodeProperties[] = [
 				operation: ['update'],
 			},
 		},
-		options: [
-			{ name: 'Meeting Created', value: 'MEETING_CREATED' },
-			{ name: 'Meeting Deleted', value: 'MEETING_DELETED' },
-			{ name: 'Meeting Updated', value: 'MEETING_UPDATED' },
-			{ name: 'Obligation Created', value: 'OBLIGATION_CREATED' },
-			{ name: 'Obligation Deleted', value: 'OBLIGATION_DELETED' },
-			{ name: 'Obligation Updated', value: 'OBLIGATION_UPDATED' },
-			{ name: 'Third Party Created', value: 'THIRD_PARTY_CREATED' },
-			{ name: 'Third Party Deleted', value: 'THIRD_PARTY_DELETED' },
-			{ name: 'Third Party Updated', value: 'THIRD_PARTY_UPDATED' },
-			{ name: 'User Created', value: 'USER_CREATED' },
-			{ name: 'User Deleted', value: 'USER_DELETED' },
-			{ name: 'User Updated', value: 'USER_UPDATED' },
-		],
+		options: WEBHOOK_EVENT_OPTIONS,
 		default: [],
 		description: 'The event types to subscribe to (replaces existing selection)',
 	},

--- a/packages/n8n-node/nodes/ProboTrigger/ProboTrigger.node.json
+++ b/packages/n8n-node/nodes/ProboTrigger/ProboTrigger.node.json
@@ -1,0 +1,19 @@
+{
+  "node": "n8n-nodes-probo.proboTrigger",
+  "nodeVersion": "1.0",
+  "codexVersion": "1.0",
+  "categories": ["Development", "Developer Tools", "Automation"],
+  "resources": {
+    "credentialDocumentation": [
+      {
+        "url": "https://www.probo.com/docs"
+      }
+    ],
+    "primaryDocumentation": [
+      {
+        "url": "https://www.probo.com/docs"
+      }
+    ],
+    "generic": []
+  }
+}

--- a/packages/n8n-node/nodes/ProboTrigger/ProboTrigger.node.ts
+++ b/packages/n8n-node/nodes/ProboTrigger/ProboTrigger.node.ts
@@ -1,0 +1,344 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { createHmac, timingSafeEqual } from 'crypto';
+import {
+	NodeApiError,
+	NodeConnectionTypes,
+	type IDataObject,
+	type IHookFunctions,
+	type INodeType,
+	type INodeTypeDescription,
+	type IWebhookFunctions,
+	type IWebhookResponseData,
+	type JsonObject,
+} from 'n8n-workflow';
+import { proboApiRequest } from '../Probo/GenericFunctions';
+import { WEBHOOK_EVENT_OPTIONS } from '../Probo/actions/webhook/events';
+
+function extractNode(response: IDataObject): IDataObject | undefined {
+	const data = response?.data as IDataObject | undefined;
+	return data?.node as IDataObject | undefined;
+}
+
+function sameEventSet(a: string[], b: string[]): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+
+	const set = new Set(a);
+	return b.every((value) => set.has(value));
+}
+
+async function deleteSubscription(this: IHookFunctions, subscriptionId: string): Promise<boolean> {
+	const query = `
+		mutation DeleteWebhookSubscription($input: DeleteWebhookSubscriptionInput!) {
+			deleteWebhookSubscription(input: $input) {
+				deletedWebhookSubscriptionId
+			}
+		}
+	`;
+
+	try {
+		await proboApiRequest.call(this, query, {
+			input: { webhookSubscriptionId: subscriptionId },
+		});
+	} catch {
+		return false;
+	}
+
+	return true;
+}
+
+export class ProboTrigger implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Probo Trigger',
+		name: 'proboTrigger',
+		icon: { light: 'file:../../icons/probo-light.svg', dark: 'file:../../icons/probo.svg' },
+		group: ['trigger'],
+		version: 1,
+		subtitle: '={{$parameter["events"].join(", ")}}',
+		description: 'Starts a workflow when Probo events occur',
+		usableAsTool: true,
+		defaults: {
+			name: 'Probo Trigger',
+		},
+		inputs: [],
+		outputs: [NodeConnectionTypes.Main],
+		credentials: [
+			{
+				name: 'proboApi',
+				required: true,
+			},
+		],
+		webhooks: [
+			{
+				name: 'default',
+				httpMethod: 'POST',
+				responseMode: 'onReceived',
+				path: 'webhook',
+			},
+		],
+		properties: [
+			{
+				displayName: 'Organization ID',
+				name: 'organizationId',
+				type: 'string',
+				default: '',
+				required: true,
+				description: 'The ID of the organization to receive events from',
+			},
+			{
+				displayName: 'Events',
+				name: 'events',
+				type: 'multiOptions',
+				options: WEBHOOK_EVENT_OPTIONS,
+				default: [],
+				required: true,
+				description: 'The event types that trigger this workflow',
+			},
+			{
+				displayName: 'Verify Signature',
+				name: 'verifySignature',
+				type: 'boolean',
+				default: true,
+				description:
+					'Whether to reject deliveries whose HMAC-SHA256 signature does not match the subscription signing secret',
+			},
+			{
+				displayName: 'Timestamp Tolerance (Seconds)',
+				name: 'toleranceSeconds',
+				type: 'number',
+				default: 300,
+				typeOptions: {
+					minValue: 0,
+				},
+				displayOptions: {
+					show: {
+						verifySignature: [true],
+					},
+				},
+				description:
+					'Reject deliveries whose signed timestamp is older or further in the future than this many seconds, preventing replay of captured deliveries. Set to 0 to disable the freshness check.',
+			},
+		],
+	};
+
+	webhookMethods = {
+		default: {
+			async checkExists(this: IHookFunctions): Promise<boolean> {
+				const webhookData = this.getWorkflowStaticData('node');
+				const subscriptionId = webhookData.subscriptionId as string | undefined;
+
+				if (subscriptionId === undefined) {
+					return false;
+				}
+
+				const query = `
+					query CheckWebhookSubscription($id: ID!) {
+						node(id: $id) {
+							... on WebhookSubscription {
+								id
+								endpointUrl
+								selectedEvents
+								organization {
+									id
+								}
+							}
+						}
+					}
+				`;
+
+				const response = await proboApiRequest.call(this, query, { id: subscriptionId });
+				const node = extractNode(response);
+
+				if (node?.id === undefined) {
+					delete webhookData.subscriptionId;
+					delete webhookData.signingSecret;
+					return false;
+				}
+
+				const webhookUrl = this.getNodeWebhookUrl('default');
+				const organizationId = this.getNodeParameter('organizationId') as string;
+				const events = this.getNodeParameter('events') as string[];
+				const organization = node.organization as IDataObject | undefined;
+				const remoteEvents = (node.selectedEvents as string[] | undefined) ?? [];
+
+				const urlMatches = webhookUrl === undefined || node.endpointUrl === webhookUrl;
+				const organizationMatches = organization?.id === organizationId;
+				const eventsMatch = sameEventSet(remoteEvents, events);
+
+				if (urlMatches && organizationMatches && eventsMatch) {
+					return true;
+				}
+
+				// A node parameter changed since the subscription was created. The
+				// backend cannot move a subscription between organizations, and a stale
+				// subscription keeps delivering the old event set to the same n8n URL,
+				// so drop it here and let n8n re-create one matching the current config.
+				if (!(await deleteSubscription.call(this, subscriptionId))) {
+					// Keep the existing subscription rather than creating a second one
+					// that would deliver duplicates to the same URL; a later activation
+					// retries the cleanup.
+					return true;
+				}
+
+				delete webhookData.subscriptionId;
+				delete webhookData.signingSecret;
+
+				return false;
+			},
+
+			async create(this: IHookFunctions): Promise<boolean> {
+				const webhookUrl = this.getNodeWebhookUrl('default');
+				const organizationId = this.getNodeParameter('organizationId') as string;
+				const events = this.getNodeParameter('events') as string[];
+
+				if (webhookUrl === undefined) {
+					throw new NodeApiError(this.getNode(), {
+						message: 'Cannot create Probo webhook subscription: no webhook URL available',
+					} as JsonObject);
+				}
+
+				const query = `
+					mutation CreateWebhookSubscription($input: CreateWebhookSubscriptionInput!) {
+						createWebhookSubscription(input: $input) {
+							webhookSubscriptionEdge {
+								node {
+									id
+									signingSecret
+								}
+							}
+						}
+					}
+				`;
+
+				const response = await proboApiRequest.call(this, query, {
+					input: {
+						organizationId,
+						endpointUrl: webhookUrl,
+						selectedEvents: events,
+					},
+				});
+
+				const data = response?.data as IDataObject | undefined;
+				const payload = data?.createWebhookSubscription as IDataObject | undefined;
+				const edge = payload?.webhookSubscriptionEdge as IDataObject | undefined;
+				const node = edge?.node as IDataObject | undefined;
+
+				if (node?.id === undefined) {
+					throw new NodeApiError(this.getNode(), {
+						message: 'Cannot create Probo webhook subscription: unexpected API response',
+					} as JsonObject);
+				}
+
+				const webhookData = this.getWorkflowStaticData('node');
+				webhookData.subscriptionId = node.id as string;
+				webhookData.signingSecret = node.signingSecret as string;
+
+				return true;
+			},
+
+			async delete(this: IHookFunctions): Promise<boolean> {
+				const webhookData = this.getWorkflowStaticData('node');
+				const subscriptionId = webhookData.subscriptionId as string | undefined;
+
+				if (subscriptionId === undefined) {
+					return true;
+				}
+
+				if (!(await deleteSubscription.call(this, subscriptionId))) {
+					return false;
+				}
+
+				delete webhookData.subscriptionId;
+				delete webhookData.signingSecret;
+
+				return true;
+			},
+		},
+	};
+
+	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+		const verifySignature = this.getNodeParameter('verifySignature', true) as boolean;
+		const headers = this.getHeaderData() as IDataObject;
+		const body = this.getBodyData();
+
+		if (verifySignature) {
+			const webhookData = this.getWorkflowStaticData('node');
+			const signingSecret = webhookData.signingSecret as string | undefined;
+			const signature = headers['x-probo-webhook-signature'] as string | undefined;
+			const timestamp = headers['x-probo-webhook-timestamp'] as string | undefined;
+
+			const rejected = this.getResponseObject();
+
+			if (signingSecret === undefined || signature === undefined || timestamp === undefined) {
+				rejected.status(403).json({ message: 'Missing Probo webhook signature' });
+				return { noWebhookResponse: true };
+			}
+
+			// n8n's webhook pipeline calls parseBody() -> req.readRawBody() before
+			// invoking this handler for application/json payloads (which Probo always
+			// sends), so req.rawBody holds the exact bytes the signature was computed
+			// over. Re-serializing the parsed body would not match Go's json.Marshal
+			// output, so fail closed if the raw bytes are somehow unavailable.
+			const request = this.getRequestObject() as unknown as { rawBody?: Buffer };
+			const rawBody = request.rawBody;
+
+			if (rawBody === undefined) {
+				rejected
+					.status(403)
+					.json({ message: 'Probo webhook raw body unavailable for signature verification' });
+				return { noWebhookResponse: true };
+			}
+
+			const hmac = createHmac('sha256', signingSecret);
+			hmac.update(`${timestamp}:`);
+			hmac.update(rawBody);
+			const expected = hmac.digest('hex');
+
+			const expectedBuffer = Buffer.from(expected, 'hex');
+			const receivedBuffer = Buffer.from(signature, 'hex');
+
+			if (
+				expectedBuffer.length !== receivedBuffer.length ||
+				!timingSafeEqual(expectedBuffer, receivedBuffer)
+			) {
+				rejected.status(403).json({ message: 'Invalid Probo webhook signature' });
+				return { noWebhookResponse: true };
+			}
+
+			// The signature authenticates the timestamp, so a valid request could
+			// still be replayed verbatim. Reject deliveries outside the tolerance
+			// window to bound that replay surface.
+			const toleranceSeconds = this.getNodeParameter('toleranceSeconds', 300) as number;
+			if (toleranceSeconds > 0) {
+				const timestampSeconds = Number(timestamp);
+				const nowSeconds = Date.now() / 1000;
+
+				if (
+					!Number.isFinite(timestampSeconds) ||
+					Math.abs(nowSeconds - timestampSeconds) > toleranceSeconds
+				) {
+					rejected.status(403).json({ message: 'Stale Probo webhook timestamp' });
+					return { noWebhookResponse: true };
+				}
+			}
+		}
+
+		return {
+			workflowData: [this.helpers.returnJsonArray(body as IDataObject)],
+		};
+	}
+}

--- a/packages/n8n-node/package.json
+++ b/packages/n8n-node/package.json
@@ -25,7 +25,8 @@
       "dist/credentials/ProboApi.credentials.js"
     ],
     "nodes": [
-      "dist/nodes/Probo/Probo.node.js"
+      "dist/nodes/Probo/Probo.node.js",
+      "dist/nodes/ProboTrigger/ProboTrigger.node.js"
     ]
   },
   "license": "MIT",


### PR DESCRIPTION
The n8n package could already manage webhook subscriptions through API CRUD, but had no way to start a workflow when Probo emitted an event. A user had to drop in the generic Webhook node, create a subscription by hand, and verify the HMAC signature themselves.

Add a ProboTrigger node that owns the subscription lifecycle: it creates the subscription on activation pointing at n8n's generated webhook URL, re-checks and re-registers it if the URL drifts, and deletes it on deactivation. The webhook handler recomputes the HMAC-SHA256 over the raw request body and compares it constant-time against the delivered signature, failing closed when the bytes or headers are absent.

Drop the MEETING_* event choices from the webhook create and update operations and the CLI event list. They are not part of the backend WebhookEventType enum, so selecting them only produced API rejections.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `ProboTrigger` node to `n8n-node` to start workflows from Probo webhooks and manage the subscription lifecycle. Removes unsupported `MEETING_*` events and adds HMAC verification with timestamp replay protection.

### Package: `n8n-node` **`+396`** **`-29`**
- Add `ProboTrigger` node: creates subscription on activation, re-creates on drift (URL/org/events), deletes on deactivation; verifies HMAC-SHA256 over raw body with constant-time compare; optional timestamp tolerance to block replays.
- Centralize webhook event options; drop `MEETING_*`; register node in `package.json`.

### prb (CLI) **`+0`** **`-3`**
- Remove `MEETING_*` events to match backend enum.

<sup>Written for commit 7142757dd82a9aa25780fef9e9a9e16942194e8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

