### PR TITLE
Rename signature filter state field to profileState

### DIFF
--- a/apps/console/src/pages/organizations/documents/DocumentLayout.tsx
+++ b/apps/console/src/pages/organizations/documents/DocumentLayout.tsx
@@ -40,10 +40,10 @@ export const documentLayoutQuery = graphql`
         ...DocumentTitleFormFragment
         ...DocumentActionsDropdown_versionFragment
         ...DocumentDetailsCard_versionFragment
-        signatures(first: 0 filter: { activeContract: true, state: ACTIVE }) {
+        signatures(first: 0 filter: { activeContract: true, profileState: ACTIVE }) {
           totalCount
         }
-        signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, state: ACTIVE }) {
+        signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, profileState: ACTIVE }) {
           totalCount
         }
         approvalQuorums(first: 1, orderBy: { field: CREATED_AT, direction: DESC }) {
@@ -85,10 +85,10 @@ export const documentLayoutQuery = graphql`
               ...DocumentTitleFormFragment
               ...DocumentActionsDropdown_versionFragment
               ...DocumentDetailsCard_versionFragment
-              signatures(first: 0 filter: { activeContract: true, state: ACTIVE }) {
+              signatures(first: 0 filter: { activeContract: true, profileState: ACTIVE }) {
                 totalCount
               }
-              signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, state: ACTIVE }) {
+              signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, profileState: ACTIVE }) {
                 totalCount
               }
               approvalQuorums(first: 1, orderBy: { field: CREATED_AT, direction: DESC }) {

--- a/apps/console/src/pages/organizations/documents/_components/DocumentListItem.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/DocumentListItem.tsx
@@ -78,10 +78,10 @@ const fragment = graphql`
               }
             }
           }
-          signatures(first: 0 filter: { activeContract: true, state: ACTIVE }) {
+          signatures(first: 0 filter: { activeContract: true, profileState: ACTIVE }) {
             totalCount
           }
-          signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, state: ACTIVE }) {
+          signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, profileState: ACTIVE }) {
             totalCount
           }
         }

--- a/apps/console/src/pages/organizations/documents/signatures/_components/DocumentSignatureList.tsx
+++ b/apps/console/src/pages/organizations/documents/signatures/_components/DocumentSignatureList.tsx
@@ -29,7 +29,7 @@ const versionFragment = graphql`
   @argumentDefinitions(
     count: { type: "Int", defaultValue: 1000 }
     cursor: { type: "CursorKey" }
-    signatureFilter: { type: "DocumentVersionSignatureFilter", defaultValue: { activeContract: true, state: ACTIVE } }
+    signatureFilter: { type: "DocumentVersionSignatureFilter", defaultValue: { activeContract: true, profileState: ACTIVE } }
   ) {
     ...DocumentSignaturePlaceholder_versionFragment
     signatures(first: $count, after: $cursor, filter: $signatureFilter)
@@ -104,7 +104,7 @@ export function DocumentSignatureList(props: {
 
     const filter = {
       activeContract: true,
-      state: "ACTIVE" as const,
+      profileState: "ACTIVE" as const,
       ...(selectedStates.length > 0 ? { states: selectedStates } : {}),
     };
 

--- a/packages/n8n-node/nodes/Probo/actions/document/getAllSignatures.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/getAllSignatures.operation.ts
@@ -119,7 +119,7 @@ export async function execute(
 	const filter: IDataObject = {};
 	if ((filters.states as string[])?.length) filter.states = filters.states;
 	if (filters.activeContract !== undefined) filter.activeContract = filters.activeContract;
-	if (filters.state) filter.state = filters.state;
+	if (filters.state) filter.profileState = filters.state;
 
 	const hasFilter = Object.keys(filter).length > 0;
 

--- a/pkg/coredata/document_version_signature_filter.go
+++ b/pkg/coredata/document_version_signature_filter.go
@@ -22,15 +22,15 @@ type (
 	DocumentVersionSignatureFilter struct {
 		states         DocumentVersionSignatureStates
 		activeContract *bool
-		state          *ProfileState
+		profileState   *ProfileState
 	}
 )
 
-func NewDocumentVersionSignatureFilter(states []DocumentVersionSignatureState, activeContract *bool, state *ProfileState) *DocumentVersionSignatureFilter {
+func NewDocumentVersionSignatureFilter(states []DocumentVersionSignatureState, activeContract *bool, profileState *ProfileState) *DocumentVersionSignatureFilter {
 	return &DocumentVersionSignatureFilter{
 		states:         DocumentVersionSignatureStates(states),
 		activeContract: activeContract,
-		state:          state,
+		profileState:   profileState,
 	}
 }
 
@@ -38,7 +38,7 @@ func (f *DocumentVersionSignatureFilter) SQLArguments() pgx.StrictNamedArgs {
 	return pgx.StrictNamedArgs{
 		"states":          f.states,
 		"active_contract": f.activeContract,
-		"profile_state":   f.state,
+		"profile_state":   f.profileState,
 	}
 }
 

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -294,8 +294,8 @@ func (r *documentVersionResolver) Signatures(ctx context.Context, obj *types.Doc
 			activeContract = filter.ActiveContract
 		}
 
-		if filter.State != nil {
-			profileState = filter.State
+		if filter.ProfileState != nil {
+			profileState = filter.ProfileState
 		}
 	}
 

--- a/pkg/server/api/console/v1/graphql/document.graphql
+++ b/pkg/server/api/console/v1/graphql/document.graphql
@@ -247,7 +247,7 @@ input DocumentVersionSignatureOrder {
 input DocumentVersionSignatureFilter {
     states: [DocumentVersionSignatureState!]
     activeContract: Boolean
-    state: ProfileState
+    profileState: ProfileState
 }
 
 input DocumentVersionApprovalQuorumOrder {

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2407,8 +2407,8 @@ func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *m
 			activeContract = input.Filter.ActiveContract
 		}
 
-		if input.Filter.State != nil {
-			profileState = input.Filter.State
+		if input.Filter.ProfileState != nil {
+			profileState = input.Filter.ProfileState
 		}
 	}
 

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -6376,7 +6376,7 @@ components:
             active_contract:
               type: boolean
               description: Signatory contract status
-            state:
+            profile_state:
               $ref: "#/components/schemas/ProfileState"
               description: Signatory profile state
 


### PR DESCRIPTION
The DocumentVersionSignatureFilter exposed a field named `state` that actually filters on the signatory's profile state, which was ambiguous next to the signature `states` field. Rename it to `profileState` (GraphQL) / `profile_state` (MCP) across the schema, spec, resolvers, console app, and n8n node for clarity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rename the signature filter input from `state` to `profileState` (GraphQL) and `profile_state` (MCP) to remove confusion with signature `states`. Behavior is unchanged, but this is a breaking input rename for external clients; first‑party console and `packages/n8n-node` are updated.

### Coredata **`+4`** **`-4`**
Renamed the filter field and constructor arg to `profileState`; updated SQL args to use `profile_state`.

### GraphQL API **`+3`** **`-3`**
Changed the GraphQL input to `profileState` and updated resolvers to read the new field.

### MCP **`+3`** **`-3`**
Updated the spec to `profile_state` and the resolver to use `ProfileState` via the new field.

### App: console **`+8`** **`-8`**
Updated queries and default filters in document pages to use `profileState`.

### Package: n8n-node **`+1`** **`-1`**
`packages/n8n-node`: map incoming `filters.state` to `profileState` in the request filter.

<sup>Written for commit f83b42d2ec816d082f07833af09bd304d8041018. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

