### PR TITLE
Add display names for resource-alias OAuth scopes

### DIFF
--- a/apps/console/src/pages/iam/oauthTokens/_components/scopeLabels.ts
+++ b/apps/console/src/pages/iam/oauthTokens/_components/scopeLabels.ts
@@ -39,6 +39,8 @@ const apiScopeLabels: Record<string, string> = {
   "v1:org": "Manage organization",
   "v1:privacy:read": "Read privacy settings",
   "v1:privacy": "Manage privacy settings",
+  "v1:resource-alias:read": "Read resource aliases",
+  "v1:resource-alias": "Manage resource aliases",
   "v1:risk:read": "Read risks",
   "v1:risk": "Manage risks",
   "v1:slack-connection:read": "Read Slack connections",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes ENG-569: the OAuth token and consent UIs were showing the raw scope string `v1:resource-alias` instead of a human-readable label.

Adds the missing entries to `scopeLabels.ts`:
- `v1:resource-alias:read` → "Read resource aliases"
- `v1:resource-alias` → "Manage resource aliases"

The wording matches the existing `prb resource-alias` CLI short description.

## Test plan

- [ ] Open OAuth token creation or consent flow with a scope set that includes `v1:resource-alias`
- [ ] Confirm the scope list shows "Manage resource aliases" instead of `v1:resource-alias`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-569](https://linear.app/probo/issue/ENG-569/add-missing-name-for-v1resource-alias)

<div><a href="https://cursor.com/agents/bc-dc562783-4aae-4ee9-80b9-156f497d4c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc562783-4aae-4ee9-80b9-156f497d4c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Label the `v1:resource-alias` OAuth scopes so token creation and consent screens show clear names. Fixes ENG-569.

### App: console **`+2`** **`-0`**
- In `scopeLabels.ts`:
  - `v1:resource-alias:read` → "Read resource aliases"
  - `v1:resource-alias` → "Manage resource aliases"

<sup>Written for commit 478e34b82fc1589a5c3fb016dc14b564e61209ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

