### PR TITLE
Add org-aware third-party vetting

### DIFF
--- a/apps/console/src/pages/organizations/third-parties/ThirdPartyDetailLayout.tsx
+++ b/apps/console/src/pages/organizations/third-parties/ThirdPartyDetailLayout.tsx
@@ -63,6 +63,7 @@ export const thirdPartyDetailLayoutQuery = graphql`
         vettingStatus
         canVet: permission(action: "core:thirdParty:vet")
         canDelete: permission(action: "core:thirdParty:delete")
+        ...VettingDialogFragment
         complianceReportsInfo: complianceReports(first: 100) {
           edges {
             node {
@@ -263,10 +264,7 @@ export default function ThirdPartyDetailLayout(props: ThirdPartyDetailLayoutProp
         </div>
         <div className="flex gap-2 items-center">
           {thirdParty.canVet && !isVetting && (
-            <VettingDialog
-              thirdPartyId={thirdParty.id}
-              websiteUrl={thirdParty.websiteUrl}
-            >
+            <VettingDialog thirdParty={thirdParty}>
               <Button icon={IconPageTextLine} variant="secondary">
                 {__("Start Vetting")}
               </Button>

--- a/apps/console/src/pages/organizations/third-parties/_components/VettingDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/VettingDialog.tsx
@@ -24,14 +24,26 @@ import {
   useToast,
 } from "@probo/ui";
 import type { ReactNode } from "react";
-import { useMutation } from "react-relay";
+import { useFragment, useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
 import { z } from "zod";
 
+import type { VettingDialogFragment$key } from "#/__generated__/core/VettingDialogFragment.graphql";
 import type { VettingDialogMutation } from "#/__generated__/core/VettingDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 
+const vettingDialogFragment = graphql`
+  fragment VettingDialogFragment on ThirdParty {
+    id
+    name
+    legalName
+    websiteUrl
+  }
+`;
+
 const schema = z.object({
+  name: z.string().min(1),
+  legalName: z.string().optional(),
   url: z.string().url(),
 });
 
@@ -41,6 +53,7 @@ const vetMutation = graphql`
       thirdParty {
         id
         name
+        legalName
         websiteUrl
         vettingStatus
         ...useThirdPartyFormFragment
@@ -52,31 +65,43 @@ const vetMutation = graphql`
 `;
 
 interface VettingDialogProps {
-  thirdPartyId: string;
-  websiteUrl?: string | null;
+  thirdParty: VettingDialogFragment$key;
   children: ReactNode;
 }
 
-export function VettingDialog({ thirdPartyId, websiteUrl, children }: VettingDialogProps) {
+export function VettingDialog({ thirdParty: thirdPartyKey, children }: VettingDialogProps) {
   const { __ } = useTranslate();
   const { toast } = useToast();
   const dialogRef = useDialogRef();
+  const thirdParty = useFragment(vettingDialogFragment, thirdPartyKey);
   const { register, handleSubmit, reset, formState } = useFormWithSchema(
     schema,
     {
       defaultValues: {
-        url: websiteUrl ?? "",
+        name: thirdParty.name ?? "",
+        legalName: thirdParty.legalName ?? "",
+        url: thirdParty.websiteUrl ?? "",
       },
     },
   );
   const [vet, isVetting] = useMutation<VettingDialogMutation>(vetMutation);
 
   const onSubmit = (data: z.infer<typeof schema>) => {
+    const name = data.name.trim();
+    const legalName = data.legalName?.trim() ?? "";
+
+    // Only send identity when changed: writing it needs update permission,
+    // so an unchanged confirm stays vet-only. Empty legal name clears it.
+    const nameChanged = name !== (thirdParty.name ?? "");
+    const legalNameChanged = legalName !== (thirdParty.legalName ?? "");
+
     vet({
       variables: {
         input: {
-          id: thirdPartyId,
+          id: thirdParty.id,
           websiteUrl: data.url,
+          ...(nameChanged ? { name } : {}),
+          ...(legalNameChanged ? { legalName } : {}),
         },
       },
       onCompleted(_, errors) {
@@ -120,7 +145,20 @@ export function VettingDialog({ thirdPartyId, websiteUrl, children }: VettingDia
       className="max-w-lg"
     >
       <form onSubmit={e => void handleSubmit(onSubmit)(e)}>
-        <DialogContent padded>
+        <DialogContent padded className="space-y-4">
+          <Field
+            required
+            label={__("Name")}
+            type="text"
+            {...register("name")}
+            error={formState.errors.name?.message}
+          />
+          <Field
+            label={__("Legal name")}
+            type="text"
+            {...register("legalName")}
+            error={formState.errors.legalName?.message}
+          />
           <Field
             required
             label={__("Website URL")}

--- a/pkg/coredata/asset.go
+++ b/pkg/coredata/asset.go
@@ -272,6 +272,70 @@ WHERE
 	return nil
 }
 
+func (a *Assets) LoadByThirdPartyID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	thirdPartyID gid.GID,
+	cursor *page.Cursor[AssetOrderField],
+) error {
+	q := `
+WITH linked_assets AS (
+	SELECT
+		a.id,
+		a.tenant_id,
+		a.name,
+		a.organization_id,
+		a.owner_profile_id,
+		a.amount,
+		a.asset_type,
+		a.data_types_stored,
+		a.created_at,
+		a.updated_at
+	FROM
+		assets a
+	INNER JOIN
+		asset_third_parties atp ON a.id = atp.asset_id
+	WHERE
+		atp.third_party_id = @third_party_id
+)
+SELECT
+	id,
+	name,
+	organization_id,
+	owner_profile_id,
+	amount,
+	asset_type,
+	data_types_stored,
+	created_at,
+	updated_at
+FROM
+	linked_assets
+WHERE %s
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"third_party_id": thirdPartyID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query assets: %w", err)
+	}
+
+	assets, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[Asset])
+	if err != nil {
+		return fmt.Errorf("cannot collect assets: %w", err)
+	}
+
+	*a = assets
+
+	return nil
+}
+
 func (a *Asset) Insert(
 	ctx context.Context,
 	conn pg.Tx,

--- a/pkg/coredata/datum.go
+++ b/pkg/coredata/datum.go
@@ -258,6 +258,66 @@ WHERE
 	return nil
 }
 
+func (d *Data) LoadByThirdPartyID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	thirdPartyID gid.GID,
+	cursor *page.Cursor[DatumOrderField],
+) error {
+	q := `
+WITH linked_data AS (
+	SELECT
+		d.id,
+		d.tenant_id,
+		d.name,
+		d.organization_id,
+		d.owner_profile_id,
+		d.data_classification,
+		d.created_at,
+		d.updated_at
+	FROM
+		data d
+	INNER JOIN
+		data_third_parties dtp ON d.id = dtp.datum_id
+	WHERE
+		dtp.third_party_id = @third_party_id
+)
+SELECT
+	id,
+	name,
+	organization_id,
+	owner_profile_id,
+	data_classification,
+	created_at,
+	updated_at
+FROM
+	linked_data
+WHERE %s
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"third_party_id": thirdPartyID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query data: %w", err)
+	}
+
+	data, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[Datum])
+	if err != nil {
+		return fmt.Errorf("cannot collect data: %w", err)
+	}
+
+	*d = data
+
+	return nil
+}
+
 func (d *Datum) Insert(
 	ctx context.Context,
 	conn pg.Tx,

--- a/pkg/coredata/processing_activities.go
+++ b/pkg/coredata/processing_activities.go
@@ -441,6 +441,98 @@ WHERE
 	return nil
 }
 
+func (p *ProcessingActivities) LoadByThirdPartyID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	thirdPartyID gid.GID,
+	cursor *page.Cursor[ProcessingActivityOrderField],
+) error {
+	q := `
+WITH linked_processing_activities AS (
+	SELECT
+		pa.id,
+		pa.tenant_id,
+		pa.organization_id,
+		pa.name,
+		pa.purpose,
+		pa.data_subject_category,
+		pa.personal_data_category,
+		pa.special_or_criminal_data,
+		pa.consent_evidence_link,
+		pa.lawful_basis,
+		pa.recipients,
+		pa.location,
+		pa.international_transfers,
+		pa.transfer_safeguards,
+		pa.retention_period,
+		pa.security_measures,
+		pa.data_protection_impact_assessment_needed,
+		pa.transfer_impact_assessment_needed,
+		pa.last_review_date,
+		pa.next_review_date,
+		pa.role,
+		pa.dpo_profile_id,
+		pa.created_at,
+		pa.updated_at
+	FROM
+		processing_activities pa
+	INNER JOIN
+		processing_activity_third_parties patp ON pa.id = patp.processing_activity_id
+	WHERE
+		patp.third_party_id = @third_party_id
+)
+SELECT
+	id,
+	organization_id,
+	name,
+	purpose,
+	data_subject_category,
+	personal_data_category,
+	special_or_criminal_data,
+	consent_evidence_link,
+	lawful_basis,
+	recipients,
+	location,
+	international_transfers,
+	transfer_safeguards,
+	retention_period,
+	security_measures,
+	data_protection_impact_assessment_needed,
+	transfer_impact_assessment_needed,
+	last_review_date,
+	next_review_date,
+	role,
+	dpo_profile_id,
+	created_at,
+	updated_at
+FROM
+	linked_processing_activities
+WHERE %s
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"third_party_id": thirdPartyID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query processing activities: %w", err)
+	}
+
+	processingActivities, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[ProcessingActivity])
+	if err != nil {
+		return fmt.Errorf("cannot collect processing activities: %w", err)
+	}
+
+	*p = processingActivities
+
+	return nil
+}
+
 func (p *ProcessingActivity) Insert(
 	ctx context.Context,
 	conn pg.Tx,

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -975,12 +975,23 @@ func (impl *Implm) Run(
 		},
 	)
 
+	// On-demand profiling needs the enrichment agent config, so wire the
+	// profiler only when that config is present.
+	var vettingProfiler *thirdparty.Profiler
+	if commonThirdPartyEnrichmentCfg.LLMClient != nil {
+		vettingProfiler = thirdparty.NewProfiler(
+			commonThirdPartyEnrichmentCfg,
+			l.Named("vetting-profiler"),
+		)
+	}
+
 	vettingWorker := thirdparty.NewVettingWorker(
 		pgClient,
 		thirdPartyVetter,
 		l.Named("vetting-worker"),
 		thirdparty.VettingWorkerConfig{
 			StaleAfter: time.Duration(impl.cfg.ThirdPartyVetting.StaleAfter) * time.Second,
+			Profiler:   vettingProfiler,
 		},
 		worker.WithInterval(time.Duration(impl.cfg.ThirdPartyVetting.Interval)*time.Second),
 		worker.WithMaxConcurrency(impl.cfg.ThirdPartyVetting.MaxConcurrency),

--- a/pkg/server/api/console/v1/graphql/third_party.graphql
+++ b/pkg/server/api/console/v1/graphql/third_party.graphql
@@ -671,6 +671,8 @@ input CreateThirdPartyRiskAssessmentInput {
 
 input VetThirdPartyInput {
     id: ID!
+    name: String
+    legalName: String
     websiteUrl: String!
     procedure: String
 }

--- a/pkg/server/api/console/v1/third_party_resolvers.go
+++ b/pkg/server/api/console/v1/third_party_resolvers.go
@@ -578,10 +578,20 @@ func (r *mutationResolver) VetThirdParty(ctx context.Context, input types.VetThi
 		return nil, err
 	}
 
+	// Writing identity (name/legal name) requires update permission, not
+	// vet alone.
+	if input.Name != nil || input.LegalName != nil {
+		if _, err := r.authorize(ctx, input.ID, probo.ActionThirdPartyUpdate); err != nil {
+			return nil, err
+		}
+	}
+
 	thirdParty, err := r.thirdParty.Vet(
 		ctx, scope,
 		thirdparty.VetRequest{
 			ID:         input.ID,
+			Name:       input.Name,
+			LegalName:  input.LegalName,
 			WebsiteURL: input.WebsiteURL,
 			Procedure:  input.Procedure,
 		},

--- a/pkg/thirdparty/common_third_party_company_profile_agent.go
+++ b/pkg/thirdparty/common_third_party_company_profile_agent.go
@@ -22,7 +22,6 @@ import (
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/agent"
 	"go.probo.inc/probo/pkg/agent/tools/search"
-	"go.probo.inc/probo/pkg/coredata"
 )
 
 //go:embed prompts/common_third_party_company_profile.txt.tmpl
@@ -79,21 +78,21 @@ func buildCompanyProfileAgent(
 	return agent.New("common-third-party-company-profile", cfg.LLMClient, opts...)
 }
 
-// buildCompanyProfilePrompt renders the per-row input for Agent A. Any
-// values already on the row are passed as hints so the agent confirms or
-// corrects them rather than starting cold.
-func buildCompanyProfilePrompt(party coredata.CommonThirdParty) string {
+// buildCompanyProfilePrompt renders the input for Agent A. Any known
+// values are passed as hints so the agent confirms or corrects them
+// rather than starting cold.
+func buildCompanyProfilePrompt(in GeneralInfoInput) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "Research this company and return its profile.\n\n")
-	fmt.Fprintf(&b, "<name> %s </name>\n", party.Name)
+	fmt.Fprintf(&b, "<name> %s </name>\n", in.Name)
 
-	if party.WebsiteURL != nil && strings.TrimSpace(*party.WebsiteURL) != "" {
-		fmt.Fprintf(&b, "<known_website> %s </known_website>\n", *party.WebsiteURL)
+	if w := strings.TrimSpace(in.WebsiteURL); w != "" {
+		fmt.Fprintf(&b, "<known_website> %s </known_website>\n", w)
 	}
 
-	if party.LegalName != nil && strings.TrimSpace(*party.LegalName) != "" {
-		fmt.Fprintf(&b, "<known_legal_name> %s </known_legal_name>\n", *party.LegalName)
+	if l := strings.TrimSpace(in.LegalName); l != "" {
+		fmt.Fprintf(&b, "<known_legal_name> %s </known_legal_name>\n", l)
 	}
 
 	return b.String()

--- a/pkg/thirdparty/common_third_party_enrichment_worker.go
+++ b/pkg/thirdparty/common_third_party_enrichment_worker.go
@@ -28,8 +28,6 @@ import (
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
 	"go.gearno.de/kit/worker"
-	"go.probo.inc/probo/pkg/agent"
-	"go.probo.inc/probo/pkg/agent/tools/browser"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/filemanager"
 	"go.probo.inc/probo/pkg/gid"
@@ -163,6 +161,7 @@ type enrichmentHandler struct {
 	logger     *log.Logger
 	cfg        EnrichmentConfig
 	httpClient *http.Client
+	profiler   *Profiler
 }
 
 // NewCommonThirdPartyEnrichmentWorker builds the worker that enriches
@@ -182,6 +181,7 @@ func NewCommonThirdPartyEnrichmentWorker(
 		logger:     logger,
 		cfg:        cfg,
 		httpClient: newEnrichmentHTTPClient(),
+		profiler:   NewProfiler(cfg, logger),
 	}
 
 	return worker.New(
@@ -238,7 +238,7 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 
 	// Agent A first: it resolves website_url, which Agent B and the logo
 	// step depend on.
-	company, err := h.runCompanyProfile(ctx, party)
+	company, err := h.profiler.runCompanyProfile(ctx, generalInfoInputFromParty(party))
 	if err != nil {
 		h.logger.WarnCtx(ctx, "company profile agent failed", log.Error(err), log.String("common_third_party_id", party.ID.String()))
 		runErrors = append(runErrors, "company_profile: "+sanitizeAgentError(err))
@@ -300,11 +300,11 @@ func (h *enrichmentHandler) Process(ctx context.Context, party coredata.CommonTh
 	var wg sync.WaitGroup
 
 	wg.Go(func() {
-		compliance, complianceErr = h.runComplianceDocs(ctx, party.Name, website, legalName)
+		compliance, complianceErr = h.profiler.runComplianceDocs(ctx, party.Name, website, legalName)
 	})
 
 	wg.Go(func() {
-		domainsResult, domainsErr = h.runDomains(ctx, party.Name, website)
+		domainsResult, domainsErr = h.profiler.runDomains(ctx, party.Name, website)
 	})
 
 	wg.Go(func() {
@@ -489,134 +489,19 @@ func (h *enrichmentHandler) RecoverStale(ctx context.Context) error {
 	)
 }
 
-// runCompanyProfile builds Agent A with a per-run browser when a Chrome
-// endpoint is configured, then runs it. The browser is closed when the
-// run returns. It is not pinned to a domain so the agent can follow a
-// product site to the legal entity's corporate domain (where the legal
-// name and headquarters address live); SSRF protection still blocks
-// non-public hosts.
-func (h *enrichmentHandler) runCompanyProfile(
-	ctx context.Context,
-	party coredata.CommonThirdParty,
-) (CompanyProfileResult, error) {
-	var browserTools []agent.Tool
+// generalInfoInputFromParty maps a catalog row to the general-info input.
+func generalInfoInputFromParty(party coredata.CommonThirdParty) GeneralInfoInput {
+	in := GeneralInfoInput{Name: party.Name}
 
-	if h.cfg.ChromeAddr != "" {
-		webBrowser := browser.NewBrowser(ctx, h.cfg.ChromeAddr)
-		defer webBrowser.Close()
-
-		browserTools = browser.NewReadOnlyToolset(webBrowser).Tools()
+	if party.WebsiteURL != nil {
+		in.WebsiteURL = strings.TrimSpace(*party.WebsiteURL)
 	}
 
-	companyAgent := buildCompanyProfileAgent(h.cfg, h.logger, browserTools)
-
-	prompt := buildCompanyProfilePrompt(party)
-
-	agentCtx, cancel := context.WithTimeout(ctx, h.cfg.AgentTimeout)
-	defer cancel()
-
-	result, err := agent.RunTyped[CompanyProfileResult](
-		agentCtx,
-		companyAgent,
-		[]llm.Message{
-			{
-				Role:  llm.RoleUser,
-				Parts: []llm.Part{llm.TextPart{Text: prompt}},
-			},
-		},
-	)
-	if err != nil {
-		return CompanyProfileResult{}, fmt.Errorf("company profile agent run failed: %w", err)
+	if party.LegalName != nil {
+		in.LegalName = strings.TrimSpace(*party.LegalName)
 	}
 
-	return result.Output, nil
-}
-
-// runComplianceDocs builds Agent B with a per-run browser when a Chrome
-// endpoint is configured, then runs it. The browser is closed when the
-// run returns. The browser is intentionally not pinned to the vendor
-// domain so the agent can follow links to hosted trust portals (Vanta,
-// SafeBase, etc.); SSRF protection still blocks non-public hosts.
-func (h *enrichmentHandler) runComplianceDocs(
-	ctx context.Context,
-	name string,
-	website string,
-	legalName string,
-) (ComplianceDocsResult, error) {
-	var browserTools []agent.Tool
-
-	if h.cfg.ChromeAddr != "" {
-		webBrowser := browser.NewBrowser(ctx, h.cfg.ChromeAddr)
-		defer webBrowser.Close()
-
-		browserTools = browser.NewReadOnlyToolset(webBrowser).Tools()
-	}
-
-	complianceAgent := buildComplianceDocsAgent(h.cfg, h.logger, browserTools)
-
-	prompt := buildComplianceDocsPrompt(name, website, legalName)
-
-	agentCtx, cancel := context.WithTimeout(ctx, h.cfg.AgentTimeout)
-	defer cancel()
-
-	result, err := agent.RunTyped[ComplianceDocsResult](
-		agentCtx,
-		complianceAgent,
-		[]llm.Message{
-			{
-				Role:  llm.RoleUser,
-				Parts: []llm.Part{llm.TextPart{Text: prompt}},
-			},
-		},
-	)
-	if err != nil {
-		return ComplianceDocsResult{}, fmt.Errorf("compliance docs agent run failed: %w", err)
-	}
-
-	return result.Output, nil
-}
-
-// runDomains builds Agent C with a per-run browser when a Chrome endpoint
-// is configured, then runs it. The browser is closed when the run
-// returns. It is not pinned to the vendor domain so the agent can follow
-// links to the vendor's other owned domains; SSRF protection still blocks
-// non-public hosts.
-func (h *enrichmentHandler) runDomains(
-	ctx context.Context,
-	name string,
-	website string,
-) (DomainsResult, error) {
-	var browserTools []agent.Tool
-
-	if h.cfg.ChromeAddr != "" {
-		webBrowser := browser.NewBrowser(ctx, h.cfg.ChromeAddr)
-		defer webBrowser.Close()
-
-		browserTools = browser.NewReadOnlyToolset(webBrowser).Tools()
-	}
-
-	domainsAgent := buildCommonThirdPartyDomainsAgent(h.cfg, h.logger, browserTools)
-
-	prompt := buildCommonThirdPartyDomainsPrompt(name, website)
-
-	agentCtx, cancel := context.WithTimeout(ctx, h.cfg.AgentTimeout)
-	defer cancel()
-
-	result, err := agent.RunTyped[DomainsResult](
-		agentCtx,
-		domainsAgent,
-		[]llm.Message{
-			{
-				Role:  llm.RoleUser,
-				Parts: []llm.Part{llm.TextPart{Text: prompt}},
-			},
-		},
-	)
-	if err != nil {
-		return DomainsResult{}, fmt.Errorf("domains agent run failed: %w", err)
-	}
-
-	return result.Output, nil
+	return in
 }
 
 // effectiveWebsiteURL is the website passed to Agent B and the logo step.

--- a/pkg/thirdparty/general_info.go
+++ b/pkg/thirdparty/general_info.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/agent"
+	"go.probo.inc/probo/pkg/agent/tools/browser"
+	"go.probo.inc/probo/pkg/llm"
+)
+
+type (
+	// GeneralInfoInput is the org-agnostic input to the general-info
+	// agents. Name is required; WebsiteURL and LegalName are optional
+	// hints. It carries no catalog/org identity so the same fact-finder
+	// serves both the global catalog and org third parties.
+	GeneralInfoInput struct {
+		Name       string
+		WebsiteURL string
+		LegalName  string
+	}
+
+	// GeneralInfoProfile is the merged factual profile from the
+	// general-info agents. WebsiteURL is what the profiler scoped Agents B
+	// and C to, resolved from the input hint or Agent A's output.
+	GeneralInfoProfile struct {
+		Company    CompanyProfileResult
+		Compliance ComplianceDocsResult
+		Domains    DomainsResult
+		WebsiteURL string
+	}
+
+	// Profiler runs the general-info agents against a GeneralInfoInput and
+	// owns no persistence: callers decide what to do with the profile.
+	Profiler struct {
+		cfg    EnrichmentConfig
+		logger *log.Logger
+	}
+)
+
+// NewProfiler builds a Profiler from the enrichment worker's config.
+func NewProfiler(cfg EnrichmentConfig, logger *log.Logger) *Profiler {
+	return &Profiler{
+		cfg:    cfg.withDefaults(),
+		logger: logger,
+	}
+}
+
+// Profile runs the pipeline best-effort. Agent A runs first because the
+// website it resolves scopes Agents B and C; without a website, B and C
+// are skipped. Agent A failing is fatal; B or C failing is only logged.
+func (p *Profiler) Profile(ctx context.Context, in GeneralInfoInput) (GeneralInfoProfile, error) {
+	profile := GeneralInfoProfile{}
+
+	company, err := p.runCompanyProfile(ctx, in)
+	if err != nil {
+		return profile, fmt.Errorf("cannot run company profile agent: %w", err)
+	}
+
+	profile.Company = company
+
+	website := strings.TrimSpace(in.WebsiteURL)
+	if website == "" {
+		if v := strings.TrimSpace(company.WebsiteURL.Value); v != "" && company.WebsiteURL.Confidence >= p.cfg.ConfidenceThreshold {
+			website = v
+		}
+	}
+
+	profile.WebsiteURL = website
+
+	// B and C need a resolved website to scope to the vendor.
+	if website == "" {
+		return profile, nil
+	}
+
+	legalName := strings.TrimSpace(in.LegalName)
+	if legalName == "" {
+		if v := strings.TrimSpace(company.LegalName.Value); v != "" && company.LegalName.Confidence >= p.cfg.ConfidenceThreshold {
+			legalName = v
+		}
+	}
+
+	var (
+		compliance    ComplianceDocsResult
+		complianceErr error
+
+		domains    DomainsResult
+		domainsErr error
+	)
+
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		compliance, complianceErr = p.runComplianceDocs(ctx, in.Name, website, legalName)
+	})
+
+	wg.Go(func() {
+		domains, domainsErr = p.runDomains(ctx, in.Name, website)
+	})
+
+	wg.Wait()
+
+	if complianceErr != nil {
+		p.logger.WarnCtx(ctx, "compliance docs agent failed during profiling", log.Error(complianceErr))
+	} else {
+		profile.Compliance = compliance
+	}
+
+	if domainsErr != nil {
+		p.logger.WarnCtx(ctx, "domains agent failed during profiling", log.Error(domainsErr))
+	} else {
+		profile.Domains = domains
+	}
+
+	return profile, nil
+}
+
+// runCompanyProfile runs Agent A with a per-run browser (when ChromeAddr
+// is set). Not pinned to a domain so it can follow a product site to the
+// corporate domain where the legal name/address live; SSRF still blocks
+// non-public hosts.
+func (p *Profiler) runCompanyProfile(
+	ctx context.Context,
+	in GeneralInfoInput,
+) (CompanyProfileResult, error) {
+	var browserTools []agent.Tool
+
+	if p.cfg.ChromeAddr != "" {
+		webBrowser := browser.NewBrowser(ctx, p.cfg.ChromeAddr)
+		defer webBrowser.Close()
+
+		browserTools = browser.NewReadOnlyToolset(webBrowser).Tools()
+	}
+
+	companyAgent := buildCompanyProfileAgent(p.cfg, p.logger, browserTools)
+
+	prompt := buildCompanyProfilePrompt(in)
+
+	agentCtx, cancel := context.WithTimeout(ctx, p.cfg.AgentTimeout)
+	defer cancel()
+
+	result, err := agent.RunTyped[CompanyProfileResult](
+		agentCtx,
+		companyAgent,
+		[]llm.Message{
+			{
+				Role:  llm.RoleUser,
+				Parts: []llm.Part{llm.TextPart{Text: prompt}},
+			},
+		},
+	)
+	if err != nil {
+		return CompanyProfileResult{}, fmt.Errorf("company profile agent run failed: %w", err)
+	}
+
+	return result.Output, nil
+}
+
+// runComplianceDocs runs Agent B with a per-run browser (when ChromeAddr
+// is set). Not pinned to the vendor domain so it can follow links to
+// hosted trust portals (Vanta, SafeBase, etc.); SSRF still blocks
+// non-public hosts.
+func (p *Profiler) runComplianceDocs(
+	ctx context.Context,
+	name string,
+	website string,
+	legalName string,
+) (ComplianceDocsResult, error) {
+	var browserTools []agent.Tool
+
+	if p.cfg.ChromeAddr != "" {
+		webBrowser := browser.NewBrowser(ctx, p.cfg.ChromeAddr)
+		defer webBrowser.Close()
+
+		browserTools = browser.NewReadOnlyToolset(webBrowser).Tools()
+	}
+
+	complianceAgent := buildComplianceDocsAgent(p.cfg, p.logger, browserTools)
+
+	prompt := buildComplianceDocsPrompt(name, website, legalName)
+
+	agentCtx, cancel := context.WithTimeout(ctx, p.cfg.AgentTimeout)
+	defer cancel()
+
+	result, err := agent.RunTyped[ComplianceDocsResult](
+		agentCtx,
+		complianceAgent,
+		[]llm.Message{
+			{
+				Role:  llm.RoleUser,
+				Parts: []llm.Part{llm.TextPart{Text: prompt}},
+			},
+		},
+	)
+	if err != nil {
+		return ComplianceDocsResult{}, fmt.Errorf("compliance docs agent run failed: %w", err)
+	}
+
+	return result.Output, nil
+}
+
+// runDomains runs Agent C with a per-run browser (when ChromeAddr is
+// set). Not pinned to the vendor domain so it can follow links to the
+// vendor's other owned domains; SSRF still blocks non-public hosts.
+func (p *Profiler) runDomains(
+	ctx context.Context,
+	name string,
+	website string,
+) (DomainsResult, error) {
+	var browserTools []agent.Tool
+
+	if p.cfg.ChromeAddr != "" {
+		webBrowser := browser.NewBrowser(ctx, p.cfg.ChromeAddr)
+		defer webBrowser.Close()
+
+		browserTools = browser.NewReadOnlyToolset(webBrowser).Tools()
+	}
+
+	domainsAgent := buildCommonThirdPartyDomainsAgent(p.cfg, p.logger, browserTools)
+
+	prompt := buildCommonThirdPartyDomainsPrompt(name, website)
+
+	agentCtx, cancel := context.WithTimeout(ctx, p.cfg.AgentTimeout)
+	defer cancel()
+
+	result, err := agent.RunTyped[DomainsResult](
+		agentCtx,
+		domainsAgent,
+		[]llm.Message{
+			{
+				Role:  llm.RoleUser,
+				Parts: []llm.Part{llm.TextPart{Text: prompt}},
+			},
+		},
+	)
+	if err != nil {
+		return DomainsResult{}, fmt.Errorf("domains agent run failed: %w", err)
+	}
+
+	return result.Output, nil
+}

--- a/pkg/thirdparty/org_context.go
+++ b/pkg/thirdparty/org_context.go
@@ -1,0 +1,385 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.gearno.de/x/ref"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+)
+
+// maxOrgContextListItems caps how many items each org-context list
+// renders, keeping the prompt bounded for large organizations.
+const maxOrgContextListItems = 50
+
+// buildOrganizationContext assembles the org-specific context block fed to
+// the assessment orchestrator: the org's frameworks, the vendor's prior
+// risk rating, and the data/assets/processing routed through the vendor.
+// Best-effort: a failed load is logged and omitted. Returns an empty
+// string when nothing org-specific is known.
+func (h *vettingHandler) buildOrganizationContext(
+	ctx context.Context,
+	thirdParty *coredata.ThirdParty,
+) string {
+	scope := coredata.NewScopeFromObjectID(thirdParty.ID)
+
+	var (
+		frameworks   coredata.Frameworks
+		linkedData   coredata.Data
+		linkedAssets coredata.Assets
+		activities   coredata.ProcessingActivities
+		risk         coredata.ThirdPartyRiskAssessment
+		hasRisk      bool
+	)
+
+	err := h.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			frameworks = h.loadOrgFrameworks(ctx, conn, scope, thirdParty.OrganizationID)
+			linkedData = h.loadLinkedData(ctx, conn, scope, thirdParty.ID)
+			linkedAssets = h.loadLinkedAssets(ctx, conn, scope, thirdParty.ID)
+			activities = h.loadLinkedProcessingActivities(ctx, conn, scope, thirdParty.ID)
+
+			if err := risk.LoadLatestByThirdPartyID(ctx, conn, scope, thirdParty.ID); err != nil {
+				if !errors.Is(err, coredata.ErrResourceNotFound) {
+					h.logger.WarnCtx(
+						ctx,
+						"cannot load third party risk assessment for org context",
+						log.Error(err),
+						log.String("third_party_id", thirdParty.ID.String()),
+					)
+				}
+			} else if risk.ExpiresAt.After(time.Now()) {
+				// Skip expired ratings: they would read as current.
+				hasRisk = true
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		h.logger.WarnCtx(
+			ctx,
+			"cannot open connection for organization context",
+			log.Error(err),
+			log.String("third_party_id", thirdParty.ID.String()),
+		)
+
+		return ""
+	}
+
+	return renderOrganizationContext(
+		thirdParty,
+		frameworks,
+		risk,
+		hasRisk,
+		linkedData,
+		linkedAssets,
+		activities,
+	)
+}
+
+func (h *vettingHandler) loadOrgFrameworks(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	organizationID gid.GID,
+) coredata.Frameworks {
+	frameworks, err := page.LoadAll(
+		ctx,
+		page.OrderBy[coredata.FrameworkOrderField]{
+			Field:     coredata.FrameworkOrderFieldCreatedAt,
+			Direction: page.OrderDirectionAsc,
+		},
+		func(ctx context.Context, cursor *page.Cursor[coredata.FrameworkOrderField]) ([]*coredata.Framework, error) {
+			var batch coredata.Frameworks
+			if err := batch.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor); err != nil {
+				return nil, err
+			}
+
+			return batch, nil
+		},
+	)
+	if err != nil {
+		h.logger.WarnCtx(ctx, "cannot load organization frameworks for org context", log.Error(err))
+
+		return nil
+	}
+
+	return frameworks
+}
+
+func (h *vettingHandler) loadLinkedData(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	thirdPartyID gid.GID,
+) coredata.Data {
+	data, err := page.LoadAll(
+		ctx,
+		page.OrderBy[coredata.DatumOrderField]{
+			Field:     coredata.DatumOrderFieldCreatedAt,
+			Direction: page.OrderDirectionAsc,
+		},
+		func(ctx context.Context, cursor *page.Cursor[coredata.DatumOrderField]) ([]*coredata.Datum, error) {
+			var batch coredata.Data
+			if err := batch.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID, cursor); err != nil {
+				return nil, err
+			}
+
+			return batch, nil
+		},
+	)
+	if err != nil {
+		h.logger.WarnCtx(ctx, "cannot load linked data for org context", log.Error(err))
+
+		return nil
+	}
+
+	return data
+}
+
+func (h *vettingHandler) loadLinkedAssets(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	thirdPartyID gid.GID,
+) coredata.Assets {
+	assets, err := page.LoadAll(
+		ctx,
+		page.OrderBy[coredata.AssetOrderField]{
+			Field:     coredata.AssetOrderFieldCreatedAt,
+			Direction: page.OrderDirectionAsc,
+		},
+		func(ctx context.Context, cursor *page.Cursor[coredata.AssetOrderField]) ([]*coredata.Asset, error) {
+			var batch coredata.Assets
+			if err := batch.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID, cursor); err != nil {
+				return nil, err
+			}
+
+			return batch, nil
+		},
+	)
+	if err != nil {
+		h.logger.WarnCtx(ctx, "cannot load linked assets for org context", log.Error(err))
+
+		return nil
+	}
+
+	return assets
+}
+
+func (h *vettingHandler) loadLinkedProcessingActivities(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	thirdPartyID gid.GID,
+) coredata.ProcessingActivities {
+	activities, err := page.LoadAll(
+		ctx,
+		page.OrderBy[coredata.ProcessingActivityOrderField]{
+			Field:     coredata.ProcessingActivityOrderFieldCreatedAt,
+			Direction: page.OrderDirectionAsc,
+		},
+		func(ctx context.Context, cursor *page.Cursor[coredata.ProcessingActivityOrderField]) ([]*coredata.ProcessingActivity, error) {
+			var batch coredata.ProcessingActivities
+			if err := batch.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID, cursor); err != nil {
+				return nil, err
+			}
+
+			return batch, nil
+		},
+	)
+	if err != nil {
+		h.logger.WarnCtx(ctx, "cannot load linked processing activities for org context", log.Error(err))
+
+		return nil
+	}
+
+	return activities
+}
+
+// renderOrganizationContext formats the assembled data into the
+// <organization_context> block. Empty sections are omitted; an empty
+// string is returned when nothing org-specific is known.
+func renderOrganizationContext(
+	thirdParty *coredata.ThirdParty,
+	frameworks coredata.Frameworks,
+	risk coredata.ThirdPartyRiskAssessment,
+	hasRisk bool,
+	linkedData coredata.Data,
+	linkedAssets coredata.Assets,
+	activities coredata.ProcessingActivities,
+) string {
+	countries := countryStrings(thirdParty.Countries)
+
+	hasContent := len(frameworks) > 0 ||
+		hasRisk ||
+		len(linkedData) > 0 ||
+		len(linkedAssets) > 0 ||
+		len(activities) > 0 ||
+		len(countries) > 0
+
+	if !hasContent {
+		return ""
+	}
+
+	var b strings.Builder
+
+	b.WriteString("<organization_context>\n")
+	b.WriteString("Assess this vendor for the specific organization described below. Weight risk by how this organization uses the vendor and the obligations it must meet. Treat requirements implied by the organization's frameworks and the sensitivity of the shared data as acceptance criteria: unmet hard requirements should lower the recommendation (escalate or reject) and be called out as conditions.\n")
+
+	if len(frameworks) > 0 {
+		b.WriteString("\n<frameworks>\n")
+		b.WriteString("Compliance frameworks the organization maintains; assess the vendor against their relevant requirements:\n")
+		shown := frameworks[:min(len(frameworks), maxOrgContextListItems)]
+		for _, f := range shown {
+			fmt.Fprintf(&b, "- %s\n", strings.TrimSpace(f.Name))
+		}
+		writeMoreItems(&b, len(frameworks), len(shown))
+		b.WriteString("</frameworks>\n")
+	}
+
+	relationship := make([]string, 0, 4)
+	if category := strings.TrimSpace(thirdParty.Category.String()); category != "" {
+		relationship = append(relationship, "- vendor_category: "+category)
+	}
+	if len(countries) > 0 {
+		relationship = append(relationship, "- vendor_operating_countries: "+strings.Join(countries, ", "))
+	}
+	if hasRisk {
+		relationship = append(relationship, fmt.Sprintf("- data_sensitivity_rating: %s (from prior risk assessment)", risk.DataSensitivity.String()))
+		relationship = append(relationship, fmt.Sprintf("- business_impact_rating: %s (from prior risk assessment)", risk.BusinessImpact.String()))
+	}
+	if len(relationship) > 0 {
+		b.WriteString("\n<relationship>\n")
+		for _, line := range relationship {
+			b.WriteString(line + "\n")
+		}
+		b.WriteString("</relationship>\n")
+	}
+
+	if len(linkedData) > 0 {
+		b.WriteString("\n<shared_data>\n")
+		b.WriteString("Data the organization shares with or exposes to this vendor:\n")
+		shown := linkedData[:min(len(linkedData), maxOrgContextListItems)]
+		for _, d := range shown {
+			fmt.Fprintf(&b, "- %s (classification: %s)\n", strings.TrimSpace(d.Name), d.DataClassification.String())
+		}
+		writeMoreItems(&b, len(linkedData), len(shown))
+		b.WriteString("</shared_data>\n")
+	}
+
+	if len(linkedAssets) > 0 {
+		b.WriteString("\n<linked_assets>\n")
+		b.WriteString("Organization assets that involve this vendor:\n")
+		shown := linkedAssets[:min(len(linkedAssets), maxOrgContextListItems)]
+		for _, a := range shown {
+			dataTypes := strings.TrimSpace(a.DataTypesStored)
+			if dataTypes == "" {
+				fmt.Fprintf(&b, "- %s\n", strings.TrimSpace(a.Name))
+				continue
+			}
+
+			fmt.Fprintf(&b, "- %s (data stored: %s)\n", strings.TrimSpace(a.Name), dataTypes)
+		}
+		writeMoreItems(&b, len(linkedAssets), len(shown))
+		b.WriteString("</linked_assets>\n")
+	}
+
+	if len(activities) > 0 {
+		b.WriteString("\n<processing_activities>\n")
+		b.WriteString("Processing activities that route data through this vendor:\n")
+		shown := activities[:min(len(activities), maxOrgContextListItems)]
+		for _, pa := range shown {
+			b.WriteString(renderProcessingActivity(pa))
+		}
+		writeMoreItems(&b, len(activities), len(shown))
+		b.WriteString("</processing_activities>\n")
+	}
+
+	b.WriteString("</organization_context>")
+
+	return b.String()
+}
+
+// writeMoreItems appends a truncation marker when a list was capped.
+func writeMoreItems(b *strings.Builder, total, shown int) {
+	if total > shown {
+		fmt.Fprintf(b, "- ... and %d more\n", total-shown)
+	}
+}
+
+func renderProcessingActivity(pa *coredata.ProcessingActivity) string {
+	parts := make([]string, 0, 6)
+
+	if purpose := ref.UnrefOrZero(pa.Purpose); strings.TrimSpace(purpose) != "" {
+		parts = append(parts, "purpose: "+strings.TrimSpace(purpose))
+	}
+
+	if category := ref.UnrefOrZero(pa.PersonalDataCategory); strings.TrimSpace(category) != "" {
+		parts = append(parts, "personal data: "+strings.TrimSpace(category))
+	}
+
+	if location := ref.UnrefOrZero(pa.Location); strings.TrimSpace(location) != "" {
+		parts = append(parts, "location: "+strings.TrimSpace(location))
+	}
+
+	if pa.InternationalTransfers {
+		parts = append(parts, "international transfers: yes")
+
+		if pa.TransferSafeguard != nil {
+			parts = append(parts, "safeguard: "+pa.TransferSafeguard.String())
+		}
+	}
+
+	if basis := strings.TrimSpace(pa.LawfulBasis.String()); basis != "" {
+		parts = append(parts, "lawful basis: "+basis)
+	}
+
+	if retention := ref.UnrefOrZero(pa.RetentionPeriod); strings.TrimSpace(retention) != "" {
+		parts = append(parts, "retention: "+strings.TrimSpace(retention))
+	}
+
+	name := strings.TrimSpace(pa.Name)
+	if name == "" {
+		return fmt.Sprintf("- %s\n", strings.Join(parts, " | "))
+	}
+
+	return fmt.Sprintf("- %s — %s\n", name, strings.Join(parts, " | "))
+}
+
+func countryStrings(countries coredata.CountryCodes) []string {
+	out := make([]string, 0, len(countries))
+	for _, c := range countries {
+		code := strings.TrimSpace(c.String())
+		if code == "" {
+			continue
+		}
+
+		out = append(out, code)
+	}
+
+	return out
+}

--- a/pkg/thirdparty/vetting.go
+++ b/pkg/thirdparty/vetting.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -31,6 +32,7 @@ import (
 
 const (
 	vettingErrorMessageMaxLen  = 512
+	vettingNameMaxLength       = 1000
 	vettingWebsiteURLMaxLength = 2048
 	vettingProcedureMaxLength  = 5000
 )
@@ -46,6 +48,8 @@ type (
 			ctx context.Context,
 			websiteURL string,
 			procedure string,
+			knownFacts *vetting.KnownFacts,
+			organizationContext string,
 			reporter agent.ProgressReporter,
 			extraTools []agent.Tool,
 		) (*vetting.Result, error)
@@ -57,6 +61,12 @@ type (
 		ID         gid.GID
 		WebsiteURL string
 		Procedure  *string
+
+		// Name and LegalName confirm the vendor identity from the vetting
+		// form. When set they update the third party's canonical identity;
+		// nil leaves the existing value untouched.
+		Name      *string
+		LegalName *string
 	}
 )
 
@@ -65,6 +75,8 @@ var _ Vetter = DisabledVetter{}
 func (DisabledVetter) Assess(
 	_ context.Context,
 	_ string,
+	_ string,
+	_ *vetting.KnownFacts,
 	_ string,
 	_ agent.ProgressReporter,
 	_ []agent.Tool,
@@ -78,6 +90,8 @@ func (req VetRequest) Validate() error {
 	v.Check(req.ID, "id", validator.Required(), validator.GID(coredata.ThirdPartyEntityType))
 	v.Check(req.WebsiteURL, "website_url", validator.Required(), validator.SafeText(vettingWebsiteURLMaxLength))
 	v.Check(req.Procedure, "procedure", validator.SafeText(vettingProcedureMaxLength))
+	v.Check(req.Name, "name", validator.SafeTextNoNewLine(vettingNameMaxLength))
+	v.Check(req.LegalName, "legal_name", validator.SafeTextNoNewLine(vettingNameMaxLength))
 
 	return v.Error()
 }
@@ -120,6 +134,23 @@ func (s *Service) Vet(
 
 			if thirdParty.VettingStatus != nil && thirdParty.VettingStatus.IsActive() {
 				return ErrVettingInProgress
+			}
+
+			// Confirmed identity from the form updates the canonical name/
+			// legal name. The vetting website URL stays vetting-specific
+			// and never overwrites the identity website URL.
+			if req.Name != nil {
+				if name := strings.TrimSpace(*req.Name); name != "" {
+					thirdParty.Name = name
+				}
+			}
+
+			if req.LegalName != nil {
+				if legalName := strings.TrimSpace(*req.LegalName); legalName != "" {
+					thirdParty.LegalName = &legalName
+				} else {
+					thirdParty.LegalName = nil
+				}
 			}
 
 			pending := coredata.ThirdPartyVettingStatusPending

--- a/pkg/thirdparty/vetting_priming.go
+++ b/pkg/thirdparty/vetting_priming.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.gearno.de/x/ref"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/vetting"
+)
+
+// resolveKnownFacts gathers the vendor facts used to prime a vetting run:
+// a catalog-linked third party reuses the catalog row (no LLM), otherwise
+// the profiler runs the general-info agents on demand. Best-effort: any
+// failure is logged and vetting proceeds without facts. Never writes the
+// resolved facts back to the common catalog.
+func (h *vettingHandler) resolveKnownFacts(
+	ctx context.Context,
+	thirdParty *coredata.ThirdParty,
+) *vetting.KnownFacts {
+	if thirdParty.CommonThirdPartyID != nil {
+		facts, err := h.knownFactsFromCatalog(ctx, *thirdParty.CommonThirdPartyID)
+		if err != nil {
+			h.logger.WarnCtx(
+				ctx,
+				"cannot load common third party facts for vetting priming",
+				log.Error(err),
+				log.String("third_party_id", thirdParty.ID.String()),
+			)
+		} else if !facts.IsEmpty() {
+			return facts
+		}
+	}
+
+	if h.profiler == nil || thirdParty.VettingWebsiteURL == nil {
+		return nil
+	}
+
+	profile, err := h.profiler.Profile(
+		ctx,
+		GeneralInfoInput{
+			Name:       thirdParty.Name,
+			WebsiteURL: ref.UnrefOrZero(thirdParty.VettingWebsiteURL),
+			LegalName:  ref.UnrefOrZero(thirdParty.LegalName),
+		},
+	)
+	if err != nil {
+		h.logger.WarnCtx(
+			ctx,
+			"general-info profiling failed for vetting priming",
+			log.Error(err),
+			log.String("third_party_id", thirdParty.ID.String()),
+		)
+
+		return nil
+	}
+
+	facts := knownFactsFromProfile(thirdParty.Name, profile)
+	if facts.IsEmpty() {
+		return nil
+	}
+
+	return &facts
+}
+
+// knownFactsFromCatalog loads the catalog row and its owned domains and
+// maps them to known facts.
+func (h *vettingHandler) knownFactsFromCatalog(
+	ctx context.Context,
+	commonThirdPartyID gid.GID,
+) (*vetting.KnownFacts, error) {
+	party := &coredata.CommonThirdParty{}
+
+	var domains coredata.CommonThirdPartyDomains
+
+	err := h.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := party.LoadByID(ctx, conn, commonThirdPartyID); err != nil {
+				return fmt.Errorf("cannot load common third party: %w", err)
+			}
+
+			if err := domains.LoadByCommonThirdPartyID(ctx, conn, commonThirdPartyID); err != nil {
+				return fmt.Errorf("cannot load common third party domains: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	domainStrings := make([]string, 0, len(domains))
+	for _, d := range domains {
+		domainStrings = append(domainStrings, d.Domain)
+	}
+
+	facts := knownFactsFromCommonThirdParty(party, domainStrings)
+
+	return &facts, nil
+}
+
+// knownFactsFromCommonThirdParty maps a catalog row to vetting known facts.
+func knownFactsFromCommonThirdParty(
+	party *coredata.CommonThirdParty,
+	domains []string,
+) vetting.KnownFacts {
+	return vetting.KnownFacts{
+		Name:                          party.Name,
+		LegalName:                     ref.UnrefOrZero(party.LegalName),
+		HeadquarterAddress:            ref.UnrefOrZero(party.HeadquarterAddress),
+		WebsiteURL:                    ref.UnrefOrZero(party.WebsiteURL),
+		PrivacyPolicyURL:              ref.UnrefOrZero(party.PrivacyPolicyURL),
+		TermsOfServiceURL:             ref.UnrefOrZero(party.TermsOfServiceURL),
+		ServiceLevelAgreementURL:      ref.UnrefOrZero(party.ServiceLevelAgreementURL),
+		DataProcessingAgreementURL:    ref.UnrefOrZero(party.DataProcessingAgreementURL),
+		BusinessAssociateAgreementURL: ref.UnrefOrZero(party.BusinessAssociateAgreementURL),
+		SubprocessorsListURL:          ref.UnrefOrZero(party.SubprocessorsListURL),
+		SecurityPageURL:               ref.UnrefOrZero(party.SecurityPageURL),
+		TrustPageURL:                  ref.UnrefOrZero(party.TrustPageURL),
+		StatusPageURL:                 ref.UnrefOrZero(party.StatusPageURL),
+		Certifications:                party.Certifications,
+		Domains:                       domains,
+	}
+}
+
+// knownFactsFromProfile maps an on-demand general-info profile to known
+// facts.
+func knownFactsFromProfile(name string, profile GeneralInfoProfile) vetting.KnownFacts {
+	company := profile.Company
+	compliance := profile.Compliance
+
+	return vetting.KnownFacts{
+		Name:                          name,
+		LegalName:                     strings.TrimSpace(company.LegalName.Value),
+		HeadquarterAddress:            strings.TrimSpace(company.HeadquarterAddress.Value),
+		WebsiteURL:                    profile.WebsiteURL,
+		PrivacyPolicyURL:              strings.TrimSpace(compliance.PrivacyPolicyURL.Value),
+		TermsOfServiceURL:             strings.TrimSpace(compliance.TermsOfServiceURL.Value),
+		ServiceLevelAgreementURL:      strings.TrimSpace(compliance.ServiceLevelAgreementURL.Value),
+		DataProcessingAgreementURL:    strings.TrimSpace(compliance.DataProcessingAgreementURL.Value),
+		BusinessAssociateAgreementURL: strings.TrimSpace(compliance.BusinessAssociateAgreementURL.Value),
+		SubprocessorsListURL:          strings.TrimSpace(compliance.SubprocessorsListURL.Value),
+		SecurityPageURL:               strings.TrimSpace(compliance.SecurityPageURL.Value),
+		TrustPageURL:                  strings.TrimSpace(compliance.TrustPageURL.Value),
+		StatusPageURL:                 strings.TrimSpace(compliance.StatusPageURL.Value),
+		Certifications:                compliance.Certifications.Values,
+		Domains:                       ownedDomainStrings(profile.Domains),
+	}
+}
+
+// ownedDomainStrings collects the resolved domain names, dropping blanks.
+func ownedDomainStrings(result DomainsResult) []string {
+	out := make([]string, 0, len(result.Domains))
+	for _, d := range result.Domains {
+		domain := strings.TrimSpace(d.Domain)
+		if domain == "" {
+			continue
+		}
+
+		out = append(out, domain)
+	}
+
+	return out
+}

--- a/pkg/thirdparty/vetting_test.go
+++ b/pkg/thirdparty/vetting_test.go
@@ -108,7 +108,7 @@ func TestSanitizeVettingError(t *testing.T) {
 func TestDisabledVetter_Assess(t *testing.T) {
 	t.Parallel()
 
-	_, err := DisabledVetter{}.Assess(context.Background(), "https://example.com", "", nil, nil)
+	_, err := DisabledVetter{}.Assess(context.Background(), "https://example.com", "", nil, "", nil, nil)
 	require.ErrorIs(t, err, ErrVettingDisabled)
 }
 

--- a/pkg/thirdparty/vetting_worker.go
+++ b/pkg/thirdparty/vetting_worker.go
@@ -34,10 +34,15 @@ type (
 		vetter     Vetter
 		logger     *log.Logger
 		staleAfter time.Duration
+		profiler   *Profiler
 	}
 
 	VettingWorkerConfig struct {
 		StaleAfter time.Duration
+
+		// Profiler runs the general-info agents to prime an assessment.
+		// Optional: when nil, only catalog-linked third parties are primed.
+		Profiler *Profiler
 	}
 )
 
@@ -63,6 +68,7 @@ func NewVettingWorker(
 		vetter:     vetter,
 		logger:     logger,
 		staleAfter: staleAfter,
+		profiler:   cfg.Profiler,
 	}
 
 	return worker.New(
@@ -160,6 +166,12 @@ func (h *vettingHandler) processThirdParty(
 		WebsiteURL:     *thirdParty.VettingWebsiteURL,
 	}
 
+	// Prime the assessment with known vendor facts; best-effort.
+	knownFacts := h.resolveKnownFacts(ctx, thirdParty)
+
+	// Make the assessment specific to this organization; best-effort.
+	organizationContext := h.buildOrganizationContext(ctx, thirdParty)
+
 	// Assessment runs outside any database transaction. Persistence tools
 	// are not passed in so the agent cannot open DB transactions during
 	// the long LLM/browser phase; results are written afterward.
@@ -167,6 +179,8 @@ func (h *vettingHandler) processThirdParty(
 		ctx,
 		*thirdParty.VettingWebsiteURL,
 		procedure,
+		knownFacts,
+		organizationContext,
 		nil,
 		nil,
 	)

--- a/pkg/vetting/assessment.go
+++ b/pkg/vetting/assessment.go
@@ -173,7 +173,7 @@ func NewAssessor(cfg Config) *Assessor {
 	return &Assessor{cfg: cfg}
 }
 
-func (a *Assessor) Assess(ctx context.Context, websiteURL string, procedure string, reporter agent.ProgressReporter, extraTools []agent.Tool) (*Result, error) {
+func (a *Assessor) Assess(ctx context.Context, websiteURL string, procedure string, knownFacts *KnownFacts, organizationContext string, reporter agent.ProgressReporter, extraTools []agent.Tool) (*Result, error) {
 	u, err := url.Parse(websiteURL)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse website URL %q: %w", websiteURL, err)
@@ -205,6 +205,7 @@ func (a *Assessor) Assess(ctx context.Context, websiteURL string, procedure stri
 		a.cfg.Model,
 		a.cfg.MaxTokens,
 		procedure,
+		organizationContext,
 		a.cfg.Logger,
 		webBrowser,
 		a.cfg.FirecrawlAPIKey,
@@ -215,12 +216,21 @@ func (a *Assessor) Assess(ctx context.Context, websiteURL string, procedure stri
 		return nil, fmt.Errorf("cannot create orchestrator agent: %w", err)
 	}
 
+	// Seed known facts ahead of the website URL so the sub-agents skip
+	// rediscovering basics.
+	parts := make([]llm.Part, 0, 2)
+	if knownFacts != nil && !knownFacts.IsEmpty() {
+		parts = append(parts, llm.TextPart{Text: knownFacts.render()})
+	}
+
+	parts = append(parts, llm.TextPart{Text: websiteURL})
+
 	orchestratorResult, err := orchestrator.Run(
 		ctx,
 		[]llm.Message{
 			{
 				Role:  llm.RoleUser,
-				Parts: []llm.Part{llm.TextPart{Text: websiteURL}},
+				Parts: parts,
 			},
 		},
 	)

--- a/pkg/vetting/known_facts.go
+++ b/pkg/vetting/known_facts.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package vetting
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KnownFacts is the factual vendor profile fed to the assessment
+// orchestrator as verified starting points, sourced from the catalog or a
+// general-info profiling pass so sub-agents skip rediscovering basics.
+type KnownFacts struct {
+	Name                          string
+	LegalName                     string
+	HeadquarterAddress            string
+	WebsiteURL                    string
+	PrivacyPolicyURL              string
+	TermsOfServiceURL             string
+	ServiceLevelAgreementURL      string
+	DataProcessingAgreementURL    string
+	BusinessAssociateAgreementURL string
+	SubprocessorsListURL          string
+	SecurityPageURL               string
+	TrustPageURL                  string
+	StatusPageURL                 string
+	Certifications                []string
+	Domains                       []string
+}
+
+// IsEmpty reports whether there is nothing worth priming with. The name
+// is disregarded: it is always available and no head start on its own.
+func (k KnownFacts) IsEmpty() bool {
+	return strings.TrimSpace(k.LegalName) == "" &&
+		strings.TrimSpace(k.HeadquarterAddress) == "" &&
+		strings.TrimSpace(k.WebsiteURL) == "" &&
+		strings.TrimSpace(k.PrivacyPolicyURL) == "" &&
+		strings.TrimSpace(k.TermsOfServiceURL) == "" &&
+		strings.TrimSpace(k.ServiceLevelAgreementURL) == "" &&
+		strings.TrimSpace(k.DataProcessingAgreementURL) == "" &&
+		strings.TrimSpace(k.BusinessAssociateAgreementURL) == "" &&
+		strings.TrimSpace(k.SubprocessorsListURL) == "" &&
+		strings.TrimSpace(k.SecurityPageURL) == "" &&
+		strings.TrimSpace(k.TrustPageURL) == "" &&
+		strings.TrimSpace(k.StatusPageURL) == "" &&
+		len(k.Certifications) == 0 &&
+		len(k.Domains) == 0
+}
+
+// render formats the non-empty facts into a <known_facts> block prepended
+// to the orchestrator's first message.
+func (k KnownFacts) render() string {
+	var b strings.Builder
+
+	b.WriteString("<known_facts>\n")
+	b.WriteString("Vendor facts already known from the catalog or a prior profiling pass. Treat them as verified starting points to confirm, not as final evidence.\n")
+
+	writeFact(&b, "name", k.Name)
+	writeFact(&b, "legal_name", k.LegalName)
+	writeFact(&b, "headquarter_address", k.HeadquarterAddress)
+	writeFact(&b, "website_url", k.WebsiteURL)
+	writeFact(&b, "privacy_policy_url", k.PrivacyPolicyURL)
+	writeFact(&b, "terms_of_service_url", k.TermsOfServiceURL)
+	writeFact(&b, "service_level_agreement_url", k.ServiceLevelAgreementURL)
+	writeFact(&b, "data_processing_agreement_url", k.DataProcessingAgreementURL)
+	writeFact(&b, "business_associate_agreement_url", k.BusinessAssociateAgreementURL)
+	writeFact(&b, "subprocessors_list_url", k.SubprocessorsListURL)
+	writeFact(&b, "security_page_url", k.SecurityPageURL)
+	writeFact(&b, "trust_page_url", k.TrustPageURL)
+	writeFact(&b, "status_page_url", k.StatusPageURL)
+
+	if len(k.Certifications) > 0 {
+		writeFact(&b, "certifications", strings.Join(k.Certifications, ", "))
+	}
+
+	if len(k.Domains) > 0 {
+		writeFact(&b, "owned_domains", strings.Join(k.Domains, ", "))
+	}
+
+	b.WriteString("</known_facts>")
+
+	return b.String()
+}
+
+func writeFact(b *strings.Builder, label, value string) {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return
+	}
+
+	fmt.Fprintf(b, "- %s: %s\n", label, v)
+}

--- a/pkg/vetting/orchestrator.go
+++ b/pkg/vetting/orchestrator.go
@@ -62,6 +62,7 @@ func newOrchestratorAgent(
 	model string,
 	maxTokens int,
 	procedure string,
+	organizationContext string,
 	logger *log.Logger,
 	webBrowser *browser.Browser,
 	firecrawlAPIKey string,
@@ -243,7 +244,11 @@ func newOrchestratorAgent(
 		procedure = defaultProcedure
 	}
 
-	systemPrompt := strings.Replace(orchestratorBasePrompt, "{procedure}", procedure, 1)
+	// Substitute org context (system-generated) before the user-provided
+	// procedure so a procedure containing "{organization_context}" cannot
+	// inject into that slot.
+	systemPrompt := strings.Replace(orchestratorBasePrompt, "{organization_context}", organizationContext, 1)
+	systemPrompt = strings.Replace(systemPrompt, "{procedure}", procedure, 1)
 
 	opts := []agent.Option{
 		agent.WithLogger(logger),

--- a/pkg/vetting/prompts/orchestrator_base.txt
+++ b/pkg/vetting/prompts/orchestrator_base.txt
@@ -6,6 +6,14 @@ You are a third party due diligence assessment agent. You assess third-party thi
 Investigate the third party's website and online presence using the available assessment tools. Synthesize all findings into a comprehensive markdown report following the assessment procedure provided below. Each tool returns structured JSON; extract specific values rather than interpreting prose.
 </task>
 
+<known_facts>
+The user message may begin with a <known_facts> block: vendor identity and document URLs already known from the catalog or a prior profiling pass. Use them, but do not trust them blindly:
+- Seed the relevant tools with them instead of rediscovering basics — e.g. call `analyze_document` directly on a known privacy policy or DPA URL, and `assess_compliance` on a known trust page.
+- Confirm a fact when confirming is cheap. If a tool contradicts a known fact, trust the tool and note the discrepancy in the report.
+- Never treat a known fact as sufficient evidence on its own for a risk conclusion — still investigate.
+- A known fact that no tool can confirm is an information gap, not a finding.
+</known_facts>
+
 <workflow>
 Begin by mapping the third party's online presence with `crawl_third_party_website`. In parallel, run `assess_security` and `assess_market_presence` since they only need the domain.
 
@@ -25,6 +33,8 @@ If `research_third_party_externally` is available, use it for incidents, regulat
 <assessment_procedure>
 {procedure}
 </assessment_procedure>
+
+{organization_context}
 
 <persistence>
 After completing your analysis and writing the report:


### PR DESCRIPTION
Decompose vendor fact-finding from org-specific risk judgment so both the common catalog and org vetting share one building block:

- Extract a reusable, persistence-free Profiler (company profile, compliance docs, domains) and have the catalog enrichment worker use it.
- Prime the vetting orchestrator with KnownFacts resolved from a catalog link or an on-demand profiling pass, seeded into the orchestrator message.
- Inject broad organization context (frameworks, latest risk rating, linked data/assets/processing activities, countries) into the assessment; a user-provided procedure overrides the default playbook while org context is always applied.
- Add Data/Assets/ProcessingActivities LoadByThirdPartyID coredata loaders.
- Vetting form prefills and confirms vendor identity (name, legal name, website), updating the third party's identity to feed the assessment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make vetting org-aware by splitting general vendor profiling from org-specific risk and feeding both into the assessment. Adds a reusable `Profiler`, primes the orchestrator with catalog/on‑demand facts, injects organization context, and updates the vetting UI to confirm identity.

### Coredata **`+216`** **`-0`**
- Added `LoadByThirdPartyID` loaders for `Data`, `Assets`, and `ProcessingActivities` to pull items linked to a vendor.

### GraphQL API **`+12`** **`-0`**
- `VetThirdPartyInput` now accepts optional `name` and `legalName`; resolver enforces update permission and forwards fields to vetting.

### Service **`+1037`** **`-141`**
- Extracted a reusable `Profiler` (company profile, compliance docs, domains) and adopted it in the catalog enrichment worker.
- Vetting worker optionally runs the `Profiler` to prime assessments with `KnownFacts` (no writes to the catalog).
- Injected organization context (frameworks, prior risk, linked data/assets/processing activities, countries) into the orchestrator.
- Orchestrator and base prompt updated to consume known facts and org context; `Assess` now seeds them before crawling.
- Wired `probod` to provide the profiler to the vetting worker when enrichment config is set; minor refactors and prompt tweaks.

### App: console **`+47`** **`-11`**
- Vetting dialog now uses a fragment and pre-fills name, legal name, and website; only sends identity fields when changed.
- Third-party details page passes the fragment prop to `VettingDialog`.

### Tests **`+1`** **`-1`**
- Updated test to match the new `Assess` signature.

<sup>Written for commit db4b4ec2a5c5d8b48292d55dce4ca63b5fa9825f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

