### PR TITLE
Add bundling options to put base deps in specific chunks

### DIFF
--- a/apps/compliance-portal/vite.config.ts
+++ b/apps/compliance-portal/vite.config.ts
@@ -32,6 +32,26 @@ export default defineConfig({
   plugins: [react(), babel({ plugins: ["relay"] }), tailwindcss()],
   build: {
     assetsDir: "assets",
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [
+            {
+              name: "react",
+              test: /node_modules\/(?:react-dom|react)\//,
+            },
+            {
+              name: "relay",
+              test: /node_modules\/(?:react-relay|relay-runtime)\//,
+            },
+            {
+              name: "react-router",
+              test: /node_modules\/react-router\//,
+            },
+          ],
+        },
+      },
+    },
   },
   base: "./",
   server: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Split core dependencies into dedicated chunks in the compliance portal to improve caching and load performance. Vite now groups `react`, `react-relay`/`relay-runtime`, and `react-router` into stable bundles.

### App: compliance-portal **`+20`** **`-0`**

- Added `rolldownOptions.output.codeSplitting.groups` in `vite.config.ts`.
- Created chunk groups: `react` (`react`/`react-dom`), `relay` (`react-relay`/`relay-runtime`), and `react-router`.
- Aims for better browser caching and fewer app chunk changes.
- No runtime behavior changes.

<sup>Written for commit 776bec7ef8c8f1f358ddee9061f67d07d7c4c274. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

