### PR TITLE
Audit third-party CLI: token login, kebab-case rename, compliance report commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ prb risk list
 prb measure create --name "MFA enforced on all production systems"
 prb evidence create --measure <id> --file screenshot.png
 
-# Manage vendor compliance
-prb thirdpartymgmt vendor list
-prb thirdpartymgmt risk-assessment create --vendor <id>
+# Manage third-party compliance
+prb third-party list
+prb third-party report upload ./soc2.pdf --third-party <id> --report-date 2026-01-01
 ```
 
 Run `prb help` for the full command reference.

--- a/pkg/cli/api/client.go
+++ b/pkg/cli/api/client.go
@@ -19,9 +19,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -273,8 +276,17 @@ func (c *Client) doUploadRequest(
 		return nil, fmt.Errorf("cannot write map field: %w", err)
 	}
 
-	// Part 3: file
-	part, err := writer.CreateFormFile("0", filename)
+	// Part 3: file. CreateFormFile would hardcode the part Content-Type to
+	// application/octet-stream, which the server's file validators reject.
+	// Derive the real content type from the file extension instead.
+	partHeader := make(textproto.MIMEHeader)
+	partHeader.Set(
+		"Content-Disposition",
+		fmt.Sprintf(`form-data; name="0"; filename="%s"`, escapeQuotes(filename)),
+	)
+	partHeader.Set("Content-Type", contentTypeForFilename(filename))
+
+	part, err := writer.CreatePart(partHeader)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create form file: %w", err)
 	}
@@ -334,6 +346,30 @@ func (c *Client) doUploadRequest(
 	}
 
 	return respBody, nil
+}
+
+// contentTypeForFilename resolves the MIME type of an upload from its file
+// extension, so multipart parts declare a type the server's file validators
+// accept (e.g. application/pdf) rather than the application/octet-stream that
+// multipart.CreateFormFile would otherwise force.
+func contentTypeForFilename(filename string) string {
+	ct := mime.TypeByExtension(strings.ToLower(filepath.Ext(filename)))
+	if ct == "" {
+		return "application/octet-stream"
+	}
+
+	// Drop any "; charset=..." parameter — validators match the bare type.
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = strings.TrimSpace(ct[:i])
+	}
+
+	return ct
+}
+
+var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
+func escapeQuotes(s string) string {
+	return quoteEscaper.Replace(s)
 }
 
 func (c *Client) tryRefreshToken() error {

--- a/pkg/cmd/asset/create/create.go
+++ b/pkg/cmd/asset/create/create.go
@@ -185,7 +185,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().IntVar(&flagAmount, "amount", 0, "Asset amount")
 	cmd.Flags().StringVar(&flagOwner, "owner", "", "Owner profile ID")
 	cmd.Flags().StringVar(&flagDataTypesStored, "data-types-stored", "", "Data types stored")
-	cmd.Flags().StringSliceVar(&flagThirdPartyIDs, "thirdParty-ids", nil, "ThirdParty IDs (comma-separated)")
+	cmd.Flags().StringSliceVar(&flagThirdPartyIDs, "third-party-ids", nil, "Third party IDs (comma-separated)")
 
 	return cmd
 }

--- a/pkg/cmd/asset/update/update.go
+++ b/pkg/cmd/asset/update/update.go
@@ -108,7 +108,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				input["dataTypesStored"] = flagDataTypesStored
 			}
 
-			if cmd.Flags().Changed("thirdParty-ids") {
+			if cmd.Flags().Changed("third-party-ids") {
 				input["thirdPartyIds"] = flagThirdPartyIDs
 			}
 
@@ -146,7 +146,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().IntVar(&flagAmount, "amount", 0, "Asset amount")
 	cmd.Flags().StringVar(&flagOwner, "owner", "", "Owner profile ID")
 	cmd.Flags().StringVar(&flagDataTypesStored, "data-types-stored", "", "Data types stored")
-	cmd.Flags().StringSliceVar(&flagThirdPartyIDs, "thirdParty-ids", nil, "ThirdParty IDs (comma-separated)")
+	cmd.Flags().StringSliceVar(&flagThirdPartyIDs, "third-party-ids", nil, "Third party IDs (comma-separated)")
 
 	return cmd
 }

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -75,6 +75,7 @@ func NewCmdLogin(f *cmdutil.Factory) *cobra.Command {
 	var (
 		flagHost         string
 		flagOrganization string
+		flagToken        string
 	)
 
 	cmd := &cobra.Command{
@@ -90,7 +91,10 @@ func NewCmdLogin(f *cmdutil.Factory) *cobra.Command {
   prb auth login --hostname us.probo.com
 
   # Login to a self-hosted instance
-  prb auth login --hostname probo.example.com`,
+  prb auth login --hostname probo.example.com
+
+  # Login with a personal API key (non-interactive)
+  prb auth login --hostname eu.probo.com --token YOUR_TOKEN --org YOUR_ORG_ID`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if f.IOStreams.IsInteractive() && flagHost == "" {
 				var region string
@@ -134,6 +138,11 @@ func NewCmdLogin(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			baseURL := normalizeHostToURL(flagHost)
+
+			if flagToken != "" {
+				return loginWithToken(f, baseURL, flagHost, flagToken, flagOrganization)
+			}
+
 			httpClient := &http.Client{Timeout: 30 * time.Second}
 
 			_, _ = fmt.Fprintf(f.IOStreams.ErrOut, "Discovering OAuth2 endpoints on %s...\n", flagHost)
@@ -187,35 +196,11 @@ func NewCmdLogin(f *cmdutil.Factory) *cobra.Command {
 				_, _ = fmt.Fprintln(f.IOStreams.ErrOut, "Loading organizations...")
 				orgs, orgsErr := fetchOrganizations(baseURL, token.AccessToken)
 
-				if orgsErr == nil && len(orgs) > 0 {
-					selected := orgs[0].ID
-
-					options := make([]huh.Option[string], 0, len(orgs)+1)
-					for _, org := range orgs {
-						options = append(
-							options,
-							huh.NewOption(
-								fmt.Sprintf("%s (%s)", org.Name, org.ID),
-								org.ID,
-							),
-						)
-					}
-
-					options = append(
-						options,
-						huh.NewOption("Skip (no default)", ""),
-					)
-
-					err = huh.NewSelect[string]().
-						Title("Default organization").
-						Value(&selected).
-						Options(options...).
-						Run()
+				if orgsErr == nil {
+					flagOrganization, err = selectOrganization(orgs)
 					if err != nil {
 						return err
 					}
-
-					flagOrganization = selected
 				}
 			}
 
@@ -253,8 +238,90 @@ func NewCmdLogin(f *cmdutil.Factory) *cobra.Command {
 		"",
 		"Default organization ID",
 	)
+	cmd.Flags().StringVar(
+		&flagToken,
+		"token",
+		"",
+		"Authentication token (personal API key); skips browser login",
+	)
 
 	return cmd
+}
+
+func loginWithToken(
+	f *cmdutil.Factory,
+	baseURL string,
+	host string,
+	token string,
+	organization string,
+) error {
+	cfg, err := f.Config()
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(f.IOStreams.ErrOut, "Validating token on %s...\n", host)
+
+	orgs, err := fetchOrganizations(baseURL, token)
+	if err != nil {
+		return fmt.Errorf("cannot authenticate with token: %w", err)
+	}
+
+	if f.IOStreams.IsInteractive() && organization == "" {
+		organization, err = selectOrganization(orgs)
+		if err != nil {
+			return err
+		}
+	}
+
+	cfg.Hosts[host] = &config.HostConfig{
+		Token:        token,
+		Organization: organization,
+	}
+	cfg.ActiveHost = host
+
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(f.IOStreams.ErrOut, "Logged in to %s\n", host)
+
+	return nil
+}
+
+func selectOrganization(orgs []viewerOrganization) (string, error) {
+	if len(orgs) == 0 {
+		return "", nil
+	}
+
+	selected := orgs[0].ID
+
+	options := make([]huh.Option[string], 0, len(orgs)+1)
+	for _, org := range orgs {
+		options = append(
+			options,
+			huh.NewOption(
+				fmt.Sprintf("%s (%s)", org.Name, org.ID),
+				org.ID,
+			),
+		)
+	}
+
+	options = append(
+		options,
+		huh.NewOption("Skip (no default)", ""),
+	)
+
+	err := huh.NewSelect[string]().
+		Title("Default organization").
+		Value(&selected).
+		Options(options...).
+		Run()
+	if err != nil {
+		return "", err
+	}
+
+	return selected, nil
 }
 
 func normalizeHostToURL(host string) string {

--- a/pkg/cmd/cmdutil/time.go
+++ b/pkg/cmd/cmdutil/time.go
@@ -14,7 +14,10 @@
 
 package cmdutil
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // FormatTime parses an RFC3339 timestamp and returns a human-friendly
 // local representation. If parsing fails it returns the raw string.
@@ -25,4 +28,23 @@ func FormatTime(raw string) string {
 	}
 
 	return t.Local().Format("Jan 02, 2006 15:04 MST")
+}
+
+// NormalizeDatetime converts a user-supplied date or datetime into the RFC3339
+// format expected by the GraphQL Datetime scalar. A full RFC3339 timestamp is
+// returned unchanged; a date-only value (YYYY-MM-DD) is anchored to midnight
+// UTC. Any other format returns an error.
+func NormalizeDatetime(raw string) (string, error) {
+	if _, err := time.Parse(time.RFC3339, raw); err == nil {
+		return raw, nil
+	}
+
+	if t, err := time.Parse(time.DateOnly, raw); err == nil {
+		return t.Format(time.RFC3339), nil
+	}
+
+	return "", fmt.Errorf(
+		"invalid date %q: expected YYYY-MM-DD or RFC3339 (e.g. 2026-01-02 or 2026-01-02T15:04:05Z)",
+		raw,
+	)
 }

--- a/pkg/cmd/cmdutil/time_test.go
+++ b/pkg/cmd/cmdutil/time_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cmdutil_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+func TestNormalizeDatetime_Valid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"date only anchors to midnight UTC", "2026-01-01", "2026-01-01T00:00:00Z"},
+		{"date only end of year", "2026-12-31", "2026-12-31T00:00:00Z"},
+		{"rfc3339 passthrough", "2026-01-01T15:04:05Z", "2026-01-01T15:04:05Z"},
+		{"rfc3339 with offset passthrough", "2026-01-01T15:04:05+02:00", "2026-01-01T15:04:05+02:00"},
+		{"rfc3339 nano passthrough", "2026-01-01T15:04:05.123456789Z", "2026-01-01T15:04:05.123456789Z"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := cmdutil.NormalizeDatetime(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+
+			// The result must be accepted by the same RFC3339 parser the
+			// GraphQL Datetime scalar uses, or the server would reject it.
+			_, parseErr := time.Parse(time.RFC3339, got)
+			assert.NoError(t, parseErr)
+		})
+	}
+}
+
+func TestNormalizeDatetime_Invalid(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{"", "not-a-date", "01/02/2026", "2026-13-01", "2026-01-01 15:04:05"} {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := cmdutil.NormalizeDatetime(in)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/pkg/cmd/datum/create/create.go
+++ b/pkg/cmd/datum/create/create.go
@@ -173,7 +173,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagName, "name", "", "Datum name (required)")
 	cmd.Flags().StringVar(&flagClassification, "data-classification", "", "Data classification: PUBLIC, INTERNAL, CONFIDENTIAL, SECRET (required)")
 	cmd.Flags().StringVar(&flagOwner, "owner", "", "Owner profile ID")
-	cmd.Flags().StringSliceVar(&flagThirdPartyIDs, "thirdParty-ids", nil, "ThirdParty IDs (comma-separated)")
+	cmd.Flags().StringSliceVar(&flagThirdPartyIDs, "third-party-ids", nil, "Third party IDs (comma-separated)")
 
 	return cmd
 }

--- a/pkg/cmd/datum/update/update.go
+++ b/pkg/cmd/datum/update/update.go
@@ -96,7 +96,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
-			if cmd.Flags().Changed("thirdParty-ids") {
+			if cmd.Flags().Changed("third-party-ids") {
 				input["thirdPartyIds"] = flagThirdPartyIDs
 			}
 
@@ -132,7 +132,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagName, "name", "", "Datum name")
 	cmd.Flags().StringVar(&flagClassification, "data-classification", "", "Data classification: PUBLIC, INTERNAL, CONFIDENTIAL, SECRET")
 	cmd.Flags().StringVar(&flagOwner, "owner", "", "Owner profile ID")
-	cmd.Flags().StringSliceVar(&flagThirdPartyIDs, "thirdParty-ids", nil, "ThirdParty IDs (comma-separated)")
+	cmd.Flags().StringSliceVar(&flagThirdPartyIDs, "third-party-ids", nil, "Third party IDs (comma-separated)")
 
 	return cmd
 }

--- a/pkg/cmd/evidence/upload/upload.go
+++ b/pkg/cmd/evidence/upload/upload.go
@@ -28,10 +28,12 @@ import (
 const uploadMutation = `
 mutation($input: UploadMeasureEvidenceInput!) {
   uploadMeasureEvidence(input: $input) {
-    evidence {
-      id
-      state
-      type
+    evidenceEdge {
+      node {
+        id
+        state
+        type
+      }
     }
   }
 }
@@ -39,11 +41,13 @@ mutation($input: UploadMeasureEvidenceInput!) {
 
 type uploadResponse struct {
 	UploadMeasureEvidence struct {
-		Evidence struct {
-			ID    string `json:"id"`
-			State string `json:"state"`
-			Type  string `json:"type"`
-		} `json:"evidence"`
+		EvidenceEdge struct {
+			Node struct {
+				ID    string `json:"id"`
+				State string `json:"state"`
+				Type  string `json:"type"`
+			} `json:"node"`
+		} `json:"evidenceEdge"`
 	} `json:"uploadMeasureEvidence"`
 }
 
@@ -107,7 +111,7 @@ func NewCmdUpload(f *cmdutil.Factory) *cobra.Command {
 				return fmt.Errorf("cannot parse response: %w", err)
 			}
 
-			_, _ = fmt.Fprintf(f.IOStreams.Out, "Uploaded evidence %s\n", resp.UploadMeasureEvidence.Evidence.ID)
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Uploaded evidence %s\n", resp.UploadMeasureEvidence.EvidenceEdge.Node.ID)
 
 			return nil
 		},

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -48,7 +48,7 @@ import (
 	"go.probo.inc/probo/pkg/cmd/scim"
 	"go.probo.inc/probo/pkg/cmd/soa"
 	"go.probo.inc/probo/pkg/cmd/task"
-	"go.probo.inc/probo/pkg/cmd/thirdpartymgmt"
+	thirdparty "go.probo.inc/probo/pkg/cmd/third-party"
 	"go.probo.inc/probo/pkg/cmd/tia"
 	trackerpattern "go.probo.inc/probo/pkg/cmd/tracker-pattern"
 	trackerresource "go.probo.inc/probo/pkg/cmd/tracker-resource"
@@ -126,7 +126,7 @@ func NewCmdRoot(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(tia.NewCmdTIA(f))
 	cmd.AddCommand(trustcenter.NewCmdTrustCenter(f))
 	cmd.AddCommand(user.NewCmdUser(f))
-	cmd.AddCommand(thirdpartymgmt.NewCmdThirdParty(f))
+	cmd.AddCommand(thirdparty.NewCmdThirdParty(f))
 	cmd.AddCommand(version.NewCmdVersion(f))
 	cmd.AddCommand(webhook.NewCmdWebhook(f))
 

--- a/pkg/cmd/third-party/create/create.go
+++ b/pkg/cmd/third-party/create/create.go
@@ -63,12 +63,12 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a new thirdParty",
-		Example: `  # Create a third_party interactively
-  prb third_party create
+		Short: "Create a new third party",
+		Example: `  # Create a third party interactively
+  prb third-party create
 
-  # Create a third_party non-interactively
-  prb third_party create --name "Acme Corp" --category CLOUD_PROVIDER`,
+  # Create a third party non-interactively
+  prb third-party create --name "Acme Corp" --category CLOUD_PROVIDER`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := f.Config()
 			if err != nil {
@@ -99,7 +99,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			if f.IOStreams.IsInteractive() {
 				if flagName == "" {
 					err := huh.NewInput().
-						Title("ThirdParty name").
+						Title("Third party name").
 						Value(&flagName).
 						Run()
 					if err != nil {
@@ -109,7 +109,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 
 				if flagCategory == "" {
 					err := huh.NewSelect[string]().
-						Title("ThirdParty category").
+						Title("Third party category").
 						Options(
 							huh.NewOption("Analytics", "ANALYTICS"),
 							huh.NewOption("Cloud Monitoring", "CLOUD_MONITORING"),
@@ -188,7 +188,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			v := resp.CreateThirdParty.ThirdPartyEdge.Node
 			_, _ = fmt.Fprintf(
 				f.IOStreams.Out,
-				"Created thirdParty %s (%s)\n",
+				"Created third party %s (%s)\n",
 				v.ID,
 				v.Name,
 			)
@@ -198,9 +198,9 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
-	cmd.Flags().StringVar(&flagName, "name", "", "ThirdParty name (required)")
-	cmd.Flags().StringVar(&flagCategory, "category", "", "ThirdParty category (required)")
-	cmd.Flags().StringVar(&flagDescription, "description", "", "ThirdParty description")
+	cmd.Flags().StringVar(&flagName, "name", "", "Third party name (required)")
+	cmd.Flags().StringVar(&flagCategory, "category", "", "Third party category (required)")
+	cmd.Flags().StringVar(&flagDescription, "description", "", "Third party description")
 	cmd.Flags().StringVar(&flagLegalName, "legal-name", "", "Legal name")
 	cmd.Flags().StringVar(&flagAddress, "address", "", "Headquarter address")
 	cmd.Flags().StringVar(&flagWebsite, "website", "", "Website URL")

--- a/pkg/cmd/third-party/delete/delete.go
+++ b/pkg/cmd/third-party/delete/delete.go
@@ -36,18 +36,18 @@ func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "delete <id>",
-		Short: "Delete a thirdParty",
+		Short: "Delete a third party",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !flagYes {
 				if !f.IOStreams.IsInteractive() {
-					return fmt.Errorf("cannot delete thirdParty: confirmation required, use --yes to confirm")
+					return fmt.Errorf("cannot delete third party: confirmation required, use --yes to confirm")
 				}
 
 				var confirmed bool
 
 				err := huh.NewConfirm().
-					Title(fmt.Sprintf("Delete thirdParty %s?", args[0])).
+					Title(fmt.Sprintf("Delete third party %s?", args[0])).
 					Value(&confirmed).
 					Run()
 				if err != nil {
@@ -91,7 +91,7 @@ func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
 
 			_, _ = fmt.Fprintf(
 				f.IOStreams.Out,
-				"Deleted thirdParty %s\n",
+				"Deleted third party %s\n",
 				args[0],
 			)
 

--- a/pkg/cmd/third-party/list/list.go
+++ b/pkg/cmd/third-party/list/list.go
@@ -28,7 +28,7 @@ query($id: ID!, $first: Int, $after: CursorKey, $orderBy: ThirdPartyOrder, $filt
   node(id: $id) {
     __typename
     ... on Organization {
-      third_parties(first: $first, after: $after, orderBy: $orderBy, filter: $filter) {
+      thirdParties(first: $first, after: $after, orderBy: $orderBy, filter: $filter) {
         totalCount
         edges {
           node {
@@ -65,13 +65,13 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "list",
-		Short:   "List thirdParties in an organization",
+		Short:   "List third parties in an organization",
 		Aliases: []string{"ls"},
-		Example: `  # List third_parties in the default organization
-  prb third_party list
+		Example: `  # List third parties in the default organization
+  prb third-party list
 
-  # List third_parties sorted by name
-  prb third_party ls --order-by NAME --json`,
+  # List third parties sorted by name
+  prb third-party ls --order-by NAME --json`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
@@ -138,7 +138,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 					var resp struct {
 						Node *struct {
 							Typename     string                     `json:"__typename"`
-							ThirdParties api.Connection[thirdParty] `json:"third_parties"`
+							ThirdParties api.Connection[thirdParty] `json:"thirdParties"`
 						} `json:"node"`
 					}
 					if err := json.Unmarshal(data, &resp); err != nil {
@@ -165,7 +165,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if len(thirdParties) == 0 {
-				_, _ = fmt.Fprintln(f.IOStreams.Out, "No thirdParties found.")
+				_, _ = fmt.Fprintln(f.IOStreams.Out, "No third parties found.")
 				return nil
 			}
 
@@ -185,7 +185,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			if totalCount > len(thirdParties) {
 				_, _ = fmt.Fprintf(
 					f.IOStreams.ErrOut,
-					"\nShowing %d of %d thirdParties\n",
+					"\nShowing %d of %d third parties\n",
 					len(thirdParties),
 					totalCount,
 				)
@@ -196,7 +196,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
-	cmd.Flags().IntVarP(&flagLimit, "limit", "L", 30, "Maximum number of thirdParties to list")
+	cmd.Flags().IntVarP(&flagLimit, "limit", "L", 30, "Maximum number of third parties to list")
 	cmd.Flags().StringVar(&flagOrderBy, "order-by", "", "Order by field (NAME, CREATED_AT, UPDATED_AT)")
 	cmd.Flags().StringVar(&flagOrderDir, "order-direction", "DESC", "Sort direction (ASC, DESC)")
 	cmd.Flags().IntVar(&flagLevel, "level", 0, "Filter by third party level (1 = direct, 2+ = indirect)")

--- a/pkg/cmd/third-party/list/list.go
+++ b/pkg/cmd/third-party/list/list.go
@@ -71,7 +71,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
   prb third-party list
 
   # List third parties sorted by name
-  prb third-party ls --order-by NAME --json`,
+  prb third-party ls --order-by NAME -o json`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {

--- a/pkg/cmd/third-party/publish/publish.go
+++ b/pkg/cmd/third-party/publish/publish.go
@@ -76,12 +76,12 @@ func NewCmdPublish(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "publish",
-		Short: "Publish the thirdParty register as a document version",
-		Example: `  # Publish the third_party register
-  prb third_party publish --org ORG_ID
+		Short: "Publish the third-party register as a document version",
+		Example: `  # Publish the third-party register
+  prb third-party publish --org ORG_ID
 
   # Publish with approvers
-  prb third_party publish --org ORG_ID --approver PROFILE_ID1 --approver PROFILE_ID2`,
+  prb third-party publish --org ORG_ID --approver PROFILE_ID1 --approver PROFILE_ID2`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := f.Config()
 			if err != nil {
@@ -134,7 +134,7 @@ func NewCmdPublish(f *cmdutil.Factory) *cobra.Command {
 			v := resp.PublishThirdPartyList.DocumentVersionEdge.Node
 			_, _ = fmt.Fprintf(
 				f.IOStreams.Out,
-				"Published thirdParty register %s (v%d.%d)\n",
+				"Published third-party register %s (v%d.%d)\n",
 				v.Title,
 				v.Major,
 				v.Minor,

--- a/pkg/cmd/third-party/report/delete/delete.go
+++ b/pkg/cmd/third-party/report/delete/delete.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package delete
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const deleteMutation = `
+mutation($input: DeleteThirdPartyComplianceReportInput!) {
+  deleteThirdPartyComplianceReport(input: $input) {
+    deletedThirdPartyComplianceReportId
+  }
+}
+`
+
+func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
+	var flagYes bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <report-id>",
+		Short: "Delete a third-party compliance report",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !flagYes {
+				if !f.IOStreams.IsInteractive() {
+					return fmt.Errorf("cannot delete compliance report: confirmation required, use --yes to confirm")
+				}
+
+				var confirmed bool
+
+				err := huh.NewConfirm().
+					Title(fmt.Sprintf("Delete compliance report %s?", args[0])).
+					Value(&confirmed).
+					Run()
+				if err != nil {
+					return err
+				}
+
+				if !confirmed {
+					return nil
+				}
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			_, err = client.Do(
+				deleteMutation,
+				map[string]any{
+					"input": map[string]any{
+						"reportId": args[0],
+					},
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(
+				f.IOStreams.Out,
+				"Deleted compliance report %s\n",
+				args[0],
+			)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&flagYes, "yes", "y", false, "Skip confirmation prompt")
+
+	return cmd
+}

--- a/pkg/cmd/third-party/report/list/list.go
+++ b/pkg/cmd/third-party/report/list/list.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package list
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const listQuery = `
+query($id: ID!, $first: Int, $after: CursorKey, $orderBy: ThirdPartyComplianceReportOrder) {
+  node(id: $id) {
+    __typename
+    ... on ThirdParty {
+      complianceReports(first: $first, after: $after, orderBy: $orderBy) {
+        edges {
+          node {
+            id
+            reportName
+            reportDate
+            validUntil
+            createdAt
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+`
+
+type complianceReport struct {
+	ID         string  `json:"id"`
+	ReportName string  `json:"reportName"`
+	ReportDate string  `json:"reportDate"`
+	ValidUntil *string `json:"validUntil"`
+	CreatedAt  string  `json:"createdAt"`
+}
+
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagLimit    int
+		flagOrderBy  string
+		flagOrderDir string
+		flagOutput   *string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list <third-party-id>",
+		Short:   "List compliance reports for a third party",
+		Aliases: []string{"ls"},
+		Example: `  # List compliance reports for a third party
+  prb third-party report list <third-party-id>
+
+  # List compliance reports sorted by report date
+  prb third-party report ls <third-party-id> --order-by REPORT_DATE --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			variables := map[string]any{
+				"id": args[0],
+			}
+
+			if flagOrderBy != "" {
+				if err := cmdutil.ValidateEnum("order-by", flagOrderBy, []string{"REPORT_DATE", "CREATED_AT"}); err != nil {
+					return err
+				}
+
+				variables["orderBy"] = map[string]any{
+					"field":     flagOrderBy,
+					"direction": flagOrderDir,
+				}
+			}
+
+			reports, _, err := api.Paginate(
+				client,
+				listQuery,
+				variables,
+				flagLimit,
+				func(data json.RawMessage) (*api.Connection[complianceReport], error) {
+					var resp struct {
+						Node *struct {
+							Typename          string                           `json:"__typename"`
+							ComplianceReports api.Connection[complianceReport] `json:"complianceReports"`
+						} `json:"node"`
+					}
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return nil, err
+					}
+
+					if resp.Node == nil {
+						return nil, fmt.Errorf("third party %s not found", args[0])
+					}
+
+					if resp.Node.Typename != "ThirdParty" {
+						return nil, fmt.Errorf("expected ThirdParty node, got %s", resp.Node.Typename)
+					}
+
+					return &resp.Node.ComplianceReports, nil
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, reports)
+			}
+
+			if len(reports) == 0 {
+				_, _ = fmt.Fprintln(f.IOStreams.Out, "No compliance reports found.")
+				return nil
+			}
+
+			rows := make([][]string, 0, len(reports))
+			for _, r := range reports {
+				validUntil := ""
+				if r.ValidUntil != nil {
+					validUntil = cmdutil.FormatTime(*r.ValidUntil)
+				}
+
+				rows = append(rows, []string{
+					r.ID,
+					r.ReportName,
+					cmdutil.FormatTime(r.ReportDate),
+					validUntil,
+					cmdutil.FormatTime(r.CreatedAt),
+				})
+			}
+
+			t := cmdutil.NewTable("ID", "NAME", "REPORT DATE", "VALID UNTIL", "CREATED").Rows(rows...)
+
+			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVarP(&flagLimit, "limit", "L", 30, "Maximum number of compliance reports to list")
+	cmd.Flags().StringVar(&flagOrderBy, "order-by", "", "Order by field (REPORT_DATE, CREATED_AT)")
+	cmd.Flags().StringVar(&flagOrderDir, "order-direction", "DESC", "Sort direction (ASC, DESC)")
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/third-party/report/list/list.go
+++ b/pkg/cmd/third-party/report/list/list.go
@@ -72,7 +72,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
   prb third-party report list <third-party-id>
 
   # List compliance reports sorted by report date
-  prb third-party report ls <third-party-id> --order-by REPORT_DATE --json`,
+  prb third-party report ls <third-party-id> --order-by REPORT_DATE -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {

--- a/pkg/cmd/third-party/report/report.go
+++ b/pkg/cmd/third-party/report/report.go
@@ -12,35 +12,25 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package thirdparty
+package report
 
 import (
 	"github.com/spf13/cobra"
 	"go.probo.inc/probo/pkg/cmd/cmdutil"
-	"go.probo.inc/probo/pkg/cmd/third-party/create"
-	"go.probo.inc/probo/pkg/cmd/third-party/delete"
-	"go.probo.inc/probo/pkg/cmd/third-party/list"
-	"go.probo.inc/probo/pkg/cmd/third-party/publish"
-	"go.probo.inc/probo/pkg/cmd/third-party/report"
-	"go.probo.inc/probo/pkg/cmd/third-party/update"
-	"go.probo.inc/probo/pkg/cmd/third-party/vet"
-	"go.probo.inc/probo/pkg/cmd/third-party/view"
+	"go.probo.inc/probo/pkg/cmd/third-party/report/delete"
+	"go.probo.inc/probo/pkg/cmd/third-party/report/list"
+	"go.probo.inc/probo/pkg/cmd/third-party/report/upload"
 )
 
-func NewCmdThirdParty(f *cmdutil.Factory) *cobra.Command {
+func NewCmdReport(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "third-party <command>",
-		Short: "Manage third parties",
+		Use:   "report <command>",
+		Short: "Manage third-party compliance reports",
 	}
 
+	cmd.AddCommand(upload.NewCmdUpload(f))
 	cmd.AddCommand(list.NewCmdList(f))
-	cmd.AddCommand(create.NewCmdCreate(f))
-	cmd.AddCommand(view.NewCmdView(f))
-	cmd.AddCommand(update.NewCmdUpdate(f))
 	cmd.AddCommand(delete.NewCmdDelete(f))
-	cmd.AddCommand(vet.NewCmdVet(f))
-	cmd.AddCommand(publish.NewCmdPublish(f))
-	cmd.AddCommand(report.NewCmdReport(f))
 
 	return cmd
 }

--- a/pkg/cmd/third-party/report/upload/upload.go
+++ b/pkg/cmd/third-party/report/upload/upload.go
@@ -100,15 +100,25 @@ func NewCmdUpload(f *cmdutil.Factory) *cobra.Command {
 				flagReportName = filepath.Base(filePath)
 			}
 
+			reportDate, err := cmdutil.NormalizeDatetime(flagReportDate)
+			if err != nil {
+				return fmt.Errorf("invalid --report-date: %w", err)
+			}
+
 			input := map[string]any{
 				"thirdPartyId": flagThirdParty,
-				"reportDate":   flagReportDate,
+				"reportDate":   reportDate,
 				"reportName":   flagReportName,
 				"file":         nil,
 			}
 
 			if flagValidUntil != "" {
-				input["validUntil"] = flagValidUntil
+				validUntil, err := cmdutil.NormalizeDatetime(flagValidUntil)
+				if err != nil {
+					return fmt.Errorf("invalid --valid-until: %w", err)
+				}
+
+				input["validUntil"] = validUntil
 			}
 
 			data, err := client.DoUpload(

--- a/pkg/cmd/third-party/report/upload/upload.go
+++ b/pkg/cmd/third-party/report/upload/upload.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package upload
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const uploadMutation = `
+mutation($input: UploadThirdPartyComplianceReportInput!) {
+  uploadThirdPartyComplianceReport(input: $input) {
+    thirdPartyComplianceReportEdge {
+      node {
+        id
+        reportName
+        reportDate
+      }
+    }
+  }
+}
+`
+
+type uploadResponse struct {
+	UploadThirdPartyComplianceReport struct {
+		ThirdPartyComplianceReportEdge struct {
+			Node struct {
+				ID         string `json:"id"`
+				ReportName string `json:"reportName"`
+				ReportDate string `json:"reportDate"`
+			} `json:"node"`
+		} `json:"thirdPartyComplianceReportEdge"`
+	} `json:"uploadThirdPartyComplianceReport"`
+}
+
+func NewCmdUpload(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagThirdParty string
+		flagReportDate string
+		flagReportName string
+		flagValidUntil string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "upload <file>",
+		Short: "Upload a compliance report for a third party",
+		Example: `  # Upload a compliance report
+  prb third-party report upload ./soc2.pdf --third-party <third-party-id> --report-date 2026-01-01
+
+  # Upload with a custom name and validity date
+  prb third-party report upload ./soc2.pdf --third-party <third-party-id> --report-date 2026-01-01 --report-name "SOC 2 Type II" --valid-until 2026-12-31`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			filePath := args[0]
+
+			file, err := os.Open(filePath)
+			if err != nil {
+				return fmt.Errorf("cannot open file: %w", err)
+			}
+
+			defer func() { _ = file.Close() }()
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			if flagReportName == "" {
+				flagReportName = filepath.Base(filePath)
+			}
+
+			input := map[string]any{
+				"thirdPartyId": flagThirdParty,
+				"reportDate":   flagReportDate,
+				"reportName":   flagReportName,
+				"file":         nil,
+			}
+
+			if flagValidUntil != "" {
+				input["validUntil"] = flagValidUntil
+			}
+
+			data, err := client.DoUpload(
+				uploadMutation,
+				map[string]any{"input": input},
+				"variables.input.file",
+				filepath.Base(filePath),
+				file,
+			)
+			if err != nil {
+				return err
+			}
+
+			var resp uploadResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			node := resp.UploadThirdPartyComplianceReport.ThirdPartyComplianceReportEdge.Node
+			_, _ = fmt.Fprintf(
+				f.IOStreams.Out,
+				"Uploaded compliance report %s (%s)\n",
+				node.ID,
+				node.ReportName,
+			)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagThirdParty, "third-party", "", "Third party ID (required)")
+	cmd.Flags().StringVar(&flagReportDate, "report-date", "", "Report date (e.g. 2026-01-01) (required)")
+	cmd.Flags().StringVar(&flagReportName, "report-name", "", "Report name (defaults to the file name)")
+	cmd.Flags().StringVar(&flagValidUntil, "valid-until", "", "Valid until date (e.g. 2026-12-31)")
+	_ = cmd.MarkFlagRequired("third-party")
+	_ = cmd.MarkFlagRequired("report-date")
+
+	return cmd
+}

--- a/pkg/cmd/third-party/third_party.go
+++ b/pkg/cmd/third-party/third_party.go
@@ -12,24 +12,24 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package thirdpartymgmt
+package thirdparty
 
 import (
 	"github.com/spf13/cobra"
 	"go.probo.inc/probo/pkg/cmd/cmdutil"
-	"go.probo.inc/probo/pkg/cmd/thirdpartymgmt/create"
-	"go.probo.inc/probo/pkg/cmd/thirdpartymgmt/delete"
-	"go.probo.inc/probo/pkg/cmd/thirdpartymgmt/list"
-	"go.probo.inc/probo/pkg/cmd/thirdpartymgmt/publish"
-	"go.probo.inc/probo/pkg/cmd/thirdpartymgmt/update"
-	"go.probo.inc/probo/pkg/cmd/thirdpartymgmt/vet"
-	"go.probo.inc/probo/pkg/cmd/thirdpartymgmt/view"
+	"go.probo.inc/probo/pkg/cmd/third-party/create"
+	"go.probo.inc/probo/pkg/cmd/third-party/delete"
+	"go.probo.inc/probo/pkg/cmd/third-party/list"
+	"go.probo.inc/probo/pkg/cmd/third-party/publish"
+	"go.probo.inc/probo/pkg/cmd/third-party/update"
+	"go.probo.inc/probo/pkg/cmd/third-party/vet"
+	"go.probo.inc/probo/pkg/cmd/third-party/view"
 )
 
 func NewCmdThirdParty(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "thirdParty <command>",
-		Short: "Manage thirdParties",
+		Use:   "third-party <command>",
+		Short: "Manage third parties",
 	}
 
 	cmd.AddCommand(list.NewCmdList(f))

--- a/pkg/cmd/third-party/update/update.go
+++ b/pkg/cmd/third-party/update/update.go
@@ -26,7 +26,7 @@ import (
 const updateMutation = `
 mutation($input: UpdateThirdPartyInput!) {
   updateThirdParty(input: $input) {
-    third_party {
+    thirdParty {
       id
       name
       category
@@ -41,7 +41,7 @@ type updateResponse struct {
 			ID       string `json:"id"`
 			Name     string `json:"name"`
 			Category string `json:"category"`
-		} `json:"third_party"`
+		} `json:"thirdParty"`
 	} `json:"updateThirdParty"`
 }
 
@@ -57,7 +57,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "update <id>",
-		Short: "Update a thirdParty",
+		Short: "Update a third party",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := f.Config()
@@ -126,7 +126,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 			v := resp.UpdateThirdParty.ThirdParty
 			_, _ = fmt.Fprintf(
 				f.IOStreams.Out,
-				"Updated thirdParty %s (%s)\n",
+				"Updated third party %s (%s)\n",
 				v.ID,
 				v.Name,
 			)
@@ -135,9 +135,9 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&flagName, "name", "", "ThirdParty name")
-	cmd.Flags().StringVar(&flagDescription, "description", "", "ThirdParty description")
-	cmd.Flags().StringVar(&flagCategory, "category", "", "ThirdParty category")
+	cmd.Flags().StringVar(&flagName, "name", "", "Third party name")
+	cmd.Flags().StringVar(&flagDescription, "description", "", "Third party description")
+	cmd.Flags().StringVar(&flagCategory, "category", "", "Third party category")
 	cmd.Flags().StringVar(&flagLegalName, "legal-name", "", "Legal name")
 	cmd.Flags().StringVar(&flagAddress, "address", "", "Headquarter address")
 	cmd.Flags().StringVar(&flagWebsite, "website", "", "Website URL")

--- a/pkg/cmd/third-party/vet/vet.go
+++ b/pkg/cmd/third-party/vet/vet.go
@@ -51,7 +51,7 @@ func NewCmdVet(f *cmdutil.Factory) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "vet <thirdParty-id> --url <website-url>",
+		Use:   "vet <third-party-id> --url <website-url>",
 		Short: "Start AI vetting of a third party from its website",
 		Long:  "Queue a vetting job that crawls a third party's website using AI agents to extract security, compliance, and business information.",
 		Example: `  # Vet a third party by website URL

--- a/pkg/cmd/third-party/view/view.go
+++ b/pkg/cmd/third-party/view/view.go
@@ -63,7 +63,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "view <id>",
-		Short: "View a thirdParty",
+		Short: "View a third party",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
@@ -102,7 +102,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if resp.Node == nil {
-				return fmt.Errorf("thirdParty %s not found", args[0])
+				return fmt.Errorf("third party %s not found", args[0])
 			}
 
 			if resp.Node.Typename != "ThirdParty" {

--- a/pkg/cmd/webhook/create/create.go
+++ b/pkg/cmd/webhook/create/create.go
@@ -62,7 +62,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a webhook subscription",
-		Example: `  # Create a webhook for thirdParty events
+		Example: `  # Create a webhook for third-party events
   prb webhook create --url https://example.com/webhook --event THIRD_PARTY_CREATED --event THIRD_PARTY_UPDATED
 
   # Create a webhook for all supported events


### PR DESCRIPTION
## Summary

Audits and rounds out the `prb` third-party CLI surface. Three intended changes, plus three bugs caught while verifying end-to-end against a live org.

### Intended changes
- **Token/API-key login** — adds `prb auth login --token`, converging on the documented UX (`--hostname … --token … --org …`). Skips the browser device flow, validates the token, and persists a token-only host config. Org selection is shared with the device flow via a new `selectOrganization` helper.
- **Kebab-case rename (clean break)** — `prb thirdParty` → `prb third-party`; package `pkg/cmd/thirdpartymgmt` → `pkg/cmd/third-party`; flags `--thirdParty-ids` → `--third-party-ids` on `asset`/`datum`. No back-compat aliases. GraphQL field names and IAM action identifiers keep their canonical casing.
- **Compliance report commands** — new `prb third-party report upload | list | delete`, wrapping the existing `uploadThirdPartyComplianceReport` / `deleteThirdPartyComplianceReport` mutations and the `complianceReports` connection.

### Bugs found & fixed while verifying against a live backend
1. **Date-only flags rejected** — `--report-date 2026-01-01` (as documented) failed server-side because the `Datetime` scalar only parses RFC3339. Added `cmdutil.NormalizeDatetime` (date-only → midnight UTC, RFC3339 passthrough) with unit tests.
2. **CLI uploads sent `application/octet-stream`** — `multipart.CreateFormFile` hardcodes that Content-Type, which the server's document validator rejects; the file-validation error then surfaced as an opaque **HTTP 500**. `DoUpload` now derives the real MIME from the file extension. **This is in shared `pkg/cli/api/client.go`, so it fixes every CLI upload — `evidence upload` was broken the same way.**
3. **`evidence upload` selected a non-existent field** — its mutation queried `evidence` on `UploadMeasureEvidencePayload` (which only has `evidenceEdge`), failing GraphQL validation with an **HTTP 422** before reaching the resolver. Fixed to `evidenceEdge { node { … } }`. Pre-existing; surfaced only because fix #2 let the request reach query validation.

Also fixed a bogus `--json` example (real flag is `-o json`) in the report and third-party list commands. The same typo exists in ~21 other list commands and was left out of scope.

## Testing

Verified end-to-end against a live org (all throwaway objects cleaned up):

- `third-party list` works; old `thirdParty` command is gone (clean break confirmed).
- `report upload … --report-date 2026-01-01 --valid-until 2026-12-31` → succeeds; `report list -o json` confirms dates normalized to `2026-01-01T00:00:00Z` / `2026-12-31T00:00:00Z`.
- Invalid date → clean client-side error; `delete` without `--yes` refused; `delete --yes` removes the report.
- `evidence upload ./x.pdf --measure <id>` → succeeds (confirms both the content-type and mutation-selection fixes on that path).
- `go build`, `go vet`, `gofmt`, and `cmdutil` unit tests all green.

## Notes / follow-ups (out of scope)
- The report commands exist only in the CLI; MCP (`specification.yaml`) and n8n have no compliance-report upload operation (`api-surface.md` sync gap).
- `--json` example typo persists in ~21 other list commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds token login to `prb auth login`, renames the third-party CLI to kebab-case, and adds report upload/list/delete commands. Fixes broken uploads by sending real MIME types, normalizes date flags, and fixes evidence upload selection.

### prb (CLI) **`+716`** **`-99`**
- Token/API-key login: `prb auth login --hostname … --token … --org …` validates the token and saves a host config; shared org picker for interactive mode.
- Rename: `prb thirdParty` → `prb third-party`; flags `--thirdParty-ids` → `--third-party-ids`; updated help, prompts, and outputs. Fixed GraphQL fields in list (`thirdParties`) and update (`thirdParty`).
- Reports: new `prb third-party report upload|list|delete`. Upload supports `--report-date`, optional `--report-name`, `--valid-until`; list supports sorting and `-o json`; delete confirms or `--yes`.
- Date handling: added `cmdutil.NormalizeDatetime` to accept `YYYY-MM-DD` or RFC3339; used by report flags.
- Uploads: multipart now sets a real Content-Type from the file extension (applies to all CLI uploads, including evidence).
- Evidence upload: selects `evidenceEdge { node { … } }` to match schema.
- Minor docs/help fixes: corrected `-o json` examples; updated webhook help text.

### Tests **`+68`** **`-0`**
- Unit tests for `NormalizeDatetime`: date-only anchoring, RFC3339 passthrough, and invalid input cases.

### Other **`+3`** **`-3`**
- README: switched examples to `prb third-party` and added report upload usage.

<sup>Written for commit f110b9e499fa62f44bb846901ca7178209901fd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

