### PR TITLE
Enable compression for API

### DIFF
--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	"go.gearno.de/kit/httpserver"
 	"go.gearno.de/kit/log"
@@ -305,12 +306,21 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	router.Group(func(r chi.Router) {
 		r.Use(cors.Handler(corsOpts))
-		r.Mount("/console/v1", http.StripPrefix("/console/v1", s.consoleHandler))
-		r.Mount("/connect/v1", http.StripPrefix("/connect/v1", s.connectHandler))
+
+		// The files handler streams binary payloads and honors Range
+		// requests, and the MCP handler streams Server-Sent Events;
+		// neither can be safely gzipped, so they are mounted outside the
+		// compressor.
 		r.Mount("/files/v1", http.StripPrefix("/files/v1", s.filesHandler))
-		r.Mount("/trust/v1", http.StripPrefix("/trust/v1", s.compliancePageHandler))
 		r.Mount("/mcp/v1", http.StripPrefix("/mcp/v1", s.mcpHandler))
-		r.Mount("/slack/v1", http.StripPrefix("/slack/v1", s.slackHandler))
+
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.Compress(5))
+			r.Mount("/console/v1", http.StripPrefix("/console/v1", s.consoleHandler))
+			r.Mount("/connect/v1", http.StripPrefix("/connect/v1", s.connectHandler))
+			r.Mount("/trust/v1", http.StripPrefix("/trust/v1", s.compliancePageHandler))
+			r.Mount("/slack/v1", http.StripPrefix("/slack/v1", s.slackHandler))
+		})
 	})
 
 	s.csrf.Handler(router).ServeHTTP(w, r)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable gzip compression for most API routes to reduce bandwidth and speed up responses. Streaming endpoints are excluded to keep Range requests and SSE working correctly.

### GraphQL API **`+14`** **`-4`**
- Added `middleware.Compress(5)` to gzip responses for /console/v1, /connect/v1, /trust/v1, and /slack/v1.
- Kept /files/v1 and /mcp/v1 outside compression to preserve binary Range and SSE behavior.
- Imported `github.com/go-chi/chi/v5/middleware` and grouped mounts accordingly.

<sup>Written for commit a01fbeecc79a286bf93a014201829b224faaaa8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

