### PR TITLE
Add README to published n8n package

### DIFF
--- a/packages/n8n-node/README.md
+++ b/packages/n8n-node/README.md
@@ -1,0 +1,138 @@
+# @probo/n8n-nodes-probo
+
+n8n community node package for the [Probo](https://www.probo.com) compliance platform. Automate compliance workflows — manage controls, documents, risks, vendors, cookie banners, and more — over the Probo GraphQL API.
+
+This package provides two nodes:
+
+| Node | Type | Description |
+|------|------|-------------|
+| **Probo** | Action | Read and write Probo resources (tasks, documents, controls, organizations, and 30+ other resources) |
+| **Probo Trigger** | Trigger | Start a workflow when Probo webhook events occur (document published, user created, obligation updated, and more) |
+
+## Requirements
+
+- A self-hosted n8n instance with [community nodes enabled](https://docs.n8n.io/hosting/configuration/configuration-examples/community-nodes/)
+- A Probo account with an API key
+- n8n 1.0+ (uses the community node package format)
+
+## Installation
+
+Install the package from npm on your self-hosted n8n instance. Only users with the **Owner** or **Admin** role can install community nodes.
+
+### GUI installation (recommended)
+
+1. In n8n, go to **Settings → Community Nodes**.
+2. Click **Install**.
+3. Enter the npm package name:
+
+   ```
+   @probo/n8n-nodes-probo
+   ```
+
+   To pin a specific version, append it (for example `@probo/n8n-nodes-probo@0.199.0`).
+
+4. Accept the community node risk notice and click **Install**.
+5. Restart n8n if the new nodes do not appear in the node palette immediately.
+
+See the [n8n GUI installation guide](https://docs.n8n.io/integrations/community-nodes/installation-and-management/gui-installation/) for details.
+
+### Manual installation
+
+If you run n8n in Docker or queue mode, you can install the package manually:
+
+```bash
+mkdir -p ~/.n8n/nodes
+cd ~/.n8n/nodes
+npm install @probo/n8n-nodes-probo
+```
+
+Restart n8n after installation. See the [manual installation guide](https://docs.n8n.io/integrations/community-nodes/installation/manual-install/) for upgrade and downgrade steps.
+
+## Credentials
+
+All Probo nodes use the **Probo API** credential type. The node sends your API key as a `Bearer` token on every request.
+
+### Configure credentials in n8n
+
+1. Add a **Probo** or **Probo Trigger** node to a workflow.
+2. Open the **Credential** dropdown and select **Create New Credential**.
+3. Fill in the fields:
+
+   | Field | Default | Description |
+   |-------|---------|-------------|
+   | **Probo Server** | `https://us.console.getprobo.com` | Base URL of your Probo instance. Use `https://eu.console.getprobo.com` for the EU region, or your own URL when self-hosting. |
+   | **API Key** | — | A Probo API key with access to the organizations you automate against. |
+
+4. Click **Test** to verify connectivity. n8n calls the Probo GraphQL API and checks that the key is valid.
+5. Click **Save**. The credential is shared across all Probo nodes in your instance.
+
+### Get an API key
+
+1. Sign in to the Probo console.
+2. Go to **Settings → API Keys**.
+3. Click **Create API Key**.
+4. Copy the key immediately — it is shown only once.
+
+For self-hosted Probo, set **Probo Server** to your instance URL (for example `https://probo.example.com`). The node talks to `/api/console/v1/graphql` on that host.
+
+More detail: [Probo n8n authentication docs](https://www.probo.com/docs/api/n8n/authentication).
+
+## Workflow example: notify Slack when a document is published
+
+This workflow listens for Probo document events and posts a message to Slack.
+
+```
+Probo Trigger  →  Slack
+(document      (post message
+ published)     with document name)
+```
+
+### Steps
+
+1. **Create credentials** as described above and save them as `Probo API`.
+
+2. **Add a Probo Trigger node**
+   - **Credential:** Probo API
+   - **Organization ID:** your Probo organization GID (for example `gid://probo/Organization/…`)
+   - **Events:** `Document Version Published`
+   - **Verify Signature:** enabled (recommended)
+
+3. **Add a Slack node** (or any notification node) connected to the trigger output.
+   - Map fields from the webhook payload, for example:
+     - **Text:** `A document was published: {{ $json.data.documentVersion.document.name }}`
+
+4. **Activate the workflow.** n8n registers a webhook subscription in Probo. When a document version is published, Probo delivers the event and the Slack message is sent.
+
+### Alternative: list open tasks on a schedule
+
+Use the **Probo** action node without a trigger:
+
+1. Add a **Schedule Trigger** node (for example, every weekday at 9:00).
+2. Add a **Probo** node:
+   - **Resource:** Task
+   - **Operation:** Get Many
+   - **Organization ID:** your organization GID
+   - **Return All:** enabled (or set a **Limit**)
+3. Add a downstream node (Slack, email, or spreadsheet) to process `$json` task records.
+
+This pattern works well for daily compliance standups or overdue-task digests.
+
+## Resources
+
+The **Probo** node exposes operations across the platform, including:
+
+Access Review, Asset, Audit, Audit Log, Control, Cookie Banner, Cookie Category, Cookie Consent Record, Data, Document, DPIA, Evidence, Finding, Framework, Measure, Obligation, Organization, Processing Activity, Risk, Task, Third Party, Trust Center, User, Vendor, and more.
+
+Use the **Execute** resource to run custom GraphQL queries or mutations when a dedicated operation is not available.
+
+## Links
+
+- [Probo documentation](https://www.probo.com/docs)
+- [Probo n8n authentication](https://www.probo.com/docs/api/n8n/authentication)
+- [Package on npm](https://www.npmjs.com/package/@probo/n8n-nodes-probo)
+- [Source code](https://github.com/getprobo/probo/tree/main/packages/n8n-node)
+- [Report an issue](https://github.com/getprobo/probo/issues)
+
+## License
+
+MIT

--- a/packages/n8n-node/README.md
+++ b/packages/n8n-node/README.md
@@ -60,7 +60,7 @@ All Probo nodes use the **Probo API** credential type. The node sends your API k
 
    | Field | Default | Description |
    |-------|---------|-------------|
-   | **Probo Server** | `https://us.console.getprobo.com` | Base URL of your Probo instance. Use `https://eu.console.getprobo.com` for the EU region, or your own URL when self-hosting. |
+   | **Probo Server** | `https://us.probo.com` | Base URL of your Probo instance. Use `https://eu.probo.com` for the EU region, or your own URL when self-hosting. |
    | **API Key** | — | A Probo API key with access to the organizations you automate against. |
 
 4. Click **Test** to verify connectivity. n8n calls the Probo GraphQL API and checks that the key is valid.

--- a/packages/n8n-node/credentials/ProboApi.credentials.ts
+++ b/packages/n8n-node/credentials/ProboApi.credentials.ts
@@ -34,7 +34,7 @@ export class ProboApi implements ICredentialType {
 			displayName: 'Probo Server',
 			name: 'server',
 			type: 'string',
-			default: 'https://us.console.getprobo.com',
+			default: 'https://us.probo.com',
 			description: 'The server to connect to.',
 		},
 		{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `packages/n8n-node/README.md` for the `@probo/n8n-nodes-probo` community node package. The n8n marketplace review (ENG-576) flagged the missing README.

## Contents

- **Installation** — GUI installation via Settings → Community Nodes and manual installation for Docker/queue mode
- **Credentials** — Probo Server URL (default `https://us.console.getprobo.com`, EU/self-hosted variants) and API key setup with connection testing
- **Workflow examples**
  - Probo Trigger → Slack when a document version is published
  - Schedule Trigger → Probo Task Get Many for daily task digests
- Links to Probo docs, npm, source, and issue tracker

The README is automatically included in npm publishes (`npm pack` confirms it).

## Test plan

- [x] Verified `npm pack --dry-run` includes `README.md` in the published tarball
- [x] Content aligned with existing credential defaults in `ProboApi.credentials.ts` and [Probo n8n authentication docs](https://www.probo.com/docs/api/n8n/authentication)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-576](https://linear.app/probo/issue/ENG-576/add-readme-to-the-published-n8n-package)

<div><a href="https://cursor.com/agents/bc-62c99c6f-b1b2-4832-b740-7c22a5d35a23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62c99c6f-b1b2-4832-b740-7c22a5d35a23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a README for `@probo/n8n-nodes-probo` and updates default Probo server URLs to the current regional domains. This meets n8n marketplace requirements and aligns credentials with production hosts (ENG-576).

### Package: n8n-node **`+139`** **`-1`**
- Added README covering GUI/manual install, credential setup (default `https://us.probo.com`, EU `https://eu.probo.com`), and two workflow examples
- Updated `ProboApi` credential default server to `https://us.probo.com`
- Confirmed README is included in npm publishes and replaced legacy `console.getprobo.com` URLs

<sup>Written for commit 512fc714deb33abd6b97ee62c0a00141ba089dd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

