### PR TITLE
Rename document approval button to Approve

### DIFF
--- a/apps/console/src/pages/organizations/documents/approve/DocumentApprovePage.tsx
+++ b/apps/console/src/pages/organizations/documents/approve/DocumentApprovePage.tsx
@@ -359,7 +359,7 @@ function ViewerDecision(props: {
                 });
               }}
             >
-              {__("Review and approve")}
+              {__("Approve")}
             </Button>
           )}
         </div>

--- a/pkg/probo/document_approval_service.go
+++ b/pkg/probo/document_approval_service.go
@@ -37,7 +37,7 @@ import (
 	"go.probo.inc/probo/pkg/page"
 )
 
-const DocumentApprovalConsentText = "By clicking \"Review and approve\", I consent to approve this document electronically and agree that my electronic signature has the same legal validity as a handwritten signature."
+const DocumentApprovalConsentText = "By clicking \"Approve\", I consent to approve this document electronically and agree that my electronic signature has the same legal validity as a handwritten signature."
 
 type (
 	DocumentApprovalService struct {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes ENG-630.

The approval flow button was labeled "Review and approve", which suggested the user could leave review feedback. The action only approves the document, so the label is now **Approve**.

Also updates the electronic-signature consent text below the button so it references the new label.

## Changes

- `DocumentApprovePage.tsx`: button label `Review and approve` → `Approve`
- `document_approval_service.go`: consent text updated to match

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-630](https://linear.app/probo/issue/ENG-630/rename-approval-flow-button-to-approve)

<div><a href="https://cursor.com/agents/bc-19ff651d-a4e6-46e0-b838-6150173fc7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19ff651d-a4e6-46e0-b838-6150173fc7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the document approval button to “Approve” and updated the consent text to match, so it’s clear the action only approves the document. Addresses ENG-630.

### **App: console** **`+1`** **`-1`**
- Change button label from __("Review and approve") to __("Approve") in `DocumentApprovePage.tsx`.

### **Service** **`+1`** **`-1`**
- Update `DocumentApprovalConsentText` in `pkg/probo/document_approval_service.go` to reference “Approve”.

<sup>Written for commit 70d0424022be86b59f463ba197a06d5ea4423770. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

