### PR TITLE
Exclude unpublished docs from available accesses

### DIFF
--- a/pkg/coredata/trust_center_document_access.go
+++ b/pkg/coredata/trust_center_document_access.go
@@ -504,6 +504,7 @@ all_items AS (
     WHERE d.organization_id = o.organization_id
         AND d.deleted_at IS NULL
         AND d.trust_center_visibility = 'PRIVATE'::trust_center_visibility
+        AND d.current_published_major IS NOT NULL
 
     UNION ALL
 


### PR DESCRIPTION
The available document access list backing Grant All included documents whose trust center visibility is PRIVATE but that have no published version. Require a published major so the grantable set matches the request-all filter and the Slack notification, which already skip drafts and hidden documents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude unpublished PRIVATE documents from the available access list used by Grant All. This ensures only documents with a published major are grantable, matching the request-all filter and Slack notifications.

### Coredata **`+1`** **`-0`**
- Added `d.current_published_major IS NOT NULL` to the PRIVATE-doc query so drafts/hidden docs are not listed for bulk granting.

<sup>Written for commit bbb3a24286d99be8e1d9091c0e9705e50345c4c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

