### PR TITLE
Add loader on OAuth2 consent page submit

### DIFF
--- a/apps/console/src/pages/iam/auth/ConsentPage.tsx
+++ b/apps/console/src/pages/iam/auth/ConsentPage.tsx
@@ -24,9 +24,10 @@ import {
   IconLockOpen,
   IconUser,
   IconUserCircle,
+  Spinner,
   useToast,
 } from "@probo/ui";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { type PreloadedQuery, useMutation, usePreloadedQuery } from "react-relay";
 import { graphql } from "relay-runtime";
 
@@ -160,6 +161,10 @@ export default function ConsentPage(props: {
   const { toast } = useToast();
   const [deviceResult, setDeviceResult] = useState<"authorized" | "denied" | null>(null);
   const [pendingAction, setPendingAction] = useState<"allow" | "deny" | null>(null);
+  const [redirectState, setRedirectState] = useState<{
+    url: string;
+    approved: boolean;
+  } | null>(null);
 
   const data = usePreloadedQuery<ConsentPageQuery>(consentPageQuery, props.queryRef);
   usePageTitle(__("Authorize Application"));
@@ -177,6 +182,12 @@ export default function ConsentPage(props: {
     () => `${__("API access")} (${apiScopes.length})`,
     [__, apiScopes.length],
   );
+
+  useEffect(() => {
+    if (!redirectState) return;
+
+    window.location.href = redirectState.url;
+  }, [redirectState]);
 
   const handleAction = useCallback(
     (approved: boolean) => {
@@ -221,7 +232,10 @@ export default function ConsentPage(props: {
           }
 
           if (response.approveConsent.redirectURL) {
-            window.location.href = response.approveConsent.redirectURL;
+            setRedirectState({
+              url: response.approveConsent.redirectURL,
+              approved,
+            });
           }
         },
         onError: (err) => {
@@ -267,6 +281,27 @@ export default function ConsentPage(props: {
         <p className="text-txt-tertiary">
           {__("You have denied the authorization request. You can close this window.")}
         </p>
+      </div>
+    );
+  }
+
+  if (redirectState) {
+    return (
+      <div className="w-full max-w-md mx-auto pt-8 space-y-6 text-center">
+        <Spinner size={24} centered className="text-txt-tertiary" />
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold">
+            {redirectState.approved ? __("Authorization Complete") : __("Access Denied")}
+          </h1>
+          <p className="text-txt-tertiary">
+            {__("You will be redirected to")}
+            {" "}
+            <span className="font-medium text-txt-secondary">
+              {consent.application.name}
+            </span>
+            …
+          </p>
+        </div>
       </div>
     );
   }

--- a/apps/console/src/pages/iam/auth/ConsentPage.tsx
+++ b/apps/console/src/pages/iam/auth/ConsentPage.tsx
@@ -159,14 +159,14 @@ export default function ConsentPage(props: {
   const { __ } = useTranslate();
   const { toast } = useToast();
   const [deviceResult, setDeviceResult] = useState<"authorized" | "denied" | null>(null);
+  const [pendingAction, setPendingAction] = useState<"allow" | "deny" | null>(null);
 
   const data = usePreloadedQuery<ConsentPageQuery>(consentPageQuery, props.queryRef);
   usePageTitle(__("Authorize Application"));
 
   const { node: consent } = data;
 
-  const [approveConsent, isInFlight]
-    = useMutation<ConsentPageMutation>(approveConsentMutation);
+  const [approveConsent] = useMutation<ConsentPageMutation>(approveConsentMutation);
 
   const { oidcScopes, apiScopes } = useMemo(
     () => partitionScopes(consent.scopes ?? []),
@@ -180,7 +180,9 @@ export default function ConsentPage(props: {
 
   const handleAction = useCallback(
     (approved: boolean) => {
-      if (!consent.id) return;
+      if (!consent.id || pendingAction !== null) return;
+
+      setPendingAction(approved ? "allow" : "deny");
 
       approveConsent({
         variables: {
@@ -191,6 +193,7 @@ export default function ConsentPage(props: {
         },
         onCompleted: (response, errors) => {
           if (errors) {
+            setPendingAction(null);
             toast({
               title: __("Authorization failed"),
               description: formatError(
@@ -203,6 +206,7 @@ export default function ConsentPage(props: {
           }
 
           if (!response.approveConsent) {
+            setPendingAction(null);
             toast({
               title: __("Authorization failed"),
               description: __("Something went wrong. Please try again."),
@@ -221,6 +225,7 @@ export default function ConsentPage(props: {
           }
         },
         onError: (err) => {
+          setPendingAction(null);
           toast({
             title: __("Error"),
             description:
@@ -230,7 +235,7 @@ export default function ConsentPage(props: {
         },
       });
     },
-    [consent, approveConsent, __, toast],
+    [consent, approveConsent, __, toast, pendingAction],
   );
 
   if (!consent.application || !consent.scopes) {
@@ -310,17 +315,19 @@ export default function ConsentPage(props: {
         <Button
           variant="secondary"
           className="flex-1 h-10"
-          disabled={isInFlight}
+          disabled={pendingAction !== null}
+          loading={pendingAction === "deny"}
           onClick={() => handleAction(false)}
         >
           {__("Deny")}
         </Button>
         <Button
           className="flex-1 h-10"
-          disabled={isInFlight}
+          disabled={pendingAction !== null}
+          loading={pendingAction === "allow"}
           onClick={() => handleAction(true)}
         >
-          {isInFlight ? __("Authorizing...") : __("Allow")}
+          {__("Allow")}
         </Button>
       </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the OAuth2 consent page, clicking **Allow** or **Deny** now shows a loading spinner on the clicked button while the mutation runs. After a successful response, the form is replaced with a full-page redirect screen that names the application and shows a spinner while the browser navigates to the OAuth callback URL. This prevents double submits and gives clearer feedback during slow redirects.

## Changes

- Track a `pendingAction` state while the mutation is in flight; disable both buttons and show a spinner on the active one
- After success with a `redirectURL`, show a full-page state:
  - **Allow:** "Authorization Complete" + "You will be redirected to {app name}…"
  - **Deny:** "Access Denied" + "You will be redirected to {app name}…"
- Navigate to the callback URL via `useEffect` once the redirect screen is shown
- Reset pending state only on mutation errors

## Test plan

- [ ] Open the OAuth2 consent page (`/auth/consent?consent_id=…`)
- [ ] Click **Allow** — spinner on Allow during mutation, then redirect screen with app name
- [ ] Confirm redirect completes without duplicate consent submissions
- [ ] Click **Deny** — spinner on Deny during mutation, then redirect screen with app name
- [ ] Simulate a mutation error — buttons re-enable and toast is shown
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-579](https://linear.app/probo/issue/ENG-579/add-loader-on-oauth2-consent-page-submit)

<div><a href="https://cursor.com/agents/bc-fbb5206e-0f1e-45f9-9dca-165fa1041921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbb5206e-0f1e-45f9-9dca-165fa1041921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a loading state and a post-submit redirect screen to the OAuth2 consent page. Meets Linear ENG-579 by preventing double submits and showing clear feedback during the OAuth redirect.

### App: console **`+51`** **`-9`**
- Track `pendingAction` to block repeat clicks and disable both buttons
- Show per-button `loading` spinners; keep until redirect
- After success, replace form with a spinner redirect screen naming the app; navigate via `window.location` in `useEffect`
- Reset pending only on errors; remove `isInFlight`

<sup>Written for commit fa455c315a9167868d088c17baea416d5c4590ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

