### PR TITLE
Remove unused requestDefaults from Probo node

### DIFF
--- a/packages/n8n-node/nodes/Probo/Probo.node.ts
+++ b/packages/n8n-node/nodes/Probo/Probo.node.ts
@@ -52,12 +52,6 @@ export class Probo implements INodeType {
 				},
 			},
 		],
-		requestDefaults: {
-			headers: {
-				Accept: 'application/json',
-				'Content-Type': 'application/json',
-			},
-		},
 		properties: [
 			{
 				displayName: 'Authentication',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the dead `requestDefaults` block from the Probo n8n node description.

The node is programmatic — it implements `execute()` and dispatches to per-operation handlers via `GenericFunctions`. n8n only applies `requestDefaults` for declarative (routing) nodes, so the headers block was never used.

Fixes ENG-577.

## Test plan

- [x] Verified `requestDefaults` is no longer referenced in `packages/n8n-node`
- [ ] CI build/lint for `packages/n8n-node` (local build hit pre-existing `@types/node` issues unrelated to this change)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-577](https://linear.app/probo/issue/ENG-577/remove-unused-requestdefaults-from-programmatic-node)

<div><a href="https://cursor.com/agents/bc-bd4b0dac-8b49-4f36-a3cf-1aa095fb3179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd4b0dac-8b49-4f36-a3cf-1aa095fb3179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused requestDefaults from the Probo node in `packages/n8n-node` to address ENG-577 and marketplace review feedback. n8n only applies it to declarative nodes; this node uses execute(), so there is no runtime change.

### Package: `n8n-node` **`+0`** **`-6`**
Removed requestDefaults.headers from Probo.node.ts.

<sup>Written for commit b770e226a3e0622acd2f510805a67ca7e34af887. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

