### PR TITLE
Fix Probo codex node identifier format

### DIFF
--- a/packages/n8n-node/nodes/Probo/Probo.node.json
+++ b/packages/n8n-node/nodes/Probo/Probo.node.json
@@ -1,5 +1,5 @@
 {
-  "node": "n8n-nodes-probo",
+  "node": "@probo/n8n-nodes-probo.probo",
   "nodeVersion": "1.0",
   "codexVersion": "1.0",
   "categories": ["Development", "Utility"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes ENG-575: the n8n marketplace review flagged the `node` field in `Probo.node.json` as using the wrong identifier format.

Updates the codex identifier from `n8n-nodes-probo` to `@probo/n8n-nodes-probo.probo`, matching the scoped package name (`@probo/n8n-nodes-probo`) and the node name (`probo`) declared in `Probo.node.ts`.

## Test plan

- [x] `npm --workspace @probo/n8n-nodes-probo run lint` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-575](https://linear.app/probo/issue/ENG-575/fix-codex-node-identifier-format)

<div><a href="https://cursor.com/agents/bc-b4ab9ac9-c21f-4b3f-8bc0-b93b59a0338c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4ab9ac9-c21f-4b3f-8bc0-b93b59a0338c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ENG-575 by setting the n8n Probo codex node identifier to the required format so the marketplace review passes. Aligns the `node` field with the scoped package and node name.

### Package: n8n-node **`+1`** **`-1`**
- Changed `node` in `Probo.node.json` from `n8n-nodes-probo` to `@probo/n8n-nodes-probo.probo` to match `@probo/n8n-nodes-probo` and `probo`.

<sup>Written for commit 82bf5cdfafa7ab1a4881c53af7bcdd556e92f7a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

