### PR TITLE
Resolve SCIM users by legacy membership id

### DIFF
--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -359,18 +359,16 @@ func (s *Service) GetUser(
 	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			profile = &coredata.MembershipProfile{}
-			if err := profile.LoadByID(ctx, conn, scope, profileID); err != nil {
-				if err == coredata.ErrResourceNotFound {
+			p, err := s.loadProfileBySCIMID(ctx, conn, scope, config, profileID)
+			if err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
 					return scimerrors.ScimErrorResourceNotFound(profileID.String())
 				}
 
-				return fmt.Errorf("cannot load profile: %w", err)
+				return fmt.Errorf("cannot load profile by SCIM id: %w", err)
 			}
 
-			if profile.OrganizationID != config.OrganizationID {
-				return scimerrors.ScimErrorResourceNotFound(profileID.String())
-			}
+			profile = p
 
 			return nil
 		},
@@ -493,18 +491,16 @@ func (s *Service) updateUser(
 	err := s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			profile = &coredata.MembershipProfile{}
-			if err := profile.LoadByID(ctx, tx, scope, profileID); err != nil {
+			p, err := s.loadProfileBySCIMID(ctx, tx, scope, config, profileID)
+			if err != nil {
 				if errors.Is(err, coredata.ErrResourceNotFound) {
 					return scimerrors.ScimErrorResourceNotFound(profileID.String())
 				}
 
-				return fmt.Errorf("cannot load profile: %w", err)
+				return fmt.Errorf("cannot load profile by SCIM id: %w", err)
 			}
 
-			if profile.OrganizationID != config.OrganizationID {
-				return scimerrors.ScimErrorResourceNotFound(profileID.String())
-			}
+			profile = p
 
 			membership = &coredata.Membership{}
 			if err := membership.LoadByIdentityIDAndOrganizationID(ctx, tx, scope, profile.IdentityID, profile.OrganizationID); err != nil {
@@ -841,17 +837,13 @@ func (s *Service) DeleteUser(
 	return s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			profile := &coredata.MembershipProfile{}
-			if err := profile.LoadByID(ctx, tx, scope, profileID); err != nil {
+			profile, err := s.loadProfileBySCIMID(ctx, tx, scope, config, profileID)
+			if err != nil {
 				if errors.Is(err, coredata.ErrResourceNotFound) {
 					return scimerrors.ScimErrorResourceNotFound(profileID.String())
 				}
 
-				return fmt.Errorf("cannot load profile: %w", err)
-			}
-
-			if profile.OrganizationID != config.OrganizationID {
-				return scimerrors.ScimErrorResourceNotFound(profileID.String())
+				return fmt.Errorf("cannot load profile by SCIM id: %w", err)
 			}
 
 			var membership *coredata.Membership
@@ -1744,4 +1736,54 @@ func userToResource(p *coredata.MembershipProfile) scim.Resource {
 			LastModified: &p.UpdatedAt,
 		},
 	}
+}
+
+// loadProfileBySCIMID resolves a SCIM resource id to its MembershipProfile,
+// falling back to the membership's identity when the id is a legacy Membership
+// GID. Returns coredata.ErrResourceNotFound when nothing matches in the org.
+func (s *Service) loadProfileBySCIMID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	config *coredata.SCIMConfiguration,
+	scimID gid.GID,
+) (*coredata.MembershipProfile, error) {
+	profile := &coredata.MembershipProfile{}
+
+	if scimID.EntityType() == coredata.MembershipEntityType {
+		s.logger.WarnCtx(
+			ctx,
+			"SCIM request used a legacy membership id",
+			log.String("membership_id", scimID.String()),
+		)
+
+		membership := &coredata.Membership{}
+		if err := membership.LoadByID(ctx, conn, scope, scimID); err != nil {
+			return nil, fmt.Errorf("cannot load membership by legacy SCIM id: %w", err)
+		}
+
+		if membership.OrganizationID != config.OrganizationID {
+			return nil, coredata.ErrResourceNotFound
+		}
+
+		if err := profile.LoadByIdentityIDAndOrganizationID(
+			ctx,
+			conn,
+			scope,
+			membership.IdentityID,
+			config.OrganizationID,
+		); err != nil {
+			return nil, fmt.Errorf("cannot load profile by membership identity: %w", err)
+		}
+	} else {
+		if err := profile.LoadByID(ctx, conn, scope, scimID); err != nil {
+			return nil, fmt.Errorf("cannot load profile by id: %w", err)
+		}
+	}
+
+	if profile.OrganizationID != config.OrganizationID {
+		return nil, coredata.ErrResourceNotFound
+	}
+
+	return profile, nil
 }


### PR DESCRIPTION
SCIM resource ids are MembershipProfile GIDs, but before the id scheme changed they were Membership GIDs. IdPs provisioned before that change still address users by their old membership id, so GET/PATCH/DELETE on /Users/{id} returned 404, silently breaking updates and deprovisioning for those users.

Add a loadProfileBySCIMID fallback that, when the path id is a Membership GID, resolves the profile through the membership's identity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fallback to resolve SCIM user requests that use legacy membership IDs, fixing 404s for users provisioned before the ID scheme change. GET/PATCH/DELETE on `/Users/{id}` now work when `{id}` is a Membership GID.

### Service **`+62`** **`-20`**
- Added `loadProfileBySCIMID` to resolve profiles by SCIM ID with legacy Membership GID fallback and org check.
- Switched `GetUser`, `updateUser`, and `DeleteUser` to use the resolver; centralized org validation and consistent SCIM 404s.
- Added warning log when a legacy membership ID is used.

<sup>Written for commit b570ae5b1849fdef0ebbe64f86d29b0ed7f37890. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

