### PR TITLE
Point prb auth login at eu.probo.com and us.probo.com

### DIFF
--- a/cmd/prb/CHANGELOG.md
+++ b/cmd/prb/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `prb` CLI will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- `prb auth login` defaults and region prompts now use `eu.probo.com` and `us.probo.com` instead of `*.console.getprobo.com`
+
 ## [0.198.0] - 2026-06-30
 
 ### Removed

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	hostEU = "eu.console.getprobo.com"
-	hostUS = "us.console.getprobo.com"
+	hostEU = "eu.probo.com"
+	hostUS = "us.probo.com"
 
 	regionEU     = "eu"
 	regionUS     = "us"
@@ -84,10 +84,10 @@ func NewCmdLogin(f *cmdutil.Factory) *cobra.Command {
   prb auth login
 
   # Login to Probo EU
-  prb auth login --hostname eu.console.getprobo.com
+  prb auth login --hostname eu.probo.com
 
   # Login to Probo US
-  prb auth login --hostname us.console.getprobo.com
+  prb auth login --hostname us.probo.com
 
   # Login to a self-hosted instance
   prb auth login --hostname probo.example.com`,
@@ -98,8 +98,8 @@ func NewCmdLogin(f *cmdutil.Factory) *cobra.Command {
 				err := huh.NewSelect[string]().
 					Title("Where is your Probo account hosted?").
 					Options(
-						huh.NewOption("Probo EU (eu.console.getprobo.com)", regionEU),
-						huh.NewOption("Probo US (us.console.getprobo.com)", regionUS),
+						huh.NewOption("Probo EU (eu.probo.com)", regionEU),
+						huh.NewOption("Probo US (us.probo.com)", regionUS),
 						huh.NewOption("Other (custom domain)", regionCustom),
 					).
 					Value(&region).
@@ -245,7 +245,7 @@ func NewCmdLogin(f *cmdutil.Factory) *cobra.Command {
 		&flagHost,
 		"hostname",
 		"",
-		"Probo hostname (e.g. eu.console.getprobo.com, us.console.getprobo.com)",
+		"Probo hostname (e.g. eu.probo.com, us.probo.com)",
 	)
 	cmd.Flags().StringVar(
 		&flagOrganization,


### PR DESCRIPTION
## Summary

- Update `prb auth login` to use `eu.probo.com` and `us.probo.com` instead of `eu.console.getprobo.com` and `us.console.getprobo.com` for region defaults, interactive prompts, examples, and `--hostname` help text.
- Document the change in `cmd/prb/CHANGELOG.md` under Unreleased.
- No config migration: existing users keep their stored hostnames until they log in again.

## Test plan

- [x] `rg 'console\.getprobo' pkg/cmd pkg/cli` returns no matches
- [x] `go build -o bin/prb ./cmd/prb` succeeds
- [x] `bin/prb auth login --help` shows `eu.probo.com` and `us.probo.com` in examples and the `--hostname` flag description
- [x] Interactive `prb auth login` shows EU/US options with the new domains (optional)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `prb auth login` to use `eu.probo.com` and `us.probo.com` for region defaults, prompts, and help text. Aligns the CLI with current SaaS domains; no migration needed for existing configs.

### prb (CLI) **`+11`** **`-7`**
- Switch EU/US defaults to `eu.probo.com` and `us.probo.com` across region selection, examples, and `--hostname` help.
- Update interactive prompt labels to show new domains.
- Document in `cmd/prb/CHANGELOG.md`; no config migration—existing hostnames persist until re-login.

<sup>Written for commit be33f72f7d4f6f05c6094e2f929e7b9fe154fa88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

