### PR TITLE
Fix compliance page logo incorrectly set from org settings uploads

### DIFF
--- a/e2e/console/connect_organization_horizontal_logo_test.go
+++ b/e2e/console/connect_organization_horizontal_logo_test.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package console_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+func TestConnectOrganization_HorizontalLogoDoesNotReplaceCompliancePageLogo(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	organizationID := owner.GetOrganizationID().String()
+
+	const trustCenterQuery = `
+		query($organizationId: ID!) {
+			node(id: $organizationId) {
+				... on Organization {
+					trustCenter {
+						id
+					}
+				}
+			}
+		}
+	`
+
+	var trustCenterLookup struct {
+		Node struct {
+			TrustCenter struct {
+				ID string `json:"id"`
+			} `json:"trustCenter"`
+		} `json:"node"`
+	}
+
+	err := owner.Execute(trustCenterQuery, map[string]any{
+		"organizationId": organizationID,
+	}, &trustCenterLookup)
+	require.NoError(t, err)
+	require.NotEmpty(t, trustCenterLookup.Node.TrustCenter.ID)
+
+	trustCenterID := trustCenterLookup.Node.TrustCenter.ID
+
+	const activateMutation = `
+		mutation($input: UpdateTrustCenterInput!) {
+			updateTrustCenter(input: $input) {
+				trustCenter {
+					id
+					active
+				}
+			}
+		}
+	`
+
+	err = owner.Execute(activateMutation, map[string]any{
+		"input": map[string]any{
+			"trustCenterId": trustCenterID,
+			"active":        true,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	orgLogoPNG := []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+		0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41,
+		0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+		0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00,
+		0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+		0x42, 0x60, 0x82,
+	}
+
+	horizontalLogoPNG := []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0xbc, 0x18, 0x19,
+		0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41,
+		0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+		0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00,
+		0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+		0x42, 0x60, 0x82,
+	}
+
+	const updateOrganizationMutation = `
+		mutation UpdateOrganization($input: UpdateOrganizationInput!) {
+			updateOrganization(input: $input) {
+				organization {
+					id
+					logo {
+						id
+						fileName
+					}
+					horizontalLogo {
+						id
+						fileName
+					}
+				}
+			}
+		}
+	`
+
+	var orgLogoUploadResult struct {
+		UpdateOrganization struct {
+			Organization struct {
+				Logo *struct {
+					ID       string `json:"id"`
+					FileName string `json:"fileName"`
+				} `json:"logo"`
+			} `json:"organization"`
+		} `json:"updateOrganization"`
+	}
+
+	err = owner.ExecuteConnectWithFile(updateOrganizationMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId": organizationID,
+			"logoFile":       nil,
+		},
+	}, "input.logoFile", testutil.UploadFile{
+		Filename:    "org-logo.png",
+		ContentType: "image/png",
+		Content:     orgLogoPNG,
+	}, &orgLogoUploadResult)
+	require.NoError(t, err)
+	require.NotNil(t, orgLogoUploadResult.UpdateOrganization.Organization.Logo)
+
+	orgLogoID := orgLogoUploadResult.UpdateOrganization.Organization.Logo.ID
+
+	const trustGraphQLQuery = `
+		query {
+			currentTrustCenter {
+				logo {
+					id
+					fileName
+				}
+			}
+		}
+	`
+
+	var trustResultAfterOrgLogo struct {
+		CurrentTrustCenter struct {
+			Logo *struct {
+				ID       string `json:"id"`
+				FileName string `json:"fileName"`
+			} `json:"logo"`
+		} `json:"currentTrustCenter"`
+	}
+
+	err = owner.ExecuteTrust(trustCenterID, trustGraphQLQuery, nil, &trustResultAfterOrgLogo)
+	require.NoError(t, err)
+	require.NotNil(t, trustResultAfterOrgLogo.CurrentTrustCenter.Logo)
+	assert.Equal(t, orgLogoID, trustResultAfterOrgLogo.CurrentTrustCenter.Logo.ID)
+
+	var horizontalLogoUploadResult struct {
+		UpdateOrganization struct {
+			Organization struct {
+				HorizontalLogo *struct {
+					ID       string `json:"id"`
+					FileName string `json:"fileName"`
+				} `json:"horizontalLogo"`
+			} `json:"organization"`
+		} `json:"updateOrganization"`
+	}
+
+	err = owner.ExecuteConnectWithFile(updateOrganizationMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId":     organizationID,
+			"horizontalLogoFile": nil,
+		},
+	}, "input.horizontalLogoFile", testutil.UploadFile{
+		Filename:    "horizontal-logo.png",
+		ContentType: "image/png",
+		Content:     horizontalLogoPNG,
+	}, &horizontalLogoUploadResult)
+	require.NoError(t, err)
+	require.NotNil(t, horizontalLogoUploadResult.UpdateOrganization.Organization.HorizontalLogo)
+
+	horizontalLogoID := horizontalLogoUploadResult.UpdateOrganization.Organization.HorizontalLogo.ID
+	assert.NotEqual(t, orgLogoID, horizontalLogoID)
+
+	var trustResultAfterHorizontalLogo struct {
+		CurrentTrustCenter struct {
+			Logo *struct {
+				ID       string `json:"id"`
+				FileName string `json:"fileName"`
+			} `json:"logo"`
+		} `json:"currentTrustCenter"`
+	}
+
+	err = owner.ExecuteTrust(trustCenterID, trustGraphQLQuery, nil, &trustResultAfterHorizontalLogo)
+	require.NoError(t, err)
+	require.NotNil(t, trustResultAfterHorizontalLogo.CurrentTrustCenter.Logo)
+	assert.Equal(t, orgLogoID, trustResultAfterHorizontalLogo.CurrentTrustCenter.Logo.ID)
+	assert.NotEqual(t, horizontalLogoID, trustResultAfterHorizontalLogo.CurrentTrustCenter.Logo.ID)
+}

--- a/pkg/coredata/migrations/20260703T115912Z.sql
+++ b/pkg/coredata/migrations/20260703T115912Z.sql
@@ -1,0 +1,31 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+-- Compliance page logos were auto-copied from organization settings uploads.
+-- Clear those inherited values so the runtime fallback serves the current
+-- organization logo instead of a stale or horizontal document logo.
+UPDATE
+    trust_centers t
+SET
+    logo_file_id = NULL,
+    updated_at = NOW()
+FROM
+    organizations o
+WHERE
+    t.organization_id = o.id
+    AND t.logo_file_id IS NOT NULL
+    AND (
+        t.logo_file_id = o.logo_file_id
+        OR t.logo_file_id = o.horizontal_logo_file_id
+    );

--- a/pkg/coredata/trust_center.go
+++ b/pkg/coredata/trust_center.go
@@ -48,6 +48,18 @@ type (
 	TrustCenters []*TrustCenter
 )
 
+func (tc *TrustCenter) EffectiveLogoFileID(organization *Organization) *gid.GID {
+	if tc.LogoFileID != nil {
+		return tc.LogoFileID
+	}
+
+	if organization != nil {
+		return organization.LogoFileID
+	}
+
+	return nil
+}
+
 func (tc *TrustCenter) CursorKey(orderBy TrustCenterOrderField) page.CursorKey {
 	switch orderBy {
 	case TrustCenterOrderFieldCreatedAt:

--- a/pkg/iam/compliance_page_service.go
+++ b/pkg/iam/compliance_page_service.go
@@ -45,6 +45,7 @@ func (s *CompliancePageService) GenerateLogoURL(
 ) (*string, error) {
 	file := &coredata.File{}
 	compliancePage := &coredata.TrustCenter{}
+	organization := &coredata.Organization{}
 
 	scope := coredata.NewScopeFromObjectID(compliancePageID)
 
@@ -55,11 +56,16 @@ func (s *CompliancePageService) GenerateLogoURL(
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
-			if compliancePage.LogoFileID == nil {
+			if err := organization.LoadByID(ctx, conn, scope, compliancePage.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			logoFileID := compliancePage.EffectiveLogoFileID(organization)
+			if logoFileID == nil {
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, scope, *compliancePage.LogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *logoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -70,7 +76,8 @@ func (s *CompliancePageService) GenerateLogoURL(
 		return nil, err
 	}
 
-	if compliancePage.LogoFileID == nil {
+	logoFileID := compliancePage.EffectiveLogoFileID(organization)
+	if logoFileID == nil {
 		return nil, nil
 	}
 
@@ -104,14 +111,14 @@ func (s *CompliancePageService) EmailPresenterConfig(ctx context.Context, compli
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
-			if compliancePage.LogoFileID != nil {
-				if err := logoFile.LoadByID(ctx, conn, scope, *compliancePage.LogoFileID); err != nil {
-					return fmt.Errorf("cannot load logoFile: %w", err)
-				}
-			}
-
 			if err := organization.LoadByID(ctx, conn, scope, compliancePage.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			if logoFileID := compliancePage.EffectiveLogoFileID(organization); logoFileID != nil {
+				if err := logoFile.LoadByID(ctx, conn, scope, *logoFileID); err != nil {
+					return fmt.Errorf("cannot load logoFile: %w", err)
+				}
 			}
 
 			customDomain = &coredata.CustomDomain{}
@@ -147,7 +154,7 @@ func (s *CompliancePageService) EmailPresenterConfig(ctx context.Context, compli
 
 	emailPresenterCfg.BaseURL = baseURL.String()
 
-	if compliancePage.LogoFileID != nil {
+	if logoFileID := compliancePage.EffectiveLogoFileID(organization); logoFileID != nil {
 		if logoFile.FileKey == "" {
 			return emailPresenterCfg, nil
 		}

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -724,7 +724,6 @@ func (s *OrganizationService) CreateOrganization(
 				}
 
 				organization.LogoFileID = &logoFile.ID
-				trustCenter.LogoFileID = &logoFile.ID
 			}
 
 			if horizontalLogoFile != nil {
@@ -802,7 +801,6 @@ func (s *OrganizationService) UpdateOrganization(ctx context.Context, organizati
 		tenantID           = organizationID.TenantID()
 		scope              = coredata.NewScopeFromObjectID(organizationID)
 		organization       = &coredata.Organization{}
-		compliancePage     = &coredata.TrustCenter{}
 	)
 
 	// TODO: s3 upload happen before we validate the tenantID
@@ -924,20 +922,6 @@ func (s *OrganizationService) UpdateOrganization(ctx context.Context, organizati
 				}
 
 				organization.LogoFileID = &logoFile.ID
-
-				// Auto set the compliance page org logo in case it wasn't already specified
-				if err := compliancePage.LoadByOrganizationID(ctx, tx, scope, organizationID); err != nil {
-					return fmt.Errorf("cannot load compliance page: %w", err)
-				}
-
-				if compliancePage.LogoFileID == nil {
-					compliancePage.LogoFileID = &logoFile.ID
-					compliancePage.UpdatedAt = now
-
-					if err := compliancePage.Update(ctx, tx, scope); err != nil {
-						return fmt.Errorf("cannot update compliance page: %w", err)
-					}
-				}
 			}
 
 			if horizontalLogoFile != nil {

--- a/pkg/mailman/compliance_mailing_list.go
+++ b/pkg/mailman/compliance_mailing_list.go
@@ -81,14 +81,14 @@ func (s *Service) mailingListEmailConfig(
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
-			if compliancePage.LogoFileID != nil {
-				if err := logoFile.LoadByID(ctx, conn, scope, *compliancePage.LogoFileID); err != nil {
-					return fmt.Errorf("cannot load logo file: %w", err)
-				}
-			}
-
 			if err := organization.LoadByID(ctx, conn, scope, compliancePage.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			if logoFileID := compliancePage.EffectiveLogoFileID(organization); logoFileID != nil {
+				if err := logoFile.LoadByID(ctx, conn, scope, *logoFileID); err != nil {
+					return fmt.Errorf("cannot load logo file: %w", err)
+				}
 			}
 
 			customDomain = &coredata.CustomDomain{}
@@ -149,7 +149,7 @@ func (s *Service) presenterConfigFromTrustCenter(
 
 	cfg.BaseURL = compliancePageURL
 
-	if compliancePage.LogoFileID != nil && logoFile != nil && logoFile.FileKey != "" {
+	if logoFileID := compliancePage.EffectiveLogoFileID(organization); logoFileID != nil && logoFile != nil && logoFile.FileKey != "" {
 		cfg.SenderCompanyLogoPath = filepath.Join("/api/files/v1/public/", logoFile.ID.String())
 
 		cfg.SenderCompanyName = organization.Name

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -513,6 +513,7 @@ func (s TrustCenterService) GenerateLogoURL(
 ) (*string, error) {
 	file := &coredata.File{}
 	compliancePage := &coredata.TrustCenter{}
+	organization := &coredata.Organization{}
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -521,11 +522,16 @@ func (s TrustCenterService) GenerateLogoURL(
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
-			if compliancePage.LogoFileID == nil {
+			if err := organization.LoadByID(ctx, conn, scope, compliancePage.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			logoFileID := compliancePage.EffectiveLogoFileID(organization)
+			if logoFileID == nil {
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, scope, *compliancePage.LogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *logoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -536,7 +542,8 @@ func (s TrustCenterService) GenerateLogoURL(
 		return nil, err
 	}
 
-	if compliancePage.LogoFileID == nil {
+	logoFileID := compliancePage.EffectiveLogoFileID(organization)
+	if logoFileID == nil {
 		return nil, nil
 	}
 
@@ -614,14 +621,14 @@ func (s *TrustCenterService) EmailPresenterConfig(ctx context.Context, scope cor
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
-			if compliancePage.LogoFileID != nil {
-				if err := logoFile.LoadByID(ctx, conn, scope, *compliancePage.LogoFileID); err != nil {
-					return fmt.Errorf("cannot load logoFile: %w", err)
-				}
-			}
-
 			if err := organization.LoadByID(ctx, conn, scope, compliancePage.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			if logoFileID := compliancePage.EffectiveLogoFileID(organization); logoFileID != nil {
+				if err := logoFile.LoadByID(ctx, conn, scope, *logoFileID); err != nil {
+					return fmt.Errorf("cannot load logoFile: %w", err)
+				}
 			}
 
 			customDomain = &coredata.CustomDomain{}
@@ -657,7 +664,7 @@ func (s *TrustCenterService) EmailPresenterConfig(ctx context.Context, scope cor
 
 	emailPresenterCfg.BaseURL = baseURL.String()
 
-	if compliancePage.LogoFileID != nil {
+	if logoFileID := compliancePage.EffectiveLogoFileID(organization); logoFileID != nil {
 		if logoFile.FileKey == "" {
 			return emailPresenterCfg, nil
 		}

--- a/pkg/server/api/console/v1/trust_center_resolvers.go
+++ b/pkg/server/api/console/v1/trust_center_resolvers.go
@@ -691,15 +691,33 @@ func (r *mutationResolver) DeleteCustomDomain(ctx context.Context, input types.D
 
 // Logo is the resolver for the logo field.
 func (r *trustCenterResolver) Logo(ctx context.Context, obj *types.TrustCenter) (*types.File, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterGet)
+	if err != nil {
 		return nil, err
 	}
 
-	if obj.Logo == nil {
+	if obj.Logo != nil {
+		return r.loadFile(ctx, obj.Logo.ID)
+	}
+
+	trustCenter, err := r.probo.TrustCenters.Get(ctx, scope, obj.ID)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot load trust center for compliance page logo fallback", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	organization, err := r.probo.Organizations.Get(ctx, scope, trustCenter.OrganizationID)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot load organization for compliance page logo fallback", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	logoFileID := trustCenter.EffectiveLogoFileID(organization)
+	if logoFileID == nil {
 		return nil, nil
 	}
 
-	return r.loadFile(ctx, obj.Logo.ID)
+	return r.loadFile(ctx, *logoFileID)
 }
 
 // DarkLogo is the resolver for the darkLogo field.

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -4889,8 +4889,13 @@ func (r *Resolver) GetTrustCenterTool(ctx context.Context, req *mcp.CallToolRequ
 
 	tc := types.NewTrustCenter(trustCenter)
 
-	if trustCenter.LogoFileID != nil {
-		logo, err := r.loadFile(ctx, scope, *trustCenter.LogoFileID)
+	organization, err := prb.Organizations.Get(ctx, scope, trustCenter.OrganizationID)
+	if err != nil {
+		return nil, types.GetTrustCenterOutput{}, fmt.Errorf("cannot load organization: %w", err)
+	}
+
+	if logoFileID := trustCenter.EffectiveLogoFileID(organization); logoFileID != nil {
+		logo, err := r.loadFile(ctx, scope, *logoFileID)
 		if err != nil {
 			return nil, types.GetTrustCenterOutput{}, err
 		}

--- a/pkg/server/api/trust/v1/trust_center_resolvers.go
+++ b/pkg/server/api/trust/v1/trust_center_resolvers.go
@@ -683,8 +683,11 @@ func (r *trustCenterResolver) Logo(ctx context.Context, obj *types.TrustCenter) 
 		return r.loadPublicFile(ctx, *trustCenter.LogoFileID)
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
-	organization, err := r.trust.Organizations.Get(ctx, scope, trustCenter.OrganizationID)
+	organization, err := r.trust.Organizations.Get(
+		ctx,
+		coredata.NewScopeFromObjectID(obj.ID),
+		trustCenter.OrganizationID,
+	)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load organization for compliance page logo fallback", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/trust/v1/trust_center_resolvers.go
+++ b/pkg/server/api/trust/v1/trust_center_resolvers.go
@@ -678,11 +678,24 @@ func (r *subprocessorConnectionResolver) TotalCount(ctx context.Context, obj *ty
 // Logo is the resolver for the logo field.
 func (r *trustCenterResolver) Logo(ctx context.Context, obj *types.TrustCenter) (*types.File, error) {
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	if trustCenter.LogoFileID == nil {
+	logoFileID := trustCenter.LogoFileID
+
+	if logoFileID == nil {
+		scope := coredata.NewScopeFromObjectID(obj.ID)
+		organization, err := r.trust.Organizations.Get(ctx, scope, trustCenter.OrganizationID)
+		if err != nil {
+			r.logger.ErrorCtx(ctx, "cannot load organization for compliance page logo fallback", log.Error(err))
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		logoFileID = organization.LogoFileID
+	}
+
+	if logoFileID == nil {
 		return nil, nil
 	}
 
-	return r.loadPublicFile(ctx, *trustCenter.LogoFileID)
+	return r.loadPublicFile(ctx, *logoFileID)
 }
 
 // DarkLogo is the resolver for the darkLogo field.

--- a/pkg/server/api/trust/v1/trust_center_resolvers.go
+++ b/pkg/server/api/trust/v1/trust_center_resolvers.go
@@ -678,19 +678,19 @@ func (r *subprocessorConnectionResolver) TotalCount(ctx context.Context, obj *ty
 // Logo is the resolver for the logo field.
 func (r *trustCenterResolver) Logo(ctx context.Context, obj *types.TrustCenter) (*types.File, error) {
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	logoFileID := trustCenter.LogoFileID
 
-	if logoFileID == nil {
-		scope := coredata.NewScopeFromObjectID(obj.ID)
-		organization, err := r.trust.Organizations.Get(ctx, scope, trustCenter.OrganizationID)
-		if err != nil {
-			r.logger.ErrorCtx(ctx, "cannot load organization for compliance page logo fallback", log.Error(err))
-			return nil, gqlutils.Internal(ctx)
-		}
-
-		logoFileID = organization.LogoFileID
+	if trustCenter.LogoFileID != nil {
+		return r.loadPublicFile(ctx, *trustCenter.LogoFileID)
 	}
 
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	organization, err := r.trust.Organizations.Get(ctx, scope, trustCenter.OrganizationID)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot load organization for compliance page logo fallback", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	logoFileID := trustCenter.EffectiveLogoFileID(organization)
 	if logoFileID == nil {
 		return nil, nil
 	}

--- a/pkg/trust/trust_center_service.go
+++ b/pkg/trust/trust_center_service.go
@@ -164,6 +164,7 @@ func (s TrustCenterService) GenerateLogoURL(
 ) (*string, error) {
 	file := &coredata.File{}
 	compliancePage := &coredata.TrustCenter{}
+	organization := &coredata.Organization{}
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -172,11 +173,16 @@ func (s TrustCenterService) GenerateLogoURL(
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
-			if compliancePage.LogoFileID == nil {
+			if err := organization.LoadByID(ctx, conn, scope, compliancePage.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			logoFileID := compliancePage.EffectiveLogoFileID(organization)
+			if logoFileID == nil {
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, scope, *compliancePage.LogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *logoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -187,7 +193,8 @@ func (s TrustCenterService) GenerateLogoURL(
 		return nil, err
 	}
 
-	if compliancePage.LogoFileID == nil {
+	logoFileID := compliancePage.EffectiveLogoFileID(organization)
+	if logoFileID == nil {
 		return nil, nil
 	}
 
@@ -270,14 +277,14 @@ func (s *TrustCenterService) EmailPresenterConfig(
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
-			if compliancePage.LogoFileID != nil {
-				if err := logoFile.LoadByID(ctx, conn, scope, *compliancePage.LogoFileID); err != nil {
-					return fmt.Errorf("cannot load logoFile: %w", err)
-				}
-			}
-
 			if err := organization.LoadByID(ctx, conn, scope, compliancePage.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			if logoFileID := compliancePage.EffectiveLogoFileID(organization); logoFileID != nil {
+				if err := logoFile.LoadByID(ctx, conn, scope, *logoFileID); err != nil {
+					return fmt.Errorf("cannot load logoFile: %w", err)
+				}
 			}
 
 			customDomain = &coredata.CustomDomain{}
@@ -313,7 +320,7 @@ func (s *TrustCenterService) EmailPresenterConfig(
 
 	emailPresenterCfg.BaseURL = baseURL.String()
 
-	if compliancePage.LogoFileID != nil {
+	if logoFileID := compliancePage.EffectiveLogoFileID(organization); logoFileID != nil {
 		if logoFile.FileKey == "" {
 			return emailPresenterCfg, nil
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes ENG-583: uploading a logo in organization settings (especially on first upload) could pin the wrong asset on the public compliance page.

The root cause was an auto-copy in `UpdateOrganization` that wrote the uploaded organization logo file ID into `trust_centers.logo_file_id` whenever the compliance page had no dedicated logo yet. Once set, later uploads (including horizontal logos for documents) did not update the public page, leaving customers with a stale or incorrect logo.

## Changes

- **Remove auto-copy** of organization logo uploads into `trust_centers.logo_file_id` during org create/update.
- **Add runtime fallback**: when no dedicated compliance logo is configured, serve the organization square logo (`organizations.logo_file_id`) on the public compliance page, console brand UI, MCP, and email branding paths.
- **Data migration**: clear `trust_centers.logo_file_id` values that were inherited from organization or horizontal logo file IDs so existing tenants pick up the fallback behavior.
- **E2E test**: verify uploading a horizontal logo in IAM settings does not replace the compliance page logo.

## Testing

- Added `e2e/console/connect_organization_horizontal_logo_test.go`
- `make go-fmt` passes on touched Go files

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-583](https://linear.app/probo/issue/ENG-583/first-upload-to-settings-horizontal-logo-does-update-the-wrong)

<div><a href="https://cursor.com/agents/bc-a711776f-29ea-4b83-ad10-3660f27ef93a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a711776f-29ea-4b83-ad10-3660f27ef93a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ENG-583 by ensuring org settings uploads no longer override the compliance page logo. Removes the auto-copy and serves the org square logo as a fallback when no compliance logo is set, with a migration to clear inherited values.

### Tests **`+212`** **`-0`**
- Add e2e to confirm a horizontal logo upload in settings does not replace the compliance page logo.
- Verify the fallback serves the org logo.

### Coredata **`+43`** **`-0`**
- Add `TrustCenter.EffectiveLogoFileID` to resolve the active logo (trust-center-specific or org square).
- Migration clears `trust_centers.logo_file_id` when it matches org logo IDs.

### Service **`+58`** **`-53`**
- Remove auto-copy of org logo into compliance logo on create/update.
- Use `EffectiveLogoFileID` for logo resolution in compliance page, email branding, and mailing lists.

### GraphQL API **`+39`** **`-5`**
- Console and public resolvers load the org logo when no compliance logo is set.
- Fix wsl lint in trust resolver by inlining scope construction.

### MCP **`+7`** **`-2`**
- Tool resolver uses `EffectiveLogoFileID` so MCP reflects the same fallback behavior.

<sup>Written for commit ca946c8d16a136c368e613d733f4cf9d893409e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

