### PR TITLE
Compliance portal misc fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Detailed guides for specific subsystems live in `contrib/claude/`:
 - [`contrib/claude/hooks.md`](contrib/claude/hooks.md) — Custom hooks (_lib placement, awaitable useMutation primitive, auto error handling)
 - [`contrib/claude/react-components.md`](contrib/claude/react-components.md) — React component shape (file/export, props, configure vs data via hooks, naming/suffix taxonomy, error props)
 - [`contrib/claude/ui.md`](contrib/claude/ui.md) — @probo/ui v2 kit (Base UI headless, Tailwind, tailwind-variants, flat folders, bundle-safe skeletons)
-- [`contrib/claude/v2-tokens.md`](contrib/claude/v2-tokens.md) — v2 design tokens (color, typography, radius, shadow scales; native spacing)
+- [`contrib/claude/v2-tokens.md`](contrib/claude/v2-tokens.md) — v2 design tokens (color, typography, radius, shadow, z-index scales; native spacing)
 - [`contrib/claude/forms.md`](contrib/claude/forms.md) — Frontend forms (Base UI Field/Form tiers, native vs zod vs react-hook-form, server errors)
 - [`contrib/claude/routing.md`](contrib/claude/routing.md) — Frontend routing (@probo/routes, navigation, typed params, URL state, auth/protected routes)
 - [`contrib/claude/state-management.md`](contrib/claude/state-management.md) — Client state decision order (Relay, URL, local, context, zustand)

--- a/apps/compliance-portal/src/_locales/en-US.json
+++ b/apps/compliance-portal/src/_locales/en-US.json
@@ -75,7 +75,7 @@
     }
   },
   "home": {
-    "heroTitle": "Trust at {{name}}.",
+    "heroTitle": "Compliance at {{name}}.",
     "heroDescription": "Welcome to our Compliance Portal. Find our security documentation and certifications here.",
     "sections": {
       "compliance": "Compliance",

--- a/apps/compliance-portal/src/components/BackdropCard/BackdropCard.tsx
+++ b/apps/compliance-portal/src/components/BackdropCard/BackdropCard.tsx
@@ -28,7 +28,7 @@ import { backdropCard } from "./variants";
 interface BackdropCardProps {
   // Centered content shown above the backdrop (an icon or a logo box). The node
   // owns its own sizing/color; position it above the backdrop with `relative
-  // z-10`.
+  // z-1`.
   media: ReactNode;
   // When set, a blurred, magnified copy of this image becomes the backdrop;
   // otherwise a dotted texture is shown.

--- a/apps/compliance-portal/src/components/CommitmentCard/variants.ts
+++ b/apps/compliance-portal/src/components/CommitmentCard/variants.ts
@@ -25,6 +25,6 @@ import { tv } from "tailwind-variants/lite";
 // BackdropCard; this slot only styles the icon container.
 export const commitmentCard = tv({
   slots: {
-    icon: "relative z-10 flex size-8 items-center justify-center text-gold-9",
+    icon: "relative z-1 flex size-8 items-center justify-center text-gold-9",
   },
 });

--- a/apps/compliance-portal/src/components/MediaTile/variants.ts
+++ b/apps/compliance-portal/src/components/MediaTile/variants.ts
@@ -32,7 +32,7 @@ export const mediaTile = tv({
     backdrop: "pointer-events-none absolute inset-0",
     blurBackdrop: "pointer-events-none absolute inset-0 size-full scale-150 object-cover opacity-10 blur-lg",
     backdropFade: "pointer-events-none absolute inset-0 bg-linear-to-b from-sand-1/0 to-sand-1",
-    mediaContent: "relative z-10 flex size-16 items-center justify-center [&_img]:size-full [&_img]:object-contain",
+    mediaContent: "relative z-1 flex size-16 items-center justify-center [&_img]:size-full [&_img]:object-contain",
     caption: "flex w-full items-center justify-center px-4 py-3",
   },
   variants: {

--- a/apps/compliance-portal/src/components/PoweredBy/variants.ts
+++ b/apps/compliance-portal/src/components/PoweredBy/variants.ts
@@ -27,7 +27,7 @@ export const poweredBy = tv({
     root: "relative flex w-full items-center justify-center overflow-hidden bg-sand-2 py-6 text-sand-11",
     backdrop: "pointer-events-none absolute inset-0",
     backdropFade: "pointer-events-none absolute inset-0 bg-linear-to-b from-sand-2 to-sand-2/0",
-    content: "relative z-10 flex items-center justify-center gap-2",
+    content: "relative z-1 flex items-center justify-center gap-2",
     logo: "h-6 w-auto text-sand-9",
   },
 });

--- a/apps/compliance-portal/src/pages/documents/_components/DocumentEntry.tsx
+++ b/apps/compliance-portal/src/pages/documents/_components/DocumentEntry.tsx
@@ -113,14 +113,14 @@ export function DocumentEntry({
           ? (
               <RouterLink
                 to={viewHref}
-                className="absolute inset-0 z-10 hidden max-sm:block"
+                className="absolute inset-0 z-1 hidden max-sm:block"
                 aria-label={mobileHitLabel}
               />
             )
           : (
               <button
                 type="button"
-                className="absolute inset-0 z-10 hidden max-sm:block"
+                className="absolute inset-0 z-1 hidden max-sm:block"
                 aria-label={mobileHitLabel}
                 disabled={isRequesting}
                 onClick={onGetAccess}

--- a/apps/compliance-portal/src/pages/documents/_components/PdfPreview.tsx
+++ b/apps/compliance-portal/src/pages/documents/_components/PdfPreview.tsx
@@ -37,8 +37,19 @@ import { pdfPreview } from "./variants";
 // it from a CDN, so the viewer works under a strict trust-center CSP.
 pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 
-// Horizontal inset so pages don't kiss the viewport edge on phones.
-const PAGE_GUTTER_PX = 32;
+// Total horizontal inset (both sides) for fit-to-width at 100% zoom.
+// Desktop matches HeaderBand / hero `px-8` (32px per side); mobile keeps the
+// tighter phone gutter so pages stay readable.
+const PAGE_GUTTER_MOBILE_PX = 32;
+const PAGE_GUTTER_DESKTOP_PX = 64;
+// Tailwind `md` — same breakpoint as `max-md:px-4` on the hero band.
+const DESKTOP_MEDIA_QUERY = "(min-width: 768px)";
+
+function pageGutterPx(): number {
+  return window.matchMedia(DESKTOP_MEDIA_QUERY).matches
+    ? PAGE_GUTTER_DESKTOP_PX
+    : PAGE_GUTTER_MOBILE_PX;
+}
 
 function findCenteredPage(
   wrapper: HTMLDivElement,
@@ -110,13 +121,19 @@ export function PdfPreview({ file, scale, ref, onNumPages, onVisiblePageChange }
     }
 
     const updateWidth = () => {
-      setPageWidth(Math.max(wrapper.clientWidth - PAGE_GUTTER_PX, 1));
+      setPageWidth(Math.max(wrapper.clientWidth - pageGutterPx(), 1));
     };
 
     updateWidth();
     const observer = new ResizeObserver(updateWidth);
     observer.observe(wrapper);
-    return () => observer.disconnect();
+    // Recompute when crossing the md breakpoint so the gutter tracks hero padding.
+    const media = window.matchMedia(DESKTOP_MEDIA_QUERY);
+    media.addEventListener("change", updateWidth);
+    return () => {
+      observer.disconnect();
+      media.removeEventListener("change", updateWidth);
+    };
   }, []);
 
   // After fit-to-width / zoom reflow, the same scroll offset can center a

--- a/apps/compliance-portal/src/pages/documents/_components/PdfPreview.tsx
+++ b/apps/compliance-portal/src/pages/documents/_components/PdfPreview.tsx
@@ -37,18 +37,22 @@ import { pdfPreview } from "./variants";
 // it from a CDN, so the viewer works under a strict trust-center CSP.
 pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 
-// Total horizontal inset (both sides) for fit-to-width at 100% zoom.
-// Desktop matches HeaderBand / hero `px-8` (32px per side); mobile keeps the
-// tighter phone gutter so pages stay readable.
+// Fit-to-width at 100% zoom: mobile keeps a tight phone gutter; desktop pages
+// match HeaderBand's inner column (`px-8` + centered `max-w-5xl`).
 const PAGE_GUTTER_MOBILE_PX = 32;
-const PAGE_GUTTER_DESKTOP_PX = 64;
+const HEADER_PAD_DESKTOP_PX = 32; // Tailwind `px-8` per side
+const HEADER_CONTENT_MAX_PX = 1024; // Tailwind `max-w-5xl`
 // Tailwind `md` — same breakpoint as `max-md:px-4` on the hero band.
 const DESKTOP_MEDIA_QUERY = "(min-width: 768px)";
 
-function pageGutterPx(): number {
-  return window.matchMedia(DESKTOP_MEDIA_QUERY).matches
-    ? PAGE_GUTTER_DESKTOP_PX
-    : PAGE_GUTTER_MOBILE_PX;
+function pageWidthForWrapper(clientWidth: number): number {
+  if (!window.matchMedia(DESKTOP_MEDIA_QUERY).matches) {
+    return Math.max(clientWidth - PAGE_GUTTER_MOBILE_PX, 1);
+  }
+  return Math.max(
+    Math.min(clientWidth - HEADER_PAD_DESKTOP_PX * 2, HEADER_CONTENT_MAX_PX),
+    1,
+  );
 }
 
 function findCenteredPage(
@@ -121,13 +125,13 @@ export function PdfPreview({ file, scale, ref, onNumPages, onVisiblePageChange }
     }
 
     const updateWidth = () => {
-      setPageWidth(Math.max(wrapper.clientWidth - pageGutterPx(), 1));
+      setPageWidth(pageWidthForWrapper(wrapper.clientWidth));
     };
 
     updateWidth();
     const observer = new ResizeObserver(updateWidth);
     observer.observe(wrapper);
-    // Recompute when crossing the md breakpoint so the gutter tracks hero padding.
+    // Recompute when crossing the md breakpoint so width tracks HeaderBand.
     const media = window.matchMedia(DESKTOP_MEDIA_QUERY);
     media.addEventListener("change", updateWidth);
     return () => {

--- a/apps/compliance-portal/src/pages/subprocessors/_components/variants.ts
+++ b/apps/compliance-portal/src/pages/subprocessors/_components/variants.ts
@@ -25,7 +25,7 @@ import { tv } from "tailwind-variants/lite";
 // the body. The card frame and backdrop live in BackdropCard.
 export const subprocessorListItem = tv({
   slots: {
-    logo: "relative z-10 flex size-10 items-center justify-center overflow-hidden rounded-2 bg-sand-1",
+    logo: "relative z-1 flex size-10 items-center justify-center overflow-hidden rounded-2 bg-sand-1",
     logoImage: "size-full object-cover",
     logoFallbackIcon: "text-sand-9",
     region: "flex items-start gap-1",

--- a/apps/compliance-portal/src/pages/updates/UpdatesPageSkeleton.tsx
+++ b/apps/compliance-portal/src/pages/updates/UpdatesPageSkeleton.tsx
@@ -27,7 +27,10 @@ import { HeaderBand } from "#/components/HeaderBand/HeaderBand";
 import { pageHeader } from "#/components/PageHeader/variants";
 
 import { updatesList } from "./_components/variants";
-import { UPDATES_PAGE_SIZE } from "./_lib/constants";
+
+// Placeholder rows for the loading card — enough to read as a list, far fewer
+// than UPDATES_PAGE_SIZE so the skeleton does not dominate the viewport.
+const UPDATES_SKELETON_COUNT = 5;
 
 export function UpdatesPageSkeleton() {
   const { card, rows } = updatesList();
@@ -47,7 +50,7 @@ export function UpdatesPageSkeleton() {
         <div className="flex w-full max-w-5xl flex-col gap-8">
           <div className={card()} aria-hidden>
             <div className={rows()}>
-              {Array.from({ length: UPDATES_PAGE_SIZE }, (_, index) => (
+              {Array.from({ length: UPDATES_SKELETON_COUNT }, (_, index) => (
                 <ComplianceArticleItemSkeleton key={index} />
               ))}
             </div>

--- a/apps/compliance-portal/src/routes.tsx
+++ b/apps/compliance-portal/src/routes.tsx
@@ -20,7 +20,8 @@
 
 import { lazy } from "@probo/react-lazy";
 import { type AppRoute, routeFromAppRoute } from "@probo/routes";
-import { createBrowserRouter } from "react-router";
+import { Fragment } from "react";
+import { createBrowserRouter, redirect } from "react-router";
 
 import { PageErrorBoundary } from "#/components/errors/PageErrorBoundary";
 import { RootErrorBoundary } from "#/components/errors/RootErrorBoundary";
@@ -51,6 +52,15 @@ const routes = [
             index: true,
             Fallback: HomePageSkeleton,
             Component: lazy(() => import("#/pages/HomePageLoader")),
+          },
+          // Legacy trust-app URL; home now lives at the index route.
+          {
+            path: "overview",
+            loader: () => {
+              // eslint-disable-next-line
+              throw redirect("/");
+            },
+            Component: Fragment,
           },
           ...documentRoutes,
           ...subprocessorRoutes,

--- a/contrib/claude/ui.md
+++ b/contrib/claude/ui.md
@@ -9,7 +9,7 @@ These rules are the **source of truth**. The legacy tree (`Atoms/`, `Molecules/`
 | Topic | Guide |
 |-------|--------|
 | Component shape, props, naming/suffixes | [`contrib/claude/react-components.md`](react-components.md) |
-| v2 design tokens (color, type, radius, shadow, spacing) | [`contrib/claude/v2-tokens.md`](v2-tokens.md) |
+| v2 design tokens (color, type, radius, shadow, z-index, spacing) | [`contrib/claude/v2-tokens.md`](v2-tokens.md) |
 | App folder layout and special folders | [`contrib/claude/app-arborescence.md`](app-arborescence.md) |
 | Error boundaries and error/fallback props | [`contrib/claude/error-handling.md`](error-handling.md) |
 | Relay data loading | [`contrib/claude/relay.md`](relay.md) |
@@ -20,7 +20,7 @@ These rules are the **source of truth**. The legacy tree (`Atoms/`, `Molecules/`
 |------|------------|
 | Package | **`@probo/ui`** — v2 components under `src/v2`. Apps opt into v2 by importing the v2 theme (see [`v2-tokens.md`](v2-tokens.md)). |
 | Styling | **Tailwind v4** with the Radix-scale tokens (`bg-sand-3`, `text-sand-12`, `rounded-3`, `text-4`, …). |
-| Variants API | **`tailwind-variants/lite`** only — `import { tv } from "tailwind-variants/lite"`. The `/lite` entrypoint ships **without `tailwind-merge`**, which is required: the numbered scales (`text-1…9`, `rounded-1…6`, `shadow-1…6`) collide with the color/utility namespaces and tailwind-merge would silently drop the scale class (e.g. `text-3` next to `text-sand-11`). The legacy v1 kit stays on `tailwind-variants` (with merge). |
+| Variants API | **`tailwind-variants/lite`** only — `import { tv } from "tailwind-variants/lite"`. The `/lite` entrypoint ships **without `tailwind-merge`**, which is required: the numbered scales (`text-1…9`, `rounded-1…6`, `shadow-1…6`, `z-1…6`) collide with the color/utility namespaces and tailwind-merge would silently drop the scale class (e.g. `text-3` next to `text-sand-11`). The legacy v1 kit stays on `tailwind-variants` (with merge). |
 | Class composition | **Do not use `clsx` or `tailwind-merge`.** All conditional styling goes through `tv` variants and slots. |
 | Headless primitives | **Base UI** (`@base-ui/react`). We **style** these primitives; we do not re-implement their behavior. |
 

--- a/contrib/claude/v2-tokens.md
+++ b/contrib/claude/v2-tokens.md
@@ -2,7 +2,7 @@
 
 The v2 UI kit is built on a small set of **numbered token scales** sourced from Radix and the "Probo Radix UI" Figma file. Every token family follows the same convention as color — a numbered scale exposed as Tailwind utilities — so the kit speaks one consistent visual language: `bg-sand-3`, `text-4`, `rounded-3`, `shadow-2`.
 
-Theme entry: [`packages/ui/src/v2/theme.css`](../../packages/ui/src/v2/theme.css), aggregating `theme/colors.css`, `theme/typography.css`, `theme/radius.css`, `theme/shadows.css`.
+Theme entry: [`packages/ui/src/v2/theme.css`](../../packages/ui/src/v2/theme.css), aggregating `theme/colors.css`, `theme/typography.css`, `theme/radius.css`, `theme/shadows.css`, `theme/z-index.css`.
 
 | Family | Utilities | Steps | Source |
 |--------|-----------|-------|--------|
@@ -10,6 +10,7 @@ Theme entry: [`packages/ui/src/v2/theme.css`](../../packages/ui/src/v2/theme.css
 | Typography | `text-<1–9>` (+ font weights) | 9 | Radix type scale |
 | Radius | `rounded-<1–6>` | 6 | Radix "Medium" radius |
 | Shadow | `shadow-<1–6>`, `inset-shadow-<1–3>` | 6 / 3 | Radix elevation |
+| Z-index | `z-<1–6>` | 6 | UI layer roles |
 | Spacing | Tailwind native (`p-4`, `gap-2`, …) | — | not tokenized |
 
 Each `--<family>-*` is reset to `initial` in its theme layer, so a v2 build exposes **only** the numbered scales — Tailwind's default palette, t-shirt type sizes, and `shadow-sm/md/lg` are intentionally unavailable. Use the numbered token; never reintroduce an ad-hoc value.
@@ -255,6 +256,33 @@ Theme file: [`packages/ui/src/v2/theme/shadows.css`](../../packages/ui/src/v2/th
 
 // Bad — Tailwind default shadow (wiped) or a manual dark: override
 <div className="shadow-md dark:shadow-none">…</div>
+```
+
+# Z-index (`z-1` … `z-6`)
+
+Stacking scale by **UI layer role**, not arbitrary elevation. Prefer the step that matches the element type; never invent ad-hoc values (`z-10`, `z-[999]`) in a v2 build.
+
+Theme file: [`packages/ui/src/v2/theme/z-index.css`](../../packages/ui/src/v2/theme/z-index.css)
+
+| Step | Value | Role |
+|------|-------|------|
+| 1 | 1 | Local stacking inside a component (media over a decorative backdrop) |
+| 2 | 10 | Sticky / fixed page chrome (top bars, sticky toolbars) |
+| 3 | 30 | Floating menus (select, dropdown, tooltip, popover) |
+| 4 | 40 | Overlay backdrops (dimmers under modals / drawers) |
+| 5 | 50 | Modals and drawers |
+| 6 | 60 | Toasts / global notifications (always on top) |
+
+Put the token on the **portaled root** that participates in the document stacking context (e.g. a menu `Positioner`), not only an inner popup. A local `z-1` in the page will paint above a portaled popup that has no z-index of its own.
+
+```tsx
+// Good — local media above its own backdrop; menu sits in the popover layer
+<div className="relative z-1">…logo…</div>
+<Menu.Positioner className="z-3">…</Menu.Positioner>
+
+// Bad — Tailwind default / arbitrary z-index (wiped or discouraged in v2)
+<div className="z-10">…</div>
+<div className="z-[999]">…</div>
 ```
 
 # Spacing (Tailwind native)

--- a/packages/ui/src/v2/Dialog/variants.ts
+++ b/packages/ui/src/v2/Dialog/variants.ts
@@ -26,12 +26,12 @@ import { tv } from "tailwind-variants/lite";
 export const dialog = tv({
   slots: {
     backdrop: [
-      "fixed inset-0 z-50 bg-sand-12/40",
+      "fixed inset-0 z-4 bg-sand-12/40",
       "transition-opacity duration-150",
       "data-starting-style:opacity-0 data-ending-style:opacity-0",
     ],
     popup: [
-      "fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2",
+      "fixed left-1/2 top-1/2 z-5 -translate-x-1/2 -translate-y-1/2",
       "flex w-[calc(100vw-2rem)] max-w-[600px] flex-col gap-4",
       "max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-clip",
       "rounded-5 border border-sand-6 bg-sand-1 py-6 shadow-6 outline-none",

--- a/packages/ui/src/v2/Dialog/variants.ts
+++ b/packages/ui/src/v2/Dialog/variants.ts
@@ -32,7 +32,7 @@ export const dialog = tv({
     ],
     popup: [
       "fixed left-1/2 top-1/2 z-5 -translate-x-1/2 -translate-y-1/2",
-      "flex w-[calc(100vw-2rem)] max-w-[600px] flex-col gap-4",
+      "flex w-[calc(100vw-2rem)] max-w-150 flex-col gap-4",
       "max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-clip",
       "rounded-5 border border-sand-6 bg-sand-1 py-6 shadow-6 outline-none",
       "transition-all duration-150",
@@ -51,7 +51,7 @@ export const dialog = tv({
 // so a placeholder can render before Base UI (and the content) loads.
 export const dialogSkeleton = tv({
   base: [
-    "flex w-full max-w-[600px] flex-col gap-4",
+    "flex w-full max-w-150 flex-col gap-4",
     "rounded-5 border border-sand-6 bg-sand-1 py-6 shadow-6",
   ],
 });

--- a/packages/ui/src/v2/Drawer/variants.ts
+++ b/packages/ui/src/v2/Drawer/variants.ts
@@ -25,11 +25,11 @@ import { tv } from "tailwind-variants/lite";
 export const drawer = tv({
   slots: {
     backdrop: [
-      "fixed inset-0 z-50 bg-sand-12/40",
+      "fixed inset-0 z-4 bg-sand-12/40",
       "transition-opacity duration-200",
       "data-starting-style:opacity-0 data-ending-style:opacity-0",
     ],
-    viewport: "fixed inset-0 z-50 flex",
+    viewport: "fixed inset-0 z-5 flex",
     popup: [
       "relative flex flex-col bg-sand-1 shadow-6 outline-none",
       "transition-transform duration-200",

--- a/packages/ui/src/v2/Dropdown/DropdownPopup.tsx
+++ b/packages/ui/src/v2/Dropdown/DropdownPopup.tsx
@@ -49,7 +49,8 @@ export function DropdownPopup(props: DropdownPopupProps) {
 
   return (
     <Menu.Portal>
-      <Menu.Positioner side={side} align={align} sideOffset={sideOffset}>
+      {/* z-3 on the Positioner so the portaled root wins over in-page z-1. */}
+      <Menu.Positioner className="z-3" side={side} align={align} sideOffset={sideOffset}>
         <Menu.Popup className={dropdownPopup({ className })} {...popupProps}>
           <DropdownProvider value={{ size, variant, highContrast }}>
             {children}

--- a/packages/ui/src/v2/List/ListItemSkeleton.tsx
+++ b/packages/ui/src/v2/List/ListItemSkeleton.tsx
@@ -20,15 +20,24 @@
 
 import type { ComponentProps } from "react";
 
+import { TextSkeleton } from "../typography/TextSkeleton";
+
 import { list } from "./variants";
 
 export type ListItemSkeletonProps = Omit<ComponentProps<"li">, "children">;
 
-// Loading placeholder paired with ListItem: a pulse bar that keeps the row
-// dividers of a List.
+// Loading placeholder paired with ListItem: same row shell (card background +
+// dividers) with pulse bars for the primary column — not a filled sand-2 slab.
 export function ListItemSkeleton(props: ListItemSkeletonProps) {
   const { className, ...rest } = props;
-  const { skeletonItem } = list();
+  const { item, content } = list();
 
-  return <li className={skeletonItem({ className })} aria-hidden {...rest} />;
+  return (
+    <li className={item({ className })} aria-hidden {...rest}>
+      <div className={content()}>
+        <TextSkeleton size={2} className="w-40" />
+        <TextSkeleton size={1} className="w-24" />
+      </div>
+    </li>
+  );
 }

--- a/packages/ui/src/v2/List/variants.ts
+++ b/packages/ui/src/v2/List/variants.ts
@@ -27,6 +27,5 @@ export const list = tv({
     root: "list-none overflow-hidden rounded-4 border border-sand-a3 bg-sand-1",
     item: "flex items-center gap-4 border-b border-sand-a3 px-4 py-3 last:border-b-0",
     content: "flex min-w-0 flex-1 flex-col gap-0.5",
-    skeletonItem: "h-16 animate-pulse border-b border-sand-a3 bg-sand-2 last:border-b-0",
   },
 });

--- a/packages/ui/src/v2/Select/SelectPopup.tsx
+++ b/packages/ui/src/v2/Select/SelectPopup.tsx
@@ -43,7 +43,8 @@ export function SelectPopup(props: SelectPopupProps) {
 
   return (
     <BaseSelect.Portal>
-      <BaseSelect.Positioner side={side} align={align} sideOffset={sideOffset}>
+      {/* z-3 on the Positioner so the portaled root wins over in-page z-1. */}
+      <BaseSelect.Positioner className="z-3" side={side} align={align} sideOffset={sideOffset}>
         <BaseSelect.Popup className={selectPopup({ className })} {...popupProps}>
           {children}
         </BaseSelect.Popup>

--- a/packages/ui/src/v2/Toaster/variants.ts
+++ b/packages/ui/src/v2/Toaster/variants.ts
@@ -27,7 +27,7 @@ import { tv } from "tailwind-variants/lite";
 export const toaster = tv({
   slots: {
     viewport: [
-      "fixed bottom-0 right-0 z-60 flex w-[380px] max-w-[calc(100vw-2rem)] flex-col gap-2 p-4",
+      "fixed bottom-0 right-0 z-6 flex w-[380px] max-w-[calc(100vw-2rem)] flex-col gap-2 p-4",
       "outline-none",
     ],
     root: [

--- a/packages/ui/src/v2/theme.css
+++ b/packages/ui/src/v2/theme.css
@@ -30,6 +30,7 @@
  *   typography.css  Inter font + type scale (text-1…9) + font weights
  *   radius.css      radius scale (rounded-1…6)
  *   shadows.css     elevation scale (shadow-1…6)
+ *   z-index.css     stacking scale (z-1…6) by UI layer
  *
  * Spacing intentionally stays on Tailwind's native scale (not tokenized).
  * See contrib/claude/v2-tokens.md for the full usage guide.
@@ -38,3 +39,4 @@
 @import "./theme/typography.css";
 @import "./theme/radius.css";
 @import "./theme/shadows.css";
+@import "./theme/z-index.css";

--- a/packages/ui/src/v2/theme/z-index.css
+++ b/packages/ui/src/v2/theme/z-index.css
@@ -1,0 +1,56 @@
+/* Copyright (c) 2026 Probo Inc <hello@probo.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* ---------------------------------------------------------------------------
+ * Z-index — stacking scale by UI layer (steps 1–6)
+ *
+ * Numbered like color / type / radius / shadow. Each step is a layer role, not
+ * an arbitrary elevation. Values are spaced so a future mid-layer can land
+ * between them without renumbering consumers.
+ *
+ *   Step   value   Role
+ *   ─────  ──────  ────────────────────────────────────────────────────────
+ *   1      1       Local stacking inside a component (media over backdrop)
+ *   2      10      Sticky / fixed page chrome (top bars, sticky toolbars)
+ *   3      30      Floating menus (select, dropdown, tooltip, popover)
+ *   4      40      Overlay backdrops (dimmers under modals / drawers)
+ *   5      50      Modals and drawers
+ *   6      60      Toasts / global notifications (always on top)
+ *
+ * Put the token on the portaled root that participates in the document
+ * stacking context (e.g. the Positioner for menus, not only the inner Popup).
+ * A local z-1 inside the page will otherwise paint above a portaled popup
+ * that has no z-index of its own.
+ *
+ * --z-index-* is reset to initial so the v2 build exposes only this numeric
+ * scale (not Tailwind's z-10 / z-20 / … defaults). z-auto stays available as
+ * a static utility.
+ * ------------------------------------------------------------------------- */
+@theme {
+    --z-index-*: initial;
+
+    --z-index-1: 1;
+    --z-index-2: 10;
+    --z-index-3: 30;
+    --z-index-4: 40;
+    --z-index-5: 50;
+    --z-index-6: 60;
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces a v2 z-index token scale (`z-1…z-6`) in `@probo/ui` and migrates portal elements to it for predictable layering. Lightens loading UIs, redirects the legacy `/overview` URL, updates the home hero title, and aligns the PDF preview width and gutter with the header on desktop.

### App: compliance-portal **`+50`** **`-16`**
- Replace `z-10` with `z-1` for media, logos, and mobile hit areas.
- Show 5 update skeleton rows for a lighter loading state.
- Redirect `/overview` to `/` using React Router.
- Update home hero title to "Compliance at {{name}}.".
- Align PDF preview to HeaderBand: desktop uses `max-w-5xl` with `px-8` per side; mobile keeps 32px; recompute on md breakpoint changes.

### Package: ui **`+82`** **`-14`**
- Add z-index scale (`z-1…z-6`) via `theme/z-index.css` and import it in `theme.css`.
- Ensure portal layering: Dropdown/Select `Positioner` `z-3`; Dialog/Drawer backdrops `z-4`, surfaces `z-5`; Toaster viewport `z-6`.
- Rework `ListItemSkeleton` to the real row shell with `TextSkeleton` lines; remove the slab skeleton.
- Use tokenized width on Dialog (`max-w-150`).

### Agents **`+31`** **`-3`**
- Expand v2 tokens guide to cover z-index scale, roles, and examples.
- Update UI kit docs to note `z-1…6` and why `tailwind-variants/lite` (no merge) is required.

### Other **`+1`** **`-1`**
- Mention z-index in the token list in `AGENTS.md`.

<sup>Written for commit 854b4059792dfce7e795d911744f5c3490a7b721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

