### PR TITLE
Rename Severity label to Score on risk overview

### DIFF
--- a/packages/ui/src/Molecules/Risks/RiskOverview.tsx
+++ b/packages/ui/src/Molecules/Risks/RiskOverview.tsx
@@ -70,7 +70,7 @@ export function RiskOverview({ type, risk }: Props) {
         />
       </div>
       <div className="space-y-2">
-        <div className="font-medium text-xs">{__("Severity")}</div>
+        <div className="font-medium text-xs">{__("Score")}</div>
         <div
           className={clsx(
             severity?.bg,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the risk overview page, the combined likelihood × impact value was labeled **Severity**. This PR renames that label to **Score** for consistency with the rest of the risk UI.

## Changes

- Update the label in `RiskOverview` from `__("Severity")` to `__("Score")`

## Testing

- Verified this is the only UI occurrence of the "Severity" label on the risk page
- The underlying score calculation and badge styling are unchanged

Fixes ENG-628
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-628](https://linear.app/probo/issue/ENG-628/change-severity-to-score-on-risk-page)

<div><a href="https://cursor.com/agents/bc-ddd7f819-cc8b-4d84-aec0-dee071a9a89c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddd7f819-cc8b-4d84-aec0-dee071a9a89c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed “Severity” to “Score” on the risk overview to match the rest of the risk UI (ENG-628). No logic or styles changed.

### Package: ui **`+1`** **`-1`**
- In `packages/ui/src/Molecules/Risks/RiskOverview.tsx`, updated label from `__("Severity")` to `__("Score")`.
- Only text changed; score calculation and badge classes remain the same.

<sup>Written for commit aba2ef4cc23bb031a36a601a0048dfec5f5b118d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

