### PR TITLE
Drop string defaults duplicated in probod.New()

### DIFF
--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -67,16 +67,16 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 			},
 		},
 		Probod: probodconfig.Config{
-			BaseURL:       b.resolver.getEnvOrDefault("PROBOD_BASE_URL", "http://localhost:8080"),
+			BaseURL:       b.resolver.getEnv("PROBOD_BASE_URL"),
 			EncryptionKey: b.resolver.getEnv("PROBOD_ENCRYPTION_KEY"),
-			ChromeDPAddr:  b.resolver.getEnvOrDefault("PROBOD_CHROME_DP_ADDR", "localhost:9222"),
+			ChromeDPAddr:  b.resolver.getEnv("PROBOD_CHROME_DP_ADDR"),
 			Api: probodconfig.APIConfig{
-				Addr: b.resolver.getEnvOrDefault("PROBOD_API_ADDR", ":8080"),
+				Addr: b.resolver.getEnv("PROBOD_API_ADDR"),
 				ProxyProtocol: probodconfig.ProxyProtocolConfig{
 					TrustedProxies: b.parseOriginsList(b.resolver.getEnv("PROBOD_API_PROXY_PROTOCOL_TRUSTED_PROXIES")),
 				},
 				Cors: probodconfig.CorsConfig{
-					AllowedOrigins: b.parseOriginsList(b.resolver.getEnvOrDefault("PROBOD_API_CORS_ALLOWED_ORIGINS", "http://localhost:8080")),
+					AllowedOrigins: b.parseOriginsList(b.resolver.getEnv("PROBOD_API_CORS_ALLOWED_ORIGINS")),
 				},
 				ExtraHeaderFields: make(map[string]string),
 				GraphQL: probodconfig.GraphQLConfig{
@@ -87,10 +87,10 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 				},
 			},
 			Pg: probodconfig.PgConfig{
-				Addr:                         b.resolver.getEnvOrDefault("PROBOD_PG_ADDR", "localhost:5432"),
-				Username:                     b.resolver.getEnvOrDefault("PROBOD_PG_USERNAME", "probod"),
-				Password:                     b.resolver.getEnvOrDefault("PROBOD_PG_PASSWORD", "probod"),
-				Database:                     b.resolver.getEnvOrDefault("PROBOD_PG_DATABASE", "probod"),
+				Addr:                         b.resolver.getEnv("PROBOD_PG_ADDR"),
+				Username:                     b.resolver.getEnv("PROBOD_PG_USERNAME"),
+				Password:                     b.resolver.getEnv("PROBOD_PG_PASSWORD"),
+				Database:                     b.resolver.getEnv("PROBOD_PG_DATABASE"),
 				PoolSize:                     int32(b.resolver.getEnvIntOrDefault("PROBOD_PG_POOL_SIZE", 100)),
 				MinPoolSize:                  int32(b.resolver.getEnvIntOrDefault("PROBOD_PG_MIN_POOL_SIZE", 10)),
 				MaxConnIdleTimeSeconds:       b.resolver.getEnvIntOrDefault("PROBOD_PG_MAX_CONN_IDLE_TIME_SECONDS", 1800),
@@ -106,8 +106,8 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 				PasswordResetTokenValidity:          b.resolver.getEnvIntOrDefault("PROBOD_AUTH_PASSWORD_RESET_TOKEN_VALIDITY", 3600),
 				MagicLinkTokenValidity:              b.resolver.getEnvIntOrDefault("PROBOD_AUTH_MAGIC_LINK_TOKEN_VALIDITY", 900),
 				Cookie: probodconfig.CookieConfig{
-					Name:     b.resolver.getEnvOrDefault("PROBOD_AUTH_COOKIE_NAME", "SSID"),
-					Domain:   b.resolver.getEnvOrDefault("PROBOD_AUTH_COOKIE_DOMAIN", "localhost"),
+					Name:     b.resolver.getEnv("PROBOD_AUTH_COOKIE_NAME"),
+					Domain:   b.resolver.getEnv("PROBOD_AUTH_COOKIE_DOMAIN"),
 					Secret:   b.resolver.getEnv("PROBOD_AUTH_COOKIE_SECRET"),
 					Duration: b.resolver.getEnvIntOrDefault("PROBOD_AUTH_COOKIE_DURATION", 24),
 					Secure:   b.resolver.getEnvBoolOrDefault("PROBOD_AUTH_COOKIE_SECURE", true),
@@ -122,7 +122,7 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 					Certificate:                       samlCert,
 					PrivateKey:                        samlKey,
 					DomainVerificationIntervalSeconds: b.resolver.getEnvIntOrDefault("PROBOD_SAML_DOMAIN_VERIFICATION_INTERVAL_SECONDS", 60),
-					DomainVerificationResolverAddr:    b.resolver.getEnvOrDefault("PROBOD_SAML_DOMAIN_VERIFICATION_RESOLVER_ADDR", "8.8.8.8:53"),
+					DomainVerificationResolverAddr:    b.resolver.getEnv("PROBOD_SAML_DOMAIN_VERIFICATION_RESOLVER_ADDR"),
 				},
 				Google: probodconfig.OIDCProviderConfig{
 					ClientID:     b.resolver.getEnv("PROBOD_AUTH_GOOGLE_CLIENT_ID"),
@@ -150,15 +150,15 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 				},
 			},
 			TrustCenter: probodconfig.TrustCenterConfig{
-				HTTPAddr:  b.resolver.getEnvOrDefault("PROBOD_TRUST_CENTER_HTTP_ADDR", ":80"),
-				HTTPSAddr: b.resolver.getEnvOrDefault("PROBOD_TRUST_CENTER_HTTPS_ADDR", ":443"),
+				HTTPAddr:  b.resolver.getEnv("PROBOD_TRUST_CENTER_HTTP_ADDR"),
+				HTTPSAddr: b.resolver.getEnv("PROBOD_TRUST_CENTER_HTTPS_ADDR"),
 				ProxyProtocol: probodconfig.ProxyProtocolConfig{
 					TrustedProxies: b.parseOriginsList(b.resolver.getEnv("PROBOD_TRUST_CENTER_PROXY_PROTOCOL_TRUSTED_PROXIES")),
 				},
 			},
 			AWS: probodconfig.AWSConfig{
-				Region:          b.resolver.getEnvOrDefault("PROBOD_AWS_REGION", "us-east-1"),
-				Bucket:          b.resolver.getEnvOrDefault("PROBOD_AWS_BUCKET", "probod"),
+				Region:          b.resolver.getEnv("PROBOD_AWS_REGION"),
+				Bucket:          b.resolver.getEnv("PROBOD_AWS_BUCKET"),
 				AccessKeyID:     b.resolver.getEnv("PROBOD_AWS_ACCESS_KEY_ID"),
 				SecretAccessKey: b.resolver.getEnv("PROBOD_AWS_SECRET_ACCESS_KEY"),
 				Endpoint:        b.resolver.getEnv("PROBOD_AWS_ENDPOINT"),
@@ -166,11 +166,11 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 			},
 			Notifications: probodconfig.NotificationsConfig{
 				Mailer: probodconfig.MailerConfig{
-					SenderName:     b.resolver.getEnvOrDefault("PROBOD_MAILER_SENDER_NAME", "Probo"),
-					SenderEmail:    b.resolver.getEnvOrDefault("PROBOD_MAILER_SENDER_EMAIL", "no-reply@notification.getprobo.com"),
+					SenderName:     b.resolver.getEnv("PROBOD_MAILER_SENDER_NAME"),
+					SenderEmail:    b.resolver.getEnv("PROBOD_MAILER_SENDER_EMAIL"),
 					MailerInterval: b.resolver.getEnvIntOrDefault("PROBOD_MAILER_INTERVAL", 60),
 					SMTP: probodconfig.SMTPConfig{
-						Addr:        b.resolver.getEnvOrDefault("PROBOD_SMTP_ADDR", "localhost:1025"),
+						Addr:        b.resolver.getEnv("PROBOD_SMTP_ADDR"),
 						User:        b.resolver.getEnv("PROBOD_SMTP_USER"),
 						Password:    b.resolver.getEnv("PROBOD_SMTP_PASSWORD"),
 						TLSRequired: b.resolver.getEnvBoolOrDefault("PROBOD_SMTP_TLS_REQUIRED", false),
@@ -272,12 +272,12 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 				RenewalInterval:   b.resolver.getEnvIntOrDefault("PROBOD_CUSTOM_DOMAINS_RENEWAL_INTERVAL", 3600),
 				ProvisionInterval: b.resolver.getEnvIntOrDefault("PROBOD_CUSTOM_DOMAINS_PROVISION_INTERVAL", 30),
 				CnameTarget:       b.resolver.getEnvOrDefault("PROBOD_CUSTOM_DOMAINS_CNAME_TARGET", "custom.getprobo.com"),
-				ResolverAddr:      b.resolver.getEnvOrDefault("PROBOD_CUSTOM_DOMAINS_RESOLVER_ADDR", "8.8.8.8:53"),
+				ResolverAddr:      b.resolver.getEnv("PROBOD_CUSTOM_DOMAINS_RESOLVER_ADDR"),
 				CAAIssuerDomain:   b.resolver.getEnvOrDefault("PROBOD_CUSTOM_DOMAINS_CAA_ISSUER_DOMAIN", "letsencrypt.org"),
 				ACME: probodconfig.ACMEConfig{
-					Directory:  b.resolver.getEnvOrDefault("PROBOD_ACME_DIRECTORY", "https://acme-v02.api.letsencrypt.org/directory"),
-					Email:      b.resolver.getEnvOrDefault("PROBOD_ACME_EMAIL", "admin@probo.com"),
-					KeyType:    b.resolver.getEnvOrDefault("PROBOD_ACME_KEY_TYPE", "EC256"),
+					Directory:  b.resolver.getEnv("PROBOD_ACME_DIRECTORY"),
+					Email:      b.resolver.getEnv("PROBOD_ACME_EMAIL"),
+					KeyType:    b.resolver.getEnv("PROBOD_ACME_KEY_TYPE"),
 					RootCA:     b.resolver.getEnv("PROBOD_ACME_ROOT_CA"),
 					AccountKey: b.resolver.getEnv("PROBOD_ACME_ACCOUNT_KEY"),
 				},
@@ -287,7 +287,7 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 				PollInterval: b.resolver.getEnvIntOrDefault("PROBOD_SCIM_BRIDGE_POLL_INTERVAL", 30),
 			},
 			ESign: probodconfig.ESignConfig{
-				TSAURL: b.resolver.getEnvOrDefault("PROBOD_ESIGN_TSA_URL", "http://timestamp.digicert.com"),
+				TSAURL: b.resolver.getEnv("PROBOD_ESIGN_TSA_URL"),
 			},
 			EvidenceDescriber: probodconfig.EvidenceDescriberConfig{
 				Interval:       b.resolver.getEnvIntOrDefault("PROBOD_EVIDENCE_DESCRIBER_INTERVAL", 10),

--- a/pkg/bootstrap/builder_test.go
+++ b/pkg/bootstrap/builder_test.go
@@ -139,23 +139,23 @@ func TestBuilder_Build_Defaults(t *testing.T) {
 	assert.Equal(t, 2048, cfg.Unit.Tracing.MaxQueueSize)
 
 	// Probod base config
-	assert.Equal(t, "http://localhost:8080", cfg.Probod.BaseURL)
-	assert.Equal(t, "localhost:9222", cfg.Probod.ChromeDPAddr)
+	assert.Empty(t, cfg.Probod.BaseURL)
+	assert.Empty(t, cfg.Probod.ChromeDPAddr)
 
 	// API config
-	assert.Equal(t, ":8080", cfg.Probod.Api.Addr)
+	assert.Empty(t, cfg.Probod.Api.Addr)
 	assert.Nil(t, cfg.Probod.Api.ProxyProtocol.TrustedProxies)
-	assert.Equal(t, []string{"http://localhost:8080"}, cfg.Probod.Api.Cors.AllowedOrigins)
+	assert.Nil(t, cfg.Probod.Api.Cors.AllowedOrigins)
 	assert.Equal(t, 15000, cfg.Probod.Api.GraphQL.ParserTokenLimit)
 	assert.Equal(t, 2000, cfg.Probod.Api.GraphQL.ComplexityLimit)
 	assert.Equal(t, 1000, cfg.Probod.Api.GraphQL.QueryCacheSize)
 	assert.True(t, cfg.Probod.Api.GraphQL.DisableSuggestion)
 
 	// PG config
-	assert.Equal(t, "localhost:5432", cfg.Probod.Pg.Addr)
-	assert.Equal(t, "probod", cfg.Probod.Pg.Username)
-	assert.Equal(t, "probod", cfg.Probod.Pg.Password)
-	assert.Equal(t, "probod", cfg.Probod.Pg.Database)
+	assert.Empty(t, cfg.Probod.Pg.Addr)
+	assert.Empty(t, cfg.Probod.Pg.Username)
+	assert.Empty(t, cfg.Probod.Pg.Password)
+	assert.Empty(t, cfg.Probod.Pg.Database)
 	assert.Equal(t, int32(100), cfg.Probod.Pg.PoolSize)
 	assert.Equal(t, int32(10), cfg.Probod.Pg.MinPoolSize)
 	assert.Equal(t, 1800, cfg.Probod.Pg.MaxConnIdleTimeSeconds)
@@ -169,8 +169,8 @@ func TestBuilder_Build_Defaults(t *testing.T) {
 	assert.Equal(t, 3600, cfg.Probod.Auth.InvitationConfirmationTokenValidity)
 	assert.Equal(t, 3600, cfg.Probod.Auth.PasswordResetTokenValidity)
 	assert.Equal(t, 900, cfg.Probod.Auth.MagicLinkTokenValidity)
-	assert.Equal(t, "SSID", cfg.Probod.Auth.Cookie.Name)
-	assert.Equal(t, "localhost", cfg.Probod.Auth.Cookie.Domain)
+	assert.Empty(t, cfg.Probod.Auth.Cookie.Name)
+	assert.Empty(t, cfg.Probod.Auth.Cookie.Domain)
 	assert.Equal(t, 24, cfg.Probod.Auth.Cookie.Duration)
 	assert.True(t, cfg.Probod.Auth.Cookie.Secure)
 	assert.Equal(t, 1000000, cfg.Probod.Auth.Password.Iterations)
@@ -179,22 +179,22 @@ func TestBuilder_Build_Defaults(t *testing.T) {
 	assert.Equal(t, 604800, cfg.Probod.Auth.SAML.SessionDuration)
 	assert.Equal(t, 0, cfg.Probod.Auth.SAML.CleanupIntervalSeconds)
 	assert.Equal(t, 60, cfg.Probod.Auth.SAML.DomainVerificationIntervalSeconds)
-	assert.Equal(t, "8.8.8.8:53", cfg.Probod.Auth.SAML.DomainVerificationResolverAddr)
+	assert.Empty(t, cfg.Probod.Auth.SAML.DomainVerificationResolverAddr)
 
 	// Trust center config
-	assert.Equal(t, ":80", cfg.Probod.TrustCenter.HTTPAddr)
-	assert.Equal(t, ":443", cfg.Probod.TrustCenter.HTTPSAddr)
+	assert.Empty(t, cfg.Probod.TrustCenter.HTTPAddr)
+	assert.Empty(t, cfg.Probod.TrustCenter.HTTPSAddr)
 	assert.Nil(t, cfg.Probod.TrustCenter.ProxyProtocol.TrustedProxies)
 
 	// AWS config
-	assert.Equal(t, "us-east-1", cfg.Probod.AWS.Region)
-	assert.Equal(t, "probod", cfg.Probod.AWS.Bucket)
+	assert.Empty(t, cfg.Probod.AWS.Region)
+	assert.Empty(t, cfg.Probod.AWS.Bucket)
 	assert.False(t, cfg.Probod.AWS.UsePathStyle)
 
 	// Notifications config
-	assert.Equal(t, "Probo", cfg.Probod.Notifications.Mailer.SenderName)
-	assert.Equal(t, "no-reply@notification.getprobo.com", cfg.Probod.Notifications.Mailer.SenderEmail)
-	assert.Equal(t, "localhost:1025", cfg.Probod.Notifications.Mailer.SMTP.Addr)
+	assert.Empty(t, cfg.Probod.Notifications.Mailer.SenderName)
+	assert.Empty(t, cfg.Probod.Notifications.Mailer.SenderEmail)
+	assert.Empty(t, cfg.Probod.Notifications.Mailer.SMTP.Addr)
 	assert.False(t, cfg.Probod.Notifications.Mailer.SMTP.TLSRequired)
 	assert.Empty(t, cfg.Probod.Notifications.Mailer.SMTP.HelloName)
 	assert.Equal(t, 60, cfg.Probod.Notifications.Mailer.MailerInterval)
@@ -267,17 +267,17 @@ func TestBuilder_Build_Defaults(t *testing.T) {
 	assert.Equal(t, 3600, cfg.Probod.CustomDomains.RenewalInterval)
 	assert.Equal(t, 30, cfg.Probod.CustomDomains.ProvisionInterval)
 	assert.Equal(t, "custom.getprobo.com", cfg.Probod.CustomDomains.CnameTarget)
-	assert.Equal(t, "8.8.8.8:53", cfg.Probod.CustomDomains.ResolverAddr)
-	assert.Equal(t, "https://acme-v02.api.letsencrypt.org/directory", cfg.Probod.CustomDomains.ACME.Directory)
-	assert.Equal(t, "admin@probo.com", cfg.Probod.CustomDomains.ACME.Email)
-	assert.Equal(t, "EC256", cfg.Probod.CustomDomains.ACME.KeyType)
+	assert.Empty(t, cfg.Probod.CustomDomains.ResolverAddr)
+	assert.Empty(t, cfg.Probod.CustomDomains.ACME.Directory)
+	assert.Empty(t, cfg.Probod.CustomDomains.ACME.Email)
+	assert.Empty(t, cfg.Probod.CustomDomains.ACME.KeyType)
 
 	// SCIM bridge config
 	assert.Equal(t, 900, cfg.Probod.SCIMBridge.SyncInterval)
 	assert.Equal(t, 30, cfg.Probod.SCIMBridge.PollInterval)
 
 	// ESign config
-	assert.Equal(t, "http://timestamp.digicert.com", cfg.Probod.ESign.TSAURL)
+	assert.Empty(t, cfg.Probod.ESign.TSAURL)
 
 	// Branding
 	assert.True(t, cfg.Probod.Branding)


### PR DESCRIPTION
probod-bootstrap was repeating probod.New() literals for string env vars. Map those fields with getEnv only and leave int and bool defaults in the builder. Runtime and generated yaml pick up probod defaults when a variable is unset; dev and Helm still set env vars explicitly where needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops duplicated string defaults in `pkg/bootstrap` and relies on `probod.New()`; most string env vars now use `getEnv`, while numeric and boolean defaults stay in the builder. Unset vars fall back to `probod` defaults at runtime and in generated YAML; a few string defaults remain where they are app-level defaults (e.g., CNAME target, CAA issuer domain).

### Service **`+23`** **`-23`**
- Swapped `getEnvOrDefault` for `getEnv` on string fields across Probod, API, PG, Auth cookie, Trust Center, AWS, Mailer, CustomDomains (ACME), and ESign.
- Kept string defaults where they’re core app defaults (`CustomDomains.CnameTarget`, `CustomDomains.CAAIssuerDomain`) and retained all numeric/boolean defaults.

### Tests **`+23`** **`-23`**
- Updated expectations to empty strings or nil slices for affected fields; kept assertions for values that still default in the builder (e.g., CNAME target).

<sup>Written for commit 35ea26269160c0c3f545605f792661ddf5800aa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

