### PR TITLE
Keep nested dropdown dismissal local

### DIFF
--- a/packages/ui/src/Molecules/Dialog/Dialog.tsx
+++ b/packages/ui/src/Molecules/Dialog/Dialog.tsx
@@ -69,6 +69,8 @@ type Props = {
   closable?: boolean;
 };
 
+type DialogContentPrimitiveProps = ComponentProps<typeof Content>;
+
 export const useDialogRef = (): DialogRef => {
   return useRef(null);
 };
@@ -85,6 +87,7 @@ export function Dialog({
 }: Props) {
   const { overlay, content, header, title: titleClassname } = dialog();
   const [open, setOpen] = useState(!!defaultOpen);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (ref) {
@@ -109,8 +112,24 @@ export function Dialog({
     }
   };
 
+  const preventDismissWhenPointerIsInsideContent: DialogContentPrimitiveProps["onPointerDownOutside"] = (event) => {
+    const originalEvent = event.detail.originalEvent;
+    const rect = contentRef.current?.getBoundingClientRect();
+    if (
+      rect
+      && originalEvent.clientX >= rect.left
+      && originalEvent.clientX <= rect.right
+      && originalEvent.clientY >= rect.top
+      && originalEvent.clientY <= rect.bottom
+    ) {
+      event.preventDefault();
+    }
+  };
+
   const contentProps = closable
-    ? {}
+    ? {
+        onPointerDownOutside: preventDismissWhenPointerIsInsideContent,
+      }
     : {
         onEscapeKeyDown: (e: Event) => e.preventDefault(),
         onPointerDownOutside: (e: Event) => e.preventDefault(),
@@ -123,8 +142,10 @@ export function Dialog({
       <Portal>
         <Overlay className={overlay()} />
         <Content
+          ref={contentRef}
           aria-describedby={undefined}
           className={content({ className })}
+          style={{ pointerEvents: "auto" }}
           {...contentProps}
         >
           {title


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep dialog content pointer-interactive while a nested Radix popup is open.
- Prevent dialog outside-dismiss when Radix reports an outside pointer event whose coordinates are still inside the dialog content.

## Verification
- `npm -w @probo/ui run check`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-560](https://linear.app/probo/issue/ENG-560/popover-closes-when-clicking-outside-an-open-dropdown)

<div><a href="https://cursor.com/agents/bc-ac8f6e38-8bd1-4a87-9c50-38ea7d0d0005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac8f6e38-8bd1-4a87-9c50-38ea7d0d0005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents parent dialogs from closing when clicking inside nested, portaled dropdowns. Adds a pointer-down-outside guard on `Dialog.Content` that keeps the dialog open when the pointer is within content bounds (Fixes ENG-560).

### Package: ui **`+22`** **`-1`**
- Add `onPointerDownOutside` to `Dialog.Content` to hit-test pointer coords and cancel when inside.
- Add `ref` to content and set `pointerEvents: "auto"` for accurate hit testing.

<sup>Written for commit b61ccfdab84f742f88b14ffdb02da480af33dd0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

