### PR TITLE
Use stable url for public file

### DIFF
--- a/e2e/trust/trust_center_logo_test.go
+++ b/e2e/trust/trust_center_logo_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -166,9 +167,13 @@ func TestTrustCenter_LogoFileDownloadURL(t *testing.T) {
 		downloadURL,
 	)
 
+	// Match the e2e HTTP client convention (see internal/testutil) so a hung
+	// server fails the request instead of blocking the parallel suite forever.
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+
 	// The public endpoint streams the file bytes directly (no presigned
 	// redirect) with cache headers, so the stable URL is CDN/browser cacheable.
-	resp, err := http.Get(downloadURL)
+	resp, err := httpClient.Get(downloadURL)
 	require.NoError(t, err)
 
 	defer func() { _ = resp.Body.Close() }()
@@ -198,7 +203,7 @@ func TestTrustCenter_LogoFileDownloadURL(t *testing.T) {
 	require.NoError(t, err)
 	revalidateReq.Header.Set("If-None-Match", etag)
 
-	revalidateResp, err := http.DefaultClient.Do(revalidateReq)
+	revalidateResp, err := httpClient.Do(revalidateReq)
 	require.NoError(t, err)
 
 	defer func() { _ = revalidateResp.Body.Close() }()
@@ -214,7 +219,7 @@ func TestTrustCenter_LogoFileDownloadURL(t *testing.T) {
 	require.NoError(t, err)
 	sinceReq.Header.Set("If-Modified-Since", lastModified)
 
-	sinceResp, err := http.DefaultClient.Do(sinceReq)
+	sinceResp, err := httpClient.Do(sinceReq)
 	require.NoError(t, err)
 
 	defer func() { _ = sinceResp.Body.Close() }()

--- a/e2e/trust/trust_center_logo_test.go
+++ b/e2e/trust/trust_center_logo_test.go
@@ -170,6 +170,7 @@ func TestTrustCenter_LogoFileDownloadURL(t *testing.T) {
 	// redirect) with cache headers, so the stable URL is CDN/browser cacheable.
 	resp, err := http.Get(downloadURL)
 	require.NoError(t, err)
+
 	defer func() { _ = resp.Body.Close() }()
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -199,6 +200,7 @@ func TestTrustCenter_LogoFileDownloadURL(t *testing.T) {
 
 	revalidateResp, err := http.DefaultClient.Do(revalidateReq)
 	require.NoError(t, err)
+
 	defer func() { _ = revalidateResp.Body.Close() }()
 
 	assert.Equal(t, http.StatusNotModified, revalidateResp.StatusCode)
@@ -214,6 +216,7 @@ func TestTrustCenter_LogoFileDownloadURL(t *testing.T) {
 
 	sinceResp, err := http.DefaultClient.Do(sinceReq)
 	require.NoError(t, err)
+
 	defer func() { _ = sinceResp.Body.Close() }()
 
 	assert.Equal(t, http.StatusNotModified, sinceResp.StatusCode)

--- a/e2e/trust/trust_center_logo_test.go
+++ b/e2e/trust/trust_center_logo_test.go
@@ -15,6 +15,8 @@
 package trust_test
 
 import (
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -155,10 +157,64 @@ func TestTrustCenter_LogoFileDownloadURL(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, trustResult.CurrentTrustCenter.Logo)
 	assert.Equal(t, uploadResult.UpdateTrustCenterBrand.TrustCenter.Logo.ID, trustResult.CurrentTrustCenter.Logo.ID)
+
+	downloadURL := trustResult.CurrentTrustCenter.Logo.DownloadURL
 	assert.True(
 		t,
-		strings.Contains(trustResult.CurrentTrustCenter.Logo.DownloadURL, "/api/files/v1/public/"),
+		strings.Contains(downloadURL, "/api/files/v1/public/"),
 		"downloadUrl must route through the public files API, got %q",
-		trustResult.CurrentTrustCenter.Logo.DownloadURL,
+		downloadURL,
 	)
+
+	// The public endpoint streams the file bytes directly (no presigned
+	// redirect) with cache headers, so the stable URL is CDN/browser cacheable.
+	resp, err := http.Get(downloadURL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, pngContent, body, "public endpoint must stream the original file bytes")
+
+	cacheControl := resp.Header.Get("Cache-Control")
+	assert.Contains(t, cacheControl, "public")
+	assert.Contains(t, cacheControl, "max-age=31536000")
+	assert.Contains(t, cacheControl, "immutable")
+
+	etag := resp.Header.Get("ETag")
+	require.NotEmpty(t, etag, "public file response must carry an ETag for revalidation")
+
+	// Untrusted, unauthenticated content served from the app origin must be
+	// hardened against MIME sniffing and script execution (e.g. SVG uploads).
+	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+	assert.Contains(t, resp.Header.Get("Content-Security-Policy"), "sandbox")
+
+	// A matching If-None-Match must revalidate to 304 without transferring
+	// the body again.
+	revalidateReq, err := http.NewRequest(http.MethodGet, downloadURL, nil)
+	require.NoError(t, err)
+	revalidateReq.Header.Set("If-None-Match", etag)
+
+	revalidateResp, err := http.DefaultClient.Do(revalidateReq)
+	require.NoError(t, err)
+	defer func() { _ = revalidateResp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNotModified, revalidateResp.StatusCode)
+
+	// A matching If-Modified-Since (using the returned Last-Modified) must also
+	// revalidate to 304.
+	lastModified := resp.Header.Get("Last-Modified")
+	require.NotEmpty(t, lastModified, "public file response must carry Last-Modified")
+
+	sinceReq, err := http.NewRequest(http.MethodGet, downloadURL, nil)
+	require.NoError(t, err)
+	sinceReq.Header.Set("If-Modified-Since", lastModified)
+
+	sinceResp, err := http.DefaultClient.Do(sinceReq)
+	require.NoError(t, err)
+	defer func() { _ = sinceResp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNotModified, sinceResp.StatusCode)
 }

--- a/pkg/filemanager/s3.go
+++ b/pkg/filemanager/s3.go
@@ -31,17 +31,21 @@ import (
 )
 
 type FileObject struct {
-	Body          io.ReadCloser
-	ContentType   string
-	ContentLength int64
-	ETag          string
-	LastModified  time.Time
-	NotModified   bool
+	Body                io.ReadCloser
+	ContentType         string
+	ContentLength       int64
+	ContentRange        string
+	ETag                string
+	LastModified        time.Time
+	NotModified         bool
+	PartialContent      bool
+	RangeNotSatisfiable bool
 }
 
 type FileConditions struct {
 	IfNoneMatch     string
 	IfModifiedSince time.Time
+	Range           string
 }
 
 func (s *Service) GetFileBase64(
@@ -111,11 +115,21 @@ func (s *Service) OpenFile(
 		input.IfModifiedSince = &conds.IfModifiedSince
 	}
 
+	if conds.Range != "" {
+		input.Range = &conds.Range
+	}
+
 	result, err := s.s3Client.GetObject(ctx, input)
 	if err != nil {
 		if respErr, ok := errors.AsType[*smithyhttp.ResponseError](err); ok {
-			if respErr.HTTPStatusCode() == http.StatusNotModified {
+			switch respErr.HTTPStatusCode() {
+			case http.StatusNotModified:
 				return &FileObject{NotModified: true}, nil
+			case http.StatusRequestedRangeNotSatisfiable:
+				return &FileObject{
+					RangeNotSatisfiable: true,
+					ContentLength:       file.FileSize,
+				}, nil
 			}
 		}
 
@@ -134,6 +148,19 @@ func (s *Service) OpenFile(
 
 	if result.LastModified != nil {
 		obj.LastModified = *result.LastModified
+	}
+
+	// A Range request that S3 honors comes back as 206 Partial Content with a
+	// Content-Range header and a ContentLength scoped to the returned slice. An
+	// If-Range mismatch (or no Range) yields a normal 200 with the full object,
+	// so we only override the length/status when Content-Range is present.
+	if result.ContentRange != nil {
+		obj.ContentRange = *result.ContentRange
+		obj.PartialContent = true
+	}
+
+	if result.ContentLength != nil {
+		obj.ContentLength = *result.ContentLength
 	}
 
 	return obj, nil

--- a/pkg/filemanager/s3.go
+++ b/pkg/filemanager/s3.go
@@ -17,15 +17,38 @@ package filemanager
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"go.probo.inc/probo/pkg/coredata"
 )
+
+// FileObject carries a streamed S3 object body plus the metadata needed to set
+// HTTP response headers. NotModified is set when the caller's conditional
+// request matched the current object, in which case Body is nil.
+type FileObject struct {
+	Body          io.ReadCloser
+	ContentType   string
+	ContentLength int64
+	ETag          string
+	LastModified  time.Time
+	NotModified   bool
+}
+
+// FileConditions carries HTTP conditional-request values forwarded to S3 so it
+// can answer with 304 Not Modified without transferring the body. Zero values
+// are omitted.
+type FileConditions struct {
+	IfNoneMatch     string
+	IfModifiedSince time.Time
+}
 
 func (s *Service) GetFileBase64(
 	ctx context.Context,
@@ -75,6 +98,53 @@ func (s *Service) GetFileBytes(
 	}
 
 	return data, nil
+}
+
+// OpenFile streams an object from S3 without buffering it in memory. Conditional
+// request values in conds are forwarded to S3; a 304 Not Modified response is
+// surfaced as a FileObject with NotModified set (and a nil Body). The caller
+// owns closing Body.
+func (s *Service) OpenFile(
+	ctx context.Context,
+	file *coredata.File,
+	conds FileConditions,
+) (*FileObject, error) {
+	input := &s3.GetObjectInput{
+		Bucket: new(file.BucketName),
+		Key:    new(file.FileKey),
+	}
+	if conds.IfNoneMatch != "" {
+		input.IfNoneMatch = &conds.IfNoneMatch
+	}
+	if !conds.IfModifiedSince.IsZero() {
+		input.IfModifiedSince = &conds.IfModifiedSince
+	}
+
+	result, err := s.s3Client.GetObject(ctx, input)
+	if err != nil {
+		if respErr, ok := errors.AsType[*smithyhttp.ResponseError](err); ok {
+			if respErr.HTTPStatusCode() == http.StatusNotModified {
+				return &FileObject{NotModified: true}, nil
+			}
+		}
+
+		return nil, fmt.Errorf("cannot get file from S3: %w", err)
+	}
+
+	obj := &FileObject{
+		Body:          result.Body,
+		ContentType:   file.MimeType,
+		ContentLength: file.FileSize,
+		LastModified:  file.UpdatedAt,
+	}
+	if result.ETag != nil {
+		obj.ETag = *result.ETag
+	}
+	if result.LastModified != nil {
+		obj.LastModified = *result.LastModified
+	}
+
+	return obj, nil
 }
 
 func (s *Service) PutFile(

--- a/pkg/filemanager/s3.go
+++ b/pkg/filemanager/s3.go
@@ -30,9 +30,6 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 )
 
-// FileObject carries a streamed S3 object body plus the metadata needed to set
-// HTTP response headers. NotModified is set when the caller's conditional
-// request matched the current object, in which case Body is nil.
 type FileObject struct {
 	Body          io.ReadCloser
 	ContentType   string
@@ -42,9 +39,6 @@ type FileObject struct {
 	NotModified   bool
 }
 
-// FileConditions carries HTTP conditional-request values forwarded to S3 so it
-// can answer with 304 Not Modified without transferring the body. Zero values
-// are omitted.
 type FileConditions struct {
 	IfNoneMatch     string
 	IfModifiedSince time.Time
@@ -100,10 +94,6 @@ func (s *Service) GetFileBytes(
 	return data, nil
 }
 
-// OpenFile streams an object from S3 without buffering it in memory. Conditional
-// request values in conds are forwarded to S3; a 304 Not Modified response is
-// surfaced as a FileObject with NotModified set (and a nil Body). The caller
-// owns closing Body.
 func (s *Service) OpenFile(
 	ctx context.Context,
 	file *coredata.File,
@@ -116,6 +106,7 @@ func (s *Service) OpenFile(
 	if conds.IfNoneMatch != "" {
 		input.IfNoneMatch = &conds.IfNoneMatch
 	}
+
 	if !conds.IfModifiedSince.IsZero() {
 		input.IfModifiedSince = &conds.IfModifiedSince
 	}
@@ -140,6 +131,7 @@ func (s *Service) OpenFile(
 	if result.ETag != nil {
 		obj.ETag = *result.ETag
 	}
+
 	if result.LastModified != nil {
 		obj.LastModified = *result.LastModified
 	}

--- a/pkg/filemanager/s3.go
+++ b/pkg/filemanager/s3.go
@@ -45,6 +45,7 @@ type FileObject struct {
 type FileConditions struct {
 	IfNoneMatch     string
 	IfModifiedSince time.Time
+	IfRange         string
 	Range           string
 }
 
@@ -116,7 +117,36 @@ func (s *Service) OpenFile(
 	}
 
 	if conds.Range != "" {
-		input.Range = &conds.Range
+		honorRange := true
+
+		if conds.IfRange != "" {
+			head, err := s.s3Client.HeadObject(
+				ctx,
+				&s3.HeadObjectInput{
+					Bucket: new(file.BucketName),
+					Key:    new(file.FileKey),
+				},
+			)
+			if err != nil {
+				return nil, fmt.Errorf("cannot head file in S3: %w", err)
+			}
+
+			etag := ""
+			if head.ETag != nil {
+				etag = *head.ETag
+			}
+
+			lastModified := file.UpdatedAt
+			if head.LastModified != nil {
+				lastModified = *head.LastModified
+			}
+
+			honorRange = ifRangeMatches(conds.IfRange, etag, lastModified)
+		}
+
+		if honorRange {
+			input.Range = &conds.Range
+		}
 	}
 
 	result, err := s.s3Client.GetObject(ctx, input)
@@ -150,10 +180,11 @@ func (s *Service) OpenFile(
 		obj.LastModified = *result.LastModified
 	}
 
-	// A Range request that S3 honors comes back as 206 Partial Content with a
+	// A Range that S3 honors comes back as 206 Partial Content with a
 	// Content-Range header and a ContentLength scoped to the returned slice. An
-	// If-Range mismatch (or no Range) yields a normal 200 with the full object,
-	// so we only override the length/status when Content-Range is present.
+	// unranged request (or one whose Range we dropped above after an If-Range
+	// mismatch) yields a normal 200 with the full object, so we only override
+	// the length/status when Content-Range is present.
 	if result.ContentRange != nil {
 		obj.ContentRange = *result.ContentRange
 		obj.PartialContent = true
@@ -232,6 +263,35 @@ func (s *Service) GeneratePresignedURL(
 	}
 
 	return presignedReq.URL, nil
+}
+
+// ifRangeMatches reports whether an If-Range validator still matches the
+// current representation, following the strong-comparison rules of RFC 9110
+// section 13.1.3. S3 has no native If-Range support, so callers evaluate it
+// before deciding whether to forward a Range header. An entity-tag validator
+// must strong-match the current ETag (weak tags on either side never satisfy
+// If-Range); otherwise the validator is an HTTP-date compared for equality
+// against Last-Modified.
+func ifRangeMatches(ifRange, etag string, lastModified time.Time) bool {
+	ifRange = strings.TrimSpace(ifRange)
+	if ifRange == "" {
+		return true
+	}
+
+	if strings.HasPrefix(ifRange, `"`) {
+		return etag != "" && !strings.HasPrefix(etag, `W/`) && ifRange == etag
+	}
+
+	if strings.HasPrefix(ifRange, `W/`) {
+		return false
+	}
+
+	t, err := http.ParseTime(ifRange)
+	if err != nil {
+		return false
+	}
+
+	return !lastModified.IsZero() && lastModified.Truncate(time.Second).Equal(t)
 }
 
 func asciiFilename(filename string) string {

--- a/pkg/filemanager/s3_test.go
+++ b/pkg/filemanager/s3_test.go
@@ -153,6 +153,7 @@ func TestOpenFile_IfRangeMatchHonorsRange(t *testing.T) {
 			if r.Method == http.MethodHead {
 				w.Header().Set("ETag", etag)
 				w.WriteHeader(http.StatusOK)
+
 				return
 			}
 

--- a/pkg/filemanager/s3_test.go
+++ b/pkg/filemanager/s3_test.go
@@ -139,6 +139,111 @@ func TestOpenFile_RangeRequestReturnsPartialContent(t *testing.T) {
 	assert.Equal(t, content[:5], string(body))
 }
 
+func TestOpenFile_IfRangeMatchHonorsRange(t *testing.T) {
+	t.Parallel()
+
+	const (
+		etag    = `"abc123"`
+		content = "hello world"
+	)
+
+	svc := newTestS3Service(
+		t,
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead {
+				w.Header().Set("ETag", etag)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+
+			assert.Equal(t, "bytes=0-4", r.Header.Get("Range"))
+
+			w.Header().Set("ETag", etag)
+			w.Header().Set("Content-Range", "bytes 0-4/11")
+			w.Header().Set("Content-Length", "5")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = io.WriteString(w, content[:5])
+		},
+	)
+
+	file := &coredata.File{
+		BucketName: "uploads",
+		FileKey:    "tenant/file",
+		MimeType:   "text/plain",
+		FileSize:   int64(len(content)),
+	}
+
+	obj, err := svc.OpenFile(
+		context.Background(),
+		file,
+		filemanager.FileConditions{Range: "bytes=0-4", IfRange: etag},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+
+	defer func() { _ = obj.Body.Close() }()
+
+	assert.True(t, obj.PartialContent)
+	assert.Equal(t, "bytes 0-4/11", obj.ContentRange)
+
+	body, err := io.ReadAll(obj.Body)
+	require.NoError(t, err)
+	assert.Equal(t, content[:5], string(body))
+}
+
+func TestOpenFile_IfRangeMismatchServesFullContent(t *testing.T) {
+	t.Parallel()
+
+	const (
+		staleETag   = `"old"`
+		currentETag = `"new"`
+		content     = "hello world"
+	)
+
+	svc := newTestS3Service(
+		t,
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead {
+				w.Header().Set("ETag", currentETag)
+				w.WriteHeader(http.StatusOK)
+
+				return
+			}
+
+			// The stale If-Range guard must have dropped the Range so S3
+			// returns the full object rather than a 206 of the fresh bytes.
+			assert.Empty(t, r.Header.Get("Range"))
+
+			w.Header().Set("ETag", currentETag)
+			_, _ = io.WriteString(w, content)
+		},
+	)
+
+	file := &coredata.File{
+		BucketName: "uploads",
+		FileKey:    "tenant/file",
+		MimeType:   "text/plain",
+		FileSize:   int64(len(content)),
+	}
+
+	obj, err := svc.OpenFile(
+		context.Background(),
+		file,
+		filemanager.FileConditions{Range: "bytes=0-4", IfRange: staleETag},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+
+	defer func() { _ = obj.Body.Close() }()
+
+	assert.False(t, obj.PartialContent)
+	assert.Empty(t, obj.ContentRange)
+
+	body, err := io.ReadAll(obj.Body)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(body))
+}
+
 func TestOpenFile_RangeNotSatisfiable(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/filemanager/s3_test.go
+++ b/pkg/filemanager/s3_test.go
@@ -91,6 +91,87 @@ func TestOpenFile_StreamsBody(t *testing.T) {
 	assert.Equal(t, content, string(body))
 }
 
+func TestOpenFile_RangeRequestReturnsPartialContent(t *testing.T) {
+	t.Parallel()
+
+	const (
+		etag    = `"abc123"`
+		content = "hello world"
+	)
+
+	svc := newTestS3Service(
+		t,
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "bytes=0-4", r.Header.Get("Range"))
+
+			w.Header().Set("ETag", etag)
+			w.Header().Set("Content-Range", "bytes 0-4/11")
+			w.Header().Set("Content-Length", "5")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = io.WriteString(w, content[:5])
+		},
+	)
+
+	file := &coredata.File{
+		BucketName: "uploads",
+		FileKey:    "tenant/file",
+		MimeType:   "text/plain",
+		FileSize:   int64(len(content)),
+	}
+
+	obj, err := svc.OpenFile(
+		context.Background(),
+		file,
+		filemanager.FileConditions{Range: "bytes=0-4"},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+
+	defer func() { _ = obj.Body.Close() }()
+
+	assert.True(t, obj.PartialContent)
+	assert.False(t, obj.NotModified)
+	assert.Equal(t, "bytes 0-4/11", obj.ContentRange)
+	assert.Equal(t, int64(5), obj.ContentLength)
+
+	body, err := io.ReadAll(obj.Body)
+	require.NoError(t, err)
+	assert.Equal(t, content[:5], string(body))
+}
+
+func TestOpenFile_RangeNotSatisfiable(t *testing.T) {
+	t.Parallel()
+
+	const content = "hello world"
+
+	svc := newTestS3Service(
+		t,
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Range", "bytes */11")
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+		},
+	)
+
+	file := &coredata.File{
+		BucketName: "uploads",
+		FileKey:    "tenant/file",
+		MimeType:   "text/plain",
+		FileSize:   int64(len(content)),
+	}
+
+	obj, err := svc.OpenFile(
+		context.Background(),
+		file,
+		filemanager.FileConditions{Range: "bytes=999-1000"},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	assert.True(t, obj.RangeNotSatisfiable)
+	assert.False(t, obj.PartialContent)
+	assert.Nil(t, obj.Body)
+	assert.Equal(t, int64(len(content)), obj.ContentLength)
+}
+
 func TestOpenFile_NotModifiedByETag(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/filemanager/s3_test.go
+++ b/pkg/filemanager/s3_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package filemanager_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/filemanager"
+)
+
+func newTestS3Service(t *testing.T, handler http.HandlerFunc) *filemanager.Service {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	s3Client := awss3.NewFromConfig(
+		aws.Config{
+			Region:      "us-east-1",
+			Credentials: credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
+		},
+		func(o *awss3.Options) {
+			o.BaseEndpoint = aws.String(srv.URL)
+			o.UsePathStyle = true
+		},
+	)
+
+	return filemanager.NewService(nil, nil, s3Client)
+}
+
+func TestOpenFile_StreamsBody(t *testing.T) {
+	t.Parallel()
+
+	const (
+		etag    = `"abc123"`
+		content = "hello world"
+	)
+
+	svc := newTestS3Service(
+		t,
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("ETag", etag)
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = io.WriteString(w, content)
+		},
+	)
+
+	file := &coredata.File{
+		BucketName: "uploads",
+		FileKey:    "tenant/file",
+		MimeType:   "text/plain",
+		FileSize:   int64(len(content)),
+	}
+
+	obj, err := svc.OpenFile(context.Background(), file, filemanager.FileConditions{})
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	require.False(t, obj.NotModified)
+
+	defer func() { _ = obj.Body.Close() }()
+
+	assert.Equal(t, etag, obj.ETag)
+	assert.Equal(t, "text/plain", obj.ContentType)
+	assert.Equal(t, int64(len(content)), obj.ContentLength)
+
+	body, err := io.ReadAll(obj.Body)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(body))
+}
+
+func TestOpenFile_NotModifiedByETag(t *testing.T) {
+	t.Parallel()
+
+	const etag = `"abc123"`
+
+	svc := newTestS3Service(
+		t,
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("If-None-Match") == etag {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+
+			w.Header().Set("ETag", etag)
+			_, _ = io.WriteString(w, "content")
+		},
+	)
+
+	file := &coredata.File{
+		BucketName: "uploads",
+		FileKey:    "tenant/file",
+		MimeType:   "text/plain",
+	}
+
+	obj, err := svc.OpenFile(context.Background(), file, filemanager.FileConditions{IfNoneMatch: etag})
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	assert.True(t, obj.NotModified)
+	assert.Nil(t, obj.Body)
+}
+
+func TestOpenFile_NotModifiedByModifiedSince(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestS3Service(
+		t,
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("If-Modified-Since") != "" {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+
+			_, _ = io.WriteString(w, "content")
+		},
+	)
+
+	file := &coredata.File{
+		BucketName: "uploads",
+		FileKey:    "tenant/file",
+		MimeType:   "text/plain",
+	}
+
+	obj, err := svc.OpenFile(
+		context.Background(),
+		file,
+		filemanager.FileConditions{IfModifiedSince: time.Now()},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	assert.True(t, obj.NotModified)
+	assert.Nil(t, obj.Body)
+}

--- a/pkg/server/api/files/v1/handler.go
+++ b/pkg/server/api/files/v1/handler.go
@@ -125,6 +125,7 @@ func (h *Handler) handleGetPublicFile(w http.ResponseWriter, r *http.Request) {
 
 	conds := filemanager.FileConditions{
 		IfNoneMatch: r.Header.Get("If-None-Match"),
+		IfRange:     r.Header.Get("If-Range"),
 		Range:       r.Header.Get("Range"),
 	}
 	if ifModifiedSince := r.Header.Get("If-Modified-Since"); ifModifiedSince != "" {

--- a/pkg/server/api/files/v1/handler.go
+++ b/pkg/server/api/files/v1/handler.go
@@ -123,7 +123,10 @@ func (h *Handler) handleGetPublicFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	conds := filemanager.FileConditions{IfNoneMatch: r.Header.Get("If-None-Match")}
+	conds := filemanager.FileConditions{
+		IfNoneMatch: r.Header.Get("If-None-Match"),
+		Range:       r.Header.Get("Range"),
+	}
 	if ifModifiedSince := r.Header.Get("If-Modified-Since"); ifModifiedSince != "" {
 		if t, parseErr := http.ParseTime(ifModifiedSince); parseErr == nil {
 			conds.IfModifiedSince = t
@@ -144,6 +147,7 @@ func (h *Handler) handleGetPublicFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	w.Header().Set("Accept-Ranges", "bytes")
 
 	if obj.ETag != "" {
 		w.Header().Set("ETag", obj.ETag)
@@ -154,13 +158,25 @@ func (h *Handler) handleGetPublicFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if obj.RangeNotSatisfiable {
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", file.FileSize))
+		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+
+		return
+	}
+
 	defer func() { _ = obj.Body.Close() }()
 
 	w.Header().Set("Content-Type", file.MimeType)
-	w.Header().Set("Content-Length", strconv.FormatInt(file.FileSize, 10))
+	w.Header().Set("Content-Length", strconv.FormatInt(obj.ContentLength, 10))
 
 	if !obj.LastModified.IsZero() {
 		w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(http.TimeFormat))
+	}
+
+	if obj.PartialContent {
+		w.Header().Set("Content-Range", obj.ContentRange)
+		w.WriteHeader(http.StatusPartialContent)
 	}
 
 	if _, err := io.Copy(w, obj.Body); err != nil {

--- a/pkg/server/api/files/v1/handler.go
+++ b/pkg/server/api/files/v1/handler.go
@@ -17,7 +17,9 @@ package files_v1
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -121,11 +123,18 @@ func (h *Handler) handleGetPublicFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	presignedURL, err := h.fileSvc.GeneratePresignedURL(r.Context(), file, presignedURLExpiry)
+	conds := filemanager.FileConditions{IfNoneMatch: r.Header.Get("If-None-Match")}
+	if ifModifiedSince := r.Header.Get("If-Modified-Since"); ifModifiedSince != "" {
+		if t, parseErr := http.ParseTime(ifModifiedSince); parseErr == nil {
+			conds.IfModifiedSince = t
+		}
+	}
+
+	obj, err := h.fileSvc.OpenFile(r.Context(), file, conds)
 	if err != nil {
 		h.logger.ErrorCtx(
 			r.Context(),
-			"cannot get public file URL",
+			"cannot open public file",
 			log.Error(err),
 			log.String("file_id", fileIDStr),
 		)
@@ -134,7 +143,38 @@ func (h *Handler) handleGetPublicFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, presignedURL, http.StatusTemporaryRedirect)
+	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+
+	if obj.ETag != "" {
+		w.Header().Set("ETag", obj.ETag)
+	}
+
+	if obj.NotModified {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	defer func() { _ = obj.Body.Close() }()
+
+	w.Header().Set("Content-Type", file.MimeType)
+	w.Header().Set("Content-Length", strconv.FormatInt(file.FileSize, 10))
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
+
+	if !obj.LastModified.IsZero() {
+		w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(http.TimeFormat))
+	}
+
+	if _, err := io.Copy(w, obj.Body); err != nil {
+		h.logger.ErrorCtx(
+			r.Context(),
+			"cannot stream public file",
+			log.Error(err),
+			log.String("file_id", fileIDStr),
+		)
+
+		return
+	}
 }
 
 func (h *Handler) handleGetFile(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/api/files/v1/handler.go
+++ b/pkg/server/api/files/v1/handler.go
@@ -158,8 +158,6 @@ func (h *Handler) handleGetPublicFile(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", file.MimeType)
 	w.Header().Set("Content-Length", strconv.FormatInt(file.FileSize, 10))
-	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
 
 	if !obj.LastModified.IsZero() {
 		w.Header().Set("Last-Modified", obj.LastModified.UTC().Format(http.TimeFormat))


### PR DESCRIPTION
This will allow the CDN infrastructure to cache it properly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve public files from a stable app URL by streaming bytes with long-lived cache headers, ETag/Last-Modified revalidation, and Range (If-Range) support. This enables CDN/browser caching, removes presigned S3 redirects, and correctly returns 200/206/304/416.

### Tests **`+408`** **`-2`**
- Added unit tests for `OpenFile` streaming, 206/416 ranges, 304 via ETag/If-Modified-Since, and If-Range match/mismatch.
- Expanded trust center logo e2e to verify stable `/api/files/v1/public/` URL, byte-exact content, cache headers, security headers (`X-Content-Type-Options: nosniff`, CSP sandbox), and 304 behavior.

### Service **`+149`** **`-0`**
- Added `OpenFile` with `FileConditions`/`FileObject` to stream S3 objects, map 304/206/416, and expose ETag/Last-Modified/Content-Range; evaluates If-Range via `HeadObject` and drops Range on mismatch.

### GraphQL API **`+58`** **`-3`**
- Public file handler now streams content, sets `Cache-Control` and `Accept-Ranges`, emits ETag/Last-Modified, supports `Range`/`If-Range` with 206/416 and `Content-Range`, and returns 304 without a body when validators match.

<sup>Written for commit 21d098afb15e42b21549f490e46e6fcd5d45798f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

