### PR TITLE
Confine trust center reads and signatures to the page's tenant

### DIFF
--- a/e2e/trust/trust_center_report_export_test.go
+++ b/e2e/trust/trust_center_report_export_test.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package trust_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+const exportReportPDFMutation = `
+	mutation ExportReportPDF($input: ExportReportPDFInput!) {
+		exportReportPDF(input: $input) {
+			data
+		}
+	}
+`
+
+const nodeQuery = `
+	query Node($id: ID!) {
+		node(id: $id) {
+			__typename
+		}
+	}
+`
+
+// TestTrustCenter_ExportReportPDF_TenantIsolation verifies that a public
+// audit-report PDF can only be exported through its own organization's trust
+// center. A visitor on another organization's trust center must not be able to
+// download it by supplying the foreign report GID (cross-tenant IDOR).
+func TestTrustCenter_ExportReportPDF_TenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	victimOwner := testutil.NewClient(t, testutil.RoleOwner)
+	attackerOwner := testutil.NewClient(t, testutil.RoleOwner)
+
+	victimTrustCenterID, victimReportID := setupPublicAuditReport(t, victimOwner)
+	attackerTrustCenterID, _ := setupPublicAuditReport(t, attackerOwner)
+
+	t.Run("owning trust center can export its report", func(t *testing.T) {
+		var result struct {
+			ExportReportPDF struct {
+				Data string `json:"data"`
+			} `json:"exportReportPDF"`
+		}
+
+		err := victimOwner.ExecuteTrust(victimTrustCenterID, exportReportPDFMutation, map[string]any{
+			"input": map[string]any{"reportId": victimReportID},
+		}, &result)
+		require.NoError(t, err, "the owning trust center must serve its own public report")
+		assert.True(
+			t,
+			strings.HasPrefix(result.ExportReportPDF.Data, "data:application/pdf;base64,"),
+			"expected a base64 PDF data URL, got %q",
+			result.ExportReportPDF.Data,
+		)
+	})
+
+	t.Run("foreign trust center cannot export another org's report", func(t *testing.T) {
+		err := attackerOwner.ExecuteTrust(attackerTrustCenterID, exportReportPDFMutation, map[string]any{
+			"input": map[string]any{"reportId": victimReportID},
+		}, nil)
+		require.Error(t, err, "a foreign trust center must not export another org's report")
+		assert.Contains(
+			t,
+			err.Error(),
+			"not found",
+			"cross-tenant report GID must be rejected as not found",
+		)
+	})
+}
+
+// TestTrustCenter_Node_TenantIsolation exercises the generic node(id:) resolver:
+// a visitor on one organization's trust center must not resolve a node that
+// belongs to another organization, even with a valid foreign GID.
+func TestTrustCenter_Node_TenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	victimOwner := testutil.NewClient(t, testutil.RoleOwner)
+	attackerOwner := testutil.NewClient(t, testutil.RoleOwner)
+
+	victimTrustCenterID, _ := setupPublicAuditReport(t, victimOwner)
+	attackerTrustCenterID, _ := setupPublicAuditReport(t, attackerOwner)
+
+	t.Run("owning trust center resolves its own node", func(t *testing.T) {
+		var result struct {
+			Node struct {
+				Typename string `json:"__typename"`
+			} `json:"node"`
+		}
+
+		err := victimOwner.ExecuteTrust(victimTrustCenterID, nodeQuery, map[string]any{
+			"id": victimTrustCenterID,
+		}, &result)
+		require.NoError(t, err, "the owning trust center must resolve its own node")
+		assert.NotEmpty(t, result.Node.Typename, "expected the node to resolve to a concrete type")
+	})
+
+	t.Run("foreign trust center cannot resolve another org's node", func(t *testing.T) {
+		err := attackerOwner.ExecuteTrust(attackerTrustCenterID, nodeQuery, map[string]any{
+			"id": victimTrustCenterID,
+		}, nil)
+		require.Error(t, err, "a foreign trust center must not resolve another org's node")
+		assert.Contains(
+			t,
+			err.Error(),
+			"not found",
+			"cross-tenant GID must be rejected as not found",
+		)
+	})
+}
+
+// setupPublicAuditReport creates an audit with an uploaded report file, marks it
+// as publicly visible on the trust center, activates the trust center, and
+// returns the trust center ID and the report file ID.
+func setupPublicAuditReport(t *testing.T, owner *testutil.Client) (trustCenterID string, reportID string) {
+	t.Helper()
+
+	frameworkID := factory.NewFramework(owner).WithName(factory.SafeName("Framework")).Create()
+	auditID := factory.NewAudit(owner, frameworkID).WithName(factory.SafeName("Audit")).Create()
+
+	const uploadMutation = `
+		mutation UploadAuditReport($input: UploadAuditReportInput!) {
+			uploadAuditReport(input: $input) {
+				audit {
+					reportFile { id }
+				}
+			}
+		}
+	`
+
+	pdfContent := []byte("%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\ntrailer\n<< /Root 1 0 R >>\n%%EOF")
+
+	var uploadResult struct {
+		UploadAuditReport struct {
+			Audit struct {
+				ReportFile struct {
+					ID string `json:"id"`
+				} `json:"reportFile"`
+			} `json:"audit"`
+		} `json:"uploadAuditReport"`
+	}
+
+	err := owner.ExecuteWithFile(uploadMutation, map[string]any{
+		"input": map[string]any{
+			"auditId": auditID,
+			"file":    nil,
+		},
+	}, "input.file", testutil.UploadFile{
+		Filename:    "audit-report.pdf",
+		ContentType: "application/pdf",
+		Content:     pdfContent,
+	}, &uploadResult)
+	require.NoError(t, err)
+
+	reportID = uploadResult.UploadAuditReport.Audit.ReportFile.ID
+	require.NotEmpty(t, reportID)
+
+	const setVisibilityMutation = `
+		mutation UpdateAudit($input: UpdateAuditInput!) {
+			updateAudit(input: $input) {
+				audit { id }
+			}
+		}
+	`
+
+	err = owner.Execute(setVisibilityMutation, map[string]any{
+		"input": map[string]any{
+			"id":                    auditID,
+			"trustCenterVisibility": "PUBLIC",
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	const trustCenterQuery = `
+		query($organizationId: ID!) {
+			node(id: $organizationId) {
+				... on Organization {
+					trustCenter { id }
+				}
+			}
+		}
+	`
+
+	var trustCenterLookup struct {
+		Node struct {
+			TrustCenter struct {
+				ID string `json:"id"`
+			} `json:"trustCenter"`
+		} `json:"node"`
+	}
+
+	err = owner.Execute(trustCenterQuery, map[string]any{
+		"organizationId": owner.GetOrganizationID().String(),
+	}, &trustCenterLookup)
+	require.NoError(t, err)
+
+	trustCenterID = trustCenterLookup.Node.TrustCenter.ID
+	require.NotEmpty(t, trustCenterID)
+
+	const activateMutation = `
+		mutation($input: UpdateTrustCenterInput!) {
+			updateTrustCenter(input: $input) {
+				trustCenter { id active }
+			}
+		}
+	`
+
+	err = owner.Execute(activateMutation, map[string]any{
+		"input": map[string]any{
+			"trustCenterId": trustCenterID,
+			"active":        true,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	return trustCenterID, reportID
+}

--- a/pkg/esign/service.go
+++ b/pkg/esign/service.go
@@ -236,6 +236,7 @@ func (s *Service) CreateAndAcceptSignature(
 	if err := s.recordEvent(
 		ctx,
 		conn,
+		scope,
 		&RecordEventRequest{
 			SignatureID: sig.ID,
 			EventType:   coredata.ElectronicSignatureEventTypeSignatureAccepted,
@@ -309,9 +310,8 @@ func (s *Service) createStampedDocument(
 	return stampedFile.ID, nil
 }
 
-func (s *Service) AcceptSignature(ctx context.Context, req *AcceptSignatureRequest) (*coredata.ElectronicSignature, error) {
+func (s *Service) AcceptSignature(ctx context.Context, scope coredata.Scoper, req *AcceptSignatureRequest) (*coredata.ElectronicSignature, error) {
 	var (
-		scope     = coredata.NewScopeFromObjectID(req.SignatureID)
 		now       = time.Now()
 		signature = coredata.ElectronicSignature{}
 	)
@@ -320,6 +320,10 @@ func (s *Service) AcceptSignature(ctx context.Context, req *AcceptSignatureReque
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			if err := signature.LoadByID(ctx, tx, scope, req.SignatureID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrElectronicSignatureNotFound
+				}
+
 				return fmt.Errorf("cannot load electronic signature: %w", err)
 			}
 
@@ -347,6 +351,7 @@ func (s *Service) AcceptSignature(ctx context.Context, req *AcceptSignatureReque
 			if err := s.recordEvent(
 				ctx,
 				tx,
+				scope,
 				&RecordEventRequest{
 					SignatureID: signature.ID,
 					EventType:   coredata.ElectronicSignatureEventTypeSignatureAccepted,
@@ -369,20 +374,26 @@ func (s *Service) AcceptSignature(ctx context.Context, req *AcceptSignatureReque
 	return &signature, nil
 }
 
-func (s *Service) RecordEvent(ctx context.Context, req *RecordEventRequest) error {
+func (s *Service) RecordEvent(ctx context.Context, scope coredata.Scoper, req *RecordEventRequest) error {
 	return s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			return s.recordEvent(ctx, tx, req)
+			signature := coredata.ElectronicSignature{}
+			if err := signature.LoadByID(ctx, tx, scope, req.SignatureID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrElectronicSignatureNotFound
+				}
+
+				return fmt.Errorf("cannot load electronic signature: %w", err)
+			}
+
+			return s.recordEvent(ctx, tx, scope, req)
 		},
 	)
 }
 
-func (s *Service) recordEvent(ctx context.Context, tx pg.Tx, req *RecordEventRequest) error {
-	var (
-		now   = time.Now()
-		scope = coredata.NewScopeFromObjectID(req.SignatureID)
-	)
+func (s *Service) recordEvent(ctx context.Context, tx pg.Tx, scope coredata.Scoper, req *RecordEventRequest) error {
+	now := time.Now()
 
 	event := coredata.ElectronicSignatureEvent{
 		ID:                    gid.New(scope.GetTenantID(), coredata.ElectronicSignatureEventEntityType),
@@ -403,11 +414,8 @@ func (s *Service) recordEvent(ctx context.Context, tx pg.Tx, req *RecordEventReq
 	return nil
 }
 
-func (s *Service) GetSignatureByID(ctx context.Context, id gid.GID) (*coredata.ElectronicSignature, error) {
-	var (
-		scope     = coredata.NewScopeFromObjectID(id)
-		signature = coredata.ElectronicSignature{}
-	)
+func (s *Service) GetSignatureByID(ctx context.Context, scope coredata.Scoper, id gid.GID) (*coredata.ElectronicSignature, error) {
+	signature := coredata.ElectronicSignature{}
 
 	err := s.pg.WithConn(
 		ctx,

--- a/pkg/server/api/console/v1/trust_center_resolvers.go
+++ b/pkg/server/api/console/v1/trust_center_resolvers.go
@@ -922,7 +922,7 @@ func (r *trustCenterAccessResolver) NdaSignature(ctx context.Context, obj *types
 		return nil, nil
 	}
 
-	sig, err := r.esign.GetSignatureByID(ctx, *access.ElectronicSignatureID)
+	sig, err := r.esign.GetSignatureByID(ctx, scope, *access.ElectronicSignatureID)
 	if err != nil {
 		return nil, nil
 	}

--- a/pkg/server/api/trust/v1/base_resolvers.go
+++ b/pkg/server/api/trust/v1/base_resolvers.go
@@ -41,23 +41,27 @@ func (r *queryResolver) Viewer(ctx context.Context) (*types.Identity, error) {
 
 // Node is the resolver for the node field.
 func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error) {
-	scope := coredata.NewScopeFromObjectID(id)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
 	switch id.EntityType() {
 	case coredata.OrganizationEntityType:
 		organization, err := trustService.Organizations.Get(ctx, scope, id)
 		if err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+			}
+
 			r.logger.ErrorCtx(ctx, "cannot get organization", log.Error(err))
+
 			return nil, gqlutils.Internal(ctx)
 		}
 
 		return types.NewOrganization(organization), nil
 
 	case coredata.DocumentEntityType:
-		trustCenter := compliancepage.CompliancePageFromContext(ctx)
-
-		document, err := trustService.Documents.Get(ctx, scope, trustCenter.OrganizationID, id)
+		document, err := trustService.Documents.Get(ctx, scope, compliancePage.OrganizationID, id)
 		if err != nil {
 			if errors.Is(err, trust.ErrDocumentNotFound) || errors.Is(err, trust.ErrDocumentNotVisible) || errors.Is(err, coredata.ErrResourceNotFound) {
 				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
@@ -77,16 +81,19 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.FrameworkEntityType:
 		framework, err := trustService.Frameworks.Get(ctx, scope, id)
 		if err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+			}
+
 			r.logger.ErrorCtx(ctx, "cannot get framework", log.Error(err))
+
 			return nil, gqlutils.Internal(ctx)
 		}
 
 		return types.NewFramework(framework), nil
 
 	case coredata.FileEntityType:
-		trustCenter := compliancepage.CompliancePageFromContext(ctx)
-
-		file, err := trustService.Reports.Get(ctx, scope, trustCenter.OrganizationID, id)
+		file, err := trustService.Reports.Get(ctx, scope, compliancePage.OrganizationID, id)
 		if err != nil {
 			if errors.Is(err, trust.ErrReportNotFound) || errors.Is(err, coredata.ErrResourceNotFound) {
 				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
@@ -97,13 +104,37 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 			return nil, gqlutils.Internal(ctx)
 		}
 
+		audit, err := trustService.Audits.GetByReportFileID(ctx, scope, id)
+		if err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+			}
+
+			r.logger.ErrorCtx(ctx, "cannot get audit for report file", log.Error(err))
+
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		if audit.TrustCenterVisibility == coredata.TrustCenterVisibilityNone {
+			return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+		}
+
 		return types.NewAuditReport(file), nil
 
 	case coredata.AuditEntityType:
 		audit, err := trustService.Audits.Get(ctx, scope, id)
 		if err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+			}
+
 			r.logger.ErrorCtx(ctx, "cannot get audit", log.Error(err))
+
 			return nil, gqlutils.Internal(ctx)
+		}
+
+		if audit.TrustCenterVisibility == coredata.TrustCenterVisibilityNone {
+			return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
 		}
 
 		return types.NewAudit(audit), nil
@@ -111,8 +142,17 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ThirdPartyEntityType:
 		thirdParty, err := trustService.ThirdParties.Get(ctx, scope, id)
 		if err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+			}
+
 			r.logger.ErrorCtx(ctx, "cannot get thirdParty", log.Error(err))
+
 			return nil, gqlutils.Internal(ctx)
+		}
+
+		if !thirdParty.ShowOnTrustCenter {
+			return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
 		}
 
 		return types.NewSubprocessor(thirdParty), nil
@@ -120,7 +160,12 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.TrustCenterEntityType:
 		trustCenter, err := trustService.TrustCenters.Get(ctx, scope, id)
 		if err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+			}
+
 			r.logger.ErrorCtx(ctx, "cannot get trust center", log.Error(err))
+
 			return nil, gqlutils.Internal(ctx)
 		}
 
@@ -129,16 +174,19 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.TrustCenterReferenceEntityType:
 		reference, err := trustService.TrustCenterReferences.Get(ctx, scope, id)
 		if err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+			}
+
 			r.logger.ErrorCtx(ctx, "cannot get trust center reference", log.Error(err))
+
 			return nil, gqlutils.Internal(ctx)
 		}
 
 		return types.NewTrustCenterReference(reference), nil
 
 	case coredata.TrustCenterFileEntityType:
-		trustCenter := compliancepage.CompliancePageFromContext(ctx)
-
-		trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, scope, trustCenter.OrganizationID, id)
+		trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, scope, compliancePage.OrganizationID, id)
 		if err != nil {
 			if errors.Is(err, trust.ErrTrustCenterFileNotFound) || errors.Is(err, trust.ErrTrustCenterFileNotVisible) {
 				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
@@ -160,8 +208,8 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 func (r *queryResolver) AliasedNode(ctx context.Context, alias string) (types.Node, error) {
 	resourceID, err := gid.ParseGID(alias)
 	if err != nil {
-		trustCenter := compliancepage.CompliancePageFromContext(ctx)
-		scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+		compliancePage := compliancepage.CompliancePageFromContext(ctx)
+		scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 
 		resourceID, err = r.resourceAlias.ResolveAlias(
 			ctx,
@@ -184,18 +232,18 @@ func (r *queryResolver) AliasedNode(ctx context.Context, alias string) (types.No
 
 // CurrentTrustCenter is the resolver for the currentTrustCenter field.
 func (r *queryResolver) CurrentTrustCenter(ctx context.Context) (*types.TrustCenter, error) {
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
 
-	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
-	org, err := trustService.Organizations.Get(ctx, scope, trustCenter.OrganizationID)
+	org, err := trustService.Organizations.Get(ctx, scope, compliancePage.OrganizationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get organization", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	trustCenter, err = trustService.TrustCenters.Get(ctx, scope, trustCenter.ID)
+	trustCenter, err := trustService.TrustCenters.Get(ctx, scope, compliancePage.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get trust center", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/trust/v1/nda_directive.go
+++ b/pkg/server/api/trust/v1/nda_directive.go
@@ -54,7 +54,9 @@ func newNDADirective(
 			return next(ctx)
 		}
 
-		sig, err := esignSvc.GetSignatureByID(ctx, *membership.ElectronicSignatureID)
+		scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
+
+		sig, err := esignSvc.GetSignatureByID(ctx, scope, *membership.ElectronicSignatureID)
 		if err != nil {
 			logger.ErrorCtx(ctx, "cannot get NDA signature", log.Error(err))
 			return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/trust/v1/nda_resolvers.go
+++ b/pkg/server/api/trust/v1/nda_resolvers.go
@@ -7,6 +7,7 @@ package trust_v1
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.gearno.de/kit/log"
@@ -23,14 +24,17 @@ import (
 // AcceptElectronicSignature is the resolver for the acceptElectronicSignature field.
 func (r *mutationResolver) AcceptElectronicSignature(ctx context.Context, input types.AcceptElectronicSignatureInput) (*types.AcceptElectronicSignaturePayload, error) {
 	var (
-		identity = authn.IdentityFromContext(ctx)
-		httpReq  = gqlutils.HTTPRequestFromContext(ctx)
+		identity       = authn.IdentityFromContext(ctx)
+		httpReq        = gqlutils.HTTPRequestFromContext(ctx)
+		compliancePage = compliancepage.CompliancePageFromContext(ctx)
+		scope          = coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	)
 
 	signerIP := clientip.Extract(httpReq)
 
 	signature, err := r.esign.AcceptSignature(
 		ctx,
+		scope,
 		&esign.AcceptSignatureRequest{
 			SignatureID:    input.SignatureID,
 			SignerFullName: identity.FullName,
@@ -40,7 +44,12 @@ func (r *mutationResolver) AcceptElectronicSignature(ctx context.Context, input 
 		},
 	)
 	if err != nil {
+		if errors.Is(err, esign.ErrElectronicSignatureNotFound) {
+			return nil, gqlutils.NotFoundf(ctx, "electronic signature %q not found", input.SignatureID)
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot accept electronic signature", log.Error(err))
+
 		return nil, gqlutils.Internal(ctx)
 	}
 
@@ -52,14 +61,17 @@ func (r *mutationResolver) AcceptElectronicSignature(ctx context.Context, input 
 // RecordSigningEvent is the resolver for the recordSigningEvent field.
 func (r *mutationResolver) RecordSigningEvent(ctx context.Context, input types.RecordSigningEventInput) (*types.RecordSigningEventPayload, error) {
 	var (
-		identity = authn.IdentityFromContext(ctx)
-		httpReq  = gqlutils.HTTPRequestFromContext(ctx)
+		identity       = authn.IdentityFromContext(ctx)
+		httpReq        = gqlutils.HTTPRequestFromContext(ctx)
+		compliancePage = compliancepage.CompliancePageFromContext(ctx)
+		scope          = coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	)
 
 	actorIP := clientip.Extract(httpReq)
 
 	if err := r.esign.RecordEvent(
 		ctx,
+		scope,
 		&esign.RecordEventRequest{
 			SignatureID: input.SignatureID,
 			EventType:   input.EventType,
@@ -69,7 +81,12 @@ func (r *mutationResolver) RecordSigningEvent(ctx context.Context, input types.R
 			ActorUA:     httpReq.UserAgent(),
 		},
 	); err != nil {
+		if errors.Is(err, esign.ErrElectronicSignatureNotFound) {
+			return nil, gqlutils.NotFoundf(ctx, "electronic signature %q not found", input.SignatureID)
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot record signing event", log.Error(err))
+
 		return nil, gqlutils.Internal(ctx)
 	}
 
@@ -78,13 +95,13 @@ func (r *mutationResolver) RecordSigningEvent(ctx context.Context, input types.R
 
 // FileURL is the resolver for the fileUrl field.
 func (r *nonDisclosureAgreementResolver) FileURL(ctx context.Context, obj *types.NonDisclosureAgreement) (string, error) {
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
 
 	if identity := authn.IdentityFromContext(ctx); identity != nil && r.esign != nil {
-		scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+		scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 		trustService := r.trust
 
-		access, err := trustService.TrustCenterAccesses.GetAccess(ctx, scope, trustCenter.ID, identity.ID)
+		access, err := trustService.TrustCenterAccesses.GetAccess(ctx, scope, compliancePage.ID, identity.ID)
 		if err == nil && access.ElectronicSignatureID != nil {
 			fileURL, err := r.esign.GenerateSignatureFileURL(ctx, *access.ElectronicSignatureID, 15*time.Minute)
 			if err == nil {
@@ -95,10 +112,10 @@ func (r *nonDisclosureAgreementResolver) FileURL(ctx context.Context, obj *types
 		}
 	}
 
-	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
-	fileURL, err := trustService.TrustCenters.GenerateNDAFileURL(ctx, scope, trustCenter.ID, 15*time.Minute)
+	fileURL, err := trustService.TrustCenters.GenerateNDAFileURL(ctx, scope, compliancePage.ID, 15*time.Minute)
 	if err != nil {
 		return "", gqlutils.Internal(ctx)
 	}
@@ -113,11 +130,11 @@ func (r *nonDisclosureAgreementResolver) ViewerSignature(ctx context.Context, ob
 		return nil, nil
 	}
 
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
-	access, err := trustService.TrustCenterAccesses.GetAccess(ctx, scope, trustCenter.ID, identity.ID)
+	access, err := trustService.TrustCenterAccesses.GetAccess(ctx, scope, compliancePage.ID, identity.ID)
 	if err != nil {
 		return nil, nil
 	}
@@ -126,7 +143,7 @@ func (r *nonDisclosureAgreementResolver) ViewerSignature(ctx context.Context, ob
 		return nil, nil
 	}
 
-	sig, err := r.esign.GetSignatureByID(ctx, *access.ElectronicSignatureID)
+	sig, err := r.esign.GetSignatureByID(ctx, scope, *access.ElectronicSignatureID)
 	if err != nil {
 		return nil, nil
 	}

--- a/pkg/server/api/trust/v1/organization_resolvers.go
+++ b/pkg/server/api/trust/v1/organization_resolvers.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/server/api/compliancepage"
 	"go.probo.inc/probo/pkg/server/api/trust/v1/schema"
 	"go.probo.inc/probo/pkg/server/api/trust/v1/types"
 	"go.probo.inc/probo/pkg/server/gqlutils"
@@ -16,7 +17,8 @@ import (
 
 // Logo is the resolver for the logo field.
 func (r *organizationResolver) Logo(ctx context.Context, obj *types.Organization) (*types.File, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 
 	organization, err := r.trust.Organizations.Get(ctx, scope, obj.ID)
 	if err != nil {

--- a/pkg/server/api/trust/v1/resource_alias_resolvers.go
+++ b/pkg/server/api/trust/v1/resource_alias_resolvers.go
@@ -28,8 +28,8 @@ func (r *Resolver) ResourceAliasResolver(
 	ctx context.Context,
 	storageResourceID gid.GID,
 ) (*string, error) {
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 
 	alias, err := r.resourceAlias.GetByResourceID(ctx, scope, storageResourceID)
 	if err != nil {

--- a/pkg/server/api/trust/v1/trust_center_resolvers.go
+++ b/pkg/server/api/trust/v1/trust_center_resolvers.go
@@ -25,7 +25,8 @@ import (
 
 // Framework is the resolver for the framework field.
 func (r *auditResolver) Framework(ctx context.Context, obj *types.Audit) (*types.Framework, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
 	audit, err := trustService.Audits.Get(ctx, scope, obj.ID)
@@ -45,7 +46,8 @@ func (r *auditResolver) Framework(ctx context.Context, obj *types.Audit) (*types
 
 // ReportFile is the resolver for the reportFile field.
 func (r *auditResolver) ReportFile(ctx context.Context, obj *types.Audit) (*types.AuditReport, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
 	audit, err := trustService.Audits.Get(ctx, scope, obj.ID)
@@ -58,9 +60,7 @@ func (r *auditResolver) ReportFile(ctx context.Context, obj *types.Audit) (*type
 		return nil, nil
 	}
 
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-
-	file, err := trustService.Reports.Get(ctx, scope, trustCenter.OrganizationID, *audit.ReportFileID)
+	file, err := trustService.Reports.Get(ctx, scope, compliancePage.OrganizationID, *audit.ReportFileID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load report file", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -76,9 +76,9 @@ func (r *auditReportResolver) Alias(ctx context.Context, obj *types.AuditReport)
 
 // IsUserAuthorized is the resolver for the isUserAuthorized field.
 func (r *auditReportResolver) IsUserAuthorized(ctx context.Context, obj *types.AuditReport) (bool, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
 	audit, err := trustService.Audits.GetByReportFileID(ctx, scope, obj.ID)
 	if err != nil {
@@ -101,7 +101,7 @@ func (r *auditReportResolver) IsUserAuthorized(ctx context.Context, obj *types.A
 	}
 
 	reportAccess, err := trustService.TrustCenterAccesses.GetReportFileAccess(ctx, scope,
-		trustCenter.ID,
+		compliancePage.ID,
 		identity.ID,
 		obj.ID,
 	)
@@ -123,9 +123,9 @@ func (r *auditReportResolver) IsUserAuthorized(ctx context.Context, obj *types.A
 
 // Access is the resolver for the access field.
 func (r *auditReportResolver) Access(ctx context.Context, obj *types.AuditReport) (*types.DocumentAccess, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
 	identity := authn.IdentityFromContext(ctx)
 	if identity == nil {
@@ -134,7 +134,7 @@ func (r *auditReportResolver) Access(ctx context.Context, obj *types.AuditReport
 
 	access, err := trustService.TrustCenterAccesses.GetReportFileAccess(
 		ctx, scope,
-		trustCenter.ID,
+		compliancePage.ID,
 		identity.ID,
 		obj.ID,
 	)
@@ -162,7 +162,8 @@ func (r *auditReportResolver) Access(ctx context.Context, obj *types.AuditReport
 
 // Framework is the resolver for the framework field on ComplianceFramework.
 func (r *complianceFrameworkResolver) Framework(ctx context.Context, obj *types.ComplianceFramework) (*types.Framework, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
 	framework, err := trustService.Frameworks.Get(ctx, scope, obj.FrameworkID)
@@ -181,11 +182,11 @@ func (r *documentResolver) Alias(ctx context.Context, obj *types.Document) (*str
 
 // IsUserAuthorized is the resolver for the isUserAuthorized field.
 func (r *documentResolver) IsUserAuthorized(ctx context.Context, obj *types.Document) (bool, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-	document, err := trustService.Documents.Get(ctx, scope, trustCenter.OrganizationID, obj.ID)
+	document, err := trustService.Documents.Get(ctx, scope, compliancePage.OrganizationID, obj.ID)
 	if err != nil {
 		if errors.Is(err, trust.ErrDocumentNotFound) || errors.Is(err, trust.ErrDocumentNotVisible) || errors.Is(err, coredata.ErrResourceNotFound) {
 			return false, gqlutils.NotFoundf(ctx, "document %q not found", obj.ID)
@@ -211,7 +212,7 @@ func (r *documentResolver) IsUserAuthorized(ctx context.Context, obj *types.Docu
 
 	documentAccess, err := trustService.TrustCenterAccesses.GetDocumentAccess(
 		ctx, scope,
-		trustCenter.ID,
+		compliancePage.ID,
 		identity.ID,
 		obj.ID,
 	)
@@ -233,9 +234,9 @@ func (r *documentResolver) IsUserAuthorized(ctx context.Context, obj *types.Docu
 
 // Access is the resolver for the access field.
 func (r *documentResolver) Access(ctx context.Context, obj *types.Document) (*types.DocumentAccess, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
 	identity := authn.IdentityFromContext(ctx)
 	if identity == nil {
@@ -244,7 +245,7 @@ func (r *documentResolver) Access(ctx context.Context, obj *types.Document) (*ty
 
 	access, err := trustService.TrustCenterAccesses.GetDocumentAccess(
 		ctx, scope,
-		trustCenter.ID,
+		compliancePage.ID,
 		identity.ID,
 		obj.ID,
 	)
@@ -272,7 +273,8 @@ func (r *documentResolver) Access(ctx context.Context, obj *types.Document) (*ty
 
 // LightLogo is the resolver for the lightLogo field.
 func (r *frameworkResolver) LightLogo(ctx context.Context, obj *types.Framework) (*types.File, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 
 	framework, err := r.trust.Frameworks.Get(ctx, scope, obj.ID)
 	if err != nil {
@@ -288,7 +290,8 @@ func (r *frameworkResolver) LightLogo(ctx context.Context, obj *types.Framework)
 
 // DarkLogo is the resolver for the darkLogo field.
 func (r *frameworkResolver) DarkLogo(ctx context.Context, obj *types.Framework) (*types.File, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 
 	framework, err := r.trust.Frameworks.Get(ctx, scope, obj.ID)
 	if err != nil {
@@ -304,8 +307,8 @@ func (r *frameworkResolver) DarkLogo(ctx context.Context, obj *types.Framework) 
 
 // RequestAllAccesses is the resolver for the requestAllAccesses field.
 func (r *mutationResolver) RequestAllAccesses(ctx context.Context) (*types.RequestAccessesPayload, error) {
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
 	identity := authn.IdentityFromContext(ctx)
@@ -316,7 +319,7 @@ func (r *mutationResolver) RequestAllAccesses(ctx context.Context) (*types.Reque
 	access, err := trustService.TrustCenterAccesses.Request(
 		ctx, scope,
 		&trust.TrustCenterAccessRequest{
-			TrustCenterID: trustCenter.ID,
+			TrustCenterID: compliancePage.ID,
 			IdentityID:    identity.ID,
 			DocumentIDs:   nil,
 			ReportIDs:     nil,
@@ -338,11 +341,11 @@ func (r *mutationResolver) RequestAllAccesses(ctx context.Context) (*types.Reque
 
 // ExportDocumentPDF is the resolver for the exportDocumentPDF field.
 func (r *mutationResolver) ExportDocumentPDF(ctx context.Context, input types.ExportDocumentPDFInput) (*types.ExportDocumentPDFPayload, error) {
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-	document, err := trustService.Documents.Get(ctx, scope, trustCenter.OrganizationID, input.DocumentID)
+	document, err := trustService.Documents.Get(ctx, scope, compliancePage.OrganizationID, input.DocumentID)
 	if err != nil {
 		if errors.Is(err, trust.ErrDocumentNotFound) || errors.Is(err, trust.ErrDocumentNotVisible) || errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFoundf(ctx, "document %q not found", input.DocumentID)
@@ -376,7 +379,7 @@ func (r *mutationResolver) ExportDocumentPDF(ctx context.Context, input types.Ex
 
 	documentAccess, err := trustService.TrustCenterAccesses.GetDocumentAccess(
 		ctx, scope,
-		trustCenter.ID,
+		compliancePage.ID,
 		identity.ID,
 		input.DocumentID,
 	)
@@ -401,13 +404,18 @@ func (r *mutationResolver) ExportDocumentPDF(ctx context.Context, input types.Ex
 
 // ExportReportPDF is the resolver for the exportReportPDF field.
 func (r *mutationResolver) ExportReportPDF(ctx context.Context, input types.ExportReportPDFInput) (*types.ExportReportPDFPayload, error) {
-	scope := coredata.NewScopeFromObjectID(input.ReportID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
 	audit, err := trustService.Audits.GetByReportFileID(ctx, scope, input.ReportID)
 	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return nil, gqlutils.NotFoundf(ctx, "report %q not found", input.ReportID)
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot load audit", log.Error(err))
+
 		return nil, gqlutils.Internal(ctx)
 	}
 
@@ -430,7 +438,7 @@ func (r *mutationResolver) ExportReportPDF(ctx context.Context, input types.Expo
 
 	reportAccess, err := trustService.TrustCenterAccesses.GetReportFileAccess(
 		ctx, scope,
-		trustCenter.ID,
+		compliancePage.ID,
 		identity.ID,
 		input.ReportID,
 	)
@@ -455,11 +463,11 @@ func (r *mutationResolver) ExportReportPDF(ctx context.Context, input types.Expo
 
 // ExportTrustCenterFile is the resolver for the exportTrustCenterFile field.
 func (r *mutationResolver) ExportTrustCenterFile(ctx context.Context, input types.ExportTrustCenterFileInput) (*types.ExportTrustCenterFilePayload, error) {
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
-	trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, scope, trustCenter.OrganizationID, input.TrustCenterFileID)
+	trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, scope, compliancePage.OrganizationID, input.TrustCenterFileID)
 	if err != nil {
 		if errors.Is(err, trust.ErrTrustCenterFileNotFound) || errors.Is(err, trust.ErrTrustCenterFileNotVisible) {
 			return nil, gqlutils.NotFoundf(ctx, "trust center file %q not found", input.TrustCenterFileID)
@@ -488,7 +496,7 @@ func (r *mutationResolver) ExportTrustCenterFile(ctx context.Context, input type
 	}
 
 	fileAccess, err := trustService.TrustCenterAccesses.GetTrustCenterFileAccess(ctx, scope,
-		trustCenter.ID,
+		compliancePage.ID,
 		identity.ID,
 		input.TrustCenterFileID,
 	)
@@ -513,11 +521,11 @@ func (r *mutationResolver) ExportTrustCenterFile(ctx context.Context, input type
 
 // RequestDocumentAccess is the resolver for the requestDocumentAccess field.
 func (r *mutationResolver) RequestDocumentAccess(ctx context.Context, input types.RequestDocumentAccessInput) (*types.RequestDocumentAccessPayload, error) {
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
-	document, err := trustService.Documents.Get(ctx, scope, trustCenter.OrganizationID, input.DocumentID)
+	document, err := trustService.Documents.Get(ctx, scope, compliancePage.OrganizationID, input.DocumentID)
 	if err != nil {
 		if errors.Is(err, trust.ErrDocumentNotFound) || errors.Is(err, trust.ErrDocumentNotVisible) || errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFoundf(ctx, "document %q not found", input.DocumentID)
@@ -547,7 +555,7 @@ func (r *mutationResolver) RequestDocumentAccess(ctx context.Context, input type
 	if _, err := trustService.TrustCenterAccesses.Request(
 		ctx, scope,
 		&trust.TrustCenterAccessRequest{
-			TrustCenterID:      trustCenter.ID,
+			TrustCenterID:      compliancePage.ID,
 			IdentityID:         identity.ID,
 			DocumentIDs:        []gid.GID{input.DocumentID},
 			ReportIDs:          []gid.GID{},
@@ -565,8 +573,8 @@ func (r *mutationResolver) RequestDocumentAccess(ctx context.Context, input type
 
 // RequestReportAccess is the resolver for the requestReportAccess field.
 func (r *mutationResolver) RequestReportAccess(ctx context.Context, input types.RequestReportAccessInput) (*types.RequestReportAccessPayload, error) {
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
 	audit, err := trustService.Audits.GetByReportFileID(ctx, scope, input.ReportID)
@@ -590,7 +598,7 @@ func (r *mutationResolver) RequestReportAccess(ctx context.Context, input types.
 	if _, err := trustService.TrustCenterAccesses.Request(
 		ctx, scope,
 		&trust.TrustCenterAccessRequest{
-			TrustCenterID:      trustCenter.ID,
+			TrustCenterID:      compliancePage.ID,
 			IdentityID:         identity.ID,
 			DocumentIDs:        []gid.GID{},
 			ReportIDs:          []gid.GID{input.ReportID},
@@ -608,11 +616,11 @@ func (r *mutationResolver) RequestReportAccess(ctx context.Context, input types.
 
 // RequestTrustCenterFileAccess is the resolver for the requestTrustCenterFileAccess field.
 func (r *mutationResolver) RequestTrustCenterFileAccess(ctx context.Context, input types.RequestTrustCenterFileAccessInput) (*types.RequestFileAccessPayload, error) {
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
-	trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, scope, trustCenter.OrganizationID, input.TrustCenterFileID)
+	trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, scope, compliancePage.OrganizationID, input.TrustCenterFileID)
 	if err != nil {
 		if errors.Is(err, trust.ErrTrustCenterFileNotFound) || errors.Is(err, trust.ErrTrustCenterFileNotVisible) {
 			return nil, gqlutils.NotFoundf(ctx, "trust center file %q not found", input.TrustCenterFileID)
@@ -638,7 +646,7 @@ func (r *mutationResolver) RequestTrustCenterFileAccess(ctx context.Context, inp
 	if _, err := trustService.TrustCenterAccesses.Request(
 		ctx, scope,
 		&trust.TrustCenterAccessRequest{
-			TrustCenterID:      trustCenter.ID,
+			TrustCenterID:      compliancePage.ID,
 			IdentityID:         identity.ID,
 			DocumentIDs:        []gid.GID{},
 			ReportIDs:          []gid.GID{},
@@ -656,7 +664,8 @@ func (r *mutationResolver) RequestTrustCenterFileAccess(ctx context.Context, inp
 
 // TotalCount is the resolver for the totalCount field.
 func (r *subprocessorConnectionResolver) TotalCount(ctx context.Context, obj *types.SubprocessorConnection) (int, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
 	switch obj.Resolver.(type) {
@@ -677,32 +686,32 @@ func (r *subprocessorConnectionResolver) TotalCount(ctx context.Context, obj *ty
 
 // Logo is the resolver for the logo field.
 func (r *trustCenterResolver) Logo(ctx context.Context, obj *types.TrustCenter) (*types.File, error) {
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	if trustCenter.LogoFileID == nil {
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	if compliancePage.LogoFileID == nil {
 		return nil, nil
 	}
 
-	return r.loadPublicFile(ctx, *trustCenter.LogoFileID)
+	return r.loadPublicFile(ctx, *compliancePage.LogoFileID)
 }
 
 // DarkLogo is the resolver for the darkLogo field.
 func (r *trustCenterResolver) DarkLogo(ctx context.Context, obj *types.TrustCenter) (*types.File, error) {
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	if trustCenter.DarkLogoFileID == nil {
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	if compliancePage.DarkLogoFileID == nil {
 		return nil, nil
 	}
 
-	return r.loadPublicFile(ctx, *trustCenter.DarkLogoFileID)
+	return r.loadPublicFile(ctx, *compliancePage.DarkLogoFileID)
 }
 
 // NonDisclosureAgreement is the resolver for the nonDisclosureAgreement field.
 func (r *trustCenterResolver) NonDisclosureAgreement(ctx context.Context, obj *types.TrustCenter) (*types.NonDisclosureAgreement, error) {
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	if trustCenter.NonDisclosureAgreementFileID == nil {
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	if compliancePage.NonDisclosureAgreementFileID == nil {
 		return nil, nil
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
 	file, err := trustService.TrustCenters.GetNDAFile(ctx, scope, obj.ID)
@@ -720,8 +729,8 @@ func (r *trustCenterResolver) NonDisclosureAgreement(ctx context.Context, obj *t
 
 // ViewerSubscription is the resolver for the viewerSubscription field.
 func (r *trustCenterResolver) ViewerSubscription(ctx context.Context, obj *types.TrustCenter) (*types.MailingListSubscriber, error) {
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	if trustCenter.MailingListID == nil {
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	if compliancePage.MailingListID == nil {
 		return nil, nil
 	}
 
@@ -730,7 +739,7 @@ func (r *trustCenterResolver) ViewerSubscription(ctx context.Context, obj *types
 		return nil, nil
 	}
 
-	subscriber, err := r.mailman.GetSubscriber(ctx, *trustCenter.MailingListID, identity.EmailAddress)
+	subscriber, err := r.mailman.GetSubscriber(ctx, *compliancePage.MailingListID, identity.EmailAddress)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get mailing list subscription", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -750,7 +759,8 @@ func (r *trustCenterResolver) Organization(ctx context.Context, obj *types.Trust
 
 // Documents is the resolver for the documents field.
 func (r *trustCenterResolver) Documents(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.DocumentConnection, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldTitle,
@@ -769,7 +779,8 @@ func (r *trustCenterResolver) Documents(ctx context.Context, obj *types.TrustCen
 
 // Audits is the resolver for the audits field.
 func (r *trustCenterResolver) Audits(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.AuditConnection, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldValidFrom,
@@ -788,7 +799,8 @@ func (r *trustCenterResolver) Audits(ctx context.Context, obj *types.TrustCenter
 
 // Subprocessors is the resolver for the subprocessors field.
 func (r *trustCenterResolver) Subprocessors(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.SubprocessorConnection, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
 		Field:     coredata.ThirdPartyOrderFieldName,
@@ -807,7 +819,8 @@ func (r *trustCenterResolver) Subprocessors(ctx context.Context, obj *types.Trus
 
 // References is the resolver for the references field.
 func (r *trustCenterResolver) References(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.TrustCenterReferenceConnection, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.TrustCenterReferenceOrderField]{
 		Field:     coredata.TrustCenterReferenceOrderFieldRank,
@@ -826,7 +839,8 @@ func (r *trustCenterResolver) References(ctx context.Context, obj *types.TrustCe
 
 // TrustCenterFiles is the resolver for the trustCenterFiles field.
 func (r *trustCenterResolver) TrustCenterFiles(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.TrustCenterFileConnection, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.TrustCenterFileOrderField]{
 		Field:     coredata.TrustCenterFileOrderFieldName,
@@ -852,7 +866,8 @@ func (r *trustCenterResolver) TrustCenterFiles(ctx context.Context, obj *types.T
 
 // ComplianceFrameworks is the resolver for the complianceFrameworks field.
 func (r *trustCenterResolver) ComplianceFrameworks(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.ComplianceFrameworkConnection, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.ComplianceFrameworkOrderField]{
 		Field:     coredata.ComplianceFrameworkOrderFieldRank,
@@ -871,7 +886,8 @@ func (r *trustCenterResolver) ComplianceFrameworks(ctx context.Context, obj *typ
 
 // ExternalUrls is the resolver for the externalUrls field.
 func (r *trustCenterResolver) ExternalUrls(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.ComplianceExternalURLConnection, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.ComplianceExternalURLOrderField]{
 		Field:     coredata.ComplianceExternalURLOrderFieldRank,
@@ -890,7 +906,8 @@ func (r *trustCenterResolver) ExternalUrls(ctx context.Context, obj *types.Trust
 
 // Updates is the resolver for the updates field.
 func (r *trustCenterResolver) Updates(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.MailingListUpdateConnection, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
 
 	tc, err := trustService.TrustCenters.Get(ctx, scope, obj.ID)
@@ -925,11 +942,11 @@ func (r *trustCenterFileResolver) Alias(ctx context.Context, obj *types.TrustCen
 
 // IsUserAuthorized is the resolver for the isUserAuthorized field.
 func (r *trustCenterFileResolver) IsUserAuthorized(ctx context.Context, obj *types.TrustCenterFile) (bool, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-	trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, scope, trustCenter.OrganizationID, obj.ID)
+	trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, scope, compliancePage.OrganizationID, obj.ID)
 	if err != nil {
 		if errors.Is(err, trust.ErrTrustCenterFileNotFound) || errors.Is(err, trust.ErrTrustCenterFileNotVisible) {
 			return false, gqlutils.NotFoundf(ctx, "trust center file %q not found", obj.ID)
@@ -950,7 +967,7 @@ func (r *trustCenterFileResolver) IsUserAuthorized(ctx context.Context, obj *typ
 	}
 
 	fileAccess, err := trustService.TrustCenterAccesses.GetTrustCenterFileAccess(ctx, scope,
-		trustCenter.ID,
+		compliancePage.ID,
 		identity.ID,
 		obj.ID,
 	)
@@ -972,9 +989,9 @@ func (r *trustCenterFileResolver) IsUserAuthorized(ctx context.Context, obj *typ
 
 // Access is the resolver for the access field.
 func (r *trustCenterFileResolver) Access(ctx context.Context, obj *types.TrustCenterFile) (*types.DocumentAccess, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
-	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
 	identity := authn.IdentityFromContext(ctx)
 	if identity == nil {
@@ -983,7 +1000,7 @@ func (r *trustCenterFileResolver) Access(ctx context.Context, obj *types.TrustCe
 
 	access, err := trustService.TrustCenterAccesses.GetTrustCenterFileAccess(
 		ctx, scope,
-		trustCenter.ID,
+		compliancePage.ID,
 		identity.ID,
 		obj.ID,
 	)
@@ -1011,7 +1028,8 @@ func (r *trustCenterFileResolver) Access(ctx context.Context, obj *types.TrustCe
 
 // Logo is the resolver for the logo field.
 func (r *trustCenterReferenceResolver) Logo(ctx context.Context, obj *types.TrustCenterReference) (*types.File, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 
 	reference, err := r.trust.TrustCenterReferences.Get(ctx, scope, obj.ID)
 	if err != nil {


### PR DESCRIPTION
The public trust API derived its authorization scope from client-supplied
global IDs, so a visitor on one trust center could resolve nodes, export
audit-report PDFs, and read or mutate electronic signatures belonging to
another organization API.

Every trust API resolver now derives its scope from the active compliance
page's organization via compliancepage.ScopeFromContext, so reads are always
confined to the page's tenant. Cross-tenant or unknown IDs surface as
not-found instead of leaking data or returning a 500. Active/presence is
enforced upstream by the id and presence middlewares.

esign's signature operations (GetSignatureByID, AcceptSignature, RecordEvent)
now take a caller-provided scope instead of deriving one from the requested
ID, so signature reads and mutations are tenant-scoped at the source. This
removes the need for a resolver-level authorization helper; RecordEvent also
verifies signature ownership within scope before recording, since the event
foreign key is not tenant-composite.

Adds e2e non-regression tests covering owning vs. foreign trust center report
export and the generic node(id:) resolver.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the public trust center GraphQL reads, exports, and NDA e‑signature flows to the active trust page’s organization so all access is tenant‑scoped. Cross‑tenant IDs now return NotFound; report exports and signatures are only accessible through the owning org.

### GraphQL API **`+196`** **`-109`**
- Derive scope from the compliance page’s organization across resolvers (node, aliasedNode, CurrentTrustCenter, lists, exports, NDA; console access resolver too).
- Node: treat cross‑tenant/missing IDs as NotFound; enforce visibility for audits (via report→audit), report files, documents, and subprocessors; limit alias lookups to the tenant.
- NDA: `AcceptElectronicSignature` and `RecordSigningEvent` now use scoped operations and map missing signatures to NotFound; directive/resolvers call scoped `esign.GetSignatureByID`.

### Service **`+22`** **`-14`**
- Require caller scope for `GetSignatureByID`, `AcceptSignature`, and `RecordEvent`; `RecordEvent` verifies signature ownership in scope.
- Return `ErrElectronicSignatureNotFound` for missing or cross‑tenant signatures.

### Tests **`+234`** **`-0`**
- e2e: same‑org report export succeeds; cross‑tenant export is NotFound.
- e2e: node(id:) resolves own nodes; cross‑tenant node lookup is NotFound.

<sup>Written for commit 180a6a04200dc8855ddc529c27f1593183899713. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->







