### PR TITLE
Preserve vendor category when omitted in MCP update

### DIFF
--- a/e2e/mcp/third_party_test.go
+++ b/e2e/mcp/third_party_test.go
@@ -92,6 +92,43 @@ func TestMCP_ThirdParty_CRUD(t *testing.T) {
 	assert.Equal(t, "resource not found", msg)
 }
 
+func TestMCP_ThirdParty_UpdatePreservesCategoryWhenOmitted(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	mc := testutil.NewMCPClient(t, owner)
+	orgID := owner.GetOrganizationID().String()
+
+	var addResult struct {
+		ThirdParty struct {
+			ID       string `json:"id"`
+			Category string `json:"category"`
+		} `json:"third_party"`
+	}
+
+	name := factory.SafeName("ThirdParty")
+	mc.CallToolInto("addThirdParty", map[string]any{
+		"organizationId": orgID,
+		"name":           name,
+		"category":       "CLOUD_PROVIDER",
+	}, &addResult)
+	require.NotEmpty(t, addResult.ThirdParty.ID)
+	assert.Equal(t, "CLOUD_PROVIDER", addResult.ThirdParty.Category)
+
+	var updateResult struct {
+		ThirdParty struct {
+			ID       string `json:"id"`
+			Name     string `json:"name"`
+			Category string `json:"category"`
+		} `json:"third_party"`
+	}
+	mc.CallToolInto("updateThirdParty", map[string]any{
+		"id":   addResult.ThirdParty.ID,
+		"name": "Updated ThirdParty",
+	}, &updateResult)
+	assert.Equal(t, "Updated ThirdParty", updateResult.ThirdParty.Name)
+	assert.Equal(t, "CLOUD_PROVIDER", updateResult.ThirdParty.Category)
+}
+
 func TestMCP_ThirdParty_ValidationError(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)

--- a/pkg/probo/third_party_service.go
+++ b/pkg/probo/third_party_service.go
@@ -408,8 +408,6 @@ func (s ThirdPartyService) Update(
 
 			if req.Category != nil {
 				thirdParty.Category = *req.Category
-			} else {
-				thirdParty.Category = coredata.ThirdPartyCategoryOther
 			}
 
 			if req.SecurityPageURL != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes ENG-636.

## Problem

Updating a third party (vendor) via MCP without including `category` in the payload reset the stored category to `OTHER`. The MCP resolver already treated omitted `category` as optional (`nil`), but `ThirdPartyService.Update` incorrectly defaulted nil to `OTHER`.

## Solution

Remove the `else` branch in `ThirdPartyService.Update` so category is only changed when explicitly provided, consistent with other optional fields like `name` and `description`.

## Testing

- Added `TestMCP_ThirdParty_UpdatePreservesCategoryWhenOmitted` in `e2e/mcp/third_party_test.go`
- Creates a third party with `CLOUD_PROVIDER`, updates only the name, and asserts category remains unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-636](https://linear.app/probo/issue/ENG-636/vendor-category-resets-to-other-when-omitted-in-mcp-update)

<div><a href="https://cursor.com/agents/bc-0166ac3b-a405-43e2-a52f-aeb89349c96b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0166ac3b-a405-43e2-a52f-aeb89349c96b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves vendor category on partial updates by only applying `category` when provided, fixing resets to OTHER when omitted. Aligns MCP, GraphQL, and CLI behavior and addresses ENG-636.

### Tests **`+37`** **`-0`**
Adds an MCP e2e test that updates name without `category` and verifies the original category (e.g., CLOUD_PROVIDER) is preserved.

### Service **`+0`** **`-2`**
Removes the fallback in `ThirdPartyService.Update` that set category to OTHER when nil so `category` changes only when explicitly provided.

<sup>Written for commit e6819852febfea015d7fe4543bd36ea21ac864a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

