### PR TITLE
Fix n8n marketplace codex metadata

### DIFF
--- a/packages/n8n-node/CHANGELOG.md
+++ b/packages/n8n-node/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the `@probo/n8n-nodes-probo` package will be documented i
 
 ## Unreleased
 
+### Fixed
+
+- Use marketplace-supported codex metadata for the `ProboTrigger` node by fully
+  qualifying its node identifier and replacing unsupported categories
+
 ## [0.200.0] - 2026-07-02
 
 ### Added

--- a/packages/n8n-node/nodes/ProboTrigger/ProboTrigger.node.json
+++ b/packages/n8n-node/nodes/ProboTrigger/ProboTrigger.node.json
@@ -1,8 +1,8 @@
 {
-  "node": "n8n-nodes-probo.proboTrigger",
+  "node": "@probo/n8n-nodes-probo.proboTrigger",
   "nodeVersion": "1.0",
   "codexVersion": "1.0",
-  "categories": ["Development", "Developer Tools", "Automation"],
+  "categories": ["Development", "Utility"],
   "resources": {
     "credentialDocumentation": [
       {

--- a/packages/n8n-node/package.json
+++ b/packages/n8n-node/package.json
@@ -16,7 +16,8 @@
     "email": "hello@probo.com"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "n8n": {
     "n8nNodesApiVersion": 1,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fully qualify the Probo Trigger codex node identifier for the scoped package.
- Replace unsupported Probo Trigger codex categories with marketplace-supported values.
- Explicitly include the n8n package README in the npm files allowlist.

## Validation

- `npm -w @probo/n8n-nodes-probo run lint`
- `npm -w @probo/n8n-nodes-probo run build`
- `npm -w @probo/n8n-nodes-probo pack --dry-run`
- `make go-fmt`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-580](https://linear.app/probo/issue/ENG-580/fix-n8n-marketplace-submission-blockers-for-probo-node)

<div><a href="https://cursor.com/agents/bc-b3377586-061d-42e3-a307-bd0bf9b9b76f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3377586-061d-42e3-a307-bd0bf9b9b76f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes n8n marketplace submission blockers by correcting codex metadata for the Probo Trigger node and including the README in the published package. Aligns `@probo/n8n-nodes-probo` with ENG-580 marketplace requirements.

### Package: n8n-node **`+9`** **`-3`**
- Fully qualify node ID to `@probo/n8n-nodes-probo.proboTrigger`.
- Replace unsupported codex categories with marketplace-supported ones: Development, Utility.
- Include `README.md` in the npm `files` list and update the changelog.

<sup>Written for commit a346d8a8427c55461c740fc4c24148c5d1d37ce5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

