### PR TITLE
Raise compliance report upload limit to 30MB

### DIFF
--- a/apps/console/src/pages/organizations/third-parties/_components/UploadComplianceReportDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/UploadComplianceReportDialog.tsx
@@ -173,13 +173,13 @@ export function UploadComplianceReportDialog({
       <form onSubmit={e => void handleSubmit(onSubmit)(e)}>
         <DialogContent padded className="space-y-4">
           <Dropzone
-            description={__("Only PDF files up to 10MB are allowed")}
+            description={__("Only PDF files up to 30MB are allowed")}
             isUploading={isUploading}
             onDrop={handleDrop}
             accept={{
               "application/pdf": [".pdf"],
             }}
-            maxSize={10}
+            maxSize={30}
           />
 
           {uploadedFile && (

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -214,6 +214,7 @@ func NewService(
 		svc: svc,
 		fileValidator: filevalidation.NewValidator(
 			filevalidation.WithCategories(filevalidation.CategoryDocument),
+			filevalidation.WithMaxFileSize(30*1024*1024), // 30MB
 		),
 	}
 	svc.ThirdPartyBusinessAssociateAgreements = &ThirdPartyBusinessAssociateAgreementService{svc: svc}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Increases the third-party compliance report PDF upload limit from 10MB to 30MB (ENG-565).

- Updates the upload dialog Dropzone client-side validation and helper text
- Sets an explicit 30MB cap on the backend file validator for compliance reports

## Test plan

- [x] `go test ./pkg/filevalidation/...`
- [ ] Manually upload a PDF between 10MB and 30MB on the third-party compliance reports tab
- [ ] Confirm files above 30MB are still rejected with the "This file is too large" message

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-565](https://linear.app/probo/issue/ENG-565/increase-compliance-report-upload-limit-to-30mb)

<div><a href="https://cursor.com/agents/bc-a3da443a-2421-4f3d-85b3-fc28cf0a9521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3da443a-2421-4f3d-85b3-fc28cf0a9521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the third‑party compliance report PDF upload limit from 10MB to 30MB across the app and backend. Aligns with Linear ENG-565 and enforces a hard 30MB cap.

### App: console **`+2`** **`-2`**
- Updated Dropzone helper text to 30MB.
- Increased client-side max size to 30MB in the upload dialog.

### Service **`+1`** **`-0`**
- Set backend file validator max size to 30MB for compliance report documents.

<sup>Written for commit a0329a9696109b8f9d7a2cbbddb8f3a534da13cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

