### PR TITLE
Replace unsupported categories in Probo node codex

### DIFF
--- a/packages/n8n-node/nodes/Probo/Probo.node.json
+++ b/packages/n8n-node/nodes/Probo/Probo.node.json
@@ -2,7 +2,7 @@
   "node": "n8n-nodes-probo",
   "nodeVersion": "1.0",
   "codexVersion": "1.0",
-  "categories": ["Development", "Developer Tools", "Automation"],
+  "categories": ["Development", "Utility"],
   "resources": {
     "credentialDocumentation": [
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes ENG-578 by updating the `categories` field in `packages/n8n-node/nodes/Probo/Probo.node.json` to use n8n marketplace–supported values.

## Changes

- Removed unsupported `Developer Tools` and `Automation` categories
- Kept `Development` and added `Utility` per marketplace review guidance

**Before:** `["Development", "Developer Tools", "Automation"]`  
**After:** `["Development", "Utility"]`

## Notes

`ProboTrigger.node.json` still lists the old categories; happy to align it in a follow-up if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-578](https://linear.app/probo/issue/ENG-578/replace-unsupported-categories-in-probo-node-codex)

<div><a href="https://cursor.com/agents/bc-f6fcece7-8ad9-470a-ae6a-0653e53ef58c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6fcece7-8ad9-470a-ae6a-0653e53ef58c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Probo n8n codex categories to marketplace-supported values so the node passes review. Addresses ENG-578.

### Package: `n8n-node` **`+1`** **`-1`**
Changed `packages/n8n-node/nodes/Probo/Probo.node.json` categories from ["Development", "Developer Tools", "Automation"] to ["Development", "Utility"] per n8n marketplace guidance.

<sup>Written for commit fb03797fbe7408cb740da305f8c8fa8ef3618cda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

