### PR TITLE
Add trust center updates list and detail pages

### DIFF
--- a/apps/compliance-portal/src/_locales/en-US.json
+++ b/apps/compliance-portal/src/_locales/en-US.json
@@ -38,5 +38,9 @@
   },
   "footer": {
     "poweredBy": "Powered by"
+  },
+  "pagination": {
+    "previous": "Previous page",
+    "next": "Next page"
   }
 }

--- a/apps/compliance-portal/src/_locales/en-US.json
+++ b/apps/compliance-portal/src/_locales/en-US.json
@@ -27,10 +27,6 @@
   "documents": {
     "title": "Documents"
   },
-  "updates": {
-    "title": "Updates",
-    "subscribe": "Subscribe to updates"
-  },
   "requests": {
     "title": "Data Requests",
     "newRequest": "New Request"

--- a/apps/compliance-portal/src/_locales/fr-FR.json
+++ b/apps/compliance-portal/src/_locales/fr-FR.json
@@ -38,5 +38,9 @@
   },
   "footer": {
     "poweredBy": "Propulsé par"
+  },
+  "pagination": {
+    "previous": "Page précédente",
+    "next": "Page suivante"
   }
 }

--- a/apps/compliance-portal/src/_locales/fr-FR.json
+++ b/apps/compliance-portal/src/_locales/fr-FR.json
@@ -27,10 +27,6 @@
   "documents": {
     "title": "Documents"
   },
-  "updates": {
-    "title": "Mises à jour",
-    "subscribe": "S'abonner aux mises à jour"
-  },
   "requests": {
     "title": "Demandes de données",
     "newRequest": "Nouvelle demande"

--- a/apps/compliance-portal/src/components/ComplianceArticleItem/variants.ts
+++ b/apps/compliance-portal/src/components/ComplianceArticleItem/variants.ts
@@ -16,11 +16,12 @@ import { tv } from "tailwind-variants/lite";
 
 // Compliance article list row (Figma "Compliance Article Item"): a leading
 // icon, a title (+ optional eyebrow), and right-aligned meta. Designed to sit
-// inside a bordered list container; the last row drops its divider. Slots are
+// inside a list container that draws the dividers (e.g. `divide-y`), so rows
+// stay divider-agnostic whether or not each is wrapped in a link. Slots are
 // shared by the row and its skeleton.
 export const complianceArticleItem = tv({
   slots: {
-    root: "flex w-full items-center gap-4 border-b border-sand-a2 px-8 py-4 last:border-b-0",
+    root: "flex w-full items-center gap-4 px-8 py-4",
     icon: "flex size-6 shrink-0 items-center justify-center text-gold-9 [&_svg]:size-full",
     content: "flex min-w-0 flex-1 flex-col gap-1",
     meta: "shrink-0",

--- a/apps/compliance-portal/src/components/MailingListUpdateListItem/MailingListUpdateListItem.tsx
+++ b/apps/compliance-portal/src/components/MailingListUpdateListItem/MailingListUpdateListItem.tsx
@@ -15,6 +15,7 @@
 import { NewspaperIcon } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
+import { Link } from "react-router";
 
 import { ComplianceArticleItem } from "#/components/ComplianceArticleItem/ComplianceArticleItem";
 import { formatRelativeTime } from "#/lib/datetime/relativeTime";
@@ -23,6 +24,7 @@ import type { MailingListUpdateListItem_update$key } from "./__generated__/Maili
 
 const mailingListUpdateListItemFragment = graphql`
   fragment MailingListUpdateListItem_update on MailingListUpdate {
+    id
     title
     updatedAt
   }
@@ -32,17 +34,19 @@ interface MailingListUpdateListItemProps {
   updateKey: MailingListUpdateListItem_update$key;
 }
 
-// A single "Recent updates" row. The schema has no category, so we show the
-// title and relative date with a single generic icon.
+// A single mailing-list update row, linking to its detail page. The schema has
+// no category, so we show the title and relative date with a generic icon.
 export function MailingListUpdateListItem({ updateKey }: MailingListUpdateListItemProps) {
   const { i18n } = useTranslation();
   const update = useFragment(mailingListUpdateListItemFragment, updateKey);
 
   return (
-    <ComplianceArticleItem
-      icon={<NewspaperIcon weight="light" />}
-      title={update.title}
-      meta={formatRelativeTime(update.updatedAt, i18n.language)}
-    />
+    <Link to={`/updates/${update.id}`} className="block transition-colors hover:bg-sand-a2">
+      <ComplianceArticleItem
+        icon={<NewspaperIcon weight="light" />}
+        title={update.title}
+        meta={formatRelativeTime(update.updatedAt, i18n.language)}
+      />
+    </Link>
   );
 }

--- a/apps/compliance-portal/src/components/RecentUpdates/RecentUpdatesSection.tsx
+++ b/apps/compliance-portal/src/components/RecentUpdates/RecentUpdatesSection.tsx
@@ -17,10 +17,10 @@ import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
 
 import { HomeSection } from "#/components/HomeSection/HomeSection";
+import { MailingListUpdateListItem } from "#/components/MailingListUpdateListItem/MailingListUpdateListItem";
 import { dotPatternStyle } from "#/components/MediaTile/variants";
 
 import type { RecentUpdatesSection_trustCenter$key } from "./__generated__/RecentUpdatesSection_trustCenter.graphql";
-import { MailingListUpdateListItem } from "./MailingListUpdateListItem";
 
 const recentUpdatesSectionFragment = graphql`
   fragment RecentUpdatesSection_trustCenter on TrustCenter {
@@ -62,7 +62,7 @@ export function RecentUpdatesSection({ trustCenterKey }: RecentUpdatesSectionPro
       <div className="relative overflow-hidden rounded-5 border border-sand-3 bg-sand-1">
         <div aria-hidden className="pointer-events-none absolute inset-0" style={dotPatternStyle} />
         <div aria-hidden className="pointer-events-none absolute inset-0 bg-linear-to-r from-sand-1/0 to-sand-1 to-[96px]" />
-        <div className="relative">
+        <div className="relative divide-y divide-sand-a2">
           {updates.map(update => (
             <MailingListUpdateListItem key={update.id} updateKey={update} />
           ))}

--- a/apps/compliance-portal/src/components/RecentUpdates/RecentUpdatesSectionSkeleton.tsx
+++ b/apps/compliance-portal/src/components/RecentUpdates/RecentUpdatesSectionSkeleton.tsx
@@ -30,7 +30,7 @@ export function RecentUpdatesSectionSkeleton() {
       <div className="relative overflow-hidden rounded-5 border border-sand-3 bg-sand-1">
         <div aria-hidden className="pointer-events-none absolute inset-0" style={dotPatternStyle} />
         <div aria-hidden className="pointer-events-none absolute inset-0 bg-linear-to-r from-sand-1/0 to-sand-1 to-[96px]" />
-        <div className="relative">
+        <div className="relative divide-y divide-sand-a2">
           {Array.from({ length: 5 }, (_, index) => (
             <ComplianceArticleItemSkeleton key={index} />
           ))}

--- a/apps/compliance-portal/src/lib/datetime/formatDate.ts
+++ b/apps/compliance-portal/src/lib/datetime/formatDate.ts
@@ -12,22 +12,15 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { TextSkeleton } from "@probo/ui/src/v2/typography/TextSkeleton";
+// Locale-aware long date formatting via Intl.DateTimeFormat, e.g.
+// "August 6, 2026". The locale must be the active i18next language so the output
+// follows the UI.
+export function formatDate(date: Date | string | number, locale: string): string {
+  const target = date instanceof Date ? date : new Date(date);
 
-import { complianceArticleItem } from "./variants";
-
-// Loading placeholder paired with ComplianceArticleItem: same row layout with
-// a pulse icon and skeleton text.
-export function ComplianceArticleItemSkeleton() {
-  const slots = complianceArticleItem();
-
-  return (
-    <div className={slots.root()} aria-hidden>
-      <div className={slots.iconPlaceholder()} />
-      <div className={slots.content()}>
-        <TextSkeleton size={2} className="w-48" />
-      </div>
-      <TextSkeleton size={1} className="w-20 shrink-0" />
-    </div>
-  );
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(target);
 }

--- a/apps/compliance-portal/src/lib/datetime/formatDate.ts
+++ b/apps/compliance-portal/src/lib/datetime/formatDate.ts
@@ -12,15 +12,23 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-// Locale-aware long date formatting via Intl.DateTimeFormat, e.g.
-// "August 6, 2026". The locale must be the active i18next language so the output
-// follows the UI.
-export function formatDate(date: Date | string | number, locale: string): string {
+// Long-date defaults, e.g. "August 6, 2026". Callers can override or extend any
+// of these through the `options` argument.
+const DEFAULT_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+};
+
+// Locale-aware date formatting via Intl.DateTimeFormat. The locale must be the
+// active i18next language so the output follows the UI. `options` are merged
+// over the long-date defaults, exposing the full Intl.DateTimeFormat surface.
+export function formatDate(
+  date: Date | string | number,
+  locale: string,
+  options?: Intl.DateTimeFormatOptions,
+): string {
   const target = date instanceof Date ? date : new Date(date);
 
-  return new Intl.DateTimeFormat(locale, {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  }).format(target);
+  return new Intl.DateTimeFormat(locale, { ...DEFAULT_OPTIONS, ...options }).format(target);
 }

--- a/apps/compliance-portal/src/lib/relay/useCursorPagination.ts
+++ b/apps/compliance-portal/src/lib/relay/useCursorPagination.ts
@@ -14,33 +14,36 @@
 
 import { useCallback, useTransition } from "react";
 
-// Page size for the cursor-paginated updates list. Matches the Figma list frame.
-export const UPDATES_PAGE_SIZE = 10;
-
-export interface UpdatesPageInfo {
+// The `pageInfo` shape a Relay connection exposes for bidirectional cursor
+// pagination. Structurally compatible with generated connection page info.
+export interface CursorPageInfo {
   hasPreviousPage: boolean;
   hasNextPage: boolean;
   startCursor: string | null | undefined;
   endCursor: string | null | undefined;
 }
 
-export interface UpdatesPaginationVariables {
+// The connection pagination arguments passed to a refetch.
+export interface CursorPaginationVariables {
   first?: number | null;
   after?: string | null;
   last?: number | null;
   before?: string | null;
 }
 
-type RefetchUpdates = (variables: UpdatesPaginationVariables) => void;
+type CursorRefetch = (variables: CursorPaginationVariables) => void;
 
-// Cursor-based Prev/Next pagination for the updates list. Drives the connection
-// refetch inside a transition so the current page stays mounted (dimmed) while
-// the next one loads. Enabled/disabled state comes from the server `pageInfo`,
-// which stays correct however the page is reached. No page-number counter:
-// cursor pagination encodes a position, not an ordinal, so a reliable page
-// index (deep-linkable or refresh-safe) would need offset + totalCount, which
-// this API does not expose.
-export function useUpdatesPagination(refetch: RefetchUpdates, pageInfo: UpdatesPageInfo) {
+// Prev/Next pagination for a Relay cursor connection. Drives the refetch inside
+// a transition so the current page stays mounted (dimmed) while the next one
+// loads; Prev/Next availability comes from the server `pageInfo`, so it stays
+// correct however the page is reached. There is no page-number counter: cursor
+// pagination encodes a position, not an ordinal, so a reliable page index
+// (deep-linkable or refresh-safe) would need offset + totalCount.
+export function useCursorPagination(
+  refetch: CursorRefetch,
+  pageInfo: CursorPageInfo,
+  pageSize: number,
+) {
   const [isPending, startTransition] = useTransition();
 
   const goNext = useCallback(() => {
@@ -48,18 +51,18 @@ export function useUpdatesPagination(refetch: RefetchUpdates, pageInfo: UpdatesP
       return;
     }
     startTransition(() => {
-      refetch({ first: UPDATES_PAGE_SIZE, after: pageInfo.endCursor, last: null, before: null });
+      refetch({ first: pageSize, after: pageInfo.endCursor, last: null, before: null });
     });
-  }, [refetch, pageInfo.hasNextPage, pageInfo.endCursor]);
+  }, [refetch, pageSize, pageInfo.hasNextPage, pageInfo.endCursor]);
 
   const goPrevious = useCallback(() => {
     if (!pageInfo.hasPreviousPage || pageInfo.startCursor == null) {
       return;
     }
     startTransition(() => {
-      refetch({ first: null, after: null, last: UPDATES_PAGE_SIZE, before: pageInfo.startCursor });
+      refetch({ first: null, after: null, last: pageSize, before: pageInfo.startCursor });
     });
-  }, [refetch, pageInfo.hasPreviousPage, pageInfo.startCursor]);
+  }, [refetch, pageSize, pageInfo.hasPreviousPage, pageInfo.startCursor]);
 
   return { isPending, goPrevious, goNext };
 }

--- a/apps/compliance-portal/src/pages/updates/UpdateDetailPage.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdateDetailPage.tsx
@@ -25,6 +25,7 @@ import { formatDate } from "#/lib/datetime/formatDate";
 
 import type { UpdateDetailPageQuery } from "./__generated__/UpdateDetailPageQuery.graphql";
 import { UpdatesSubscribeButton } from "./_components/UpdatesSubscribeButton";
+import { updateArticle } from "./_components/variants";
 
 export const updateDetailPageQuery = graphql`
   query UpdateDetailPageQuery($updateId: ID!) {
@@ -52,20 +53,22 @@ export function UpdateDetailPage({ queryRef }: UpdateDetailPageProps) {
   }
   const update = data.node;
 
+  const { toolbar, content, article, meta, metaIcon, body } = updateArticle();
+
   return (
     <>
       <HeaderBand>
-        <div className="flex w-full items-center justify-between gap-4">
+        <div className={toolbar()}>
           <Link to="/updates" variant="soft" color="neutral" highContrast iconStart={<CaretLeftIcon />}>
             {t("backToUpdates")}
           </Link>
           <UpdatesSubscribeButton />
         </div>
       </HeaderBand>
-      <div className="flex w-full flex-col items-center px-8 py-8">
-        <article className="flex w-full max-w-2xl flex-col gap-4">
-          <div className="flex items-center gap-1.5">
-            <NewspaperIcon weight="light" className="size-4 text-gold-9" />
+      <div className={content()}>
+        <article className={article()}>
+          <div className={meta()}>
+            <NewspaperIcon weight="light" className={metaIcon()} />
             <Text size={1} color="gold">
               {formatDate(update.updatedAt, i18n.language)}
             </Text>
@@ -73,7 +76,7 @@ export function UpdateDetailPage({ queryRef }: UpdateDetailPageProps) {
           <Heading level={1} size={7} weight="medium" highContrast>
             {update.title}
           </Heading>
-          <Text size={3} className="block whitespace-pre-wrap">
+          <Text size={3} className={body()}>
             {update.body}
           </Text>
         </article>

--- a/apps/compliance-portal/src/pages/updates/UpdateDetailPage.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdateDetailPage.tsx
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { CaretLeftIcon, NewspaperIcon } from "@phosphor-icons/react";
+import { Link } from "@probo/ui/src/v2/Button/Link";
+import { Heading } from "@probo/ui/src/v2/typography/Heading";
+import { Text } from "@probo/ui/src/v2/typography/Text";
+import { useTranslation } from "react-i18next";
+import type { PreloadedQuery } from "react-relay";
+import { graphql, usePreloadedQuery } from "react-relay";
+
+import { HeaderBand } from "#/components/HeaderBand/HeaderBand";
+import { formatDate } from "#/lib/datetime/formatDate";
+
+import type { UpdateDetailPageQuery } from "./__generated__/UpdateDetailPageQuery.graphql";
+import { UpdatesSubscribeButton } from "./_components/UpdatesSubscribeButton";
+
+export const updateDetailPageQuery = graphql`
+  query UpdateDetailPageQuery($updateId: ID!) {
+    node(id: $updateId) {
+      __typename
+      ... on MailingListUpdate {
+        title
+        body
+        updatedAt
+      }
+    }
+  }
+`;
+
+interface UpdateDetailPageProps {
+  queryRef: PreloadedQuery<UpdateDetailPageQuery>;
+}
+
+export function UpdateDetailPage({ queryRef }: UpdateDetailPageProps) {
+  const { t, i18n } = useTranslation("updates");
+  const data = usePreloadedQuery<UpdateDetailPageQuery>(updateDetailPageQuery, queryRef);
+
+  if (data.node?.__typename !== "MailingListUpdate") {
+    throw new Error("Update not found");
+  }
+  const update = data.node;
+
+  return (
+    <>
+      <HeaderBand>
+        <div className="flex w-full items-center justify-between gap-4">
+          <Link to="/updates" variant="soft" color="neutral" highContrast iconStart={<CaretLeftIcon />}>
+            {t("backToUpdates")}
+          </Link>
+          <UpdatesSubscribeButton />
+        </div>
+      </HeaderBand>
+      <div className="flex w-full flex-col items-center px-8 py-8">
+        <article className="flex w-full max-w-2xl flex-col gap-4">
+          <div className="flex items-center gap-1.5">
+            <NewspaperIcon weight="light" className="size-4 text-gold-9" />
+            <Text size={1} color="gold">
+              {formatDate(update.updatedAt, i18n.language)}
+            </Text>
+          </div>
+          <Heading level={1} size={7} weight="medium" highContrast>
+            {update.title}
+          </Heading>
+          <Text size={3} className="block whitespace-pre-wrap">
+            {update.body}
+          </Text>
+        </article>
+      </div>
+    </>
+  );
+}

--- a/apps/compliance-portal/src/pages/updates/UpdateDetailPageLoader.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdateDetailPageLoader.tsx
@@ -22,13 +22,16 @@ import { UpdateDetailPageSkeleton } from "./UpdateDetailPageSkeleton";
 
 export default function UpdateDetailPageLoader() {
   const { updateId } = useParams<{ updateId: string }>();
-  const [queryRef, loadQuery] = useQueryLoader<UpdateDetailPageQuery>(updateDetailPageQuery);
+  const [queryRef, loadQuery, disposeQuery] = useQueryLoader<UpdateDetailPageQuery>(updateDetailPageQuery);
 
+  // Dispose on updateId change so navigating between updates shows the skeleton
+  // during the transition instead of the previous update's content.
   useEffect(() => {
     if (updateId) {
       loadQuery({ updateId });
     }
-  }, [loadQuery, updateId]);
+    return () => disposeQuery();
+  }, [loadQuery, disposeQuery, updateId]);
 
   if (!queryRef) {
     return <UpdateDetailPageSkeleton />;

--- a/apps/compliance-portal/src/pages/updates/UpdateDetailPageLoader.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdateDetailPageLoader.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useEffect } from "react";
+import { useQueryLoader } from "react-relay";
+import { useParams } from "react-router";
+
+import type { UpdateDetailPageQuery } from "./__generated__/UpdateDetailPageQuery.graphql";
+import { UpdateDetailPage, updateDetailPageQuery } from "./UpdateDetailPage";
+import { UpdateDetailPageSkeleton } from "./UpdateDetailPageSkeleton";
+
+export default function UpdateDetailPageLoader() {
+  const { updateId } = useParams<{ updateId: string }>();
+  const [queryRef, loadQuery] = useQueryLoader<UpdateDetailPageQuery>(updateDetailPageQuery);
+
+  useEffect(() => {
+    if (updateId) {
+      loadQuery({ updateId });
+    }
+  }, [loadQuery, updateId]);
+
+  if (!queryRef) {
+    return <UpdateDetailPageSkeleton />;
+  }
+
+  return <UpdateDetailPage queryRef={queryRef} />;
+}

--- a/apps/compliance-portal/src/pages/updates/UpdateDetailPageSkeleton.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdateDetailPageSkeleton.tsx
@@ -18,24 +18,28 @@ import { TextSkeleton } from "@probo/ui/src/v2/typography/TextSkeleton";
 
 import { HeaderBand } from "#/components/HeaderBand/HeaderBand";
 
-const BODY_PLACEHOLDERS = ["a", "b", "c", "d", "e"];
+import { updateArticle } from "./_components/variants";
+
+const BODY_LINE_COUNT = 5;
 
 export function UpdateDetailPageSkeleton() {
+  const { toolbar, content, article } = updateArticle();
+
   return (
     <>
       <HeaderBand>
-        <div className="flex w-full items-center justify-between gap-4">
+        <div className={toolbar()}>
           <ButtonSkeleton size={2} />
           <ButtonSkeleton size={2} />
         </div>
       </HeaderBand>
-      <div className="flex w-full flex-col items-center px-8 py-8">
-        <div className="flex w-full max-w-2xl flex-col gap-4" aria-hidden>
+      <div className={content()}>
+        <div className={article()} aria-hidden>
           <TextSkeleton size={1} className="w-28" />
           <HeadingSkeleton size={7} className="w-96" />
           <div className="flex flex-col gap-2">
-            {BODY_PLACEHOLDERS.map(placeholder => (
-              <TextSkeleton key={placeholder} size={3} className="w-full" />
+            {Array.from({ length: BODY_LINE_COUNT }, (_, index) => (
+              <TextSkeleton key={index} size={3} className="w-full" />
             ))}
           </div>
         </div>

--- a/apps/compliance-portal/src/pages/updates/UpdateDetailPageSkeleton.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdateDetailPageSkeleton.tsx
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { ButtonSkeleton } from "@probo/ui/src/v2/Button/ButtonSkeleton";
+import { HeadingSkeleton } from "@probo/ui/src/v2/typography/HeadingSkeleton";
+import { TextSkeleton } from "@probo/ui/src/v2/typography/TextSkeleton";
+
+import { HeaderBand } from "#/components/HeaderBand/HeaderBand";
+
+const BODY_PLACEHOLDERS = ["a", "b", "c", "d", "e"];
+
+export function UpdateDetailPageSkeleton() {
+  return (
+    <>
+      <HeaderBand>
+        <div className="flex w-full items-center justify-between gap-4">
+          <ButtonSkeleton size={2} />
+          <ButtonSkeleton size={2} />
+        </div>
+      </HeaderBand>
+      <div className="flex w-full flex-col items-center px-8 py-8">
+        <div className="flex w-full max-w-2xl flex-col gap-4" aria-hidden>
+          <TextSkeleton size={1} className="w-28" />
+          <HeadingSkeleton size={7} className="w-96" />
+          <div className="flex flex-col gap-2">
+            {BODY_PLACEHOLDERS.map(placeholder => (
+              <TextSkeleton key={placeholder} size={3} className="w-full" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/compliance-portal/src/pages/updates/UpdatesPage.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdatesPage.tsx
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { Pagination } from "@probo/ui/src/v2/Pagination/Pagination";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import type { PreloadedQuery } from "react-relay";
+import { graphql, usePreloadedQuery, useRefetchableFragment } from "react-relay";
+
+import { MailingListUpdateListItem } from "#/components/MailingListUpdateListItem/MailingListUpdateListItem";
+import { PageHeader } from "#/components/PageHeader/PageHeader";
+
+import type { UpdatesPage_query$key } from "./__generated__/UpdatesPage_query.graphql";
+import type { UpdatesPageQuery } from "./__generated__/UpdatesPageQuery.graphql";
+import type { UpdatesPageRefetchQuery } from "./__generated__/UpdatesPageRefetchQuery.graphql";
+import { UpdatesEmpty } from "./_components/UpdatesEmpty";
+import { UpdatesSubscribeButton } from "./_components/UpdatesSubscribeButton";
+import type { UpdatesPaginationVariables } from "./_lib/useUpdatesPagination";
+import { useUpdatesPagination } from "./_lib/useUpdatesPagination";
+
+export const updatesPageQuery = graphql`
+  query UpdatesPageQuery($first: Int, $after: CursorKey, $last: Int, $before: CursorKey) {
+    ...UpdatesPage_query @arguments(first: $first, after: $after, last: $last, before: $before)
+  }
+`;
+
+const updatesPageFragment = graphql`
+  fragment UpdatesPage_query on Query
+  @refetchable(queryName: "UpdatesPageRefetchQuery")
+  @argumentDefinitions(
+    first: { type: "Int" }
+    after: { type: "CursorKey" }
+    last: { type: "Int" }
+    before: { type: "CursorKey" }
+  ) {
+    currentTrustCenter @required(action: THROW) {
+      updates(first: $first, after: $after, last: $last, before: $before) {
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
+        }
+        edges {
+          node {
+            id
+            ...MailingListUpdateListItem_update
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface UpdatesPageProps {
+  queryRef: PreloadedQuery<UpdatesPageQuery>;
+}
+
+export function UpdatesPage({ queryRef }: UpdatesPageProps) {
+  const { t } = useTranslation("updates");
+  const root = usePreloadedQuery<UpdatesPageQuery>(updatesPageQuery, queryRef);
+  const [data, refetch] = useRefetchableFragment<UpdatesPageRefetchQuery, UpdatesPage_query$key>(
+    updatesPageFragment,
+    root,
+  );
+
+  const refetchUpdates = useCallback((variables: UpdatesPaginationVariables) => {
+    refetch(variables, { fetchPolicy: "store-or-network" });
+  }, [refetch]);
+
+  const { updates } = data.currentTrustCenter;
+  const { pageInfo } = updates;
+  const { isPending, goPrevious, goNext } = useUpdatesPagination(refetchUpdates, pageInfo);
+
+  const nodes = updates.edges.map(edge => edge.node);
+  const isEmpty = nodes.length === 0;
+
+  return (
+    <>
+      <PageHeader title={t("title")} actions={isEmpty ? undefined : <UpdatesSubscribeButton />} />
+      <div className="flex w-full flex-col items-center px-8 py-8">
+        <div className="w-full max-w-5xl">
+          {isEmpty
+            ? <UpdatesEmpty />
+            : (
+                <div className="flex flex-col gap-8">
+                  <div
+                    aria-busy={isPending}
+                    className={`overflow-hidden rounded-5 border border-sand-3 bg-sand-1 transition-opacity duration-150 ${isPending ? "opacity-60" : ""}`}
+                  >
+                    <div className="divide-y divide-sand-a2">
+                      {nodes.map(node => (
+                        <MailingListUpdateListItem key={node.id} updateKey={node} />
+                      ))}
+                    </div>
+                  </div>
+                  <Pagination
+                    hasPrevious={pageInfo.hasPreviousPage}
+                    hasNext={pageInfo.hasNextPage}
+                    previousLabel={t("pagination.previous")}
+                    nextLabel={t("pagination.next")}
+                    onPrevious={goPrevious}
+                    onNext={goNext}
+                  />
+                </div>
+              )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/compliance-portal/src/pages/updates/UpdatesPage.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdatesPage.tsx
@@ -20,14 +20,16 @@ import { graphql, usePreloadedQuery, useRefetchableFragment } from "react-relay"
 
 import { MailingListUpdateListItem } from "#/components/MailingListUpdateListItem/MailingListUpdateListItem";
 import { PageHeader } from "#/components/PageHeader/PageHeader";
+import type { CursorPaginationVariables } from "#/lib/relay/useCursorPagination";
+import { useCursorPagination } from "#/lib/relay/useCursorPagination";
 
 import type { UpdatesPage_query$key } from "./__generated__/UpdatesPage_query.graphql";
 import type { UpdatesPageQuery } from "./__generated__/UpdatesPageQuery.graphql";
 import type { UpdatesPageRefetchQuery } from "./__generated__/UpdatesPageRefetchQuery.graphql";
 import { UpdatesEmpty } from "./_components/UpdatesEmpty";
+import { UpdatesList } from "./_components/UpdatesList";
 import { UpdatesSubscribeButton } from "./_components/UpdatesSubscribeButton";
-import type { UpdatesPaginationVariables } from "./_lib/useUpdatesPagination";
-import { useUpdatesPagination } from "./_lib/useUpdatesPagination";
+import { UPDATES_PAGE_SIZE } from "./_lib/constants";
 
 export const updatesPageQuery = graphql`
   query UpdatesPageQuery($first: Int, $after: CursorKey, $last: Int, $before: CursorKey) {
@@ -69,19 +71,20 @@ interface UpdatesPageProps {
 
 export function UpdatesPage({ queryRef }: UpdatesPageProps) {
   const { t } = useTranslation("updates");
+  const { t: tCommon } = useTranslation();
   const root = usePreloadedQuery<UpdatesPageQuery>(updatesPageQuery, queryRef);
   const [data, refetch] = useRefetchableFragment<UpdatesPageRefetchQuery, UpdatesPage_query$key>(
     updatesPageFragment,
     root,
   );
 
-  const refetchUpdates = useCallback((variables: UpdatesPaginationVariables) => {
+  const refetchUpdates = useCallback((variables: CursorPaginationVariables) => {
     refetch(variables, { fetchPolicy: "store-or-network" });
   }, [refetch]);
 
   const { updates } = data.currentTrustCenter;
   const { pageInfo } = updates;
-  const { isPending, goPrevious, goNext } = useUpdatesPagination(refetchUpdates, pageInfo);
+  const { isPending, goPrevious, goNext } = useCursorPagination(refetchUpdates, pageInfo, UPDATES_PAGE_SIZE);
 
   const nodes = updates.edges.map(edge => edge.node);
   const isEmpty = nodes.length === 0;
@@ -95,21 +98,16 @@ export function UpdatesPage({ queryRef }: UpdatesPageProps) {
             ? <UpdatesEmpty />
             : (
                 <div className="flex flex-col gap-8">
-                  <div
-                    aria-busy={isPending}
-                    className={`overflow-hidden rounded-5 border border-sand-3 bg-sand-1 transition-opacity duration-150 ${isPending ? "opacity-60" : ""}`}
-                  >
-                    <div className="divide-y divide-sand-a2">
-                      {nodes.map(node => (
-                        <MailingListUpdateListItem key={node.id} updateKey={node} />
-                      ))}
-                    </div>
-                  </div>
+                  <UpdatesList busy={isPending}>
+                    {nodes.map(node => (
+                      <MailingListUpdateListItem key={node.id} updateKey={node} />
+                    ))}
+                  </UpdatesList>
                   <Pagination
                     hasPrevious={pageInfo.hasPreviousPage}
                     hasNext={pageInfo.hasNextPage}
-                    previousLabel={t("pagination.previous")}
-                    nextLabel={t("pagination.next")}
+                    previousLabel={tCommon("pagination.previous")}
+                    nextLabel={tCommon("pagination.next")}
                     onPrevious={goPrevious}
                     onNext={goNext}
                   />

--- a/apps/compliance-portal/src/pages/updates/UpdatesPageLoader.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdatesPageLoader.tsx
@@ -12,22 +12,24 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { TextSkeleton } from "@probo/ui/src/v2/typography/TextSkeleton";
+import { useEffect } from "react";
+import { useQueryLoader } from "react-relay";
 
-import { complianceArticleItem } from "./variants";
+import type { UpdatesPageQuery } from "./__generated__/UpdatesPageQuery.graphql";
+import { UPDATES_PAGE_SIZE } from "./_lib/useUpdatesPagination";
+import { UpdatesPage, updatesPageQuery } from "./UpdatesPage";
+import { UpdatesPageSkeleton } from "./UpdatesPageSkeleton";
 
-// Loading placeholder paired with ComplianceArticleItem: same row layout with
-// a pulse icon and skeleton text.
-export function ComplianceArticleItemSkeleton() {
-  const slots = complianceArticleItem();
+export default function UpdatesPageLoader() {
+  const [queryRef, loadQuery] = useQueryLoader<UpdatesPageQuery>(updatesPageQuery);
 
-  return (
-    <div className={slots.root()} aria-hidden>
-      <div className={slots.iconPlaceholder()} />
-      <div className={slots.content()}>
-        <TextSkeleton size={2} className="w-48" />
-      </div>
-      <TextSkeleton size={1} className="w-20 shrink-0" />
-    </div>
-  );
+  useEffect(() => {
+    loadQuery({ first: UPDATES_PAGE_SIZE });
+  }, [loadQuery]);
+
+  if (!queryRef) {
+    return <UpdatesPageSkeleton />;
+  }
+
+  return <UpdatesPage queryRef={queryRef} />;
 }

--- a/apps/compliance-portal/src/pages/updates/UpdatesPageSkeleton.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdatesPageSkeleton.tsx
@@ -18,9 +18,13 @@ import { HeadingSkeleton } from "@probo/ui/src/v2/typography/HeadingSkeleton";
 import { ComplianceArticleItemSkeleton } from "#/components/ComplianceArticleItem/ComplianceArticleItemSkeleton";
 import { HeaderBand } from "#/components/HeaderBand/HeaderBand";
 
-const ROW_PLACEHOLDERS = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
+import { updatesList } from "./_components/variants";
+
+const ROW_COUNT = 10;
 
 export function UpdatesPageSkeleton() {
+  const { card, rows } = updatesList();
+
   return (
     <>
       <HeaderBand>
@@ -30,10 +34,10 @@ export function UpdatesPageSkeleton() {
       </HeaderBand>
       <div className="flex w-full flex-col items-center px-8 py-8">
         <div className="flex w-full max-w-5xl flex-col gap-8">
-          <div className="overflow-hidden rounded-5 border border-sand-3 bg-sand-1" aria-hidden>
-            <div className="divide-y divide-sand-a2">
-              {ROW_PLACEHOLDERS.map(placeholder => (
-                <ComplianceArticleItemSkeleton key={placeholder} />
+          <div className={card()} aria-hidden>
+            <div className={rows()}>
+              {Array.from({ length: ROW_COUNT }, (_, index) => (
+                <ComplianceArticleItemSkeleton key={index} />
               ))}
             </div>
           </div>

--- a/apps/compliance-portal/src/pages/updates/UpdatesPageSkeleton.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdatesPageSkeleton.tsx
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { PaginationSkeleton } from "@probo/ui/src/v2/Pagination/PaginationSkeleton";
+import { HeadingSkeleton } from "@probo/ui/src/v2/typography/HeadingSkeleton";
+
+import { ComplianceArticleItemSkeleton } from "#/components/ComplianceArticleItem/ComplianceArticleItemSkeleton";
+import { HeaderBand } from "#/components/HeaderBand/HeaderBand";
+
+const ROW_PLACEHOLDERS = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
+
+export function UpdatesPageSkeleton() {
+  return (
+    <>
+      <HeaderBand>
+        <div className="flex w-full flex-col gap-2">
+          <HeadingSkeleton size={7} className="w-40" />
+        </div>
+      </HeaderBand>
+      <div className="flex w-full flex-col items-center px-8 py-8">
+        <div className="flex w-full max-w-5xl flex-col gap-8">
+          <div className="overflow-hidden rounded-5 border border-sand-3 bg-sand-1" aria-hidden>
+            <div className="divide-y divide-sand-a2">
+              {ROW_PLACEHOLDERS.map(placeholder => (
+                <ComplianceArticleItemSkeleton key={placeholder} />
+              ))}
+            </div>
+          </div>
+          <PaginationSkeleton />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/compliance-portal/src/pages/updates/UpdatesPageSkeleton.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdatesPageSkeleton.tsx
@@ -19,8 +19,7 @@ import { ComplianceArticleItemSkeleton } from "#/components/ComplianceArticleIte
 import { HeaderBand } from "#/components/HeaderBand/HeaderBand";
 
 import { updatesList } from "./_components/variants";
-
-const ROW_COUNT = 10;
+import { UPDATES_PAGE_SIZE } from "./_lib/constants";
 
 export function UpdatesPageSkeleton() {
   const { card, rows } = updatesList();
@@ -36,7 +35,7 @@ export function UpdatesPageSkeleton() {
         <div className="flex w-full max-w-5xl flex-col gap-8">
           <div className={card()} aria-hidden>
             <div className={rows()}>
-              {Array.from({ length: ROW_COUNT }, (_, index) => (
+              {Array.from({ length: UPDATES_PAGE_SIZE }, (_, index) => (
                 <ComplianceArticleItemSkeleton key={index} />
               ))}
             </div>

--- a/apps/compliance-portal/src/pages/updates/_components/UpdatesEmpty.tsx
+++ b/apps/compliance-portal/src/pages/updates/_components/UpdatesEmpty.tsx
@@ -12,22 +12,24 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { TextSkeleton } from "@probo/ui/src/v2/typography/TextSkeleton";
+import { NewspaperIcon } from "@phosphor-icons/react";
+import { useTranslation } from "react-i18next";
 
-import { complianceArticleItem } from "./variants";
+import { EmptyState } from "#/components/EmptyState/EmptyState";
 
-// Loading placeholder paired with ComplianceArticleItem: same row layout with
-// a pulse icon and skeleton text.
-export function ComplianceArticleItemSkeleton() {
-  const slots = complianceArticleItem();
+import { UpdatesSubscribeButton } from "./UpdatesSubscribeButton";
+
+// Empty state for the updates list: shown when the trust center has published no
+// updates yet, inviting the visitor to subscribe.
+export function UpdatesEmpty() {
+  const { t } = useTranslation("updates");
 
   return (
-    <div className={slots.root()} aria-hidden>
-      <div className={slots.iconPlaceholder()} />
-      <div className={slots.content()}>
-        <TextSkeleton size={2} className="w-48" />
-      </div>
-      <TextSkeleton size={1} className="w-20 shrink-0" />
-    </div>
+    <EmptyState
+      icon={<NewspaperIcon weight="light" />}
+      title={t("empty.title")}
+      description={t("empty.description")}
+      action={<UpdatesSubscribeButton />}
+    />
   );
 }

--- a/apps/compliance-portal/src/pages/updates/_components/UpdatesList.tsx
+++ b/apps/compliance-portal/src/pages/updates/_components/UpdatesList.tsx
@@ -12,24 +12,24 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { useEffect } from "react";
-import { useQueryLoader } from "react-relay";
+import type { ReactNode } from "react";
 
-import type { UpdatesPageQuery } from "./__generated__/UpdatesPageQuery.graphql";
-import { UPDATES_PAGE_SIZE } from "./_lib/constants";
-import { UpdatesPage, updatesPageQuery } from "./UpdatesPage";
-import { UpdatesPageSkeleton } from "./UpdatesPageSkeleton";
+import { updatesList } from "./variants";
 
-export default function UpdatesPageLoader() {
-  const [queryRef, loadQuery] = useQueryLoader<UpdatesPageQuery>(updatesPageQuery);
+interface UpdatesListProps {
+  // Dims the list while a page change is loading.
+  busy?: boolean;
+  // The rendered update rows.
+  children: ReactNode;
+}
 
-  useEffect(() => {
-    loadQuery({ first: UPDATES_PAGE_SIZE });
-  }, [loadQuery]);
+// White card surface holding divider-separated update rows.
+export function UpdatesList({ busy = false, children }: UpdatesListProps) {
+  const { card, rows } = updatesList();
 
-  if (!queryRef) {
-    return <UpdatesPageSkeleton />;
-  }
-
-  return <UpdatesPage queryRef={queryRef} />;
+  return (
+    <div className={card({ busy })} aria-busy={busy || undefined}>
+      <div className={rows()}>{children}</div>
+    </div>
+  );
 }

--- a/apps/compliance-portal/src/pages/updates/_components/UpdatesSubscribeButton.tsx
+++ b/apps/compliance-portal/src/pages/updates/_components/UpdatesSubscribeButton.tsx
@@ -12,22 +12,18 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { TextSkeleton } from "@probo/ui/src/v2/typography/TextSkeleton";
+import { BellIcon } from "@phosphor-icons/react";
+import { Button } from "@probo/ui/src/v2/Button/Button";
+import { useTranslation } from "react-i18next";
 
-import { complianceArticleItem } from "./variants";
-
-// Loading placeholder paired with ComplianceArticleItem: same row layout with
-// a pulse icon and skeleton text.
-export function ComplianceArticleItemSkeleton() {
-  const slots = complianceArticleItem();
+// "Subscribe to updates" call to action shared by the list header and the
+// detail toolbar. Mailing-list subscription wiring is not implemented yet.
+export function UpdatesSubscribeButton() {
+  const { t } = useTranslation("updates");
 
   return (
-    <div className={slots.root()} aria-hidden>
-      <div className={slots.iconPlaceholder()} />
-      <div className={slots.content()}>
-        <TextSkeleton size={2} className="w-48" />
-      </div>
-      <TextSkeleton size={1} className="w-20 shrink-0" />
-    </div>
+    <Button variant="soft" color="neutral" highContrast iconStart={<BellIcon />}>
+      {t("subscribe")}
+    </Button>
   );
 }

--- a/apps/compliance-portal/src/pages/updates/_components/variants.ts
+++ b/apps/compliance-portal/src/pages/updates/_components/variants.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { tv } from "tailwind-variants/lite";
+
+// Updates list surface: a white card holding divider-separated rows. The card
+// dims while a page change is loading. Slots are shared by the list and its
+// skeleton so the loading placeholder matches the real layout.
+export const updatesList = tv({
+  slots: {
+    card: "overflow-hidden rounded-5 border border-sand-3 bg-sand-1 transition-opacity duration-150",
+    rows: "divide-y divide-sand-a2",
+  },
+  variants: {
+    busy: {
+      true: { card: "opacity-60" },
+      false: {},
+    },
+  },
+  defaultVariants: {
+    busy: false,
+  },
+});
+
+// Update detail article layout: the toolbar row (back link + subscribe), the
+// centered content column, and the article body with its gold metadata row.
+// Slots are shared by the detail page and its skeleton.
+export const updateArticle = tv({
+  slots: {
+    toolbar: "flex w-full items-center justify-between gap-4",
+    content: "flex w-full flex-col items-center px-8 py-8",
+    article: "flex w-full max-w-2xl flex-col gap-4",
+    meta: "flex items-center gap-1.5",
+    metaIcon: "size-4 text-gold-9",
+    body: "block whitespace-pre-wrap",
+  },
+});

--- a/apps/compliance-portal/src/pages/updates/_lib/constants.ts
+++ b/apps/compliance-portal/src/pages/updates/_lib/constants.ts
@@ -12,24 +12,5 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { useEffect } from "react";
-import { useQueryLoader } from "react-relay";
-
-import type { UpdatesPageQuery } from "./__generated__/UpdatesPageQuery.graphql";
-import { UPDATES_PAGE_SIZE } from "./_lib/constants";
-import { UpdatesPage, updatesPageQuery } from "./UpdatesPage";
-import { UpdatesPageSkeleton } from "./UpdatesPageSkeleton";
-
-export default function UpdatesPageLoader() {
-  const [queryRef, loadQuery] = useQueryLoader<UpdatesPageQuery>(updatesPageQuery);
-
-  useEffect(() => {
-    loadQuery({ first: UPDATES_PAGE_SIZE });
-  }, [loadQuery]);
-
-  if (!queryRef) {
-    return <UpdatesPageSkeleton />;
-  }
-
-  return <UpdatesPage queryRef={queryRef} />;
-}
+// Page size for the cursor-paginated updates list.
+export const UPDATES_PAGE_SIZE = 25;

--- a/apps/compliance-portal/src/pages/updates/_lib/useUpdatesPagination.ts
+++ b/apps/compliance-portal/src/pages/updates/_lib/useUpdatesPagination.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useCallback, useTransition } from "react";
+
+// Page size for the cursor-paginated updates list. Matches the Figma list frame.
+export const UPDATES_PAGE_SIZE = 10;
+
+export interface UpdatesPageInfo {
+  hasPreviousPage: boolean;
+  hasNextPage: boolean;
+  startCursor: string | null | undefined;
+  endCursor: string | null | undefined;
+}
+
+export interface UpdatesPaginationVariables {
+  first?: number | null;
+  after?: string | null;
+  last?: number | null;
+  before?: string | null;
+}
+
+type RefetchUpdates = (variables: UpdatesPaginationVariables) => void;
+
+// Cursor-based Prev/Next pagination for the updates list. Drives the connection
+// refetch inside a transition so the current page stays mounted (dimmed) while
+// the next one loads. Enabled/disabled state comes from the server `pageInfo`,
+// which stays correct however the page is reached. No page-number counter:
+// cursor pagination encodes a position, not an ordinal, so a reliable page
+// index (deep-linkable or refresh-safe) would need offset + totalCount, which
+// this API does not expose.
+export function useUpdatesPagination(refetch: RefetchUpdates, pageInfo: UpdatesPageInfo) {
+  const [isPending, startTransition] = useTransition();
+
+  const goNext = useCallback(() => {
+    if (!pageInfo.hasNextPage || pageInfo.endCursor == null) {
+      return;
+    }
+    startTransition(() => {
+      refetch({ first: UPDATES_PAGE_SIZE, after: pageInfo.endCursor, last: null, before: null });
+    });
+  }, [refetch, pageInfo.hasNextPage, pageInfo.endCursor]);
+
+  const goPrevious = useCallback(() => {
+    if (!pageInfo.hasPreviousPage || pageInfo.startCursor == null) {
+      return;
+    }
+    startTransition(() => {
+      refetch({ first: null, after: null, last: UPDATES_PAGE_SIZE, before: pageInfo.startCursor });
+    });
+  }, [refetch, pageInfo.hasPreviousPage, pageInfo.startCursor]);
+
+  return { isPending, goPrevious, goNext };
+}

--- a/apps/compliance-portal/src/pages/updates/_locales/en-US.json
+++ b/apps/compliance-portal/src/pages/updates/_locales/en-US.json
@@ -5,9 +5,5 @@
   "empty": {
     "title": "No updates yet.",
     "description": "Subscribe to get notified when new updates are published."
-  },
-  "pagination": {
-    "previous": "Previous page",
-    "next": "Next page"
   }
 }

--- a/apps/compliance-portal/src/pages/updates/_locales/en-US.json
+++ b/apps/compliance-portal/src/pages/updates/_locales/en-US.json
@@ -1,0 +1,13 @@
+{
+  "title": "Updates",
+  "subscribe": "Subscribe to updates",
+  "backToUpdates": "All updates",
+  "empty": {
+    "title": "No updates yet.",
+    "description": "Subscribe to get notified when new updates are published."
+  },
+  "pagination": {
+    "previous": "Previous page",
+    "next": "Next page"
+  }
+}

--- a/apps/compliance-portal/src/pages/updates/_locales/fr-FR.json
+++ b/apps/compliance-portal/src/pages/updates/_locales/fr-FR.json
@@ -5,9 +5,5 @@
   "empty": {
     "title": "Aucune mise à jour pour le moment.",
     "description": "Abonnez-vous pour être informé lors de la publication de nouvelles mises à jour."
-  },
-  "pagination": {
-    "previous": "Page précédente",
-    "next": "Page suivante"
   }
 }

--- a/apps/compliance-portal/src/pages/updates/_locales/fr-FR.json
+++ b/apps/compliance-portal/src/pages/updates/_locales/fr-FR.json
@@ -1,0 +1,13 @@
+{
+  "title": "Mises à jour",
+  "subscribe": "S'abonner aux mises à jour",
+  "backToUpdates": "Toutes les mises à jour",
+  "empty": {
+    "title": "Aucune mise à jour pour le moment.",
+    "description": "Abonnez-vous pour être informé lors de la publication de nouvelles mises à jour."
+  },
+  "pagination": {
+    "previous": "Page précédente",
+    "next": "Page suivante"
+  }
+}

--- a/apps/compliance-portal/src/pages/updates/routes.ts
+++ b/apps/compliance-portal/src/pages/updates/routes.ts
@@ -12,22 +12,21 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { TextSkeleton } from "@probo/ui/src/v2/typography/TextSkeleton";
+import { lazy } from "@probo/react-lazy";
+import type { AppRoute } from "@probo/routes";
 
-import { complianceArticleItem } from "./variants";
+import { UpdateDetailPageSkeleton } from "./UpdateDetailPageSkeleton";
+import { UpdatesPageSkeleton } from "./UpdatesPageSkeleton";
 
-// Loading placeholder paired with ComplianceArticleItem: same row layout with
-// a pulse icon and skeleton text.
-export function ComplianceArticleItemSkeleton() {
-  const slots = complianceArticleItem();
-
-  return (
-    <div className={slots.root()} aria-hidden>
-      <div className={slots.iconPlaceholder()} />
-      <div className={slots.content()}>
-        <TextSkeleton size={2} className="w-48" />
-      </div>
-      <TextSkeleton size={1} className="w-20 shrink-0" />
-    </div>
-  );
-}
+export const updateRoutes = [
+  {
+    path: "updates",
+    Fallback: UpdatesPageSkeleton,
+    Component: lazy(() => import("./UpdatesPageLoader")),
+  },
+  {
+    path: "updates/:updateId",
+    Fallback: UpdateDetailPageSkeleton,
+    Component: lazy(() => import("./UpdateDetailPageLoader")),
+  },
+] satisfies AppRoute[];

--- a/apps/compliance-portal/src/routes.tsx
+++ b/apps/compliance-portal/src/routes.tsx
@@ -20,6 +20,7 @@ import { getPathPrefix } from "#/lib/http/pathPrefix";
 import { HomePageSkeleton } from "#/pages/HomePageSkeleton";
 import { MainLayoutSkeleton } from "#/pages/MainLayoutSkeleton";
 import { subprocessorRoutes } from "#/pages/subprocessors/routes";
+import { updateRoutes } from "#/pages/updates/routes";
 
 const routes = [
   {
@@ -37,10 +38,7 @@ const routes = [
         Component: lazy(() => import("#/pages/DocumentsPage")),
       },
       ...subprocessorRoutes,
-      {
-        path: "updates",
-        Component: lazy(() => import("#/pages/UpdatesPage")),
-      },
+      ...updateRoutes,
       {
         path: "requests",
         Component: lazy(() => import("#/pages/RequestsPage")),

--- a/packages/ui/src/v2/Pagination/Pagination.stories.tsx
+++ b/packages/ui/src/v2/Pagination/Pagination.stories.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Pagination } from "./Pagination";
+import { PaginationSkeleton } from "./PaginationSkeleton";
+
+const noop = () => {};
+
+export default {
+  title: "v2/Pagination",
+  component: Pagination,
+  args: {
+    hasPrevious: true,
+    hasNext: true,
+    onPrevious: noop,
+    onNext: noop,
+  },
+} satisfies Meta<typeof Pagination>;
+
+type Story = StoryObj<typeof Pagination>;
+
+export const Playground: Story = {};
+
+// Each arrow only shows when its page exists, but its slot stays reserved so a
+// lone arrow sits in the same position as when both are present.
+export const States: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <Pagination hasPrevious hasNext onPrevious={noop} onNext={noop} />
+      <Pagination hasPrevious={false} hasNext onPrevious={noop} onNext={noop} />
+      <Pagination hasPrevious hasNext={false} onPrevious={noop} onNext={noop} />
+    </div>
+  ),
+};
+
+export const WithLabel: Story = {
+  args: {
+    label: "Page 2",
+  },
+};
+
+export const Skeleton: Story = {
+  render: () => <PaginationSkeleton />,
+};

--- a/packages/ui/src/v2/Pagination/Pagination.tsx
+++ b/packages/ui/src/v2/Pagination/Pagination.tsx
@@ -71,7 +71,7 @@ export function Pagination(props: PaginationProps) {
         variant="ghost"
         color="neutral"
         size={2}
-        iconStart={<CaretRightIcon />}
+        iconEnd={<CaretRightIcon />}
         aria-label={nextLabel}
         className={hasNext ? undefined : "invisible"}
         onClick={onNext}

--- a/packages/ui/src/v2/Pagination/Pagination.tsx
+++ b/packages/ui/src/v2/Pagination/Pagination.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { CaretLeftIcon, CaretRightIcon } from "@phosphor-icons/react";
+import type { ComponentProps, ReactNode } from "react";
+
+import { Button } from "../Button/Button";
+import { Text } from "../typography/Text";
+
+import { pagination } from "./variants";
+
+export type PaginationProps = Omit<ComponentProps<"nav">, "onChange"> & {
+  hasPrevious: boolean;
+  hasNext: boolean;
+  // Current-position label rendered between the arrows (e.g. "Page 2").
+  label?: ReactNode;
+  // Accessible labels for the arrow controls.
+  previousLabel?: string;
+  nextLabel?: string;
+  onPrevious: () => void;
+  onNext: () => void;
+};
+
+// Prev/Next pager for cursor-paginated lists. Page numbers are intentionally
+// omitted because cursor pagination cannot compute a total page count; an
+// optional current-position label sits between the arrows instead. Each arrow
+// only renders when its page exists, but its slot is always reserved (the
+// missing arrow is kept invisible) so a visible arrow sits in the exact same
+// position whether or not the other is present. Renders nothing when neither
+// page exists.
+export function Pagination(props: PaginationProps) {
+  const {
+    hasPrevious, hasNext, label,
+    previousLabel = "Previous page", nextLabel = "Next page",
+    onPrevious, onNext, className, ...rest
+  } = props;
+  const { root, label: labelSlot } = pagination();
+
+  if (!hasPrevious && !hasNext) {
+    return null;
+  }
+
+  return (
+    <nav className={root({ className })} {...rest}>
+      <Button
+        variant="ghost"
+        color="neutral"
+        size={2}
+        iconStart={<CaretLeftIcon />}
+        aria-label={previousLabel}
+        className={hasPrevious ? undefined : "invisible"}
+        onClick={onPrevious}
+      />
+      {label != null && (
+        <Text size={2} color="faint" className={labelSlot()}>
+          {label}
+        </Text>
+      )}
+      <Button
+        variant="ghost"
+        color="neutral"
+        size={2}
+        iconStart={<CaretRightIcon />}
+        aria-label={nextLabel}
+        className={hasNext ? undefined : "invisible"}
+        onClick={onNext}
+      />
+    </nav>
+  );
+}

--- a/packages/ui/src/v2/Pagination/PaginationSkeleton.tsx
+++ b/packages/ui/src/v2/Pagination/PaginationSkeleton.tsx
@@ -12,14 +12,19 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
+import type { ComponentProps } from "react";
+
 import { pagination } from "./variants";
 
+export type PaginationSkeletonProps = Omit<ComponentProps<"div">, "children">;
+
 // Loading placeholder paired with Pagination: two pulse arrow blocks.
-export function PaginationSkeleton() {
+export function PaginationSkeleton(props: PaginationSkeletonProps) {
+  const { className, ...rest } = props;
   const { root, buttonPlaceholder } = pagination();
 
   return (
-    <div className={root()} aria-hidden>
+    <div className={root({ className })} {...rest} aria-hidden>
       <div className={buttonPlaceholder()} />
       <div className={buttonPlaceholder()} />
     </div>

--- a/packages/ui/src/v2/Pagination/PaginationSkeleton.tsx
+++ b/packages/ui/src/v2/Pagination/PaginationSkeleton.tsx
@@ -12,22 +12,16 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { BellIcon } from "@phosphor-icons/react";
-import { Button } from "@probo/ui/src/v2/Button/Button";
-import { useTranslation } from "react-i18next";
+import { pagination } from "./variants";
 
-import { PageHeader } from "#/components/PageHeader/PageHeader";
+// Loading placeholder paired with Pagination: two pulse arrow blocks.
+export function PaginationSkeleton() {
+  const { root, buttonPlaceholder } = pagination();
 
-export default function UpdatesPage() {
-  const { t } = useTranslation();
   return (
-    <PageHeader
-      title={t("updates.title")}
-      actions={(
-        <Button variant="soft" color="neutral" highContrast iconStart={<BellIcon />}>
-          {t("updates.subscribe")}
-        </Button>
-      )}
-    />
+    <div className={root()} aria-hidden>
+      <div className={buttonPlaceholder()} />
+      <div className={buttonPlaceholder()} />
+    </div>
   );
 }

--- a/packages/ui/src/v2/Pagination/variants.ts
+++ b/packages/ui/src/v2/Pagination/variants.ts
@@ -12,22 +12,15 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { TextSkeleton } from "@probo/ui/src/v2/typography/TextSkeleton";
+import { tv } from "tailwind-variants/lite";
 
-import { complianceArticleItem } from "./variants";
-
-// Loading placeholder paired with ComplianceArticleItem: same row layout with
-// a pulse icon and skeleton text.
-export function ComplianceArticleItemSkeleton() {
-  const slots = complianceArticleItem();
-
-  return (
-    <div className={slots.root()} aria-hidden>
-      <div className={slots.iconPlaceholder()} />
-      <div className={slots.content()}>
-        <TextSkeleton size={2} className="w-48" />
-      </div>
-      <TextSkeleton size={1} className="w-20 shrink-0" />
-    </div>
-  );
-}
+// Prev/Next pager (Figma "Pagination"). A centered row with a previous button,
+// a current-position label, and a next button. Slots are shared by the pager
+// and its skeleton so the loading placeholder matches the real layout.
+export const pagination = tv({
+  slots: {
+    root: "flex items-center justify-center gap-2",
+    label: "min-w-16 text-center",
+    buttonPlaceholder: "size-8 shrink-0 animate-pulse rounded-2 bg-sand-3",
+  },
+});

--- a/pkg/server/api/trust/v1/base_resolvers.go
+++ b/pkg/server/api/trust/v1/base_resolvers.go
@@ -13,6 +13,7 @@ import (
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/mailman"
 	"go.probo.inc/probo/pkg/server/api/authn"
 	"go.probo.inc/probo/pkg/server/api/compliancepage"
 	"go.probo.inc/probo/pkg/server/api/trust/v1/schema"
@@ -198,6 +199,35 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 
 		return types.NewTrustCenterFile(trustCenterFile), nil
+
+	case coredata.MailingListUpdateEntityType:
+		update, err := r.mailman.GetMailingListUpdate(ctx, id)
+		if err != nil {
+			if errors.Is(err, mailman.ErrMailingListUpdateNotFound) || errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+			}
+
+			r.logger.ErrorCtx(ctx, "cannot get mailing list update", log.Error(err))
+
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		if update.Status != coredata.MailingListUpdateStatusSent {
+			return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+		}
+
+		trustCenter, err := trustService.TrustCenters.Get(ctx, scope, compliancePage.ID)
+		if err != nil {
+			r.logger.ErrorCtx(ctx, "cannot get trust center", log.Error(err))
+
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		if trustCenter.MailingListID == nil || *trustCenter.MailingListID != update.MailingListID {
+			return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+		}
+
+		return types.NewMailingListUpdate(update), nil
 
 	default:
 		return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)


### PR DESCRIPTION
Build the public Updates pages in the compliance portal: a cursor-paginated list of sent mailing-list updates and a detail view for a single update, replacing the previous stub page.

Add a MailingListUpdate case to the trust API node resolver, guarded so only SENT updates belonging to the current trust center's mailing list are exposed, so the detail page can load an update by URL.

Add a Prev/Next Pagination primitive to the v2 UI kit. Page numbers are omitted because cursor pagination cannot derive an ordinal page index; each arrow only shows when its page exists while keeping its slot reserved so a visible arrow never shifts position.

Relocate the shared MailingListUpdateListItem to its own component folder and wrap each row in a link to the detail page, so both the home recent-updates section and the list navigate to detail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds public Updates list and detail pages to the compliance portal with cursor-based Prev/Next navigation. Adds a guarded GraphQL node resolver, v2 `@probo/ui` Pagination (with Storybook), a reusable pagination hook, and polish from review to fix arrow placement, pass className on the skeleton, and prevent loading flashes.

### GraphQL API **`+30`** **`-0`**
- Resolve `MailingListUpdate` in the trust node resolver.
- Only expose SENT updates for the current trust center’s mailing list; others return NotFound.
- Allow loading a single update by URL.

### Package: ui **`+196`** **`-0`**
- Add v2 `Pagination` with Prev/Next arrows, optional label, and reserved arrow slots; move Next arrow to `iconEnd`.
- Add `PaginationSkeleton` with `className` passthrough.
- Add Storybook stories for playground, arrow states, optional label, and skeleton.

### Other **`+699`** **`-36`**
- Build Updates list and detail pages with loaders and skeletons; link rows to detail; size list skeleton to the page size; dispose detail query on ID change to avoid flicker.
- Add `useCursorPagination` hook (page-size param) and `UPDATES_PAGE_SIZE` (25); dim list during refetch.
- Move generic pager labels to root `pagination.*` i18n and add en/fr; add updates namespace strings.
- Add `formatDate` helper (Intl options); centralize list and article layouts in tv variants with container-drawn dividers; apply to Recent Updates and new pages; add routes for list and detail.

<sup>Written for commit a6aabc6dadd45e2b116d4bcad9ba07995a9b26ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

