### PR TITLE
Compliance portal sub processors

### DIFF
--- a/.cursor/rules/list-filtering.mdc
+++ b/.cursor/rules/list-filtering.mdc
@@ -1,0 +1,117 @@
+---
+description: Structure list filtering — a pure URL-state hook, a single-owner debounced search input, and refetch inside a transition (no whole-page Suspense fallback)
+globs: "**/*.{ts,tsx}"
+alwaysApply: false
+---
+
+# List filtering (URL state, debounced search, transition refetch)
+
+Filterable lists (a toolbar of selects + a search field driving a server-side
+query) have three recurring traps. Follow all three rules.
+
+## 1. The URL-filter hook is pure — no local state, no effects
+
+Filter values (category, status, sort, search term) live in the URL
+(`useSearchParams`). The hook that exposes them must be **pure**: read the
+params, return values + setters, and nothing else. No `useState`, no
+`useEffect`. A pure hook can be called by any number of components (page,
+loader, toolbar, empty state) that all read the same source of truth.
+
+The moment a URL-filter hook holds its own `useState` mirror **and** an effect
+that writes that mirror back to the URL, every component that calls the hook
+runs its own copy of that effect. Only one of them updates the mirror (the
+input), so the others keep a **stale** mirror and fight the real writer —
+producing an infinite loop that flips the list between filtered and unfiltered.
+
+```ts
+// BAD — hook owns a mirror + write-back effect; N callers = N fighting writers
+export function useListFilters() {
+  const [params, setParams] = useSearchParams();
+  const query = params.get("q") ?? "";
+  const [input, setInput] = useState(query);           // per-instance state
+  useEffect(() => {                                     // per-instance effect
+    if (input !== query) setParams(/* write q=input */, { replace: true });
+  }, [input, query, setParams]);
+  return { query, input, setInput /* … */ };
+}
+```
+
+```ts
+// GOOD — pure URL state; safe to call from many components
+export function useListFilters() {
+  const [params, setParams] = useSearchParams();
+  const setParam = useCallback((k: string, v: string) => {
+    setParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (v) next.set(k, v); else next.delete(k);
+      return next;
+    }, { replace: true });
+  }, [setParams]);
+  return {
+    query: params.get("q") ?? "",
+    category: params.get("category") ?? "",
+    setQuery: (v: string) => setParam("q", v),
+    setCategory: (v: string) => setParam("category", v),
+    clear: () => setParams({}, { replace: true }),
+  };
+}
+```
+
+## 2. The debounced search input is a single-owner hook
+
+The one piece of local state a filter needs is the free-text search box (typed
+immediately, committed to the URL after a debounce). Put it in a **separate**
+hook mounted in **exactly one** component (the toolbar) — it is the single
+writer of the `q` param. Guard the URL→input sync with a ref so the hook's own
+debounced writes are not echoed back onto the input (which would drop in-flight
+keystrokes); only *external* changes (a Clear button, back/forward) sync.
+
+```ts
+// GOOD — single-owner debounced input; ref distinguishes own writes from external
+export function useListSearch(): [string, (v: string) => void] {
+  const { query, setQuery } = useListFilters();
+  const [input, setInput] = useState(query);
+  const lastCommitted = useRef(query);
+
+  useEffect(() => {                          // debounce: input → URL
+    if (input === query) return;
+    const h = setTimeout(() => { lastCommitted.current = input; setQuery(input); }, 300);
+    return () => clearTimeout(h);
+  }, [input, query, setQuery]);
+
+  useEffect(() => {                          // sync URL → input for EXTERNAL changes only
+    if (query !== lastCommitted.current) { lastCommitted.current = query; setInput(query); }
+  }, [query]);
+
+  return [input, setInput];
+}
+```
+
+## 3. Refetch inside a transition — scope the loading state
+
+When a filter changes, refetch inside `startTransition` (React `useTransition`).
+Relay's `refetch` (and `loadQuery`/`usePaginationFragment`) suspends, and the
+nearest boundary is usually the **route-level `Suspense`** whose fallback is the
+whole-page skeleton — so without a transition the toolbar and results blank out
+on every keystroke. A transition keeps the current UI mounted and exposes
+`isPending`; dim only the results container (or show a scoped inline spinner),
+never the whole tree.
+
+```tsx
+// BAD — refetch suspends to the route skeleton; toolbar + results flash on every change
+useEffect(() => { refetch(vars); }, [refetch, vars]);
+```
+
+```tsx
+// GOOD — transition keeps the toolbar/results mounted; only the results dim
+const [isPending, startTransition] = useTransition();
+useEffect(() => {
+  startTransition(() => refetch(vars, { fetchPolicy: "store-or-network" }));
+}, [refetch, vars]);
+
+// results container only:
+<div aria-busy={isPending} className={`… transition-opacity ${isPending ? "opacity-60" : ""}`}>
+```
+
+See [`contrib/claude/state-management.md`](../../contrib/claude/state-management.md#filtering-a-list)
+and [`contrib/claude/relay.md`](../../contrib/claude/relay.md#refetch-inside-a-transition).

--- a/apps/compliance-portal/src/_locales/en-US.json
+++ b/apps/compliance-portal/src/_locales/en-US.json
@@ -27,9 +27,6 @@
   "documents": {
     "title": "Documents"
   },
-  "subprocessors": {
-    "title": "Subprocessors"
-  },
   "updates": {
     "title": "Updates",
     "subscribe": "Subscribe to updates"

--- a/apps/compliance-portal/src/_locales/fr-FR.json
+++ b/apps/compliance-portal/src/_locales/fr-FR.json
@@ -27,9 +27,6 @@
   "documents": {
     "title": "Documents"
   },
-  "subprocessors": {
-    "title": "Sous-traitants"
-  },
   "updates": {
     "title": "Mises à jour",
     "subscribe": "S'abonner aux mises à jour"

--- a/apps/compliance-portal/src/components/BackdropCard/BackdropCard.tsx
+++ b/apps/compliance-portal/src/components/BackdropCard/BackdropCard.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { Card } from "@probo/ui/src/v2/Card/Card";
+import type { ReactNode } from "react";
+
+import { dotPatternStyle } from "#/components/MediaTile/variants";
+
+import { backdropCard } from "./variants";
+
+interface BackdropCardProps {
+  // Centered content shown above the backdrop (an icon or a logo box). The node
+  // owns its own sizing/color; position it above the backdrop with `relative
+  // z-10`.
+  media: ReactNode;
+  // When set, a blurred, magnified copy of this image becomes the backdrop;
+  // otherwise a dotted texture is shown.
+  backdropSrc?: string;
+  // Left-aligned body below the header.
+  children: ReactNode;
+}
+
+// Soft Card frame with a decorative-backdrop header above a body. Purely
+// presentational, so it doubles as the layout for its consumers' skeletons.
+export function BackdropCard({ media, backdropSrc, children }: BackdropCardProps) {
+  const slots = backdropCard();
+
+  return (
+    <Card variant="soft" size={3} padding="none">
+      <div className={slots.header()}>
+        {backdropSrc != null
+          ? <img src={backdropSrc} alt="" aria-hidden className={slots.blurBackdrop()} />
+          : <div className={slots.backdrop()} style={dotPatternStyle} />}
+        <div className={slots.backdropFade()} />
+        {media}
+      </div>
+      <div className={slots.body()}>{children}</div>
+    </Card>
+  );
+}

--- a/apps/compliance-portal/src/components/BackdropCard/variants.ts
+++ b/apps/compliance-portal/src/components/BackdropCard/variants.ts
@@ -14,11 +14,15 @@
 
 import { tv } from "tailwind-variants/lite";
 
-// Commitment card (Figma "Commitment Card"): the leading icon box placed over
-// the BackdropCard header. The card frame and dotted backdrop live in
-// BackdropCard; this slot only styles the icon container.
-export const commitmentCard = tv({
+// Soft Card frame shared by the commitment / subprocessor cards: a header with a
+// decorative backdrop (dotted texture or a blurred, magnified logo) faded toward
+// the card surface, with centered media on top, above a left-aligned body.
+export const backdropCard = tv({
   slots: {
-    icon: "relative z-10 flex size-8 items-center justify-center text-gold-9",
+    header: "relative flex w-full items-center overflow-hidden p-8",
+    blurBackdrop: "pointer-events-none absolute inset-0 size-full scale-150 object-cover opacity-10 blur-lg",
+    backdrop: "pointer-events-none absolute inset-0",
+    backdropFade: "pointer-events-none absolute inset-0 bg-linear-to-b from-sand-1/0 to-sand-1",
+    body: "flex flex-col gap-2 px-8 pb-8",
   },
 });

--- a/apps/compliance-portal/src/components/CommitmentCard/CommitmentCard.tsx
+++ b/apps/compliance-portal/src/components/CommitmentCard/CommitmentCard.tsx
@@ -12,10 +12,9 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { Card } from "@probo/ui/src/v2/Card/Card";
 import type { ReactNode } from "react";
 
-import { dotPatternStyle } from "#/components/MediaTile/variants";
+import { BackdropCard } from "#/components/BackdropCard/BackdropCard";
 
 import { commitmentCard } from "./variants";
 
@@ -30,24 +29,18 @@ export interface CommitmentCardProps {
   description: ReactNode;
 }
 
-// Commitment card, composing the soft Card surface. Region props are placed into
-// the layout slots; the consumer supplies typography (Text). Purely
-// presentational, so it doubles as the layout for its skeleton.
+// Commitment card, composing the shared BackdropCard frame over its dotted
+// backdrop. Region props are placed into the body; the consumer supplies
+// typography (Text). Purely presentational, so it doubles as the layout for its
+// skeleton.
 export function CommitmentCard({ icon, eyebrow, title, description }: CommitmentCardProps) {
-  const slots = commitmentCard();
+  const { icon: iconSlot } = commitmentCard();
 
   return (
-    <Card variant="soft" size={3} padding="none">
-      <div className={slots.icon()}>
-        <div className={slots.backdrop()} style={dotPatternStyle} />
-        <div className={slots.backdropFade()} />
-        <div className={slots.iconContent()}>{icon}</div>
-      </div>
-      <div className={slots.body()}>
-        {eyebrow}
-        {title}
-        {description}
-      </div>
-    </Card>
+    <BackdropCard media={<div className={iconSlot()}>{icon}</div>}>
+      {eyebrow}
+      {title}
+      {description}
+    </BackdropCard>
   );
 }

--- a/apps/compliance-portal/src/components/EmptyState/EmptyState.tsx
+++ b/apps/compliance-portal/src/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { Text } from "@probo/ui/src/v2/typography/Text";
+import type { ReactNode } from "react";
+
+import { emptyState } from "./variants";
+
+interface EmptyStateProps {
+  // Leading phosphor icon, toned and sized by the icon slot.
+  icon: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  // Optional call to action (e.g. a Button) below the copy.
+  action?: ReactNode;
+}
+
+// Generic empty-state placeholder shared across list/collection regions: a
+// faint icon, a title, optional guidance, and an optional call to action.
+// Purely presentational; consumers supply their own copy and action.
+export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+  const slots = emptyState();
+
+  return (
+    <div className={slots.root()}>
+      <span className={slots.icon()}>{icon}</span>
+      <div className={slots.body()}>
+        <Text size={2} weight="medium" color="faint">
+          {title}
+        </Text>
+        {description != null && (
+          <Text size={2} color="faint">
+            {description}
+          </Text>
+        )}
+      </div>
+      {action}
+    </div>
+  );
+}

--- a/apps/compliance-portal/src/components/EmptyState/variants.ts
+++ b/apps/compliance-portal/src/components/EmptyState/variants.ts
@@ -14,11 +14,13 @@
 
 import { tv } from "tailwind-variants/lite";
 
-// Commitment card (Figma "Commitment Card"): the leading icon box placed over
-// the BackdropCard header. The card frame and dotted backdrop live in
-// BackdropCard; this slot only styles the icon container.
-export const commitmentCard = tv({
+// Empty-state placeholder: a faint icon above a centered title / description
+// and an optional call to action. The icon slot tones and sizes any phosphor
+// icon passed in, so consumers hand in a bare icon element.
+export const emptyState = tv({
   slots: {
-    icon: "relative z-10 flex size-8 items-center justify-center text-gold-9",
+    root: "flex flex-col items-center gap-5 py-8 text-center",
+    icon: "text-sand-a8 [&_svg]:size-6",
+    body: "flex max-w-xs flex-col items-center gap-2",
   },
 });

--- a/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPage.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPage.tsx
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useTranslation } from "react-i18next";
+import type { PreloadedQuery } from "react-relay";
+import { graphql, usePreloadedQuery } from "react-relay";
+
+import { PageHeader } from "#/components/PageHeader/PageHeader";
+
+import { SubprocessorCategorySection } from "./_components/SubprocessorCategorySection";
+import type { SubprocessorNode } from "./_components/SubprocessorCategorySection";
+import { SubprocessorsEmpty } from "./_components/SubprocessorsEmpty";
+import { groupByCategory } from "./_lib/groupByCategory";
+import type { SubprocessorsPageQuery } from "./__generated__/SubprocessorsPageQuery.graphql";
+
+export const subprocessorsPageQuery = graphql`
+  query SubprocessorsPageQuery {
+    currentTrustCenter @required(action: THROW) {
+      subprocessors(first: 250) {
+        totalCount
+        edges {
+          node {
+            id
+            category
+            ...SubprocessorListItem_subprocessor
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface SubprocessorsPageProps {
+  queryRef: PreloadedQuery<SubprocessorsPageQuery>;
+}
+
+export function SubprocessorsPage({ queryRef }: SubprocessorsPageProps) {
+  const { t } = useTranslation("subprocessors");
+  const data = usePreloadedQuery<SubprocessorsPageQuery>(subprocessorsPageQuery, queryRef);
+  const { subprocessors } = data.currentTrustCenter;
+
+  const nodes: SubprocessorNode[] = subprocessors.edges.map(edge => edge.node);
+  const groups = groupByCategory(nodes, category => t(`categories.${category}.label`));
+
+  return (
+    <>
+      <PageHeader title={t("title")} count={subprocessors.totalCount} />
+      <div className="flex w-full flex-col items-center px-8 py-8">
+        <div className="flex w-full max-w-5xl flex-col gap-8">
+          {groups.length === 0
+            ? <SubprocessorsEmpty />
+            : groups.map(group => (
+                <SubprocessorCategorySection
+                  key={group.category}
+                  category={group.category}
+                  subprocessors={group.nodes}
+                />
+              ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPage.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPage.tsx
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import type { PreloadedQuery } from "react-relay";
 import { graphql, usePreloadedQuery, useRefetchableFragment } from "react-relay";
@@ -74,16 +74,21 @@ export function SubprocessorsPage({ queryRef }: SubprocessorsPageProps) {
 
   const filters = useSubprocessorFilters();
   const { query, category, country } = filters;
+  const [isRefetching, startTransition] = useTransition();
 
   // The initial query already loaded with the URL's filter values; only refetch
-  // on subsequent filter changes.
+  // on subsequent filter changes. Refetch inside a transition so the toolbar and
+  // current results stay mounted (no whole-page Suspense fallback) while the
+  // filtered results load — the results are just dimmed via `isRefetching`.
   const isFirstRender = useRef(true);
   useEffect(() => {
     if (isFirstRender.current) {
       isFirstRender.current = false;
       return;
     }
-    refetch(toQueryVariables({ query, category, country }), { fetchPolicy: "store-or-network" });
+    startTransition(() => {
+      refetch(toQueryVariables({ query, category, country }), { fetchPolicy: "store-or-network" });
+    });
   }, [refetch, query, category, country]);
 
   const { subprocessors } = data.currentTrustCenter;
@@ -96,7 +101,10 @@ export function SubprocessorsPage({ queryRef }: SubprocessorsPageProps) {
         <SubprocessorsToolbar queryKey={root} />
       </PageHeader>
       <div className="flex w-full flex-col items-center px-8 py-8">
-        <div className="flex w-full max-w-5xl flex-col gap-8">
+        <div
+          aria-busy={isRefetching}
+          className={`flex w-full max-w-5xl flex-col gap-8 transition-opacity duration-150 ${isRefetching ? "opacity-60" : ""}`}
+        >
           {groups.length === 0
             ? <SubprocessorsEmpty />
             : groups.map(group => (

--- a/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPage.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPage.tsx
@@ -12,22 +12,41 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type { PreloadedQuery } from "react-relay";
-import { graphql, usePreloadedQuery } from "react-relay";
+import { graphql, usePreloadedQuery, useRefetchableFragment } from "react-relay";
 
 import { PageHeader } from "#/components/PageHeader/PageHeader";
 
 import { SubprocessorCategorySection } from "./_components/SubprocessorCategorySection";
 import type { SubprocessorNode } from "./_components/SubprocessorCategorySection";
 import { SubprocessorsEmpty } from "./_components/SubprocessorsEmpty";
+import { SubprocessorsToolbar } from "./_components/SubprocessorsToolbar";
 import { groupByCategory } from "./_lib/groupByCategory";
+import { toQueryVariables } from "./_lib/toQueryVariables";
+import { useSubprocessorFilters } from "./_lib/useSubprocessorFilters";
 import type { SubprocessorsPageQuery } from "./__generated__/SubprocessorsPageQuery.graphql";
+import type { SubprocessorsPageRefetchQuery } from "./__generated__/SubprocessorsPageRefetchQuery.graphql";
+import type { SubprocessorsPage_query$key } from "./__generated__/SubprocessorsPage_query.graphql";
 
 export const subprocessorsPageQuery = graphql`
-  query SubprocessorsPageQuery {
+  query SubprocessorsPageQuery($query: String, $category: SubprocessorCategory, $country: CountryCode) {
+    ...SubprocessorsPage_query @arguments(query: $query, category: $category, country: $country)
+    ...SubprocessorsToolbar_query
+  }
+`;
+
+const subprocessorsPageFragment = graphql`
+  fragment SubprocessorsPage_query on Query
+  @refetchable(queryName: "SubprocessorsPageRefetchQuery")
+  @argumentDefinitions(
+    query: { type: "String" }
+    category: { type: "SubprocessorCategory" }
+    country: { type: "CountryCode" }
+  ) {
     currentTrustCenter @required(action: THROW) {
-      subprocessors(first: 250) {
+      subprocessors(first: 250, filter: { query: $query, category: $category, country: $country }) {
         totalCount
         edges {
           node {
@@ -47,15 +66,35 @@ interface SubprocessorsPageProps {
 
 export function SubprocessorsPage({ queryRef }: SubprocessorsPageProps) {
   const { t } = useTranslation("subprocessors");
-  const data = usePreloadedQuery<SubprocessorsPageQuery>(subprocessorsPageQuery, queryRef);
-  const { subprocessors } = data.currentTrustCenter;
+  const root = usePreloadedQuery<SubprocessorsPageQuery>(subprocessorsPageQuery, queryRef);
+  const [data, refetch] = useRefetchableFragment<SubprocessorsPageRefetchQuery, SubprocessorsPage_query$key>(
+    subprocessorsPageFragment,
+    root,
+  );
 
+  const filters = useSubprocessorFilters();
+  const { query, category, country } = filters;
+
+  // The initial query already loaded with the URL's filter values; only refetch
+  // on subsequent filter changes.
+  const isFirstRender = useRef(true);
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    refetch(toQueryVariables({ query, category, country }), { fetchPolicy: "store-or-network" });
+  }, [refetch, query, category, country]);
+
+  const { subprocessors } = data.currentTrustCenter;
   const nodes: SubprocessorNode[] = subprocessors.edges.map(edge => edge.node);
-  const groups = groupByCategory(nodes, category => t(`categories.${category}.label`));
+  const groups = groupByCategory(nodes, value => t(`categories.${value}.label`));
 
   return (
     <>
-      <PageHeader title={t("title")} count={subprocessors.totalCount} />
+      <PageHeader title={t("title")} count={subprocessors.totalCount}>
+        <SubprocessorsToolbar queryKey={root} />
+      </PageHeader>
       <div className="flex w-full flex-col items-center px-8 py-8">
         <div className="flex w-full max-w-5xl flex-col gap-8">
           {groups.length === 0

--- a/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPage.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPage.tsx
@@ -19,16 +19,16 @@ import { graphql, usePreloadedQuery, useRefetchableFragment } from "react-relay"
 
 import { PageHeader } from "#/components/PageHeader/PageHeader";
 
-import { SubprocessorCategorySection } from "./_components/SubprocessorCategorySection";
+import type { SubprocessorsPage_query$key } from "./__generated__/SubprocessorsPage_query.graphql";
+import type { SubprocessorsPageQuery } from "./__generated__/SubprocessorsPageQuery.graphql";
+import type { SubprocessorsPageRefetchQuery } from "./__generated__/SubprocessorsPageRefetchQuery.graphql";
 import type { SubprocessorNode } from "./_components/SubprocessorCategorySection";
+import { SubprocessorCategorySection } from "./_components/SubprocessorCategorySection";
 import { SubprocessorsEmpty } from "./_components/SubprocessorsEmpty";
 import { SubprocessorsToolbar } from "./_components/SubprocessorsToolbar";
 import { groupByCategory } from "./_lib/groupByCategory";
 import { toQueryVariables } from "./_lib/toQueryVariables";
 import { useSubprocessorFilters } from "./_lib/useSubprocessorFilters";
-import type { SubprocessorsPageQuery } from "./__generated__/SubprocessorsPageQuery.graphql";
-import type { SubprocessorsPageRefetchQuery } from "./__generated__/SubprocessorsPageRefetchQuery.graphql";
-import type { SubprocessorsPage_query$key } from "./__generated__/SubprocessorsPage_query.graphql";
 
 export const subprocessorsPageQuery = graphql`
   query SubprocessorsPageQuery($query: String, $category: SubprocessorCategory, $country: CountryCode) {

--- a/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPageLoader.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPageLoader.tsx
@@ -12,18 +12,25 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useQueryLoader } from "react-relay";
 
 import { SubprocessorsPage, subprocessorsPageQuery } from "./SubprocessorsPage";
 import { SubprocessorsPageSkeleton } from "./SubprocessorsPageSkeleton";
+import { toQueryVariables } from "./_lib/toQueryVariables";
+import { useSubprocessorFilters } from "./_lib/useSubprocessorFilters";
 import type { SubprocessorsPageQuery } from "./__generated__/SubprocessorsPageQuery.graphql";
 
 export default function SubprocessorsPageLoader() {
+  const filters = useSubprocessorFilters();
   const [queryRef, loadQuery] = useQueryLoader<SubprocessorsPageQuery>(subprocessorsPageQuery);
 
+  // Seed the first fetch with the URL's filter values; later changes are handled
+  // by the page's refetch.
+  const initialVariables = useRef(toQueryVariables(filters));
+
   useEffect(() => {
-    loadQuery({});
+    loadQuery(initialVariables.current);
   }, [loadQuery]);
 
   if (!queryRef) {

--- a/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPageLoader.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPageLoader.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useEffect } from "react";
+import { useQueryLoader } from "react-relay";
+
+import { SubprocessorsPage, subprocessorsPageQuery } from "./SubprocessorsPage";
+import { SubprocessorsPageSkeleton } from "./SubprocessorsPageSkeleton";
+import type { SubprocessorsPageQuery } from "./__generated__/SubprocessorsPageQuery.graphql";
+
+export default function SubprocessorsPageLoader() {
+  const [queryRef, loadQuery] = useQueryLoader<SubprocessorsPageQuery>(subprocessorsPageQuery);
+
+  useEffect(() => {
+    loadQuery({});
+  }, [loadQuery]);
+
+  if (!queryRef) {
+    return <SubprocessorsPageSkeleton />;
+  }
+
+  return <SubprocessorsPage queryRef={queryRef} />;
+}

--- a/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPageLoader.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPageLoader.tsx
@@ -15,11 +15,11 @@
 import { useEffect, useRef } from "react";
 import { useQueryLoader } from "react-relay";
 
-import { SubprocessorsPage, subprocessorsPageQuery } from "./SubprocessorsPage";
-import { SubprocessorsPageSkeleton } from "./SubprocessorsPageSkeleton";
+import type { SubprocessorsPageQuery } from "./__generated__/SubprocessorsPageQuery.graphql";
 import { toQueryVariables } from "./_lib/toQueryVariables";
 import { useSubprocessorFilters } from "./_lib/useSubprocessorFilters";
-import type { SubprocessorsPageQuery } from "./__generated__/SubprocessorsPageQuery.graphql";
+import { SubprocessorsPage, subprocessorsPageQuery } from "./SubprocessorsPage";
+import { SubprocessorsPageSkeleton } from "./SubprocessorsPageSkeleton";
 
 export default function SubprocessorsPageLoader() {
   const filters = useSubprocessorFilters();

--- a/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPageSkeleton.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/SubprocessorsPageSkeleton.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { HeadingSkeleton } from "@probo/ui/src/v2/typography/HeadingSkeleton";
+import { TextSkeleton } from "@probo/ui/src/v2/typography/TextSkeleton";
+
+import { HeaderBand } from "#/components/HeaderBand/HeaderBand";
+
+const CARD_PLACEHOLDERS = ["a", "b", "c", "d", "e", "f"];
+
+export function SubprocessorsPageSkeleton() {
+  return (
+    <>
+      <HeaderBand>
+        <div className="flex w-full flex-col gap-2">
+          <HeadingSkeleton size={7} className="w-64" />
+        </div>
+      </HeaderBand>
+      <div className="flex w-full flex-col items-center px-8 py-8">
+        <div className="flex w-full max-w-5xl flex-col gap-4">
+          <TextSkeleton size={3} className="w-48" />
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {CARD_PLACEHOLDERS.map(placeholder => (
+              <div key={placeholder} className="h-56 animate-pulse rounded-5 bg-sand-3" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorCategorySection.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorCategorySection.tsx
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { Text } from "@probo/ui/src/v2/typography/Text";
+import { useTranslation } from "react-i18next";
+
+import type { SubprocessorListItem_subprocessor$key } from "./__generated__/SubprocessorListItem_subprocessor.graphql";
+import { SubprocessorListItem } from "./SubprocessorListItem";
+
+// A subprocessor edge node: the list-item fragment key plus the fields the page
+// reads to group and key the list.
+export type SubprocessorNode = SubprocessorListItem_subprocessor$key & {
+  readonly id: string;
+  readonly category: string;
+};
+
+interface SubprocessorCategorySectionProps {
+  category: string;
+  subprocessors: readonly SubprocessorNode[];
+}
+
+// One category group: a localized header (label + description) above a
+// responsive grid of subprocessor cards.
+export function SubprocessorCategorySection({ category, subprocessors }: SubprocessorCategorySectionProps) {
+  const { t } = useTranslation("subprocessors");
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <Text size={3} weight="medium" color="neutral" highContrast>
+          {t(`categories.${category}.label`)}
+        </Text>
+        <Text size={2} color="neutral">
+          {t(`categories.${category}.description`)}
+        </Text>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {subprocessors.map(subprocessor => (
+          <SubprocessorListItem key={subprocessor.id} subprocessorKey={subprocessor} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorCategorySection.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorCategorySection.tsx
@@ -38,7 +38,7 @@ export function SubprocessorCategorySection({ category, subprocessors }: Subproc
   return (
     <section className="flex flex-col gap-4">
       <div className="flex flex-col gap-1">
-        <Text size={3} weight="medium" color="neutral" highContrast>
+        <Text size={3} weight="medium" color="neutral" highContrast role="heading" aria-level={2}>
           {t(`categories.${category}.label`)}
         </Text>
         <Text size={2} color="neutral">

--- a/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorCategorySection.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorCategorySection.tsx
@@ -45,7 +45,7 @@ export function SubprocessorCategorySection({ category, subprocessors }: Subproc
           {t(`categories.${category}.description`)}
         </Text>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid grid-cols-1 items-start gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {subprocessors.map(subprocessor => (
           <SubprocessorListItem key={subprocessor.id} subprocessorKey={subprocessor} />
         ))}

--- a/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorCategorySection.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorCategorySection.tsx
@@ -45,7 +45,7 @@ export function SubprocessorCategorySection({ category, subprocessors }: Subproc
           {t(`categories.${category}.description`)}
         </Text>
       </div>
-      <div className="grid grid-cols-1 items-start gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {subprocessors.map(subprocessor => (
           <SubprocessorListItem key={subprocessor.id} subprocessorKey={subprocessor} />
         ))}

--- a/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorListItem.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorListItem.tsx
@@ -14,13 +14,15 @@
 
 import { BuildingsIcon, MapPinSimpleIcon } from "@phosphor-icons/react";
 import { faviconUrl } from "@probo/helpers";
-import { Card } from "@probo/ui/src/v2/Card/Card";
 import { Text } from "@probo/ui/src/v2/typography/Text";
 import { graphql, useFragment } from "react-relay";
+
+import { BackdropCard } from "#/components/BackdropCard/BackdropCard";
 
 import { useCountryLabel } from "../_lib/useCountryLabel";
 
 import type { SubprocessorListItem_subprocessor$key } from "./__generated__/SubprocessorListItem_subprocessor.graphql";
+import { subprocessorListItem } from "./variants";
 
 const subprocessorListItemFragment = graphql`
   fragment SubprocessorListItem_subprocessor on Subprocessor {
@@ -42,43 +44,35 @@ export function SubprocessorListItem({ subprocessorKey }: SubprocessorListItemPr
   const countryLabel = useCountryLabel();
   const logoUrl = faviconUrl(subprocessor.websiteUrl);
   const countries = subprocessor.countries.map(countryLabel).join(", ");
+  const slots = subprocessorListItem();
 
   return (
-    <Card variant="soft" size={3} padding="none">
-      <div className="relative flex items-center overflow-hidden p-8">
-        {logoUrl != null && (
-          <img
-            src={logoUrl}
-            alt=""
-            aria-hidden
-            className="pointer-events-none absolute inset-0 size-full scale-150 object-cover opacity-10 blur-lg"
-          />
-        )}
-        <div className="pointer-events-none absolute inset-0 bg-linear-to-b from-sand-1/0 to-sand-1" />
-        <div className="relative z-10 flex size-10 items-center justify-center overflow-hidden rounded-2 bg-sand-1">
+    <BackdropCard
+      backdropSrc={logoUrl ?? undefined}
+      media={(
+        <div className={slots.logo()}>
           {logoUrl != null
-            ? <img src={logoUrl} alt="" className="size-full object-cover" />
-            : <BuildingsIcon size={24} weight="duotone" className="text-sand-9" />}
+            ? <img src={logoUrl} alt="" className={slots.logoImage()} />
+            : <BuildingsIcon size={24} weight="duotone" className={slots.logoFallbackIcon()} />}
         </div>
-      </div>
-      <div className="flex flex-col gap-2 px-8 pb-8">
-        <Text size={4} weight="medium" color="neutral" highContrast>
-          {subprocessor.name}
+      )}
+    >
+      <Text size={4} weight="medium" color="neutral" highContrast>
+        {subprocessor.name}
+      </Text>
+      {subprocessor.description != null && subprocessor.description !== "" && (
+        <Text size={2} color="neutral">
+          {subprocessor.description}
         </Text>
-        {subprocessor.description != null && subprocessor.description !== "" && (
-          <Text size={2} color="neutral">
-            {subprocessor.description}
+      )}
+      {countries !== "" && (
+        <div className={slots.region()}>
+          <MapPinSimpleIcon className={slots.regionIcon()} />
+          <Text size={1} color="gold">
+            {countries}
           </Text>
-        )}
-        {countries !== "" && (
-          <div className="flex items-start gap-1">
-            <MapPinSimpleIcon className="mt-0.5 size-4 shrink-0 text-gold-11" />
-            <Text size={1} color="gold">
-              {countries}
-            </Text>
-          </div>
-        )}
-      </div>
-    </Card>
+        </div>
+      )}
+    </BackdropCard>
   );
 }

--- a/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorListItem.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorListItem.tsx
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { BuildingsIcon, MapPinSimpleIcon } from "@phosphor-icons/react";
+import { faviconUrl } from "@probo/helpers";
+import { Card } from "@probo/ui/src/v2/Card/Card";
+import { Text } from "@probo/ui/src/v2/typography/Text";
+import { graphql, useFragment } from "react-relay";
+
+import { useCountryLabel } from "../_lib/useCountryLabel";
+
+import type { SubprocessorListItem_subprocessor$key } from "./__generated__/SubprocessorListItem_subprocessor.graphql";
+
+const subprocessorListItemFragment = graphql`
+  fragment SubprocessorListItem_subprocessor on Subprocessor {
+    name
+    description
+    websiteUrl
+    countries
+  }
+`;
+
+interface SubprocessorListItemProps {
+  subprocessorKey: SubprocessorListItem_subprocessor$key;
+}
+
+// A single subprocessor card: a favicon logo over a blurred backdrop, the name,
+// description, and the hosting regions.
+export function SubprocessorListItem({ subprocessorKey }: SubprocessorListItemProps) {
+  const subprocessor = useFragment(subprocessorListItemFragment, subprocessorKey);
+  const countryLabel = useCountryLabel();
+  const logoUrl = faviconUrl(subprocessor.websiteUrl);
+  const countries = subprocessor.countries.map(countryLabel).join(", ");
+
+  return (
+    <Card variant="soft" size={3} padding="none">
+      <div className="relative flex items-center overflow-hidden p-8">
+        {logoUrl != null && (
+          <img
+            src={logoUrl}
+            alt=""
+            aria-hidden
+            className="pointer-events-none absolute inset-0 size-full scale-150 object-cover opacity-10 blur-lg"
+          />
+        )}
+        <div className="pointer-events-none absolute inset-0 bg-linear-to-b from-sand-1/0 to-sand-1" />
+        <div className="relative z-10 flex size-10 items-center justify-center overflow-hidden rounded-2 bg-sand-1">
+          {logoUrl != null
+            ? <img src={logoUrl} alt="" className="size-full object-cover" />
+            : <BuildingsIcon size={24} weight="duotone" className="text-sand-9" />}
+        </div>
+      </div>
+      <div className="flex flex-col gap-2 px-8 pb-8">
+        <Text size={4} weight="medium" color="neutral" highContrast>
+          {subprocessor.name}
+        </Text>
+        {subprocessor.description != null && subprocessor.description !== "" && (
+          <Text size={2} color="neutral">
+            {subprocessor.description}
+          </Text>
+        )}
+        {countries !== "" && (
+          <div className="flex items-start gap-1">
+            <MapPinSimpleIcon className="mt-0.5 size-4 shrink-0 text-gold-11" />
+            <Text size={1} color="gold">
+              {countries}
+            </Text>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorsEmpty.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorsEmpty.tsx
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { Text } from "@probo/ui/src/v2/typography/Text";
+import { useTranslation } from "react-i18next";
+
+// Empty state shown when the trust center lists no subprocessors.
+export function SubprocessorsEmpty() {
+  const { t } = useTranslation("subprocessors");
+
+  return (
+    <div className="flex flex-col items-center gap-5 py-8 text-center">
+      <MagnifyingGlassIcon className="size-6 text-sand-a8" />
+      <div className="flex max-w-xs flex-col items-center gap-2">
+        <Text size={2} weight="medium" color="faint">
+          {t("empty.title")}
+        </Text>
+        <Text size={2} color="faint">
+          {t("empty.description")}
+        </Text>
+      </div>
+    </div>
+  );
+}

--- a/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorsEmpty.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorsEmpty.tsx
@@ -12,25 +12,40 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { ArrowCounterClockwiseIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { Button } from "@probo/ui/src/v2/Button/Button";
 import { Text } from "@probo/ui/src/v2/typography/Text";
 import { useTranslation } from "react-i18next";
 
-// Empty state shown when the trust center lists no subprocessors.
+import { useSubprocessorFilters } from "../_lib/useSubprocessorFilters";
+
+// Empty state for the subprocessor list. When filters are active it offers to
+// clear them; otherwise it states the trust center lists no subprocessors.
 export function SubprocessorsEmpty() {
   const { t } = useTranslation("subprocessors");
+  const { hasActiveFilters, clear } = useSubprocessorFilters();
 
   return (
     <div className="flex flex-col items-center gap-5 py-8 text-center">
       <MagnifyingGlassIcon className="size-6 text-sand-a8" />
       <div className="flex max-w-xs flex-col items-center gap-2">
         <Text size={2} weight="medium" color="faint">
-          {t("empty.title")}
+          {hasActiveFilters ? t("empty.filteredTitle") : t("empty.title")}
         </Text>
         <Text size={2} color="faint">
-          {t("empty.description")}
+          {hasActiveFilters ? t("empty.filteredDescription") : t("empty.description")}
         </Text>
       </div>
+      {hasActiveFilters && (
+        <Button
+          variant="soft"
+          color="neutral"
+          iconStart={<ArrowCounterClockwiseIcon />}
+          onClick={clear}
+        >
+          {t("empty.clearFilters")}
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorsEmpty.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorsEmpty.tsx
@@ -14,8 +14,9 @@
 
 import { ArrowCounterClockwiseIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
 import { Button } from "@probo/ui/src/v2/Button/Button";
-import { Text } from "@probo/ui/src/v2/typography/Text";
 import { useTranslation } from "react-i18next";
+
+import { EmptyState } from "#/components/EmptyState/EmptyState";
 
 import { useSubprocessorFilters } from "../_lib/useSubprocessorFilters";
 
@@ -26,17 +27,11 @@ export function SubprocessorsEmpty() {
   const { hasActiveFilters, clear } = useSubprocessorFilters();
 
   return (
-    <div className="flex flex-col items-center gap-5 py-8 text-center">
-      <MagnifyingGlassIcon className="size-6 text-sand-a8" />
-      <div className="flex max-w-xs flex-col items-center gap-2">
-        <Text size={2} weight="medium" color="faint">
-          {hasActiveFilters ? t("empty.filteredTitle") : t("empty.title")}
-        </Text>
-        <Text size={2} color="faint">
-          {hasActiveFilters ? t("empty.filteredDescription") : t("empty.description")}
-        </Text>
-      </div>
-      {hasActiveFilters && (
+    <EmptyState
+      icon={<MagnifyingGlassIcon />}
+      title={hasActiveFilters ? t("empty.filteredTitle") : t("empty.title")}
+      description={hasActiveFilters ? t("empty.filteredDescription") : t("empty.description")}
+      action={hasActiveFilters && (
         <Button
           variant="soft"
           color="neutral"
@@ -46,6 +41,6 @@ export function SubprocessorsEmpty() {
           {t("empty.clearFilters")}
         </Button>
       )}
-    </div>
+    />
   );
 }

--- a/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorsToolbar.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorsToolbar.tsx
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { Select } from "@probo/ui/src/v2/Select/Select";
+import { SelectItem } from "@probo/ui/src/v2/Select/SelectItem";
+import { SelectPopup } from "@probo/ui/src/v2/Select/SelectPopup";
+import { SelectTrigger } from "@probo/ui/src/v2/Select/SelectTrigger";
+import { TextField } from "@probo/ui/src/v2/form/TextField";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { graphql, useFragment } from "react-relay";
+
+import { useCountryLabel } from "../_lib/useCountryLabel";
+import { useSubprocessorFilters } from "../_lib/useSubprocessorFilters";
+
+import type { SubprocessorsToolbar_query$key } from "./__generated__/SubprocessorsToolbar_query.graphql";
+
+// Unfiltered facet data: the distinct categories and countries actually present,
+// used to populate the filter dropdowns (aliased so it does not collide with the
+// filtered list selection on the same trust center).
+const subprocessorsToolbarFragment = graphql`
+  fragment SubprocessorsToolbar_query on Query {
+    currentTrustCenter @required(action: THROW) {
+      allSubprocessors: subprocessors(first: 250) {
+        edges {
+          node {
+            id
+            category
+            countries
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface SubprocessorsToolbarProps {
+  queryKey: SubprocessorsToolbar_query$key;
+}
+
+// Category / region / search controls. Writes filter state to the URL via the
+// filter hook; the page reacts to those changes and refetches server-side.
+export function SubprocessorsToolbar({ queryKey }: SubprocessorsToolbarProps) {
+  const { t } = useTranslation("subprocessors");
+  const data = useFragment(subprocessorsToolbarFragment, queryKey);
+  const countryLabel = useCountryLabel();
+  const { queryInput, category, country, setQueryInput, setCategory, setCountry } = useSubprocessorFilters();
+
+  const nodes = data.currentTrustCenter.allSubprocessors.edges.map(edge => edge.node);
+
+  const categoryOptions = useMemo(() => {
+    const present = [...new Set(nodes.map(node => node.category))];
+    return present.sort((a, b) => t(`categories.${a}.label`).localeCompare(t(`categories.${b}.label`)));
+  }, [nodes, t]);
+
+  const countryOptions = useMemo(() => {
+    const present = [...new Set(nodes.flatMap(node => node.countries))];
+    return present.sort((a, b) => countryLabel(a).localeCompare(countryLabel(b)));
+  }, [nodes, countryLabel]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <div className="w-40">
+        <Select value={category || null} onValueChange={value => setCategory(value ?? "")}>
+          <SelectTrigger placeholder={t("filters.allCategories")}>
+            {(value: string | null) => (value ? t(`categories.${value}.label`) : t("filters.allCategories"))}
+          </SelectTrigger>
+          <SelectPopup>
+            <SelectItem value={null}>{t("filters.allCategories")}</SelectItem>
+            {categoryOptions.map(option => (
+              <SelectItem key={option} value={option}>{t(`categories.${option}.label`)}</SelectItem>
+            ))}
+          </SelectPopup>
+        </Select>
+      </div>
+      <div className="w-40">
+        <Select value={country || null} onValueChange={value => setCountry(value ?? "")}>
+          <SelectTrigger placeholder={t("filters.allRegions")}>
+            {(value: string | null) => (value ? countryLabel(value) : t("filters.allRegions"))}
+          </SelectTrigger>
+          <SelectPopup>
+            <SelectItem value={null}>{t("filters.allRegions")}</SelectItem>
+            {countryOptions.map(option => (
+              <SelectItem key={option} value={option}>{countryLabel(option)}</SelectItem>
+            ))}
+          </SelectPopup>
+        </Select>
+      </div>
+      <div className="w-60">
+        <TextField
+          value={queryInput}
+          onValueChange={setQueryInput}
+          placeholder={t("filters.searchPlaceholder")}
+          aria-label={t("filters.searchPlaceholder")}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorsToolbar.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorsToolbar.tsx
@@ -23,6 +23,7 @@ import { graphql, useFragment } from "react-relay";
 
 import { useCountryLabel } from "../_lib/useCountryLabel";
 import { useSubprocessorFilters } from "../_lib/useSubprocessorFilters";
+import { useSubprocessorSearch } from "../_lib/useSubprocessorSearch";
 
 import type { SubprocessorsToolbar_query$key } from "./__generated__/SubprocessorsToolbar_query.graphql";
 
@@ -55,7 +56,8 @@ export function SubprocessorsToolbar({ queryKey }: SubprocessorsToolbarProps) {
   const { t } = useTranslation("subprocessors");
   const data = useFragment(subprocessorsToolbarFragment, queryKey);
   const countryLabel = useCountryLabel();
-  const { queryInput, category, country, setQueryInput, setCategory, setCountry } = useSubprocessorFilters();
+  const { category, country, setCategory, setCountry } = useSubprocessorFilters();
+  const [queryInput, setQueryInput] = useSubprocessorSearch();
 
   const nodes = data.currentTrustCenter.allSubprocessors.edges.map(edge => edge.node);
 

--- a/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorsToolbar.tsx
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/SubprocessorsToolbar.tsx
@@ -12,11 +12,11 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
+import { TextField } from "@probo/ui/src/v2/form/TextField";
 import { Select } from "@probo/ui/src/v2/Select/Select";
 import { SelectItem } from "@probo/ui/src/v2/Select/SelectItem";
 import { SelectPopup } from "@probo/ui/src/v2/Select/SelectPopup";
 import { SelectTrigger } from "@probo/ui/src/v2/Select/SelectTrigger";
-import { TextField } from "@probo/ui/src/v2/form/TextField";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
@@ -27,21 +27,14 @@ import { useSubprocessorSearch } from "../_lib/useSubprocessorSearch";
 
 import type { SubprocessorsToolbar_query$key } from "./__generated__/SubprocessorsToolbar_query.graphql";
 
-// Unfiltered facet data: the distinct categories and countries actually present,
-// used to populate the filter dropdowns (aliased so it does not collide with the
-// filtered list selection on the same trust center).
+// Facet data: the distinct categories and countries actually present across the
+// trust center's published subprocessors, used to populate the filter dropdowns
+// (server-computed so the options never dead-end on an empty result).
 const subprocessorsToolbarFragment = graphql`
   fragment SubprocessorsToolbar_query on Query {
     currentTrustCenter @required(action: THROW) {
-      allSubprocessors: subprocessors(first: 250) {
-        edges {
-          node {
-            id
-            category
-            countries
-          }
-        }
-      }
+      subprocessorCategories
+      subprocessorCountries
     }
   }
 `;
@@ -59,17 +52,15 @@ export function SubprocessorsToolbar({ queryKey }: SubprocessorsToolbarProps) {
   const { category, country, setCategory, setCountry } = useSubprocessorFilters();
   const [queryInput, setQueryInput] = useSubprocessorSearch();
 
-  const nodes = data.currentTrustCenter.allSubprocessors.edges.map(edge => edge.node);
+  const { subprocessorCategories, subprocessorCountries } = data.currentTrustCenter;
 
   const categoryOptions = useMemo(() => {
-    const present = [...new Set(nodes.map(node => node.category))];
-    return present.sort((a, b) => t(`categories.${a}.label`).localeCompare(t(`categories.${b}.label`)));
-  }, [nodes, t]);
+    return [...subprocessorCategories].sort((a, b) => t(`categories.${a}.label`).localeCompare(t(`categories.${b}.label`)));
+  }, [subprocessorCategories, t]);
 
   const countryOptions = useMemo(() => {
-    const present = [...new Set(nodes.flatMap(node => node.countries))];
-    return present.sort((a, b) => countryLabel(a).localeCompare(countryLabel(b)));
-  }, [nodes, countryLabel]);
+    return [...subprocessorCountries].sort((a, b) => countryLabel(a).localeCompare(countryLabel(b)));
+  }, [subprocessorCountries, countryLabel]);
 
   return (
     <div className="flex flex-wrap items-center gap-3">

--- a/apps/compliance-portal/src/pages/subprocessors/_components/variants.ts
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/variants.ts
@@ -23,6 +23,6 @@ export const subprocessorListItem = tv({
     logoImage: "size-full object-cover",
     logoFallbackIcon: "text-sand-9",
     region: "flex items-start gap-1",
-    regionIcon: "mt-0.5 size-4 shrink-0 text-gold-11",
+    regionIcon: "size-4 shrink-0 text-gold-11",
   },
 });

--- a/apps/compliance-portal/src/pages/subprocessors/_components/variants.ts
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/variants.ts
@@ -14,11 +14,15 @@
 
 import { tv } from "tailwind-variants/lite";
 
-// Commitment card (Figma "Commitment Card"): the leading icon box placed over
-// the BackdropCard header. The card frame and dotted backdrop live in
-// BackdropCard; this slot only styles the icon container.
-export const commitmentCard = tv({
+// Subprocessor card: the logo box placed over the BackdropCard header (backed by
+// a blurred, magnified copy of the logo) and the hosting-regions row shown in
+// the body. The card frame and backdrop live in BackdropCard.
+export const subprocessorListItem = tv({
   slots: {
-    icon: "relative z-10 flex size-8 items-center justify-center text-gold-9",
+    logo: "relative z-10 flex size-10 items-center justify-center overflow-hidden rounded-2 bg-sand-1",
+    logoImage: "size-full object-cover",
+    logoFallbackIcon: "text-sand-9",
+    region: "flex items-start gap-1",
+    regionIcon: "mt-0.5 size-4 shrink-0 text-gold-11",
   },
 });

--- a/apps/compliance-portal/src/pages/subprocessors/_lib/groupByCategory.ts
+++ b/apps/compliance-portal/src/pages/subprocessors/_lib/groupByCategory.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+export interface CategoryGroup<T> {
+  category: string;
+  nodes: T[];
+}
+
+// Groups subprocessor nodes into their (non-empty) categories, ordered by the
+// localized category label. Presentational only — filtering happens server-side.
+export function groupByCategory<T extends { readonly category: string }>(
+  nodes: readonly T[],
+  getLabel: (category: string) => string,
+): CategoryGroup<T>[] {
+  const groups = new Map<string, T[]>();
+
+  for (const node of nodes) {
+    const existing = groups.get(node.category);
+    if (existing) {
+      existing.push(node);
+    } else {
+      groups.set(node.category, [node]);
+    }
+  }
+
+  return [...groups.entries()]
+    .map(([category, groupNodes]) => ({ category, nodes: groupNodes }))
+    .sort((a, b) => getLabel(a.category).localeCompare(getLabel(b.category)));
+}

--- a/apps/compliance-portal/src/pages/subprocessors/_lib/toQueryVariables.ts
+++ b/apps/compliance-portal/src/pages/subprocessors/_lib/toQueryVariables.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { SubprocessorsPageQuery$variables } from "../__generated__/SubprocessorsPageQuery.graphql";
+
+interface FilterValues {
+  query: string;
+  category: string;
+  country: string;
+}
+
+// Maps the string-based URL filter state to the typed GraphQL query variables,
+// treating empty strings as "no filter". The category/country strings originate
+// from the enum-constrained Select options, so the cast is safe.
+export function toQueryVariables(filters: FilterValues): SubprocessorsPageQuery$variables {
+  return {
+    query: filters.query || null,
+    category: (filters.category || null) as SubprocessorsPageQuery$variables["category"],
+    country: (filters.country || null) as SubprocessorsPageQuery$variables["country"],
+  };
+}

--- a/apps/compliance-portal/src/pages/subprocessors/_lib/useCountryLabel.ts
+++ b/apps/compliance-portal/src/pages/subprocessors/_lib/useCountryLabel.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+// Resolves a trust-center CountryCode to a localized display name. ISO 3166
+// alpha-2 codes go through Intl.DisplayNames (locale-aware); the schema's two
+// pseudo-regions (GLOBAL, EU) fall back to translated labels.
+export function useCountryLabel(): (code: string) => string {
+  const { t, i18n } = useTranslation("subprocessors");
+
+  return useMemo(() => {
+    const display = new Intl.DisplayNames([i18n.language], { type: "region" });
+
+    return (code: string): string => {
+      if (code === "GLOBAL") {
+        return t("regions.global");
+      }
+      if (code === "EU") {
+        return t("regions.eu");
+      }
+      try {
+        return display.of(code) ?? code;
+      } catch {
+        return code;
+      }
+    };
+  }, [i18n.language, t]);
+}

--- a/apps/compliance-portal/src/pages/subprocessors/_lib/useSubprocessorFilters.ts
+++ b/apps/compliance-portal/src/pages/subprocessors/_lib/useSubprocessorFilters.ts
@@ -12,56 +12,31 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import { useSearchParams } from "react-router";
 
-const SEARCH_DEBOUNCE_MS = 300;
-
 export interface SubprocessorFilters {
-  // Debounced search term written to the URL (drives the query variables).
   query: string;
   category: string;
   country: string;
-  // Immediate search input value (updates on every keystroke).
-  queryInput: string;
   hasActiveFilters: boolean;
-  setQueryInput: (value: string) => void;
+  setQuery: (value: string) => void;
   setCategory: (value: string) => void;
   setCountry: (value: string) => void;
   clear: () => void;
 }
 
 // Subprocessor filter state, persisted in the URL so it is shareable and
-// survives reloads. The search term is debounced before it is committed to the
-// URL (and therefore before it triggers a refetch).
+// survives reloads. This hook is pure URL state (no local component state or
+// effects), so it can be read from any number of components without them
+// fighting over the search params. The debounced search *input* lives in a
+// single-owner hook (`useSubprocessorSearch`) to avoid write-back loops.
 export function useSubprocessorFilters(): SubprocessorFilters {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const category = searchParams.get("category") ?? "";
   const country = searchParams.get("country") ?? "";
   const query = searchParams.get("q") ?? "";
-
-  const [queryInput, setQueryInput] = useState(query);
-
-  useEffect(() => {
-    if (queryInput === query) {
-      return;
-    }
-
-    const handle = setTimeout(() => {
-      setSearchParams((previous) => {
-        const next = new URLSearchParams(previous);
-        if (queryInput) {
-          next.set("q", queryInput);
-        } else {
-          next.delete("q");
-        }
-        return next;
-      }, { replace: true });
-    }, SEARCH_DEBOUNCE_MS);
-
-    return () => clearTimeout(handle);
-  }, [queryInput, query, setSearchParams]);
 
   const setParam = useCallback((key: string, value: string) => {
     setSearchParams((previous) => {
@@ -75,11 +50,11 @@ export function useSubprocessorFilters(): SubprocessorFilters {
     }, { replace: true });
   }, [setSearchParams]);
 
+  const setQuery = useCallback((value: string) => setParam("q", value), [setParam]);
   const setCategory = useCallback((value: string) => setParam("category", value), [setParam]);
   const setCountry = useCallback((value: string) => setParam("country", value), [setParam]);
 
   const clear = useCallback(() => {
-    setQueryInput("");
     setSearchParams({}, { replace: true });
   }, [setSearchParams]);
 
@@ -87,9 +62,8 @@ export function useSubprocessorFilters(): SubprocessorFilters {
     query,
     category,
     country,
-    queryInput,
     hasActiveFilters: query !== "" || category !== "" || country !== "",
-    setQueryInput,
+    setQuery,
     setCategory,
     setCountry,
     clear,

--- a/apps/compliance-portal/src/pages/subprocessors/_lib/useSubprocessorFilters.ts
+++ b/apps/compliance-portal/src/pages/subprocessors/_lib/useSubprocessorFilters.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "react-router";
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export interface SubprocessorFilters {
+  // Debounced search term written to the URL (drives the query variables).
+  query: string;
+  category: string;
+  country: string;
+  // Immediate search input value (updates on every keystroke).
+  queryInput: string;
+  hasActiveFilters: boolean;
+  setQueryInput: (value: string) => void;
+  setCategory: (value: string) => void;
+  setCountry: (value: string) => void;
+  clear: () => void;
+}
+
+// Subprocessor filter state, persisted in the URL so it is shareable and
+// survives reloads. The search term is debounced before it is committed to the
+// URL (and therefore before it triggers a refetch).
+export function useSubprocessorFilters(): SubprocessorFilters {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const category = searchParams.get("category") ?? "";
+  const country = searchParams.get("country") ?? "";
+  const query = searchParams.get("q") ?? "";
+
+  const [queryInput, setQueryInput] = useState(query);
+
+  useEffect(() => {
+    if (queryInput === query) {
+      return;
+    }
+
+    const handle = setTimeout(() => {
+      setSearchParams((previous) => {
+        const next = new URLSearchParams(previous);
+        if (queryInput) {
+          next.set("q", queryInput);
+        } else {
+          next.delete("q");
+        }
+        return next;
+      }, { replace: true });
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(handle);
+  }, [queryInput, query, setSearchParams]);
+
+  const setParam = useCallback((key: string, value: string) => {
+    setSearchParams((previous) => {
+      const next = new URLSearchParams(previous);
+      if (value) {
+        next.set(key, value);
+      } else {
+        next.delete(key);
+      }
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
+
+  const setCategory = useCallback((value: string) => setParam("category", value), [setParam]);
+  const setCountry = useCallback((value: string) => setParam("country", value), [setParam]);
+
+  const clear = useCallback(() => {
+    setQueryInput("");
+    setSearchParams({}, { replace: true });
+  }, [setSearchParams]);
+
+  return {
+    query,
+    category,
+    country,
+    queryInput,
+    hasActiveFilters: query !== "" || category !== "" || country !== "",
+    setQueryInput,
+    setCategory,
+    setCountry,
+    clear,
+  };
+}

--- a/apps/compliance-portal/src/pages/subprocessors/_lib/useSubprocessorSearch.ts
+++ b/apps/compliance-portal/src/pages/subprocessors/_lib/useSubprocessorSearch.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useEffect, useRef, useState } from "react";
+
+import { useSubprocessorFilters } from "./useSubprocessorFilters";
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+// Owns the debounced search input for the toolbar. Mount this in exactly ONE
+// component (the toolbar) — it is the single writer of the `q` URL param. It
+// keeps an immediate local value for the input and, after a debounce, commits it
+// to the URL. A ref tracks our own writes so the URL→input sync only reacts to
+// *external* changes (clear button, back/forward), never echoing our own commit
+// back onto the input (which would drop in-flight keystrokes).
+export function useSubprocessorSearch(): [string, (value: string) => void] {
+  const { query, setQuery } = useSubprocessorFilters();
+  const [input, setInput] = useState(query);
+  const lastCommittedRef = useRef(query);
+
+  useEffect(() => {
+    if (input === query) {
+      return;
+    }
+
+    const handle = setTimeout(() => {
+      lastCommittedRef.current = input;
+      setQuery(input);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(handle);
+  }, [input, query, setQuery]);
+
+  useEffect(() => {
+    if (query !== lastCommittedRef.current) {
+      lastCommittedRef.current = query;
+      setInput(query);
+    }
+  }, [query]);
+
+  return [input, setInput];
+}

--- a/apps/compliance-portal/src/pages/subprocessors/_locales/en-US.json
+++ b/apps/compliance-portal/src/pages/subprocessors/_locales/en-US.json
@@ -1,0 +1,101 @@
+{
+  "title": "Subprocessors",
+  "empty": {
+    "title": "No subprocessors listed.",
+    "description": "This trust center has not published any subprocessors yet."
+  },
+  "regions": {
+    "global": "Global",
+    "eu": "European Union"
+  },
+  "categories": {
+    "ANALYTICS": {
+      "label": "Analytics",
+      "description": "Usage analytics and product telemetry."
+    },
+    "CLOUD_MONITORING": {
+      "label": "Cloud Monitoring",
+      "description": "Observability, logging, and uptime monitoring."
+    },
+    "CLOUD_PROVIDER": {
+      "label": "Cloud Provider",
+      "description": "Cloud hosting, compute, storage, and networking."
+    },
+    "COLLABORATION": {
+      "label": "Collaboration",
+      "description": "Communication, scheduling, and teamwork tools."
+    },
+    "CUSTOMER_SUPPORT": {
+      "label": "Customer Support",
+      "description": "Help desk, ticketing, and customer messaging."
+    },
+    "DATA_STORAGE_AND_PROCESSING": {
+      "label": "Data Storage and Processing",
+      "description": "Databases, data warehouses, and processing pipelines."
+    },
+    "DOCUMENT_MANAGEMENT": {
+      "label": "Document Management",
+      "description": "Document storage, signing, and e-signature."
+    },
+    "EMPLOYEE_MANAGEMENT": {
+      "label": "Employee Management",
+      "description": "HR, payroll, and people operations."
+    },
+    "ENGINEERING": {
+      "label": "Engineering",
+      "description": "Developer tooling and engineering platforms."
+    },
+    "FINANCE": {
+      "label": "Finance",
+      "description": "Billing, payments, and accounting."
+    },
+    "IDENTITY_PROVIDER": {
+      "label": "Identity Provider",
+      "description": "Authentication, SSO, and identity management."
+    },
+    "IT": {
+      "label": "IT",
+      "description": "IT administration and device management."
+    },
+    "MARKETING": {
+      "label": "Marketing",
+      "description": "Marketing, CRM, and audience engagement."
+    },
+    "OFFICE_OPERATIONS": {
+      "label": "Office Operations",
+      "description": "Workplace and office operations."
+    },
+    "OTHER": {
+      "label": "Other",
+      "description": "Other supporting services."
+    },
+    "PASSWORD_MANAGEMENT": {
+      "label": "Password Management",
+      "description": "Credential and secret management."
+    },
+    "PRODUCT_AND_DESIGN": {
+      "label": "Product and Design",
+      "description": "Product and design tooling."
+    },
+    "PROFESSIONAL_SERVICES": {
+      "label": "Professional Services",
+      "description": "Consulting and professional services."
+    },
+    "RECRUITING": {
+      "label": "Recruiting",
+      "description": "Hiring, sourcing, and applicant tracking."
+    },
+    "SALES": {
+      "label": "Sales",
+      "description": "Sales enablement and CRM."
+    },
+    "SECURITY": {
+      "label": "Security",
+      "description": "Security, monitoring, and secure access."
+    },
+    "VERSION_CONTROL": {
+      "label": "Version Control",
+      "description": "Source control and code hosting."
+    }
+  }
+}

--- a/apps/compliance-portal/src/pages/subprocessors/_locales/en-US.json
+++ b/apps/compliance-portal/src/pages/subprocessors/_locales/en-US.json
@@ -1,8 +1,16 @@
 {
   "title": "Subprocessors",
+  "filters": {
+    "allCategories": "All categories",
+    "allRegions": "All regions",
+    "searchPlaceholder": "Search..."
+  },
   "empty": {
     "title": "No subprocessors listed.",
-    "description": "This trust center has not published any subprocessors yet."
+    "description": "This trust center has not published any subprocessors yet.",
+    "filteredTitle": "No subprocessors match your filters.",
+    "filteredDescription": "Adjust your search or filters to see available subprocessors.",
+    "clearFilters": "Clear filters"
   },
   "regions": {
     "global": "Global",

--- a/apps/compliance-portal/src/pages/subprocessors/_locales/fr-FR.json
+++ b/apps/compliance-portal/src/pages/subprocessors/_locales/fr-FR.json
@@ -1,0 +1,101 @@
+{
+  "title": "Sous-traitants",
+  "empty": {
+    "title": "Aucun sous-traitant répertorié.",
+    "description": "Ce centre de confiance n'a pas encore publié de sous-traitants."
+  },
+  "regions": {
+    "global": "International",
+    "eu": "Union européenne"
+  },
+  "categories": {
+    "ANALYTICS": {
+      "label": "Analytique",
+      "description": "Analyse d'usage et télémétrie produit."
+    },
+    "CLOUD_MONITORING": {
+      "label": "Supervision cloud",
+      "description": "Observabilité, journalisation et supervision."
+    },
+    "CLOUD_PROVIDER": {
+      "label": "Fournisseur cloud",
+      "description": "Hébergement, calcul, stockage et réseau cloud."
+    },
+    "COLLABORATION": {
+      "label": "Collaboration",
+      "description": "Communication, planification et travail d'équipe."
+    },
+    "CUSTOMER_SUPPORT": {
+      "label": "Support client",
+      "description": "Assistance, tickets et messagerie client."
+    },
+    "DATA_STORAGE_AND_PROCESSING": {
+      "label": "Stockage et traitement des données",
+      "description": "Bases de données, entrepôts et traitements."
+    },
+    "DOCUMENT_MANAGEMENT": {
+      "label": "Gestion documentaire",
+      "description": "Stockage, signature et e-signature de documents."
+    },
+    "EMPLOYEE_MANAGEMENT": {
+      "label": "Gestion des employés",
+      "description": "RH, paie et opérations RH."
+    },
+    "ENGINEERING": {
+      "label": "Ingénierie",
+      "description": "Outils et plateformes d'ingénierie."
+    },
+    "FINANCE": {
+      "label": "Finance",
+      "description": "Facturation, paiements et comptabilité."
+    },
+    "IDENTITY_PROVIDER": {
+      "label": "Fournisseur d'identité",
+      "description": "Authentification, SSO et gestion des identités."
+    },
+    "IT": {
+      "label": "Informatique",
+      "description": "Administration informatique et gestion des appareils."
+    },
+    "MARKETING": {
+      "label": "Marketing",
+      "description": "Marketing, CRM et engagement de l'audience."
+    },
+    "OFFICE_OPERATIONS": {
+      "label": "Opérations de bureau",
+      "description": "Opérations et gestion des bureaux."
+    },
+    "OTHER": {
+      "label": "Autre",
+      "description": "Autres services de support."
+    },
+    "PASSWORD_MANAGEMENT": {
+      "label": "Gestion des mots de passe",
+      "description": "Gestion des identifiants et des secrets."
+    },
+    "PRODUCT_AND_DESIGN": {
+      "label": "Produit et design",
+      "description": "Outils de produit et de design."
+    },
+    "PROFESSIONAL_SERVICES": {
+      "label": "Services professionnels",
+      "description": "Conseil et services professionnels."
+    },
+    "RECRUITING": {
+      "label": "Recrutement",
+      "description": "Recrutement, sourcing et suivi des candidatures."
+    },
+    "SALES": {
+      "label": "Ventes",
+      "description": "Aide à la vente et CRM."
+    },
+    "SECURITY": {
+      "label": "Sécurité",
+      "description": "Sécurité, supervision et accès sécurisé."
+    },
+    "VERSION_CONTROL": {
+      "label": "Gestion de versions",
+      "description": "Gestion de sources et hébergement de code."
+    }
+  }
+}

--- a/apps/compliance-portal/src/pages/subprocessors/_locales/fr-FR.json
+++ b/apps/compliance-portal/src/pages/subprocessors/_locales/fr-FR.json
@@ -1,8 +1,16 @@
 {
   "title": "Sous-traitants",
+  "filters": {
+    "allCategories": "Toutes les catégories",
+    "allRegions": "Toutes les régions",
+    "searchPlaceholder": "Rechercher..."
+  },
   "empty": {
     "title": "Aucun sous-traitant répertorié.",
-    "description": "Ce centre de confiance n'a pas encore publié de sous-traitants."
+    "description": "Ce centre de confiance n'a pas encore publié de sous-traitants.",
+    "filteredTitle": "Aucun sous-traitant ne correspond à vos filtres.",
+    "filteredDescription": "Ajustez votre recherche ou vos filtres pour voir les sous-traitants disponibles.",
+    "clearFilters": "Réinitialiser les filtres"
   },
   "regions": {
     "global": "International",

--- a/apps/compliance-portal/src/pages/subprocessors/routes.ts
+++ b/apps/compliance-portal/src/pages/subprocessors/routes.ts
@@ -12,13 +12,15 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { useTranslation } from "react-i18next";
+import { lazy } from "@probo/react-lazy";
+import type { AppRoute } from "@probo/routes";
 
-import { PageHeader } from "#/components/PageHeader/PageHeader";
+import { SubprocessorsPageSkeleton } from "./SubprocessorsPageSkeleton";
 
-// Toolbar (category/region filters, search, Download CSV) and the subprocessor
-// count are deferred until the v2 Select/TextField components exist.
-export default function SubprocessorsPage() {
-  const { t } = useTranslation();
-  return <PageHeader title={t("subprocessors.title")} />;
-}
+export const subprocessorRoutes = [
+  {
+    path: "subprocessors",
+    Fallback: SubprocessorsPageSkeleton,
+    Component: lazy(() => import("./SubprocessorsPageLoader")),
+  },
+] satisfies AppRoute[];

--- a/apps/compliance-portal/src/routes.tsx
+++ b/apps/compliance-portal/src/routes.tsx
@@ -19,6 +19,7 @@ import { createBrowserRouter } from "react-router";
 import { getPathPrefix } from "#/lib/http/pathPrefix";
 import { HomePageSkeleton } from "#/pages/HomePageSkeleton";
 import { MainLayoutSkeleton } from "#/pages/MainLayoutSkeleton";
+import { subprocessorRoutes } from "#/pages/subprocessors/routes";
 
 const routes = [
   {
@@ -35,10 +36,7 @@ const routes = [
         path: "documents",
         Component: lazy(() => import("#/pages/DocumentsPage")),
       },
-      {
-        path: "subprocessors",
-        Component: lazy(() => import("#/pages/SubprocessorsPage")),
-      },
+      ...subprocessorRoutes,
       {
         path: "updates",
         Component: lazy(() => import("#/pages/UpdatesPage")),

--- a/contrib/claude/relay.md
+++ b/contrib/claude/relay.md
@@ -297,6 +297,44 @@ const [data, refetch] = useRefetchableFragment(thirdPartyContactsFragment, third
 const connectionId = data.contacts.__id;
 ```
 
+## Refetch inside a transition
+
+`refetch` (and `loadQuery` / `usePaginationFragment`) **suspends** while the new
+data loads. The nearest `Suspense` boundary is usually the **route-level** one,
+whose fallback is the whole-page skeleton — so a bare `refetch` (e.g. re-running
+a list query when a filter changes) blanks the entire page, toolbar included, on
+every change.
+
+Wrap the refetch in `startTransition` (React `useTransition`). A transition keeps
+the current UI mounted instead of falling back to the boundary, and exposes
+`isPending` so you can scope the loading affordance to just the results — a dim,
+an inline spinner, or a small placeholder — never the whole tree. This is the
+default for filter/sort refetches; prefer a scoped transition over a page-level
+Suspense fallback.
+
+```tsx
+// Bad — refetch suspends to the route skeleton; the toolbar and results flash
+useEffect(() => { refetch(variables); }, [refetch, variables]);
+```
+
+```tsx
+// Good — transition keeps the toolbar + current results mounted; only results dim
+const [isPending, startTransition] = useTransition();
+useEffect(() => {
+  startTransition(() => {
+    refetch(variables, { fetchPolicy: "store-or-network" });
+  });
+}, [refetch, variables]);
+
+// scope the loading state to the results container:
+<div aria-busy={isPending} className={`… transition-opacity ${isPending ? "opacity-60" : ""}`}>
+  {/* list */}
+</div>
+```
+
+See [`state-management.md`](state-management.md#filtering-a-list) for the full
+list-filtering pattern (pure URL-state hook + single-owner debounced search).
+
 ## Pagination
 
 Use `usePaginationFragment` for cursor-based Relay pagination:

--- a/contrib/claude/state-management.md
+++ b/contrib/claude/state-management.md
@@ -65,6 +65,87 @@ useFilterStore();   // global singleton for a local concern
 
 `zustand` is available (it's a `@probo/ui` dependency) — use it deliberately for app-wide ephemeral state, not as a shortcut around prop-passing or the URL.
 
+## Filtering a list
+
+A filterable list (a toolbar of selects + a search box driving a server-side
+query) combines several of the rules above. Three points matter, in order:
+
+1. **The filter values live in the URL** (rule 2): category, status, sort, and
+   the search term go in `useSearchParams`. Expose them through a hook that is
+   **pure** — it reads the params and returns values + setters, with **no
+   `useState` and no `useEffect`**. A pure hook is safe to call from every
+   component that needs the filters (page, loader, toolbar, empty state); they
+   all read one source of truth.
+
+   The failure mode: a URL-filter hook that keeps its own `useState` mirror
+   **and** an effect writing that mirror back to the URL. Every caller runs its
+   own copy of that effect, but only one (the input) updates the mirror — the
+   rest keep a **stale** mirror and fight the real writer, flipping the list
+   between filtered and unfiltered in an infinite loop.
+
+2. **The debounced search input is the one piece of local state** — and it lives
+   in a **separate, single-owner hook** mounted in exactly one component (the
+   toolbar), the single writer of the search param. It holds the immediate input
+   value and commits it to the URL after a debounce. Guard the URL→input sync
+   with a `ref` tracking your own writes, so a debounced commit isn't echoed
+   back onto the input (which would drop in-flight keystrokes); only *external*
+   changes (a Clear button, back/forward) sync.
+
+3. **Refetch on change inside a transition** so the loading state is scoped to
+   the results, not the whole page — see
+   [`relay.md`](relay.md#refetch-inside-a-transition).
+
+```ts
+// Bad — URL-filter hook with a per-instance mirror + write-back effect.
+// Called by the page, loader, toolbar and empty state → four fighting writers.
+export function useThirdPartyFilters() {
+  const [params, setParams] = useSearchParams();
+  const query = params.get("q") ?? "";
+  const [input, setInput] = useState(query);
+  useEffect(() => {
+    if (input !== query) setParams(/* write q=input */, { replace: true });
+  }, [input, query, setParams]);
+  return { query, input, setInput /* … */ };
+}
+```
+
+```ts
+// Good — pure URL-state hook (no state/effects); safe to call anywhere
+export function useThirdPartyFilters() {
+  const [params, setParams] = useSearchParams();
+  const setParam = useCallback((k: string, v: string) => {
+    setParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (v) next.set(k, v); else next.delete(k);
+      return next;
+    }, { replace: true });
+  }, [setParams]);
+  return {
+    query: params.get("q") ?? "",
+    category: params.get("category") ?? "",
+    setQuery: (v: string) => setParam("q", v),
+    setCategory: (v: string) => setParam("category", v),
+    clear: () => setParams({}, { replace: true }),
+  };
+}
+
+// Good — debounced search input in its own single-owner hook (used by the toolbar)
+export function useThirdPartySearch(): [string, (v: string) => void] {
+  const { query, setQuery } = useThirdPartyFilters();
+  const [input, setInput] = useState(query);
+  const lastCommitted = useRef(query);
+  useEffect(() => {                          // debounce input → URL
+    if (input === query) return;
+    const h = setTimeout(() => { lastCommitted.current = input; setQuery(input); }, 300);
+    return () => clearTimeout(h);
+  }, [input, query, setQuery]);
+  useEffect(() => {                          // sync URL → input for external changes only
+    if (query !== lastCommitted.current) { lastCommitted.current = query; setInput(query); }
+  }, [query]);
+  return [input, setInput];
+}
+```
+
 ## Anti-patterns to avoid
 
 - **Prop-drilling data** that a child could read from Relay (`useFragment`) or the router (`useParams`) itself.

--- a/e2e/trust/helpers_test.go
+++ b/e2e/trust/helpers_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package trust_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+// lookupTrustCenterID resolves the trust center ID of the owner's organization.
+func lookupTrustCenterID(t *testing.T, owner *testutil.Client) string {
+	t.Helper()
+
+	const query = `
+		query($organizationId: ID!) {
+			node(id: $organizationId) {
+				... on Organization {
+					trustCenter { id }
+				}
+			}
+		}
+	`
+
+	var result struct {
+		Node struct {
+			TrustCenter struct {
+				ID string `json:"id"`
+			} `json:"trustCenter"`
+		} `json:"node"`
+	}
+
+	err := owner.Execute(query, map[string]any{
+		"organizationId": owner.GetOrganizationID().String(),
+	}, &result)
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Node.TrustCenter.ID)
+
+	return result.Node.TrustCenter.ID
+}
+
+// activateTrustCenter flips the trust center to active so its public surface
+// (NDA, subprocessors, reports, branding) becomes reachable by visitors.
+func activateTrustCenter(t *testing.T, owner *testutil.Client, trustCenterID string) {
+	t.Helper()
+
+	const query = `
+		mutation($input: UpdateTrustCenterInput!) {
+			updateTrustCenter(input: $input) {
+				trustCenter { id active }
+			}
+		}
+	`
+
+	err := owner.Execute(query, map[string]any{
+		"input": map[string]any{
+			"trustCenterId": trustCenterID,
+			"active":        true,
+		},
+	}, nil)
+	require.NoError(t, err)
+}

--- a/e2e/trust/subprocessors_filter_test.go
+++ b/e2e/trust/subprocessors_filter_test.go
@@ -148,6 +148,7 @@ func querySubprocessors(
 	`
 
 	var result subprocessorsResult
+
 	err := owner.ExecuteTrust(trustCenterID, query, map[string]any{"filter": filter}, &result)
 	require.NoError(t, err)
 

--- a/e2e/trust/subprocessors_filter_test.go
+++ b/e2e/trust/subprocessors_filter_test.go
@@ -27,7 +27,8 @@ func TestTrustCenter_SubprocessorsFilter(t *testing.T) {
 	t.Parallel()
 
 	owner := testutil.NewClient(t, testutil.RoleOwner)
-	trustCenterID := activateTrustCenter(t, owner)
+	trustCenterID := lookupTrustCenterID(t, owner)
+	activateTrustCenter(t, owner, trustCenterID)
 
 	awsName := factory.SafeName("AWS")
 	awsID := factory.NewThirdParty(owner).WithName(awsName).WithCategory("CLOUD_PROVIDER").Create()
@@ -153,52 +154,6 @@ func querySubprocessors(
 	require.NoError(t, err)
 
 	return result
-}
-
-func activateTrustCenter(t *testing.T, owner *testutil.Client) string {
-	t.Helper()
-
-	const trustCenterQuery = `
-		query($organizationId: ID!) {
-			node(id: $organizationId) {
-				... on Organization {
-					trustCenter { id }
-				}
-			}
-		}
-	`
-
-	var lookup struct {
-		Node struct {
-			TrustCenter struct {
-				ID string `json:"id"`
-			} `json:"trustCenter"`
-		} `json:"node"`
-	}
-
-	err := owner.Execute(trustCenterQuery, map[string]any{
-		"organizationId": owner.GetOrganizationID().String(),
-	}, &lookup)
-	require.NoError(t, err)
-	require.NotEmpty(t, lookup.Node.TrustCenter.ID)
-
-	const activateMutation = `
-		mutation($input: UpdateTrustCenterInput!) {
-			updateTrustCenter(input: $input) {
-				trustCenter { id active }
-			}
-		}
-	`
-
-	err = owner.Execute(activateMutation, map[string]any{
-		"input": map[string]any{
-			"trustCenterId": lookup.Node.TrustCenter.ID,
-			"active":        true,
-		},
-	}, nil)
-	require.NoError(t, err)
-
-	return lookup.Node.TrustCenter.ID
 }
 
 func publishSubprocessor(t *testing.T, owner *testutil.Client, thirdPartyID string, countries []string) {

--- a/e2e/trust/subprocessors_filter_test.go
+++ b/e2e/trust/subprocessors_filter_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package trust_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+func TestTrustCenter_SubprocessorsFilter(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	trustCenterID := activateTrustCenter(t, owner)
+
+	awsName := factory.SafeName("AWS")
+	awsID := factory.NewThirdParty(owner).WithName(awsName).WithCategory("CLOUD_PROVIDER").Create()
+	publishSubprocessor(t, owner, awsID, []string{"US"})
+
+	stripeName := factory.SafeName("Stripe")
+	stripeID := factory.NewThirdParty(owner).WithName(stripeName).WithCategory("FINANCE").Create()
+	publishSubprocessor(t, owner, stripeID, []string{"US", "IE"})
+
+	slackName := factory.SafeName("Slack")
+	slackID := factory.NewThirdParty(owner).WithName(slackName).WithCategory("COLLABORATION").Create()
+	publishSubprocessor(t, owner, slackID, []string{"US"})
+
+	t.Run("no filter returns every published subprocessor", func(t *testing.T) {
+		t.Parallel()
+
+		result := querySubprocessors(t, owner, trustCenterID, nil)
+		assert.Equal(t, 3, result.CurrentTrustCenter.Subprocessors.TotalCount)
+		assert.Len(t, result.CurrentTrustCenter.Subprocessors.Edges, 3)
+	})
+
+	t.Run("category filter narrows to one category", func(t *testing.T) {
+		t.Parallel()
+
+		result := querySubprocessors(t, owner, trustCenterID, map[string]any{
+			"category": "CLOUD_PROVIDER",
+		})
+		require.Equal(t, 1, result.CurrentTrustCenter.Subprocessors.TotalCount)
+		require.Len(t, result.CurrentTrustCenter.Subprocessors.Edges, 1)
+		assert.Equal(t, awsName, result.CurrentTrustCenter.Subprocessors.Edges[0].Node.Name)
+	})
+
+	t.Run("country filter matches array membership", func(t *testing.T) {
+		t.Parallel()
+
+		result := querySubprocessors(t, owner, trustCenterID, map[string]any{
+			"country": "IE",
+		})
+		require.Equal(t, 1, result.CurrentTrustCenter.Subprocessors.TotalCount)
+		require.Len(t, result.CurrentTrustCenter.Subprocessors.Edges, 1)
+		assert.Equal(t, stripeName, result.CurrentTrustCenter.Subprocessors.Edges[0].Node.Name)
+	})
+
+	t.Run("query filter matches name substring", func(t *testing.T) {
+		t.Parallel()
+
+		result := querySubprocessors(t, owner, trustCenterID, map[string]any{
+			"query": slackName,
+		})
+		require.Equal(t, 1, result.CurrentTrustCenter.Subprocessors.TotalCount)
+		require.Len(t, result.CurrentTrustCenter.Subprocessors.Edges, 1)
+		assert.Equal(t, slackName, result.CurrentTrustCenter.Subprocessors.Edges[0].Node.Name)
+	})
+
+	t.Run("combined filters intersect", func(t *testing.T) {
+		t.Parallel()
+
+		result := querySubprocessors(t, owner, trustCenterID, map[string]any{
+			"category": "FINANCE",
+			"country":  "US",
+		})
+		require.Equal(t, 1, result.CurrentTrustCenter.Subprocessors.TotalCount)
+		require.Len(t, result.CurrentTrustCenter.Subprocessors.Edges, 1)
+		assert.Equal(t, stripeName, result.CurrentTrustCenter.Subprocessors.Edges[0].Node.Name)
+	})
+
+	t.Run("non-matching filter returns empty set", func(t *testing.T) {
+		t.Parallel()
+
+		result := querySubprocessors(t, owner, trustCenterID, map[string]any{
+			"category": "SECURITY",
+		})
+		assert.Equal(t, 0, result.CurrentTrustCenter.Subprocessors.TotalCount)
+		assert.Empty(t, result.CurrentTrustCenter.Subprocessors.Edges)
+	})
+}
+
+type subprocessorsResult struct {
+	CurrentTrustCenter struct {
+		Subprocessors struct {
+			TotalCount int `json:"totalCount"`
+			Edges      []struct {
+				Node struct {
+					ID        string   `json:"id"`
+					Name      string   `json:"name"`
+					Category  string   `json:"category"`
+					Countries []string `json:"countries"`
+				} `json:"node"`
+			} `json:"edges"`
+		} `json:"subprocessors"`
+	} `json:"currentTrustCenter"`
+}
+
+func querySubprocessors(
+	t *testing.T,
+	owner *testutil.Client,
+	trustCenterID string,
+	filter map[string]any,
+) subprocessorsResult {
+	t.Helper()
+
+	const query = `
+		query($filter: SubprocessorFilter) {
+			currentTrustCenter {
+				subprocessors(first: 50, filter: $filter) {
+					totalCount
+					edges {
+						node {
+							id
+							name
+							category
+							countries
+						}
+					}
+				}
+			}
+		}
+	`
+
+	var result subprocessorsResult
+	err := owner.ExecuteTrust(trustCenterID, query, map[string]any{"filter": filter}, &result)
+	require.NoError(t, err)
+
+	return result
+}
+
+func activateTrustCenter(t *testing.T, owner *testutil.Client) string {
+	t.Helper()
+
+	const trustCenterQuery = `
+		query($organizationId: ID!) {
+			node(id: $organizationId) {
+				... on Organization {
+					trustCenter { id }
+				}
+			}
+		}
+	`
+
+	var lookup struct {
+		Node struct {
+			TrustCenter struct {
+				ID string `json:"id"`
+			} `json:"trustCenter"`
+		} `json:"node"`
+	}
+
+	err := owner.Execute(trustCenterQuery, map[string]any{
+		"organizationId": owner.GetOrganizationID().String(),
+	}, &lookup)
+	require.NoError(t, err)
+	require.NotEmpty(t, lookup.Node.TrustCenter.ID)
+
+	const activateMutation = `
+		mutation($input: UpdateTrustCenterInput!) {
+			updateTrustCenter(input: $input) {
+				trustCenter { id active }
+			}
+		}
+	`
+
+	err = owner.Execute(activateMutation, map[string]any{
+		"input": map[string]any{
+			"trustCenterId": lookup.Node.TrustCenter.ID,
+			"active":        true,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	return lookup.Node.TrustCenter.ID
+}
+
+func publishSubprocessor(t *testing.T, owner *testutil.Client, thirdPartyID string, countries []string) {
+	t.Helper()
+
+	const mutation = `
+		mutation($input: UpdateThirdPartyInput!) {
+			updateThirdParty(input: $input) {
+				thirdParty { id showOnTrustCenter countries }
+			}
+		}
+	`
+
+	err := owner.Execute(mutation, map[string]any{
+		"input": map[string]any{
+			"id":                thirdPartyID,
+			"showOnTrustCenter": true,
+			"countries":         countries,
+		},
+	}, nil)
+	require.NoError(t, err)
+}

--- a/e2e/trust/trust_center_logo_test.go
+++ b/e2e/trust/trust_center_logo_test.go
@@ -30,54 +30,8 @@ func TestTrustCenter_LogoFileDownloadURL(t *testing.T) {
 	t.Parallel()
 
 	owner := testutil.NewClient(t, testutil.RoleOwner)
-	organizationID := owner.GetOrganizationID().String()
-
-	const trustCenterQuery = `
-		query($organizationId: ID!) {
-			node(id: $organizationId) {
-				... on Organization {
-					trustCenter {
-						id
-					}
-				}
-			}
-		}
-	`
-
-	var trustCenterLookup struct {
-		Node struct {
-			TrustCenter struct {
-				ID string `json:"id"`
-			} `json:"trustCenter"`
-		} `json:"node"`
-	}
-
-	err := owner.Execute(trustCenterQuery, map[string]any{
-		"organizationId": organizationID,
-	}, &trustCenterLookup)
-	require.NoError(t, err)
-	require.NotEmpty(t, trustCenterLookup.Node.TrustCenter.ID)
-
-	trustCenterID := trustCenterLookup.Node.TrustCenter.ID
-
-	const activateMutation = `
-		mutation($input: UpdateTrustCenterInput!) {
-			updateTrustCenter(input: $input) {
-				trustCenter {
-					id
-					active
-				}
-			}
-		}
-	`
-
-	err = owner.Execute(activateMutation, map[string]any{
-		"input": map[string]any{
-			"trustCenterId": trustCenterID,
-			"active":        true,
-		},
-	}, nil)
-	require.NoError(t, err)
+	trustCenterID := lookupTrustCenterID(t, owner)
+	activateTrustCenter(t, owner, trustCenterID)
 
 	const uploadMutation = `
 		mutation UpdateTrustCenterBrand($input: UpdateTrustCenterBrandInput!) {
@@ -119,7 +73,7 @@ func TestTrustCenter_LogoFileDownloadURL(t *testing.T) {
 		} `json:"updateTrustCenterBrand"`
 	}
 
-	err = owner.ExecuteWithFile(uploadMutation, map[string]any{
+	err := owner.ExecuteWithFile(uploadMutation, map[string]any{
 		"input": map[string]any{
 			"trustCenterId": trustCenterID,
 			"logoFile":      nil,

--- a/e2e/trust/trust_center_nda_signature_test.go
+++ b/e2e/trust/trust_center_nda_signature_test.go
@@ -113,36 +113,6 @@ func TestTrustCenter_AcceptElectronicSignature_RejectsForeignSignature(t *testin
 	assert.Equal(t, "ACCEPTED", acceptResult.AcceptElectronicSignature.Signature.Status)
 }
 
-func lookupTrustCenterID(t *testing.T, owner *testutil.Client) string {
-	t.Helper()
-
-	const query = `
-		query($organizationId: ID!) {
-			node(id: $organizationId) {
-				... on Organization {
-					trustCenter { id }
-				}
-			}
-		}
-	`
-
-	var result struct {
-		Node struct {
-			TrustCenter struct {
-				ID string `json:"id"`
-			} `json:"trustCenter"`
-		} `json:"node"`
-	}
-
-	err := owner.Execute(query, map[string]any{
-		"organizationId": owner.GetOrganizationID().String(),
-	}, &result)
-	require.NoError(t, err)
-	require.NotEmpty(t, result.Node.TrustCenter.ID)
-
-	return result.Node.TrustCenter.ID
-}
-
 func uploadTrustCenterNDA(t *testing.T, owner *testutil.Client, trustCenterID string) {
 	t.Helper()
 
@@ -167,26 +137,6 @@ func uploadTrustCenterNDA(t *testing.T, owner *testutil.Client, trustCenterID st
 		Filename:    "nda.pdf",
 		ContentType: "application/pdf",
 		Content:     pdfContent,
-	}, nil)
-	require.NoError(t, err)
-}
-
-func activateTrustCenter(t *testing.T, owner *testutil.Client, trustCenterID string) {
-	t.Helper()
-
-	const query = `
-		mutation($input: UpdateTrustCenterInput!) {
-			updateTrustCenter(input: $input) {
-				trustCenter { id active }
-			}
-		}
-	`
-
-	err := owner.Execute(query, map[string]any{
-		"input": map[string]any{
-			"trustCenterId": trustCenterID,
-			"active":        true,
-		},
 	}, nil)
 	require.NoError(t, err)
 }

--- a/e2e/trust/trust_center_report_export_test.go
+++ b/e2e/trust/trust_center_report_export_test.go
@@ -188,47 +188,8 @@ func setupPublicAuditReport(t *testing.T, owner *testutil.Client) (trustCenterID
 	}, nil)
 	require.NoError(t, err)
 
-	const trustCenterQuery = `
-		query($organizationId: ID!) {
-			node(id: $organizationId) {
-				... on Organization {
-					trustCenter { id }
-				}
-			}
-		}
-	`
-
-	var trustCenterLookup struct {
-		Node struct {
-			TrustCenter struct {
-				ID string `json:"id"`
-			} `json:"trustCenter"`
-		} `json:"node"`
-	}
-
-	err = owner.Execute(trustCenterQuery, map[string]any{
-		"organizationId": owner.GetOrganizationID().String(),
-	}, &trustCenterLookup)
-	require.NoError(t, err)
-
-	trustCenterID = trustCenterLookup.Node.TrustCenter.ID
-	require.NotEmpty(t, trustCenterID)
-
-	const activateMutation = `
-		mutation($input: UpdateTrustCenterInput!) {
-			updateTrustCenter(input: $input) {
-				trustCenter { id active }
-			}
-		}
-	`
-
-	err = owner.Execute(activateMutation, map[string]any{
-		"input": map[string]any{
-			"trustCenterId": trustCenterID,
-			"active":        true,
-		},
-	}, nil)
-	require.NoError(t, err)
+	trustCenterID = lookupTrustCenterID(t, owner)
+	activateTrustCenter(t, owner, trustCenterID)
 
 	return trustCenterID, reportID
 }

--- a/packages/ui/src/v2/Select/Select.stories.tsx
+++ b/packages/ui/src/v2/Select/Select.stories.tsx
@@ -64,7 +64,10 @@ export function Controlled() {
           </SelectPopup>
         </Select>
       </div>
-      <span className="text-2 text-sand-11">Selected: {value ?? "none"}</span>
+      <span className="text-2 text-sand-11">
+        Selected:
+        {value ?? "none"}
+      </span>
     </div>
   );
 }

--- a/packages/ui/src/v2/Select/Select.stories.tsx
+++ b/packages/ui/src/v2/Select/Select.stories.tsx
@@ -48,6 +48,27 @@ export function Default() {
   );
 }
 
+export function Variants() {
+  return (
+    <div className="flex flex-col gap-3">
+      {(["classic", "surface", "soft", "ghost"] as const).map(variant => (
+        <div key={variant} className="w-40">
+          <Select>
+            <SelectTrigger variant={variant} placeholder={variant}>
+              {(value: string | null) => (value ? fruits[value] : null)}
+            </SelectTrigger>
+            <SelectPopup>
+              {Object.entries(fruits).map(([value, label]) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
+            </SelectPopup>
+          </Select>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function Controlled() {
   const [value, setValue] = useState<string | null>(null);
   return (

--- a/packages/ui/src/v2/Select/Select.stories.tsx
+++ b/packages/ui/src/v2/Select/Select.stories.tsx
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useState } from "react";
+
+import { Select } from "./Select";
+import { SelectItem } from "./SelectItem";
+import { SelectPopup } from "./SelectPopup";
+import { SelectSkeleton } from "./SelectSkeleton";
+import { SelectTrigger } from "./SelectTrigger";
+
+export default {
+  title: "v2/Select",
+  component: Select,
+};
+
+const fruits: Record<string, string> = {
+  apple: "Apple",
+  banana: "Banana",
+  cherry: "Cherry",
+};
+
+export function Default() {
+  return (
+    <div className="w-40">
+      <Select>
+        <SelectTrigger placeholder="Select a fruit">
+          {(value: string | null) => (value ? fruits[value] : null)}
+        </SelectTrigger>
+        <SelectPopup>
+          {Object.entries(fruits).map(([value, label]) => (
+            <SelectItem key={value} value={value}>{label}</SelectItem>
+          ))}
+        </SelectPopup>
+      </Select>
+    </div>
+  );
+}
+
+export function Controlled() {
+  const [value, setValue] = useState<string | null>(null);
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="w-40">
+        <Select value={value} onValueChange={setValue}>
+          <SelectTrigger placeholder="All categories">
+            {(current: string | null) => (current ? fruits[current] : null)}
+          </SelectTrigger>
+          <SelectPopup>
+            {Object.entries(fruits).map(([key, label]) => (
+              <SelectItem key={key} value={key}>{label}</SelectItem>
+            ))}
+          </SelectPopup>
+        </Select>
+      </div>
+      <span className="text-2 text-sand-11">Selected: {value ?? "none"}</span>
+    </div>
+  );
+}
+
+export function Skeleton() {
+  return <SelectSkeleton />;
+}

--- a/packages/ui/src/v2/Select/Select.stories.tsx
+++ b/packages/ui/src/v2/Select/Select.stories.tsx
@@ -87,6 +87,7 @@ export function Controlled() {
       </div>
       <span className="text-2 text-sand-11">
         Selected:
+        {" "}
         {value ?? "none"}
       </span>
     </div>

--- a/packages/ui/src/v2/Select/Select.tsx
+++ b/packages/ui/src/v2/Select/Select.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { Select as BaseSelect } from "@base-ui/react/select";
+
+// Root of the select (Radix "Select"). Controlled the same way as Base UI's
+// Select: `value` / `onValueChange`, or left uncontrolled. Generic over the
+// option value type. See contrib/claude/ui.md.
+export type SelectProps<Value = string, Multiple extends boolean | undefined = false>
+  = BaseSelect.Root.Props<Value, Multiple>;
+
+export function Select<Value = string, Multiple extends boolean | undefined = false>(
+  props: SelectProps<Value, Multiple>,
+) {
+  return <BaseSelect.Root {...props} />;
+}

--- a/packages/ui/src/v2/Select/SelectItem.tsx
+++ b/packages/ui/src/v2/Select/SelectItem.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { Select as BaseSelect } from "@base-ui/react/select";
+import { CheckIcon } from "@phosphor-icons/react";
+import type { ComponentProps } from "react";
+
+import { selectItem } from "./variants";
+
+export type SelectItemProps
+  = & Omit<ComponentProps<typeof BaseSelect.Item>, "className">
+    & { className?: string };
+
+// A single option. Shows a trailing check when selected. Inherits highlight
+// styling from the popup surface.
+export function SelectItem(props: SelectItemProps) {
+  const { className, children, ...rest } = props;
+  const { item, label, indicator } = selectItem();
+
+  return (
+    <BaseSelect.Item className={item({ className })} {...rest}>
+      <span className={label()}>
+        <BaseSelect.ItemText>{children}</BaseSelect.ItemText>
+      </span>
+      <BaseSelect.ItemIndicator className={indicator()}>
+        <CheckIcon />
+      </BaseSelect.ItemIndicator>
+    </BaseSelect.Item>
+  );
+}

--- a/packages/ui/src/v2/Select/SelectPopup.tsx
+++ b/packages/ui/src/v2/Select/SelectPopup.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { Select as BaseSelect } from "@base-ui/react/select";
+import type { ComponentProps } from "react";
+
+import { selectPopup } from "./variants";
+
+export type SelectPopupProps
+  = & Omit<ComponentProps<typeof BaseSelect.Popup>, "className">
+    & {
+      className?: string;
+      // Positioner placement passthrough.
+      side?: ComponentProps<typeof BaseSelect.Positioner>["side"];
+      align?: ComponentProps<typeof BaseSelect.Positioner>["align"];
+      sideOffset?: ComponentProps<typeof BaseSelect.Positioner>["sideOffset"];
+    };
+
+// Portal + positioner + styled popup holding the select items.
+export function SelectPopup(props: SelectPopupProps) {
+  const {
+    className, children,
+    side = "bottom", align = "start", sideOffset = 4,
+    ...popupProps
+  } = props;
+
+  return (
+    <BaseSelect.Portal>
+      <BaseSelect.Positioner side={side} align={align} sideOffset={sideOffset}>
+        <BaseSelect.Popup className={selectPopup({ className })} {...popupProps}>
+          {children}
+        </BaseSelect.Popup>
+      </BaseSelect.Positioner>
+    </BaseSelect.Portal>
+  );
+}

--- a/packages/ui/src/v2/Select/SelectSkeleton.tsx
+++ b/packages/ui/src/v2/Select/SelectSkeleton.tsx
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { ComponentProps } from "react";
+import type { VariantProps } from "tailwind-variants/lite";
+
+import { selectSkeleton } from "./variants";
+
+export type SelectSkeletonProps = Omit<ComponentProps<"span">, "children"> & VariantProps<typeof selectSkeleton>;
+
+// Loading placeholder paired with the Select trigger: a pulse block matching its
+// size and radius.
+export function SelectSkeleton(props: SelectSkeletonProps) {
+  const { size, className, ...rest } = props;
+
+  return <span className={selectSkeleton({ size, className })} {...rest} aria-hidden />;
+}

--- a/packages/ui/src/v2/Select/SelectTrigger.tsx
+++ b/packages/ui/src/v2/Select/SelectTrigger.tsx
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { Select as BaseSelect } from "@base-ui/react/select";
+import { CaretDownIcon } from "@phosphor-icons/react";
+import type { ComponentProps, ReactNode } from "react";
+
+import { selectTrigger } from "./variants";
+
+export type SelectTriggerProps
+  = & Omit<ComponentProps<typeof BaseSelect.Trigger>, "className" | "children">
+    & {
+      className?: string;
+      size?: 1 | 2;
+      // Shown when no value is selected.
+      placeholder?: ReactNode;
+      // Renders the selected value; pass a function to map a value to its label.
+      children?: BaseSelect.Value.Props["children"];
+    };
+
+// The bordered surface button that opens the popup, showing the selected value
+// (or placeholder) and a trailing chevron.
+export function SelectTrigger(props: SelectTriggerProps) {
+  const { className, size, placeholder, children, ...rest } = props;
+  const { trigger, value, icon } = selectTrigger({ size });
+
+  return (
+    <BaseSelect.Trigger className={trigger({ className })} {...rest}>
+      <BaseSelect.Value className={value()} placeholder={placeholder}>
+        {children}
+      </BaseSelect.Value>
+      <BaseSelect.Icon className={icon()}>
+        <CaretDownIcon />
+      </BaseSelect.Icon>
+    </BaseSelect.Trigger>
+  );
+}

--- a/packages/ui/src/v2/Select/SelectTrigger.tsx
+++ b/packages/ui/src/v2/Select/SelectTrigger.tsx
@@ -23,6 +23,8 @@ export type SelectTriggerProps
     & {
       className?: string;
       size?: 1 | 2;
+      // Surface treatment (defaults to "surface").
+      variant?: "classic" | "surface" | "soft" | "ghost";
       // Shown when no value is selected.
       placeholder?: ReactNode;
       // Renders the selected value; pass a function to map a value to its label.
@@ -32,8 +34,8 @@ export type SelectTriggerProps
 // The bordered surface button that opens the popup, showing the selected value
 // (or placeholder) and a trailing chevron.
 export function SelectTrigger(props: SelectTriggerProps) {
-  const { className, size, placeholder, children, ...rest } = props;
-  const { trigger, value, icon } = selectTrigger({ size });
+  const { className, size, variant, placeholder, children, ...rest } = props;
+  const { trigger, value, icon } = selectTrigger({ size, variant });
 
   return (
     <BaseSelect.Trigger className={trigger({ className })} {...rest}>

--- a/packages/ui/src/v2/Select/variants.ts
+++ b/packages/ui/src/v2/Select/variants.ts
@@ -20,8 +20,8 @@ import { tv } from "tailwind-variants/lite";
 export const selectTrigger = tv({
   slots: {
     trigger: [
-      "flex w-full items-center justify-between gap-2 rounded-2 border border-sand-a7 bg-sand-1 text-2 text-sand-12",
-      "cursor-pointer outline-none transition-colors hover:bg-sand-2",
+      "flex w-full items-center justify-between gap-2 rounded-2 text-2 text-sand-12",
+      "cursor-pointer outline-none transition-colors",
       "focus-visible:ring-2 focus-visible:ring-sand-8 focus-visible:ring-offset-1 focus-visible:ring-offset-sand-1",
       "data-disabled:pointer-events-none data-disabled:opacity-50 data-placeholder:text-sand-a10",
     ],
@@ -33,9 +33,19 @@ export const selectTrigger = tv({
       1: { trigger: "h-7 px-2" },
       2: { trigger: "h-8 px-3" },
     },
+    // Surface treatment. Only the accent (gold) color ships, matching Figma;
+    // classic adds a recessed inset shadow (Figma can't express its gradient),
+    // soft drops the border for a tint, ghost is transparent until hover.
+    variant: {
+      classic: { trigger: "border border-sand-a7 bg-sand-1 inset-shadow-2 hover:bg-sand-2" },
+      surface: { trigger: "border border-sand-a7 bg-sand-1 hover:bg-sand-2" },
+      soft: { trigger: "bg-gold-3 hover:bg-gold-4" },
+      ghost: { trigger: "hover:bg-sand-2" },
+    },
   },
   defaultVariants: {
     size: 2,
+    variant: "surface",
   },
 });
 

--- a/packages/ui/src/v2/Select/variants.ts
+++ b/packages/ui/src/v2/Select/variants.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { tv } from "tailwind-variants/lite";
+
+// Select (Radix "Select" over Base UI's Select). A bordered surface trigger on
+// the neutral background, with an accent-highlighted popup of items.
+
+export const selectTrigger = tv({
+  slots: {
+    trigger: [
+      "flex w-full items-center justify-between gap-2 rounded-2 border border-sand-a7 bg-sand-1 text-2 text-sand-12",
+      "cursor-pointer outline-none transition-colors hover:bg-sand-2",
+      "focus-visible:ring-2 focus-visible:ring-sand-8 focus-visible:ring-offset-1 focus-visible:ring-offset-sand-1",
+      "data-disabled:pointer-events-none data-disabled:opacity-50 data-placeholder:text-sand-a10",
+    ],
+    value: "min-w-0 flex-1 truncate text-left",
+    icon: "flex size-4 shrink-0 items-center justify-center text-sand-a10 [&_svg]:size-4",
+  },
+  variants: {
+    size: {
+      1: { trigger: "h-7 px-2" },
+      2: { trigger: "h-8 px-3" },
+    },
+  },
+  defaultVariants: {
+    size: 2,
+  },
+});
+
+export const selectPopup = tv({
+  base: [
+    "max-h-(--available-height) min-w-(--anchor-width) origin-(--transform-origin) overflow-y-auto rounded-3 bg-sand-1 p-1 shadow-3 outline-none",
+    "transition-[scale,opacity] duration-150 ease-out data-starting-style:scale-95 data-starting-style:opacity-0",
+    "data-ending-style:scale-95 data-ending-style:opacity-0",
+  ],
+});
+
+export const selectItem = tv({
+  slots: {
+    item: [
+      "flex h-8 cursor-pointer items-center justify-between gap-2 rounded-2 px-3 text-2 text-sand-12 outline-none select-none",
+      "data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-sand-3",
+    ],
+    label: "min-w-0 flex-1 truncate",
+    indicator: "flex size-4 shrink-0 items-center justify-center text-sand-12 [&_svg]:size-4",
+  },
+});
+
+export const selectSkeleton = tv({
+  base: "inline-block animate-pulse rounded-2 bg-sand-3 align-middle",
+  variants: {
+    size: {
+      1: "h-7 w-40",
+      2: "h-8 w-40",
+    },
+  },
+  defaultVariants: {
+    size: 2,
+  },
+});

--- a/packages/ui/src/v2/form/TextField.stories.tsx
+++ b/packages/ui/src/v2/form/TextField.stories.tsx
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+
+import { TextField } from "./TextField";
+import { TextFieldSkeleton } from "./TextFieldSkeleton";
+
+export default {
+  title: "v2/form/TextField",
+  component: TextField,
+};
+
+export function Default() {
+  return (
+    <div className="w-60">
+      <TextField placeholder="Search..." />
+    </div>
+  );
+}
+
+export function WithIcon() {
+  return (
+    <div className="w-60">
+      <TextField icon={<MagnifyingGlassIcon />} placeholder="Search..." />
+    </div>
+  );
+}
+
+export function Controlled() {
+  const [value, setValue] = useState("");
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="w-60">
+        <TextField value={value} onValueChange={setValue} placeholder="Type here" />
+      </div>
+      <span className="text-2 text-sand-11">Value: {value || "(empty)"}</span>
+    </div>
+  );
+}
+
+export function Skeleton() {
+  return <TextFieldSkeleton />;
+}

--- a/packages/ui/src/v2/form/TextField.stories.tsx
+++ b/packages/ui/src/v2/form/TextField.stories.tsx
@@ -46,7 +46,10 @@ export function Controlled() {
       <div className="w-60">
         <TextField value={value} onValueChange={setValue} placeholder="Type here" />
       </div>
-      <span className="text-2 text-sand-11">Value: {value || "(empty)"}</span>
+      <span className="text-2 text-sand-11">
+        Value:
+        {value || "(empty)"}
+      </span>
     </div>
   );
 }

--- a/packages/ui/src/v2/form/TextField.stories.tsx
+++ b/packages/ui/src/v2/form/TextField.stories.tsx
@@ -39,6 +39,16 @@ export function WithIcon() {
   );
 }
 
+export function Variants() {
+  return (
+    <div className="flex w-60 flex-col gap-3">
+      <TextField variant="classic" icon={<MagnifyingGlassIcon />} placeholder="Classic" />
+      <TextField variant="surface" icon={<MagnifyingGlassIcon />} placeholder="Surface" />
+      <TextField variant="soft" icon={<MagnifyingGlassIcon />} placeholder="Soft" />
+    </div>
+  );
+}
+
 export function Controlled() {
   const [value, setValue] = useState("");
   return (

--- a/packages/ui/src/v2/form/TextField.tsx
+++ b/packages/ui/src/v2/form/TextField.tsx
@@ -23,6 +23,8 @@ export type TextFieldProps
       // Applied to the bordered container (the top-level element).
       className?: string;
       size?: 1 | 2;
+      // Surface treatment (defaults to "surface").
+      variant?: "classic" | "surface" | "soft";
       // Leading icon slot (e.g. a MagnifyingGlassIcon for search).
       icon?: ReactNode;
     };
@@ -31,8 +33,8 @@ export type TextFieldProps
 // node; all native input props spread onto the inner control. Controlled with
 // Base UI's `value` / `onValueChange` (or native `value` / `onChange`).
 export function TextField(props: TextFieldProps) {
-  const { className, size, icon, ...inputProps } = props;
-  const { root, icon: iconSlot, input } = textField({ size });
+  const { className, size, variant, icon, ...inputProps } = props;
+  const { root, icon: iconSlot, input } = textField({ size, variant });
 
   return (
     <div className={root({ className })}>

--- a/packages/ui/src/v2/form/TextField.tsx
+++ b/packages/ui/src/v2/form/TextField.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { Input } from "@base-ui/react/input";
+import type { ComponentProps, ReactNode } from "react";
+
+import { textField } from "./variants";
+
+export type TextFieldProps
+  = & Omit<ComponentProps<typeof Input>, "className">
+    & {
+      // Applied to the bordered container (the top-level element).
+      className?: string;
+      size?: 1 | 2;
+      // Leading icon slot (e.g. a MagnifyingGlassIcon for search).
+      icon?: ReactNode;
+    };
+
+// Single-line text input on a bordered surface. The container is the top-level
+// node; all native input props spread onto the inner control. Controlled with
+// Base UI's `value` / `onValueChange` (or native `value` / `onChange`).
+export function TextField(props: TextFieldProps) {
+  const { className, size, icon, ...inputProps } = props;
+  const { root, icon: iconSlot, input } = textField({ size });
+
+  return (
+    <div className={root({ className })}>
+      {icon != null && <span className={iconSlot()}>{icon}</span>}
+      <Input className={input()} {...inputProps} />
+    </div>
+  );
+}

--- a/packages/ui/src/v2/form/TextFieldSkeleton.tsx
+++ b/packages/ui/src/v2/form/TextFieldSkeleton.tsx
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { ComponentProps } from "react";
+import type { VariantProps } from "tailwind-variants/lite";
+
+import { textFieldSkeleton } from "./variants";
+
+export type TextFieldSkeletonProps = Omit<ComponentProps<"span">, "children"> & VariantProps<typeof textFieldSkeleton>;
+
+// Loading placeholder paired with TextField: a pulse block matching its size and
+// radius.
+export function TextFieldSkeleton(props: TextFieldSkeletonProps) {
+  const { size, className, ...rest } = props;
+
+  return <span className={textFieldSkeleton({ size, className })} {...rest} aria-hidden />;
+}

--- a/packages/ui/src/v2/form/variants.ts
+++ b/packages/ui/src/v2/form/variants.ts
@@ -19,7 +19,7 @@ import { tv } from "tailwind-variants/lite";
 export const textField = tv({
   slots: {
     root: [
-      "flex items-center gap-2 rounded-2 border border-sand-a5 bg-sand-1 text-2 text-sand-12 transition-colors",
+      "flex items-center gap-2 rounded-2 text-2 text-sand-12 transition-colors",
       "focus-within:ring-2 focus-within:ring-sand-8 focus-within:ring-offset-1 focus-within:ring-offset-sand-1",
       "has-[input:disabled]:pointer-events-none has-[input:disabled]:opacity-50",
     ],
@@ -31,9 +31,17 @@ export const textField = tv({
       1: { root: "h-7 px-2" },
       2: { root: "h-8 px-2" },
     },
+    // Surface treatment. Only the accent (gold) color ships, matching Figma;
+    // classic adds a recessed inset shadow, soft drops the border for a tint.
+    variant: {
+      classic: { root: "border border-sand-a5 bg-sand-1 inset-shadow-2" },
+      surface: { root: "border border-sand-a5 bg-sand-1" },
+      soft: { root: "bg-gold-3" },
+    },
   },
   defaultVariants: {
     size: 2,
+    variant: "surface",
   },
 });
 

--- a/packages/ui/src/v2/form/variants.ts
+++ b/packages/ui/src/v2/form/variants.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { tv } from "tailwind-variants/lite";
+
+// Text input (Radix "Text Field" over Base UI's Input). A bordered surface on
+// the neutral background with an optional leading icon slot.
+export const textField = tv({
+  slots: {
+    root: [
+      "flex items-center gap-2 rounded-2 border border-sand-a5 bg-sand-1 text-2 text-sand-12 transition-colors",
+      "focus-within:ring-2 focus-within:ring-sand-8 focus-within:ring-offset-1 focus-within:ring-offset-sand-1",
+      "has-[input:disabled]:pointer-events-none has-[input:disabled]:opacity-50",
+    ],
+    icon: "flex size-4 shrink-0 items-center justify-center text-sand-a9 [&_svg]:size-4",
+    input: "min-w-0 flex-1 bg-transparent text-sand-12 outline-none placeholder:text-sand-a9",
+  },
+  variants: {
+    size: {
+      1: { root: "h-7 px-2" },
+      2: { root: "h-8 px-2" },
+    },
+  },
+  defaultVariants: {
+    size: 2,
+  },
+});
+
+export const textFieldSkeleton = tv({
+  base: "inline-block animate-pulse rounded-2 bg-sand-3 align-middle",
+  variants: {
+    size: {
+      1: "h-7 w-60",
+      2: "h-8 w-60",
+    },
+  },
+  defaultVariants: {
+    size: 2,
+  },
+});

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -1433,7 +1433,7 @@ func (h *trackerMappingHandler) prepareOrgThirdParty(
 		},
 		func(ctx context.Context, cursor *page.Cursor[coredata.ThirdPartyOrderField]) ([]*coredata.ThirdParty, error) {
 			var batch coredata.ThirdParties
-			if err := batch.LoadByOrganizationID(ctx, conn, scope, tp.OrganizationID, cursor, coredata.NewThirdPartyFilter(nil, &firstLevel, nil)); err != nil {
+			if err := batch.LoadByOrganizationID(ctx, conn, scope, tp.OrganizationID, cursor, coredata.NewThirdPartyFilter(nil, &firstLevel, nil, nil, nil)); err != nil {
 				return nil, fmt.Errorf("cannot load org third parties: %w", err)
 			}
 

--- a/pkg/coredata/third_party.go
+++ b/pkg/coredata/third_party.go
@@ -800,7 +800,7 @@ ORDER BY
 `
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
-	args := pgx.NamedArgs{"organization_id": organizationID}
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
 	maps.Copy(args, scope.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)
@@ -836,7 +836,7 @@ ORDER BY
 `
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
-	args := pgx.NamedArgs{"organization_id": organizationID}
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
 	maps.Copy(args, scope.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)

--- a/pkg/coredata/third_party.go
+++ b/pkg/coredata/third_party.go
@@ -780,6 +780,78 @@ WHERE
 	return count, nil
 }
 
+func (v *ThirdParties) LoadDistinctTrustCenterCategoriesByOrganizationID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	organizationID gid.GID,
+) ([]ThirdPartyCategory, error) {
+	q := `
+SELECT DISTINCT
+    category
+FROM
+    third_parties
+WHERE
+    %s
+    AND organization_id = @organization_id
+    AND show_on_trust_center = true
+ORDER BY
+    category ASC
+`
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.NamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query thirdParty categories: %w", err)
+	}
+
+	categories, err := pgx.CollectRows(rows, pgx.RowTo[ThirdPartyCategory])
+	if err != nil {
+		return nil, fmt.Errorf("cannot collect thirdParty categories: %w", err)
+	}
+
+	return categories, nil
+}
+
+func (v *ThirdParties) LoadDistinctTrustCenterCountriesByOrganizationID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	organizationID gid.GID,
+) ([]CountryCode, error) {
+	q := `
+SELECT DISTINCT
+    unnest(countries) AS country
+FROM
+    third_parties
+WHERE
+    %s
+    AND organization_id = @organization_id
+    AND show_on_trust_center = true
+ORDER BY
+    country ASC
+`
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.NamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query thirdParty countries: %w", err)
+	}
+
+	countries, err := pgx.CollectRows(rows, pgx.RowTo[CountryCode])
+	if err != nil {
+		return nil, fmt.Errorf("cannot collect thirdParty countries: %w", err)
+	}
+
+	return countries, nil
+}
+
 func (v *ThirdParties) LoadByOrganizationID(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/coredata/third_party_filter.go
+++ b/pkg/coredata/third_party_filter.go
@@ -23,14 +23,24 @@ type (
 		showOnTrustCenter *bool
 		level             *int
 		query             *string
+		category          *ThirdPartyCategory
+		country           *CountryCode
 	}
 )
 
-func NewThirdPartyFilter(showOnTrustCenter *bool, level *int, query *string) *ThirdPartyFilter {
+func NewThirdPartyFilter(
+	showOnTrustCenter *bool,
+	level *int,
+	query *string,
+	category *ThirdPartyCategory,
+	country *CountryCode,
+) *ThirdPartyFilter {
 	return &ThirdPartyFilter{
 		showOnTrustCenter: showOnTrustCenter,
 		level:             level,
 		query:             query,
+		category:          category,
+		country:           country,
 	}
 }
 
@@ -39,6 +49,8 @@ func (f *ThirdPartyFilter) SQLArguments() pgx.StrictNamedArgs {
 		"show_on_trust_center": nil,
 		"filter_query":         nil,
 		"level":                nil,
+		"filter_category":      nil,
+		"filter_country":       nil,
 	}
 
 	if f.showOnTrustCenter != nil {
@@ -51,6 +63,14 @@ func (f *ThirdPartyFilter) SQLArguments() pgx.StrictNamedArgs {
 
 	if f.level != nil {
 		args["level"] = *f.level
+	}
+
+	if f.category != nil {
+		args["filter_category"] = string(*f.category)
+	}
+
+	if f.country != nil {
+		args["filter_country"] = string(*f.country)
 	}
 
 	return args
@@ -72,6 +92,16 @@ func (f *ThirdPartyFilter) SQLFragment() string {
 	AND CASE
 		WHEN @filter_query::text IS NOT NULL AND @filter_query::text <> '' THEN
 			name ILIKE '%' || @filter_query || '%'
+		ELSE TRUE
+	END
+	AND CASE
+		WHEN @filter_category::text IS NOT NULL THEN
+			category = @filter_category::third_party_category
+		ELSE TRUE
+	END
+	AND CASE
+		WHEN @filter_country::text IS NOT NULL THEN
+			@filter_country::country_code = ANY(countries)
 		ELSE TRUE
 	END
 )`

--- a/pkg/probo/generated_document_service.go
+++ b/pkg/probo/generated_document_service.go
@@ -2508,7 +2508,7 @@ func (s *GeneratedDocumentService) buildThirdPartyListDocumentData(
 		},
 		func(ctx context.Context, cursor *page.Cursor[coredata.ThirdPartyOrderField]) ([]*coredata.ThirdParty, error) {
 			var batch coredata.ThirdParties
-			if err := batch.LoadByOrganizationID(ctx, conn, scope, organization.ID, cursor, coredata.NewThirdPartyFilter(nil, &firstLevel, nil)); err != nil {
+			if err := batch.LoadByOrganizationID(ctx, conn, scope, organization.ID, cursor, coredata.NewThirdPartyFilter(nil, &firstLevel, nil, nil, nil)); err != nil {
 				return nil, fmt.Errorf("cannot load thirdParties: %w", err)
 			}
 

--- a/pkg/probo/third_party_service.go
+++ b/pkg/probo/third_party_service.go
@@ -174,7 +174,7 @@ func (s ThirdPartyService) CountForOrganizationID(
 	var count int
 
 	if filter == nil {
-		filter = coredata.NewThirdPartyFilter(nil, nil, nil)
+		filter = coredata.NewThirdPartyFilter(nil, nil, nil, nil, nil)
 	}
 
 	err := s.svc.pg.WithConn(

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -1284,7 +1284,7 @@ func (r *organizationResolver) ThirdParties(ctx context.Context, obj *types.Orga
 		query = filter.Query
 	}
 
-	thirdPartyFilter := coredata.NewThirdPartyFilter(nil, level, query)
+	thirdPartyFilter := coredata.NewThirdPartyFilter(nil, level, query, nil, nil)
 
 	page, err := r.probo.ThirdParties.ListForOrganizationID(ctx, scope, obj.ID, cursor, thirdPartyFilter)
 	if err != nil {

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -75,7 +75,7 @@ func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRe
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	thirdPartyFilter := coredata.NewThirdPartyFilter(nil, input.Level, nil)
+	thirdPartyFilter := coredata.NewThirdPartyFilter(nil, input.Level, nil, nil, nil)
 
 	page, err := prb.ThirdParties.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor, thirdPartyFilter)
 	if err != nil {

--- a/pkg/server/api/trust/v1/graphql/trust_center.graphql
+++ b/pkg/server/api/trust/v1/graphql/trust_center.graphql
@@ -33,6 +33,11 @@ type TrustCenter implements Node {
     filter: SubprocessorFilter
   ): SubprocessorConnection! @goField(forceResolver: true)
 
+  subprocessorCategories: [SubprocessorCategory!]!
+    @goField(forceResolver: true)
+
+  subprocessorCountries: [CountryCode!]! @goField(forceResolver: true)
+
   references(
     first: Int
     after: CursorKey

--- a/pkg/server/api/trust/v1/graphql/trust_center.graphql
+++ b/pkg/server/api/trust/v1/graphql/trust_center.graphql
@@ -30,6 +30,7 @@ type TrustCenter implements Node {
     after: CursorKey
     last: Int
     before: CursorKey
+    filter: SubprocessorFilter
   ): SubprocessorConnection! @goField(forceResolver: true)
 
   references(
@@ -243,6 +244,12 @@ type Subprocessor implements Node @nda {
   websiteUrl: String
   privacyPolicyUrl: String
   countries: [CountryCode!]!
+}
+
+input SubprocessorFilter {
+  query: String
+  category: SubprocessorCategory
+  country: CountryCode
 }
 
 type SubprocessorConnection

--- a/pkg/server/api/trust/v1/trust_center_resolvers.go
+++ b/pkg/server/api/trust/v1/trust_center_resolvers.go
@@ -670,7 +670,7 @@ func (r *subprocessorConnectionResolver) TotalCount(ctx context.Context, obj *ty
 
 	switch obj.Resolver.(type) {
 	case *trustCenterResolver:
-		count, err := trustService.ThirdParties.CountForTrustCenterId(ctx, scope, obj.ParentID)
+		count, err := trustService.ThirdParties.CountForTrustCenterId(ctx, scope, obj.ParentID, obj.Filter)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count subprocessors", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -798,7 +798,7 @@ func (r *trustCenterResolver) Audits(ctx context.Context, obj *types.TrustCenter
 }
 
 // Subprocessors is the resolver for the subprocessors field.
-func (r *trustCenterResolver) Subprocessors(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.SubprocessorConnection, error) {
+func (r *trustCenterResolver) Subprocessors(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, filter *types.SubprocessorFilter) (*types.SubprocessorConnection, error) {
 	compliancePage := compliancepage.CompliancePageFromContext(ctx)
 	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 	trustService := r.trust
@@ -808,13 +808,27 @@ func (r *trustCenterResolver) Subprocessors(ctx context.Context, obj *types.Trus
 	}
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	thirdPartyPage, err := trustService.ThirdParties.ListForOrganizationId(ctx, scope, obj.Organization.ID, cursor)
+	var (
+		query    *string
+		category *coredata.ThirdPartyCategory
+		country  *coredata.CountryCode
+	)
+	if filter != nil {
+		query = filter.Query
+		category = filter.Category
+		country = filter.Country
+	}
+
+	showOnTrustCenter := true
+	thirdPartyFilter := coredata.NewThirdPartyFilter(&showOnTrustCenter, nil, query, category, country)
+
+	thirdPartyPage, err := trustService.ThirdParties.ListForOrganizationId(ctx, scope, obj.Organization.ID, cursor, thirdPartyFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list subprocessors", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	return types.NewSubprocessorConnection(thirdPartyPage, r, obj.ID), nil
+	return types.NewSubprocessorConnection(thirdPartyPage, r, obj.ID, thirdPartyFilter), nil
 }
 
 // References is the resolver for the references field.

--- a/pkg/server/api/trust/v1/trust_center_resolvers.go
+++ b/pkg/server/api/trust/v1/trust_center_resolvers.go
@@ -819,6 +819,14 @@ func (r *trustCenterResolver) Subprocessors(ctx context.Context, obj *types.Trus
 		country = filter.Country
 	}
 
+	if category != nil && !category.IsValid() {
+		return nil, gqlutils.Invalidf(ctx, "invalid subprocessor category filter: %q", string(*category))
+	}
+
+	if country != nil && !country.IsValid() {
+		return nil, gqlutils.Invalidf(ctx, "invalid subprocessor country filter: %q", string(*country))
+	}
+
 	showOnTrustCenter := true
 	thirdPartyFilter := coredata.NewThirdPartyFilter(&showOnTrustCenter, nil, query, category, country)
 

--- a/pkg/server/api/trust/v1/trust_center_resolvers.go
+++ b/pkg/server/api/trust/v1/trust_center_resolvers.go
@@ -831,6 +831,34 @@ func (r *trustCenterResolver) Subprocessors(ctx context.Context, obj *types.Trus
 	return types.NewSubprocessorConnection(thirdPartyPage, r, obj.ID, thirdPartyFilter), nil
 }
 
+// SubprocessorCategories is the resolver for the subprocessorCategories field.
+func (r *trustCenterResolver) SubprocessorCategories(ctx context.Context, obj *types.TrustCenter) ([]coredata.ThirdPartyCategory, error) {
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
+
+	categories, err := r.trust.ThirdParties.ListDistinctTrustCenterCategoriesForOrganizationID(ctx, scope, obj.Organization.ID)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot list subprocessor categories", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return categories, nil
+}
+
+// SubprocessorCountries is the resolver for the subprocessorCountries field.
+func (r *trustCenterResolver) SubprocessorCountries(ctx context.Context, obj *types.TrustCenter) ([]coredata.CountryCode, error) {
+	compliancePage := compliancepage.CompliancePageFromContext(ctx)
+	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
+
+	countries, err := r.trust.ThirdParties.ListDistinctTrustCenterCountriesForOrganizationID(ctx, scope, obj.Organization.ID)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot list subprocessor countries", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return countries, nil
+}
+
 // References is the resolver for the references field.
 func (r *trustCenterResolver) References(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.TrustCenterReferenceConnection, error) {
 	compliancePage := compliancepage.CompliancePageFromContext(ctx)

--- a/pkg/server/api/trust/v1/types/third_party.go
+++ b/pkg/server/api/trust/v1/types/third_party.go
@@ -28,6 +28,7 @@ type (
 
 		Resolver any
 		ParentID gid.GID
+		Filter   *coredata.ThirdPartyFilter
 	}
 )
 
@@ -35,6 +36,7 @@ func NewSubprocessorConnection(
 	p *page.Page[*coredata.ThirdParty, coredata.ThirdPartyOrderField],
 	parentType any,
 	parentID gid.GID,
+	filter *coredata.ThirdPartyFilter,
 ) *SubprocessorConnection {
 	edges := make([]*SubprocessorEdge, len(p.Data))
 	for i, thirdParty := range p.Data {
@@ -47,6 +49,7 @@ func NewSubprocessorConnection(
 
 		Resolver: parentType,
 		ParentID: parentID,
+		Filter:   filter,
 	}
 }
 

--- a/pkg/trust/compliance_page_service.go
+++ b/pkg/trust/compliance_page_service.go
@@ -553,7 +553,10 @@ func (s *Service) fetchThirdParties(ctx context.Context, scope coredata.Scoper, 
 			},
 		)
 
-		result, err := s.ThirdParties.ListForOrganizationId(ctx, scope, orgID, cursor)
+		showOnTrustCenter := true
+		filter := coredata.NewThirdPartyFilter(&showOnTrustCenter, nil, nil, nil, nil)
+
+		result, err := s.ThirdParties.ListForOrganizationId(ctx, scope, orgID, cursor, filter)
 		if err != nil {
 			return nil, fmt.Errorf("cannot list thirdParties: %w", err)
 		}

--- a/pkg/trust/third_party_service.go
+++ b/pkg/trust/third_party_service.go
@@ -58,15 +58,13 @@ func (s ThirdPartyService) ListForOrganizationId(
 	scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.ThirdPartyOrderField],
+	filter *coredata.ThirdPartyFilter,
 ) (*page.Page[*coredata.ThirdParty, coredata.ThirdPartyOrderField], error) {
 	var thirdParties coredata.ThirdParties
 
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			showOnTrustCenter := true
-			filter := coredata.NewThirdPartyFilter(&showOnTrustCenter, nil, nil)
-
 			err := thirdParties.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load thirdParties: %w", err)
@@ -86,6 +84,7 @@ func (s ThirdPartyService) CountForTrustCenterId(
 	ctx context.Context,
 	scope coredata.Scoper,
 	trustCenterID gid.GID,
+	filter *coredata.ThirdPartyFilter,
 ) (int, error) {
 	var count int
 
@@ -98,8 +97,6 @@ func (s ThirdPartyService) CountForTrustCenterId(
 			}
 
 			thirdParties := &coredata.ThirdParties{}
-			showOnTrustCenter := true
-			filter := coredata.NewThirdPartyFilter(&showOnTrustCenter, nil, nil)
 
 			count, err = thirdParties.CountByOrganizationID(ctx, conn, scope, trustCenter.OrganizationID, filter)
 			if err != nil {

--- a/pkg/trust/third_party_service.go
+++ b/pkg/trust/third_party_service.go
@@ -60,6 +60,10 @@ func (s ThirdPartyService) ListForOrganizationId(
 	cursor *page.Cursor[coredata.ThirdPartyOrderField],
 	filter *coredata.ThirdPartyFilter,
 ) (*page.Page[*coredata.ThirdParty, coredata.ThirdPartyOrderField], error) {
+	if filter == nil {
+		filter = coredata.NewThirdPartyFilter(nil, nil, nil, nil, nil)
+	}
+
 	var thirdParties coredata.ThirdParties
 
 	err := s.svc.pg.WithConn(

--- a/pkg/trust/third_party_service.go
+++ b/pkg/trust/third_party_service.go
@@ -80,6 +80,64 @@ func (s ThirdPartyService) ListForOrganizationId(
 	return page.NewPage(thirdParties, cursor), nil
 }
 
+func (s ThirdPartyService) ListDistinctTrustCenterCategoriesForOrganizationID(
+	ctx context.Context,
+	scope coredata.Scoper,
+	organizationID gid.GID,
+) ([]coredata.ThirdPartyCategory, error) {
+	var categories []coredata.ThirdPartyCategory
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			thirdParties := &coredata.ThirdParties{}
+
+			result, err := thirdParties.LoadDistinctTrustCenterCategoriesByOrganizationID(ctx, conn, scope, organizationID)
+			if err != nil {
+				return fmt.Errorf("cannot load thirdParty categories: %w", err)
+			}
+
+			categories = result
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return categories, nil
+}
+
+func (s ThirdPartyService) ListDistinctTrustCenterCountriesForOrganizationID(
+	ctx context.Context,
+	scope coredata.Scoper,
+	organizationID gid.GID,
+) ([]coredata.CountryCode, error) {
+	var countries []coredata.CountryCode
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			thirdParties := &coredata.ThirdParties{}
+
+			result, err := thirdParties.LoadDistinctTrustCenterCountriesByOrganizationID(ctx, conn, scope, organizationID)
+			if err != nil {
+				return fmt.Errorf("cannot load thirdParty countries: %w", err)
+			}
+
+			countries = result
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return countries, nil
+}
+
 func (s ThirdPartyService) CountForTrustCenterId(
 	ctx context.Context,
 	scope coredata.Scoper,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Builds the Compliance Portal Subprocessors page with server-side filters (category, region, search) driven by pure URL state, a single-owner debounced search, and transition-scoped refetch. Facets come from the server; `packages/ui` adds v2 Select/TextField; shared BackdropCard/EmptyState are added; the card grid stretches so bottoms align; tests now share trust-center helpers.

### Coredata **`+103`** **`-1`**
Extends ThirdPartyFilter with category and country, adds SQL args/WHERE for both, and DISTINCT facet queries for trust-center categories and countries; facet queries use `pgx.StrictNamedArgs`.

### GraphQL API **`+70`** **`-5`**
Adds `SubprocessorFilter` (query, category, country), exposes `subprocessorCategories` and `subprocessorCountries`, threads filters through resolvers, keeps `totalCount` scoped to the filtered set, and rejects invalid values with an INVALID error.

### MCP **`+1`** **`-1`**
Updates resolver to use the new ThirdPartyFilter constructor.

### Service **`+71`** **`-9`**
Threads filters and counts through trust/probo services (respecting showOnTrustCenter), adds distinct category/country methods for toolbar facets, defaults a nil filter at the boundary, and updates related call sites.

### Package: ui **`+575`** **`-0`**
Adds v2 Select and TextField components (trigger, popup/items, variants, skeletons) and missing variants; fixes a small story label spacing issue.

### Tests **`+258`** **`-140`**
Adds e2e coverage for filtering by category, country, query, intersections, and empty results; consolidates trust-center lookup/activation into shared helpers and removes duplicated inline helpers.

### Agents **`+236`** **`-0`**
Documents the list-filtering pattern: pure URL-state hook, single-owner debounced search, and transition-scoped refetch; adds a Cursor rule and expands Relay/state-management guides.

### Other **`+1152`** **`-44`**
Builds the compliance-portal Subprocessors page: grouped cards and a toolbar (category, region, search) driven by pure URL state and transition-based refetch; adds loader/skeleton, page-scoped i18n, resource-folder routing, and shared BackdropCard/EmptyState; refactors card layouts with an aria heading for category groups and a dotted fallback when no website; fixes vertical spacing and stretches the category grid so card bottoms align across each row.

<sup>Written for commit 99fa2bdde85d78e5b9fb859d6fc573060702cb96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

