### PR TITLE
Fix n8n ProboTrigger node package review issues

### DIFF
--- a/packages/n8n-node/nodes/ProboTrigger/ProboTrigger.node.json
+++ b/packages/n8n-node/nodes/ProboTrigger/ProboTrigger.node.json
@@ -1,8 +1,8 @@
 {
-  "node": "n8n-nodes-probo.proboTrigger",
+  "node": "@probo/n8n-nodes-probo.proboTrigger",
   "nodeVersion": "1.0",
   "codexVersion": "1.0",
-  "categories": ["Development", "Developer Tools", "Automation"],
+  "categories": ["Development", "Utility"],
   "resources": {
     "credentialDocumentation": [
       {

--- a/packages/n8n-node/nodes/ProboTrigger/ProboTrigger.node.ts
+++ b/packages/n8n-node/nodes/ProboTrigger/ProboTrigger.node.ts
@@ -60,7 +60,11 @@ async function deleteSubscription(this: IHookFunctions, subscriptionId: string):
 		await proboApiRequest.call(this, query, {
 			input: { webhookSubscriptionId: subscriptionId },
 		});
-	} catch {
+	} catch (error) {
+		this.logger.error(`Failed to delete Probo webhook subscription "${subscriptionId}"`, {
+			subscriptionId,
+			error,
+		});
 		return false;
 	}
 


### PR DESCRIPTION
- Log delete failures in deleteSubscription instead of swallowing them
- Correct codex node prefix to @probo/n8n-nodes-probo.proboTrigger
- Replace unsupported codex categories with Development and Utility

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `n8n` ProboTrigger node review items. Updates codex metadata and adds clear logging when webhook subscription deletion fails.

### Package: n8n-node **`+7`** **`-3`**
- Set codex node id to `@probo/n8n-nodes-probo.proboTrigger`.
- Replace unsupported codex categories with "Development" and "Utility".
- Log errors in deleteSubscription and still return false.

<sup>Written for commit f14d8115b6c02ffe79bc0b40e5672e4990e09037. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

