### PR TITLE
Prevent removing the last active owner

### DIFF
--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -293,6 +293,29 @@ func TestUser_UpdateMembershipRejectsLastOwnerDemotion(t *testing.T) {
 	assert.Equal(t, "OWNER", membershipResult.Node.Role)
 }
 
+func TestUser_DeactivateUserRejectsLastOwner(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	err := owner.ExecuteConnect(`
+		mutation($input: DeactivateUserInput!) {
+			deactivateUser(input: $input) {
+				success
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"profileId":      owner.GetProfileID().String(),
+		},
+	}, nil)
+	testutil.RequireErrorCode(t, err, "CONFLICT")
+
+	var gqlErrors testutil.GraphQLErrors
+	require.ErrorAs(t, err, &gqlErrors)
+	assert.Equal(t, "cannot deactivate last active owner", gqlErrors[0].Message)
+}
+
 func TestUser_RemoveUser(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)

--- a/pkg/coredata/organization.go
+++ b/pkg/coredata/organization.go
@@ -150,6 +150,59 @@ LIMIT 1;
 	return nil
 }
 
+func (o *Organization) LockByID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+SELECT
+    tenant_id,
+    id,
+    name,
+    logo_file_id,
+    horizontal_logo_file_id,
+    description,
+    website_url,
+    email,
+    headquarter_address,
+    custom_domain_id,
+    created_at,
+    updated_at
+FROM
+    organizations
+WHERE
+    %s
+    AND id = @organization_id
+LIMIT 1
+FOR UPDATE;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query organizations: %w", err)
+	}
+
+	organization, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[Organization])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect organization: %w", err)
+	}
+
+	*o = organization
+
+	return nil
+}
+
 func (o *Organizations) LoadByIDs(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -244,6 +244,36 @@ func NewOrganizationService(svc *Service) *OrganizationService {
 	return &OrganizationService{Service: svc}
 }
 
+func (s *OrganizationService) ensureActiveOwnerCanBeRemoved(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	organizationID gid.GID,
+	resourceID gid.GID,
+) error {
+	organization := coredata.Organization{}
+	if err := organization.LockByID(ctx, tx, scope, organizationID); err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return NewOrganizationNotFoundError(organizationID)
+		}
+
+		return fmt.Errorf("cannot lock organization: %w", err)
+	}
+
+	profiles := coredata.MembershipProfiles{}
+
+	count, err := profiles.CountActiveOwnerByOrganizationID(ctx, tx, scope, organizationID)
+	if err != nil {
+		return fmt.Errorf("cannot count active owners: %w", err)
+	}
+
+	if count <= 1 {
+		return NewLastActiveOwnerError(resourceID)
+	}
+
+	return nil
+}
+
 func (s *OrganizationService) UpdateMembership(
 	ctx context.Context,
 	organizationID gid.GID,
@@ -275,15 +305,8 @@ func (s *OrganizationService) UpdateMembership(
 			}
 
 			if membership.Role == coredata.MembershipRoleOwner && role != coredata.MembershipRoleOwner && profile.State == coredata.ProfileStateActive {
-				profiles := coredata.MembershipProfiles{}
-
-				count, err := profiles.CountActiveOwnerByOrganizationID(ctx, tx, scope, organizationID)
-				if err != nil {
-					return fmt.Errorf("cannot count active owners: %w", err)
-				}
-
-				if count <= 1 {
-					return NewLastActiveOwnerError(membershipID)
+				if err := s.ensureActiveOwnerCanBeRemoved(ctx, tx, scope, organizationID, membershipID); err != nil {
+					return err
 				}
 			}
 
@@ -341,15 +364,8 @@ func (s *OrganizationService) RemoveUser(
 			}
 
 			if membership.Role == coredata.MembershipRoleOwner && profile.State == coredata.ProfileStateActive {
-				profiles := coredata.MembershipProfiles{}
-
-				count, err := profiles.CountActiveOwnerByOrganizationID(ctx, tx, scope, profile.OrganizationID)
-				if err != nil {
-					return fmt.Errorf("cannot count active owners: %w", err)
-				}
-
-				if count <= 1 {
-					return NewLastActiveOwnerError(profileID)
+				if err := s.ensureActiveOwnerCanBeRemoved(ctx, tx, scope, profile.OrganizationID, profileID); err != nil {
+					return err
 				}
 			}
 
@@ -397,21 +413,18 @@ func (s *OrganizationService) ArchiveUser(
 				return NewUserManagedBySCIMError(profileID)
 			}
 
+			if profile.OrganizationID != organizationID {
+				return NewProfileNotFoundError(profileID)
+			}
+
 			membership := &coredata.Membership{}
 			if err := membership.LoadByIdentityIDAndOrganizationID(ctx, tx, scope, profile.IdentityID, profile.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load membership: %w", err)
 			}
 
 			if membership.Role == coredata.MembershipRoleOwner && profile.State == coredata.ProfileStateActive {
-				profiles := coredata.MembershipProfiles{}
-
-				count, err := profiles.CountActiveOwnerByOrganizationID(ctx, tx, scope, organizationID)
-				if err != nil {
-					return fmt.Errorf("cannot count active owners: %w", err)
-				}
-
-				if count <= 1 {
-					return NewLastActiveOwnerError(profileID)
+				if err := s.ensureActiveOwnerCanBeRemoved(ctx, tx, scope, profile.OrganizationID, profileID); err != nil {
+					return err
 				}
 			}
 
@@ -1173,6 +1186,19 @@ func (s *OrganizationService) UpdateUserState(
 		func(ctx context.Context, tx pg.Tx) error {
 			if err := profile.LoadByID(ctx, tx, scope, userID); err != nil {
 				return fmt.Errorf("cannot load profile: %w", err)
+			}
+
+			if state == coredata.ProfileStateInactive && profile.State == coredata.ProfileStateActive {
+				membership := &coredata.Membership{}
+				if err := membership.LoadByIdentityIDAndOrganizationID(ctx, tx, scope, profile.IdentityID, profile.OrganizationID); err != nil {
+					return fmt.Errorf("cannot load membership: %w", err)
+				}
+
+				if membership.Role == coredata.MembershipRoleOwner {
+					if err := s.ensureActiveOwnerCanBeRemoved(ctx, tx, scope, profile.OrganizationID, profile.ID); err != nil {
+						return err
+					}
+				}
 			}
 
 			profile.State = state

--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -86,6 +86,41 @@ func (s *Service) Run(ctx context.Context) error {
 	return s.bridgeRunner.Run(ctx)
 }
 
+func ensureActiveOwnerCanBeRemoved(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	organizationID gid.GID,
+	profile *coredata.MembershipProfile,
+	membership *coredata.Membership,
+) error {
+	if membership == nil || membership.Role != coredata.MembershipRoleOwner || profile.State != coredata.ProfileStateActive {
+		return nil
+	}
+
+	organization := coredata.Organization{}
+	if err := organization.LockByID(ctx, tx, scope, organizationID); err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return scimerrors.ScimErrorResourceNotFound(organizationID.String())
+		}
+
+		return fmt.Errorf("cannot lock organization: %w", err)
+	}
+
+	profiles := coredata.MembershipProfiles{}
+
+	count, err := profiles.CountActiveOwnerByOrganizationID(ctx, tx, scope, organizationID)
+	if err != nil {
+		return fmt.Errorf("cannot count active owners: %w", err)
+	}
+
+	if count <= 1 {
+		return scimerrors.ScimErrorBadRequest("cannot remove last active owner")
+	}
+
+	return nil
+}
+
 func HashToken(token string) []byte {
 	return hash.SHA256String(token)
 }
@@ -220,6 +255,19 @@ func (s *Service) CreateUser(
 						oldIdentityID,
 						config.OrganizationID,
 					); err == nil {
+						if !attrs.Active {
+							if err := ensureActiveOwnerCanBeRemoved(
+								ctx,
+								tx,
+								scope,
+								config.OrganizationID,
+								profile,
+								existingMembership,
+							); err != nil {
+								return err
+							}
+						}
+
 						existingMembership.IdentityID = identity.ID
 
 						existingMembership.UpdatedAt = now
@@ -266,6 +314,30 @@ func (s *Service) CreateUser(
 		} else {
 			if profile.Source == coredata.ProfileSourceSCIM {
 				return scimerrors.ScimErrorUniqueness
+			}
+
+			if !attrs.Active && profile.State == coredata.ProfileStateActive {
+				existingMembership := &coredata.Membership{}
+				if err := existingMembership.LoadByIdentityIDAndOrganizationID(
+					ctx,
+					tx,
+					scope,
+					profile.IdentityID,
+					config.OrganizationID,
+				); err != nil {
+					if !errors.Is(err, coredata.ErrResourceNotFound) {
+						return fmt.Errorf("cannot load membership: %w", err)
+					}
+				} else if err := ensureActiveOwnerCanBeRemoved(
+					ctx,
+					tx,
+					scope,
+					config.OrganizationID,
+					profile,
+					existingMembership,
+				); err != nil {
+					return err
+				}
 			}
 
 			if externalIdPtr != nil {
@@ -513,6 +585,19 @@ func (s *Service) updateUser(
 
 			shouldReactivate := attrs.Active != nil && *attrs.Active && profile.State == coredata.ProfileStateInactive
 			shouldDeactivate := attrs.Active != nil && !*attrs.Active && profile.State == coredata.ProfileStateActive
+
+			if shouldDeactivate {
+				if err := ensureActiveOwnerCanBeRemoved(
+					ctx,
+					tx,
+					scope,
+					config.OrganizationID,
+					profile,
+					membership,
+				); err != nil {
+					return err
+				}
+			}
 
 			if attrs.FullName != "" {
 				profile.FullName = attrs.FullName
@@ -867,6 +952,17 @@ func (s *Service) DeleteUser(
 				membership = m
 			}
 
+			if err := ensureActiveOwnerCanBeRemoved(
+				ctx,
+				tx,
+				scope,
+				config.OrganizationID,
+				profile,
+				membership,
+			); err != nil {
+				return err
+			}
+
 			if err := profile.Delete(ctx, tx, scope, profile.ID); err != nil {
 				if errors.Is(err, coredata.ErrResourceInUse) {
 					s.logger.WarnCtx(
@@ -923,6 +1019,17 @@ func (s *Service) deactivateProfileInTx(
 ) error {
 	if profile.State == coredata.ProfileStateInactive {
 		return nil
+	}
+
+	if err := ensureActiveOwnerCanBeRemoved(
+		ctx,
+		tx,
+		scope,
+		config.OrganizationID,
+		profile,
+		membership,
+	); err != nil {
+		return err
 	}
 
 	now := time.Now()

--- a/pkg/server/api/connect/v1/profile_resolvers.go
+++ b/pkg/server/api/connect/v1/profile_resolvers.go
@@ -73,6 +73,10 @@ func (r *mutationResolver) DeactivateUser(ctx context.Context, input types.Deact
 		coredata.ProfileStateInactive,
 	)
 	if err != nil {
+		if _, ok := errors.AsType[*iam.ErrLastActiveOwner](err); ok {
+			return nil, gqlutils.Conflictf(ctx, "cannot deactivate last active owner")
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot deactivate profile", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Lock the organization row before counting active owners so concurrent owner removal paths serialize per organization.
- Reuse the guard for owner demotion, removal, archive, profile deactivation, and SCIM delete/deactivation paths.
- Return a conflict for attempts to deactivate the last active owner and add a console e2e regression test.

## Tests

- `go test ./pkg/coredata ./pkg/iam ./pkg/iam/scim ./pkg/server/api/connect/v1`
- `make test-e2e TEST_FLAGS='-run TestUser_DeactivateUserRejectsLastOwner'` (fails: local Postgres on `localhost:5432` is unavailable for `probod_test`)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-592](https://linear.app/probo/issue/ENG-592/prevent-race-condition-deleting-all-org-owners)

<div><a href="https://cursor.com/agents/bc-0a9a3fe9-7f06-485b-ad03-2b7f902cd7c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a9a3fe9-7f06-485b-ad03-2b7f902cd7c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents removing or deactivating the last active organization owner by locking the org row and enforcing a shared guard across all owner-change paths. Addresses ENG-592 and returns a conflict when attempting to deactivate the last active owner; adds an e2e regression test.

### Coredata **`+53`** **`-0`**
- Added `LockByID` to lock the organization row (FOR UPDATE) so owner-related changes serialize per org.

### Service **`+160`** **`-27`**
- Added `ensureActiveOwnerCanBeRemoved` and used it for demotion, removal, archive, and deactivation flows.
- Applied the same guard in SCIM create/update/delete/deactivate paths to block removing the last active owner.

### GraphQL API **`+4`** **`-0`**
- Map last-active-owner errors to a GraphQL CONFLICT with message "cannot deactivate last active owner".

### Tests **`+23`** **`-0`**
- Added console e2e test to reject deactivating the last active owner.

<sup>Written for commit d788403e1f70226be33f7e956dea91dbfbdf88ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

