### PR TITLE
Fix Anthropic thinking budgets

### DIFF
--- a/pkg/llm/anthropic/provider.go
+++ b/pkg/llm/anthropic/provider.go
@@ -47,6 +47,11 @@ type (
 	}
 )
 
+const (
+	anthropicThinkingMinBudgetTokens    = 1024
+	anthropicThinkingOutputTokenReserve = 1024
+)
+
 func WithHTTPClient(c *http.Client) Option {
 	return func(cfg *config) { cfg.httpClient = c }
 }
@@ -163,8 +168,8 @@ func buildParams(req *llm.ChatCompletionRequest) (anthropic.MessageNewParams, er
 		params.ToolChoice = buildToolChoice(req.ToolChoice)
 	}
 
-	if req.Thinking != nil && req.Thinking.Enabled {
-		params.Thinking = anthropic.ThinkingConfigParamOfEnabled(int64(req.Thinking.BudgetTokens))
+	if budgetTokens, ok := resolveThinkingBudget(*req.MaxTokens, req.Thinking); ok {
+		params.Thinking = anthropic.ThinkingConfigParamOfEnabled(int64(budgetTokens))
 	}
 
 	if req.ResponseFormat != nil {
@@ -190,6 +195,28 @@ func buildParams(req *llm.ChatCompletionRequest) (anthropic.MessageNewParams, er
 	}
 
 	return params, nil
+}
+
+func resolveThinkingBudget(maxTokens int, thinking *llm.ThinkingConfig) (int, bool) {
+	if thinking == nil || !thinking.Enabled || thinking.BudgetTokens <= 0 {
+		return 0, false
+	}
+
+	if maxTokens <= anthropicThinkingMinBudgetTokens {
+		return 0, false
+	}
+
+	maxBudgetTokens := maxTokens - anthropicThinkingOutputTokenReserve
+	if maxBudgetTokens < anthropicThinkingMinBudgetTokens {
+		maxBudgetTokens = maxTokens - 1
+	}
+
+	budgetTokens := max(min(thinking.BudgetTokens, maxBudgetTokens), anthropicThinkingMinBudgetTokens)
+	if budgetTokens >= maxTokens {
+		return 0, false
+	}
+
+	return budgetTokens, true
 }
 
 func extractSystem(messages []llm.Message) (system []string, rest []llm.Message) {

--- a/pkg/llm/anthropic/provider_test.go
+++ b/pkg/llm/anthropic/provider_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/llm"
+)
+
+func TestResolveThinkingBudget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		maxTokens int
+		thinking  *llm.ThinkingConfig
+		want      int
+		wantOK    bool
+	}{
+		{
+			name:      "disabled",
+			maxTokens: 4096,
+			thinking:  &llm.ThinkingConfig{Enabled: false, BudgetTokens: 4000},
+		},
+		{
+			name:      "leaves valid budget unchanged",
+			maxTokens: 49152,
+			thinking:  &llm.ThinkingConfig{Enabled: true, BudgetTokens: 40000},
+			want:      40000,
+			wantOK:    true,
+		},
+		{
+			name:      "caps oversized default budget",
+			maxTokens: 4096,
+			thinking:  &llm.ThinkingConfig{Enabled: true, BudgetTokens: 40000},
+			want:      3072,
+			wantOK:    true,
+		},
+		{
+			name:      "caps oversized raised budget",
+			maxTokens: 32768,
+			thinking:  &llm.ThinkingConfig{Enabled: true, BudgetTokens: 40000},
+			want:      31744,
+			wantOK:    true,
+		},
+		{
+			name:      "omits thinking when max tokens cannot hold minimum budget",
+			maxTokens: 1024,
+			thinking:  &llm.ThinkingConfig{Enabled: true, BudgetTokens: 4000},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := resolveThinkingBudget(tt.maxTokens, tt.thinking)
+
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBuildParamsNormalizesThinkingBudget(t *testing.T) {
+	t.Parallel()
+
+	maxTokens := 32768
+	params, err := buildParams(&llm.ChatCompletionRequest{
+		Model: "claude-sonnet-test",
+		Messages: []llm.Message{
+			{
+				Role:  llm.RoleUser,
+				Parts: []llm.Part{llm.TextPart{Text: "assess this vendor"}},
+			},
+		},
+		MaxTokens: &maxTokens,
+		Thinking: &llm.ThinkingConfig{
+			Enabled:      true,
+			BudgetTokens: 40000,
+		},
+	})
+	require.NoError(t, err)
+
+	budgetTokens := params.Thinking.GetBudgetTokens()
+	require.NotNil(t, budgetTokens)
+	assert.Equal(t, int64(31744), *budgetTokens)
+	assert.Less(t, *budgetTokens, params.MaxTokens)
+}
+
+func TestBuildParamsOmitsInvalidThinkingBudget(t *testing.T) {
+	t.Parallel()
+
+	maxTokens := 1024
+	params, err := buildParams(&llm.ChatCompletionRequest{
+		Model: "claude-sonnet-test",
+		Messages: []llm.Message{
+			{
+				Role:  llm.RoleUser,
+				Parts: []llm.Part{llm.TextPart{Text: "assess this vendor"}},
+			},
+		},
+		MaxTokens: &maxTokens,
+		Thinking: &llm.ThinkingConfig{
+			Enabled:      true,
+			BudgetTokens: 4000,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Nil(t, params.Thinking.GetBudgetTokens())
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Normalize Anthropic thinking budgets while building message parameters so budget_tokens stays below max_tokens with response headroom. When the configured max token budget is too small to support Anthropic's minimum thinking budget, omit thinking for that request instead of sending an invalid payload.

## Tests
- `make go-fmt`
- `CGO_ENABLED=0 go fix -diff -omitzero=false ./pkg/llm/anthropic`
- `go test ./pkg/llm/anthropic`
- `go test ./pkg/llm/anthropic ./pkg/agent ./pkg/vetting`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-581](https://linear.app/probo/issue/ENG-581/fix-agent-token-and-streaming-failures-in-github-issue-1456)

<div><a href="https://cursor.com/agents/bc-1e7490c5-49c2-4cac-b8cf-bd1b4eb1fb99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e7490c5-49c2-4cac-b8cf-bd1b4eb1fb99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes Anthropic thinking budgets so `budget_tokens` always stays below `max_tokens` with 1024 tokens reserved for the reply. If `max_tokens` can’t meet Anthropic’s 1024-token minimum, thinking is omitted. Addresses ENG-581.

### Service **`+29`** **`-2`**
- In `pkg/llm/anthropic`, add `resolveThinkingBudget` (min 1024; 1024 output reserve) and wire into `buildParams` to cap or omit thinking budgets safely.

### Tests **`+127`** **`-0`**
- Unit tests cover budget capping, omission when `max_tokens` is too low, and `buildParams` integration.

<sup>Written for commit 73023fc2b8a95c5e51de95a7c9d35d32ddc0a864. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



