### PR TITLE
Harden cert provisioning failure and write-back

### DIFF
--- a/apps/console/src/pages/organizations/compliance-page/domain/_components/CompliancePageDomainCard.tsx
+++ b/apps/console/src/pages/organizations/compliance-page/domain/_components/CompliancePageDomainCard.tsx
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 import {
+  getCertificateProvisioningErrorMessage,
   getCustomDomainStatusBadgeLabel,
   getCustomDomainStatusBadgeVariant,
 } from "@probo/helpers";
@@ -55,7 +56,10 @@ export function CompliancePageDomainCard(props: {
 
   const domain = useFragment<CompliancePageDomainCardFragment$key>(fragment, fKey);
   const sslStatus = domain.certificate?.status ?? "PENDING";
-  const provisioningError = domain.certificate?.provisioningError;
+  const provisioningErrorMessage = getCertificateProvisioningErrorMessage(
+    domain.certificate?.provisioningError,
+    __,
+  );
 
   return (
     <Card padded>
@@ -73,8 +77,8 @@ export function CompliancePageDomainCard(props: {
           <p className="text-sm text-txt-secondary">
             {sslStatus === "ACTIVE"
               ? __("Verified and serving traffic")
-              : provisioningError
-                ? provisioningError
+              : provisioningErrorMessage
+                ? provisioningErrorMessage
                 : __("Pending DNS verification")}
           </p>
         </div>

--- a/apps/console/src/pages/organizations/compliance-page/domain/_components/CompliancePageDomainDialog.tsx
+++ b/apps/console/src/pages/organizations/compliance-page/domain/_components/CompliancePageDomainDialog.tsx
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 import {
+  getCertificateProvisioningErrorMessage,
   getCustomDomainStatusBadgeLabel,
   getCustomDomainStatusBadgeVariant,
 } from "@probo/helpers";
@@ -76,7 +77,10 @@ export function CompliancePageDomainDialog(props: CompliancePageDomainDialogProp
   const domain = useFragment<CompliancePageDomainDialogFragment$key>(fragment, fKey);
   const sslStatus = domain.certificate?.status ?? "PENDING";
   const expiresAt = domain.certificate?.expiresAt;
-  const provisioningError = domain.certificate?.provisioningError;
+  const provisioningErrorMessage = getCertificateProvisioningErrorMessage(
+    domain.certificate?.provisioningError,
+    __,
+  );
 
   return (
     <Dialog
@@ -127,10 +131,10 @@ export function CompliancePageDomainDialog(props: CompliancePageDomainDialogProp
             )
           : (
               <div>
-                {provisioningError && (
+                {provisioningErrorMessage && (
                   <div className="bg-danger-subtle text-danger rounded-lg p-4 mb-4">
                     <p className="text-sm font-medium mb-1">{__("Provisioning error")}</p>
-                    <p className="text-sm">{provisioningError}</p>
+                    <p className="text-sm">{provisioningErrorMessage}</p>
                   </div>
                 )}
 

--- a/packages/helpers/src/customDomain.ts
+++ b/packages/helpers/src/customDomain.ts
@@ -63,3 +63,34 @@ export const getCustomDomainStatusBadgeLabel = (
   }
   return __("Unknown");
 };
+
+const provisioningErrorMessages: Record<string, string> = {
+  DNS_CNAME: "DNS is not configured correctly yet. Check the CNAME record.",
+  DNS_CAA: "DNS CAA records do not allow our certificate authority.",
+  ACME_RATE_LIMITED:
+    "Certificate authority is temporarily rate-limiting. We will retry automatically.",
+  ACME_INVALID_ORDER:
+    "Domain ownership could not be verified. We will retry automatically.",
+  ACME_TEMPORARY:
+    "Certificate provisioning hit a temporary error. We will retry automatically.",
+  ACME_FAILED:
+    "Certificate provisioning failed. Contact support if this persists.",
+};
+
+export const getCertificateProvisioningErrorMessage = (
+  provisioningError: string | null | undefined,
+  __: (key: string) => string,
+) => {
+  if (!provisioningError) {
+    return null;
+  }
+
+  const knownMessage = provisioningErrorMessages[provisioningError];
+  if (knownMessage) {
+    return __(knownMessage);
+  }
+
+  return __(
+    "Certificate provisioning failed. Contact support if this persists.",
+  );
+};

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -21,6 +21,7 @@
 export { objectKeys, objectEntries, cleanFormData } from "./object";
 export { sprintf, faviconUrl, slugify } from "./string";
 export {
+  getCertificateProvisioningErrorMessage,
   getCustomDomainStatusBadgeLabel,
   getCustomDomainStatusBadgeVariant,
 } from "./customDomain";

--- a/pkg/certmanager/acme.go
+++ b/pkg/certmanager/acme.go
@@ -30,8 +30,10 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.gearno.de/kit/httpclient"
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/crypto/keys"
@@ -49,10 +51,13 @@ type (
 	}
 
 	ACMEService struct {
-		client  *acme.Client
-		email   string
-		keyType keys.Type
-		logger  *log.Logger
+		client        *acme.Client
+		email         string
+		keyType       keys.Type
+		logger        *log.Logger
+		metrics       *metrics
+		cooldownMu    sync.RWMutex
+		cooldownUntil time.Time
 	}
 
 	HTTPChallenge struct {
@@ -62,7 +67,21 @@ type (
 		URL      string
 		OrderURL string
 	}
+
+	OrderPollStatus string
 )
+
+const (
+	OrderPollStatusNotReady OrderPollStatus = "not_ready"
+	OrderPollStatusReady    OrderPollStatus = "ready"
+	OrderPollStatusValid    OrderPollStatus = "valid"
+	OrderPollStatusInvalid  OrderPollStatus = "invalid"
+)
+
+type OrderPollResult struct {
+	Status OrderPollStatus
+	Order  *acme.Order
+}
 
 func NewACMEService(
 	email string,
@@ -71,6 +90,7 @@ func NewACMEService(
 	accountKey crypto.Signer,
 	rootCAs *x509.CertPool,
 	logger *log.Logger,
+	registerer prometheus.Registerer,
 ) (*ACMEService, error) {
 	if accountKey == nil {
 		var err error
@@ -110,6 +130,7 @@ func NewACMEService(
 		email:   email,
 		keyType: keyType,
 		logger:  logger.Named("acme"),
+		metrics: newMetrics(registerer),
 	}
 
 	ctx := context.Background()
@@ -118,6 +139,35 @@ func NewACMEService(
 	}
 
 	return service, nil
+}
+
+func (s *ACMEService) InCooldown() bool {
+	s.cooldownMu.RLock()
+	defer s.cooldownMu.RUnlock()
+
+	active := time.Now().Before(s.cooldownUntil)
+
+	s.metrics.setCooldown(active)
+
+	return active
+}
+
+func (s *ACMEService) CooldownUntil() time.Time {
+	s.cooldownMu.RLock()
+	defer s.cooldownMu.RUnlock()
+
+	return s.cooldownUntil
+}
+
+func (s *ACMEService) enterCooldown(until time.Time) {
+	s.cooldownMu.Lock()
+	defer s.cooldownMu.Unlock()
+
+	if until.After(s.cooldownUntil) {
+		s.cooldownUntil = until
+	}
+
+	s.metrics.setCooldown(time.Now().Before(s.cooldownUntil))
 }
 
 func (s *ACMEService) registerAccount(ctx context.Context) error {
@@ -132,10 +182,14 @@ func (s *ACMEService) registerAccount(ctx context.Context) error {
 	return nil
 }
 
-func (s *ACMEService) GetHTTPChallenge(ctx context.Context, domain string) (*HTTPChallenge, error) {
+// StartHTTPChallenge creates an ACME order, accepts the HTTP-01 challenge, and
+// returns the persisted challenge metadata. It never waits for order completion.
+func (s *ACMEService) StartHTTPChallenge(ctx context.Context, domain string) (*HTTPChallenge, error) {
+	started := time.Now()
+
 	order, err := s.client.AuthorizeOrder(ctx, acme.DomainIDs(domain))
 	if err != nil {
-		return nil, fmt.Errorf("cannot create order: %w", err)
+		return nil, s.handleError(provisionPhaseCreateOrder, started, "cannot create order", err)
 	}
 
 	var challenge *acme.Challenge
@@ -143,7 +197,7 @@ func (s *ACMEService) GetHTTPChallenge(ctx context.Context, domain string) (*HTT
 	for _, auth := range order.AuthzURLs {
 		authz, err := s.client.GetAuthorization(ctx, auth)
 		if err != nil {
-			return nil, fmt.Errorf("cannot get authorization: %w", err)
+			return nil, s.handleError(provisionPhaseCreateOrder, started, "cannot get authorization", err)
 		}
 
 		for _, ch := range authz.Challenges {
@@ -159,13 +213,26 @@ func (s *ACMEService) GetHTTPChallenge(ctx context.Context, domain string) (*HTT
 	}
 
 	if challenge == nil {
+		s.metrics.observeStep(provisionPhaseCreateOrder, provisionResultError, started)
 		return nil, fmt.Errorf("no HTTP-01 challenge found")
 	}
 
 	keyAuth, err := s.client.HTTP01ChallengeResponse(challenge.Token)
 	if err != nil {
+		s.metrics.observeStep(provisionPhaseCreateOrder, provisionResultError, started)
 		return nil, fmt.Errorf("cannot get challenge response: %w", err)
 	}
+
+	challenge1 := &acme.Challenge{
+		URI:   challenge.URI,
+		Token: challenge.Token,
+	}
+
+	if _, err := s.client.Accept(ctx, challenge1); err != nil && !isChallengeAlreadyValid(err) {
+		return nil, s.handleError(provisionPhaseCreateOrder, started, "cannot accept challenge", err)
+	}
+
+	s.metrics.observeStep(provisionPhaseCreateOrder, provisionResultOK, started)
 
 	return &HTTPChallenge{
 		Domain:   domain,
@@ -176,41 +243,85 @@ func (s *ACMEService) GetHTTPChallenge(ctx context.Context, domain string) (*HTT
 	}, nil
 }
 
-func (s *ACMEService) CompleteHTTPChallenge(
-	ctx context.Context,
-	challenge0 *HTTPChallenge,
-) (*Certificate, error) {
-	challenge1 := &acme.Challenge{
-		URI:   challenge0.URL,
-		Token: challenge0.Token,
-	}
+// PollOrder performs a single GetOrder call and classifies the result.
+func (s *ACMEService) PollOrder(ctx context.Context, orderURL string) (*OrderPollResult, error) {
+	started := time.Now()
 
-	if _, err := s.client.Accept(ctx, challenge1); err != nil && !isChallengeAlreadyValid(err) {
-		return nil, fmt.Errorf("cannot accept challenge: %w", err)
-	}
-
-	order, err := s.client.WaitOrder(ctx, challenge0.OrderURL)
+	order, err := s.client.GetOrder(ctx, orderURL)
 	if err != nil {
-		return nil, fmt.Errorf("cannot wait for order: %w", err)
+		return nil, s.handleError(provisionPhasePollOrder, started, "cannot get order", err)
+	}
+
+	result := &OrderPollResult{Order: order}
+
+	switch order.Status {
+	case acme.StatusPending, acme.StatusProcessing:
+		result.Status = OrderPollStatusNotReady
+
+		s.metrics.observeStep(provisionPhasePollOrder, provisionResultNotReady, started)
+	case acme.StatusReady:
+		result.Status = OrderPollStatusReady
+
+		s.metrics.observeStep(provisionPhasePollOrder, provisionResultOK, started)
+	case acme.StatusValid:
+		result.Status = OrderPollStatusValid
+
+		s.metrics.observeStep(provisionPhasePollOrder, provisionResultOK, started)
+	case acme.StatusInvalid:
+		result.Status = OrderPollStatusInvalid
+
+		s.metrics.observeStep(provisionPhasePollOrder, provisionResultError, started)
+	default:
+		s.metrics.observeStep(provisionPhasePollOrder, provisionResultError, started)
+		return nil, fmt.Errorf("order is in unexpected status %q", order.Status)
+	}
+
+	return result, nil
+}
+
+// IssueCertificate finalizes a ready order or fetches a valid certificate.
+func (s *ACMEService) IssueCertificate(
+	ctx context.Context,
+	challenge *HTTPChallenge,
+	poll *OrderPollResult,
+) (*Certificate, error) {
+	started := time.Now()
+
+	if poll == nil || poll.Order == nil {
+		s.metrics.observeStep(provisionPhaseIssueCert, provisionResultError, started)
+		return nil, fmt.Errorf("missing order to issue certificate")
+	}
+
+	if poll.Status == OrderPollStatusInvalid {
+		s.metrics.observeStep(provisionPhaseIssueCert, provisionResultError, started)
+		return nil, ErrOrderInvalid
+	}
+
+	if poll.Status != OrderPollStatusReady && poll.Status != OrderPollStatusValid {
+		s.metrics.observeStep(provisionPhaseIssueCert, provisionResultNotReady, started)
+		return nil, ErrOrderNotReady
 	}
 
 	certKey, err := keys.Generate(s.keyType)
 	if err != nil {
+		s.metrics.observeStep(provisionPhaseIssueCert, provisionResultError, started)
 		return nil, fmt.Errorf("cannot generate certificate key: %w", err)
 	}
 
-	csr, err := createCSR(challenge0.Domain, certKey)
+	csr, err := createCSR(challenge.Domain, certKey)
 	if err != nil {
+		s.metrics.observeStep(provisionPhaseIssueCert, provisionResultError, started)
 		return nil, fmt.Errorf("cannot create CSR: %w", err)
 	}
 
-	der, err := s.issueOrderCertificate(ctx, order, challenge0.OrderURL, csr)
+	der, err := s.issueOrderCertificate(ctx, poll.Order, challenge.OrderURL, csr)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create certificate: %w", err)
+		return nil, s.handleError(provisionPhaseIssueCert, started, "cannot create certificate", err)
 	}
 
 	cert, err := x509.ParseCertificate(der[0])
 	if err != nil {
+		s.metrics.observeStep(provisionPhaseIssueCert, provisionResultError, started)
 		return nil, fmt.Errorf("cannot parse certificate: %w", err)
 	}
 
@@ -218,6 +329,7 @@ func (s *ACMEService) CompleteHTTPChallenge(
 
 	keyPEM, err := pem.EncodePrivateKey(certKey)
 	if err != nil {
+		s.metrics.observeStep(provisionPhaseIssueCert, provisionResultError, started)
 		return nil, fmt.Errorf("cannot encode key: %w", err)
 	}
 
@@ -227,6 +339,8 @@ func (s *ACMEService) CompleteHTTPChallenge(
 	}
 
 	chainPEM := pem.EncodeCertificateChain(chainDER)
+
+	s.metrics.observeStep(provisionPhaseIssueCert, provisionResultOK, started)
 
 	return &Certificate{
 		CertPEM:   certPEM,
@@ -238,6 +352,27 @@ func (s *ACMEService) CompleteHTTPChallenge(
 
 func (s *ACMEService) CheckRenewalNeeded(expiresAt time.Time, threshold time.Duration) bool {
 	return time.Until(expiresAt) <= threshold
+}
+
+func (s *ACMEService) handleError(
+	phase provisionPhase,
+	started time.Time,
+	op string,
+	err error,
+) error {
+	acmeErr := newACMEError(op, err)
+	s.metrics.recordACMEError(acmeErr.problemType)
+
+	result := provisionResultError
+	if acmeErr.rateLimited {
+		result = provisionResultRateLimited
+
+		s.enterCooldown(time.Now().Add(acmeErr.RetryAfter()))
+	}
+
+	s.metrics.observeStep(phase, result, started)
+
+	return acmeErr
 }
 
 func isChallengeAlreadyValid(err error) bool {
@@ -271,10 +406,6 @@ func (s *ACMEService) issueOrderCertificate(
 			return der, nil
 		}
 
-		// CreateOrderCert finalizes the order but may fail to download the
-		// certificate when the CA marks the order valid before the certificate
-		// URL is populated. Poll the order using the known order URL because
-		// some CAs omit the Location header on poll responses, leaving order.URI empty.
 		return s.fetchOrderCertificateAfterFinalize(ctx, pollURL, err)
 	default:
 		return nil, fmt.Errorf("order is in unexpected status %q", order.Status)
@@ -300,10 +431,7 @@ func (s *ACMEService) fetchOrderCertificateAfterFinalize(
 	}
 
 	if refreshed.Status != acme.StatusValid {
-		refreshed, err = s.client.WaitOrder(ctx, orderURL)
-		if err != nil {
-			return nil, fmt.Errorf("cannot wait for order after finalize: %w", err)
-		}
+		return nil, fmt.Errorf("%w: order status %q after finalize", ErrOrderNotReady, refreshed.Status)
 	}
 
 	der, err := s.fetchOrderCertificate(ctx, orderURL, refreshed)
@@ -319,7 +447,7 @@ func (s *ACMEService) fetchOrderCertificate(
 	orderURL string,
 	order *acme.Order,
 ) ([][]byte, error) {
-	orderWithCertURL, err := s.waitForCertificateURL(ctx, orderURL, order)
+	orderWithCertURL, err := s.refreshOrderCertificateURL(ctx, orderURL, order)
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +460,7 @@ func (s *ACMEService) fetchOrderCertificate(
 	return der, nil
 }
 
-func (s *ACMEService) waitForCertificateURL(
+func (s *ACMEService) refreshOrderCertificateURL(
 	ctx context.Context,
 	orderURL string,
 	order *acme.Order,
@@ -341,30 +469,20 @@ func (s *ACMEService) waitForCertificateURL(
 		return order, nil
 	}
 
-	deadline := time.Now().Add(30 * time.Second)
-
-	for time.Now().Before(deadline) {
-		refreshed, err := s.client.GetOrder(ctx, orderURL)
-		if err != nil {
-			return nil, fmt.Errorf("cannot refresh order: %w", err)
-		}
-
-		if refreshed.CertURL != "" {
-			return refreshed, nil
-		}
-
-		if refreshed.Status != acme.StatusValid {
-			return nil, fmt.Errorf("order left valid state while waiting for certificate URL")
-		}
-
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(500 * time.Millisecond):
-		}
+	refreshed, err := s.client.GetOrder(ctx, orderURL)
+	if err != nil {
+		return nil, fmt.Errorf("cannot refresh order: %w", err)
 	}
 
-	return nil, fmt.Errorf("timed out waiting for certificate URL")
+	if refreshed.CertURL != "" {
+		return refreshed, nil
+	}
+
+	if refreshed.Status != acme.StatusValid {
+		return nil, fmt.Errorf("%w: order left valid state while waiting for certificate URL", ErrOrderNotReady)
+	}
+
+	return nil, fmt.Errorf("%w: certificate URL not yet available", ErrOrderNotReady)
 }
 
 func createCSR(domain string, key crypto.Signer) ([]byte, error) {

--- a/pkg/certmanager/acme.go
+++ b/pkg/certmanager/acme.go
@@ -78,6 +78,8 @@ const (
 	OrderPollStatusInvalid  OrderPollStatus = "invalid"
 )
 
+const certificateURLPollInterval = 2 * time.Second
+
 type OrderPollResult struct {
 	Status OrderPollStatus
 	Order  *acme.Order
@@ -435,7 +437,14 @@ func (s *ACMEService) fetchOrderCertificateAfterFinalize(
 	}
 
 	if refreshed.Status != acme.StatusValid {
-		return nil, fmt.Errorf("%w: order status %q after finalize", ErrOrderNotReady, refreshed.Status)
+		// Keep finalizeErr in the chain so a rate-limited finalize still reaches
+		// handleError and triggers the ACME cooldown.
+		return nil, fmt.Errorf(
+			"%w: order status %q after finalize: %w",
+			ErrOrderNotReady,
+			refreshed.Status,
+			finalizeErr,
+		)
 	}
 
 	der, err := s.fetchOrderCertificate(ctx, orderURL, refreshed)
@@ -473,20 +482,29 @@ func (s *ACMEService) refreshOrderCertificateURL(
 		return order, nil
 	}
 
-	refreshed, err := s.client.GetOrder(ctx, orderURL)
-	if err != nil {
-		return nil, fmt.Errorf("cannot refresh order: %w", err)
-	}
+	for {
+		refreshed, err := s.client.GetOrder(ctx, orderURL)
+		if err != nil {
+			return nil, fmt.Errorf("cannot refresh order: %w", err)
+		}
 
-	if refreshed.CertURL != "" {
-		return refreshed, nil
-	}
+		if refreshed.CertURL != "" {
+			return refreshed, nil
+		}
 
-	if refreshed.Status != acme.StatusValid {
-		return nil, fmt.Errorf("%w: order left valid state while waiting for certificate URL", ErrOrderNotReady)
-	}
+		if refreshed.Status != acme.StatusValid {
+			return nil, fmt.Errorf("%w: order left valid state while waiting for certificate URL", ErrOrderNotReady)
+		}
 
-	return nil, fmt.Errorf("%w: certificate URL not yet available", ErrOrderNotReady)
+		// Order is VALID but CertURL not published yet; keep polling within this
+		// tick so we fetch the certificate while we still hold the key that
+		// finalized it, rather than abandoning the order next tick.
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("%w: certificate URL not yet available: %w", ErrOrderNotReady, ctx.Err())
+		case <-time.After(certificateURLPollInterval):
+		}
+	}
 }
 
 func createCSR(domain string, key crypto.Signer) ([]byte, error) {

--- a/pkg/certmanager/acme.go
+++ b/pkg/certmanager/acme.go
@@ -182,8 +182,6 @@ func (s *ACMEService) registerAccount(ctx context.Context) error {
 	return nil
 }
 
-// StartHTTPChallenge creates an ACME order, accepts the HTTP-01 challenge, and
-// returns the persisted challenge metadata. It never waits for order completion.
 func (s *ACMEService) StartHTTPChallenge(ctx context.Context, domain string) (*HTTPChallenge, error) {
 	started := time.Now()
 
@@ -223,15 +221,6 @@ func (s *ACMEService) StartHTTPChallenge(ctx context.Context, domain string) (*H
 		return nil, fmt.Errorf("cannot get challenge response: %w", err)
 	}
 
-	challenge1 := &acme.Challenge{
-		URI:   challenge.URI,
-		Token: challenge.Token,
-	}
-
-	if _, err := s.client.Accept(ctx, challenge1); err != nil && !isChallengeAlreadyValid(err) {
-		return nil, s.handleError(provisionPhaseCreateOrder, started, "cannot accept challenge", err)
-	}
-
 	s.metrics.observeStep(provisionPhaseCreateOrder, provisionResultOK, started)
 
 	return &HTTPChallenge{
@@ -243,7 +232,23 @@ func (s *ACMEService) StartHTTPChallenge(ctx context.Context, domain string) (*H
 	}, nil
 }
 
-// PollOrder performs a single GetOrder call and classifies the result.
+func (s *ACMEService) AcceptHTTPChallenge(ctx context.Context, challenge *HTTPChallenge) error {
+	started := time.Now()
+
+	acceptChallenge := &acme.Challenge{
+		URI:   challenge.URL,
+		Token: challenge.Token,
+	}
+
+	if _, err := s.client.Accept(ctx, acceptChallenge); err != nil && !isChallengeAlreadyValid(err) {
+		return s.handleError(provisionPhaseCreateOrder, started, "cannot accept challenge", err)
+	}
+
+	s.metrics.observeStep(provisionPhaseCreateOrder, provisionResultOK, started)
+
+	return nil
+}
+
 func (s *ACMEService) PollOrder(ctx context.Context, orderURL string) (*OrderPollResult, error) {
 	started := time.Now()
 
@@ -279,7 +284,6 @@ func (s *ACMEService) PollOrder(ctx context.Context, orderURL string) (*OrderPol
 	return result, nil
 }
 
-// IssueCertificate finalizes a ready order or fetches a valid certificate.
 func (s *ACMEService) IssueCertificate(
 	ctx context.Context,
 	challenge *HTTPChallenge,

--- a/pkg/certmanager/acme_errors.go
+++ b/pkg/certmanager/acme_errors.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package certmanager
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/acme"
+)
+
+const defaultCooldown = time.Hour
+
+var (
+	ErrACMERateLimited = errors.New("acme rate limited")
+	ErrOrderNotReady   = errors.New("acme order not ready")
+	ErrOrderInvalid    = errors.New("acme order invalid")
+)
+
+type ACMEError struct {
+	op          string
+	err         error
+	problemType string
+	detail      string
+	rateLimited bool
+	retryAfter  time.Duration
+}
+
+func (e *ACMEError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	if e.err != nil {
+		return fmt.Sprintf("%s: %v", e.op, e.err)
+	}
+
+	return e.op
+}
+
+func (e *ACMEError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.err
+}
+
+func (e *ACMEError) Is(target error) bool {
+	return e != nil && e.rateLimited && target == ErrACMERateLimited
+}
+
+// RetryAfter returns how long callers should wait before retrying.
+// For rate-limited errors it prefers the ACME Retry-After value and falls back
+// to defaultCooldown when the header is absent. Non-rate-limited errors return 0.
+func (e *ACMEError) RetryAfter() time.Duration {
+	if e == nil || !e.rateLimited {
+		return 0
+	}
+
+	if e.retryAfter > 0 {
+		return e.retryAfter
+	}
+
+	return defaultCooldown
+}
+
+func (e *ACMEError) ProblemType() string {
+	if e == nil {
+		return ""
+	}
+
+	return e.problemType
+}
+
+func (e *ACMEError) Detail() string {
+	if e == nil {
+		return ""
+	}
+
+	return e.detail
+}
+
+func newACMEError(op string, err error) *ACMEError {
+	if err == nil {
+		return nil
+	}
+
+	out := &ACMEError{
+		op:  op,
+		err: err,
+	}
+
+	acmeErr, ok := errors.AsType[*acme.Error](err)
+	if !ok {
+		out.detail = err.Error()
+		return out
+	}
+
+	out.problemType = acmeErr.ProblemType
+	out.detail = acmeErr.Detail
+
+	if retryAfter, ok := acme.RateLimit(acmeErr); ok {
+		out.rateLimited = true
+		out.retryAfter = retryAfter
+	}
+
+	return out
+}

--- a/pkg/certmanager/acme_errors.go
+++ b/pkg/certmanager/acme_errors.go
@@ -151,12 +151,12 @@ func parseRetryAfter(header http.Header) (time.Duration, bool) {
 	}
 
 	// The delta-seconds form is an unsigned decimal integer (RFC 9110 §10.2.3).
-	// Parsing it as unsigned rejects negative or otherwise malformed values so
-	// they fall back to the caller's default cooldown instead of collapsing to a
-	// zero/negative duration that would disable the rate-limit cooldown. A value
+	// Parse as signed 64-bit to match time.Duration's underlying type and avoid
+	// unsigned-to-signed narrowing conversions. Negative or malformed values are
+	// treated as unparseable so callers can apply their default cooldown. A value
 	// larger than time.Duration can hold is clamped to the maximum duration.
-	if seconds, err := strconv.ParseUint(value, 10, 64); err == nil {
-		maxSeconds := uint64(math.MaxInt64 / int64(time.Second))
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds >= 0 {
+		maxSeconds := int64(math.MaxInt64 / int64(time.Second))
 		if seconds > maxSeconds {
 			return time.Duration(math.MaxInt64), true
 		}

--- a/pkg/certmanager/acme_errors.go
+++ b/pkg/certmanager/acme_errors.go
@@ -23,6 +23,8 @@ package certmanager
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"strconv"
 	"time"
 
 	"golang.org/x/crypto/acme"
@@ -37,12 +39,13 @@ var (
 )
 
 type ACMEError struct {
-	op          string
-	err         error
-	problemType string
-	detail      string
-	rateLimited bool
-	retryAfter  time.Duration
+	op            string
+	err           error
+	problemType   string
+	detail        string
+	rateLimited   bool
+	retryAfter    time.Duration
+	retryAfterSet bool
 }
 
 func (e *ACMEError) Error() string {
@@ -70,14 +73,20 @@ func (e *ACMEError) Is(target error) bool {
 }
 
 // RetryAfter returns how long callers should wait before retrying.
-// For rate-limited errors it prefers the ACME Retry-After value and falls back
-// to defaultCooldown when the header is absent. Non-rate-limited errors return 0.
+// For rate-limited errors it honors the ACME Retry-After value whenever the
+// header is present and parseable — including a zero (or past) value, which the
+// CA uses to permit an immediate retry. It falls back to defaultCooldown only
+// when the header is absent or invalid. Non-rate-limited errors return 0.
 func (e *ACMEError) RetryAfter() time.Duration {
 	if e == nil || !e.rateLimited {
 		return 0
 	}
 
-	if e.retryAfter > 0 {
+	if e.retryAfterSet {
+		if e.retryAfter < 0 {
+			return 0
+		}
+
 		return e.retryAfter
 	}
 
@@ -119,10 +128,43 @@ func newACMEError(op string, err error) *ACMEError {
 	out.problemType = acmeErr.ProblemType
 	out.detail = acmeErr.Detail
 
-	if retryAfter, ok := acme.RateLimit(acmeErr); ok {
+	if _, ok := acme.RateLimit(acmeErr); ok {
 		out.rateLimited = true
-		out.retryAfter = retryAfter
+
+		// acme.RateLimit collapses "Retry-After: 0", an invalid header, and a
+		// missing header all to a zero duration, so inspect the header directly
+		// to tell an explicit zero (immediate retry) apart from an absent one
+		// (fall back to defaultCooldown in RetryAfter).
+		if retryAfter, ok := parseRetryAfter(acmeErr.Header); ok {
+			out.retryAfter = retryAfter
+			out.retryAfterSet = true
+		}
 	}
 
 	return out
+}
+
+// parseRetryAfter reports the Retry-After delay and whether the header was
+// present and parseable. It mirrors the delta-seconds and HTTP-date forms the
+// ACME client understands. An absent or unparseable value returns ok=false so
+// callers can apply their own fallback.
+func parseRetryAfter(header http.Header) (time.Duration, bool) {
+	if header == nil {
+		return 0, false
+	}
+
+	value := header.Get("Retry-After")
+	if value == "" {
+		return 0, false
+	}
+
+	if seconds, err := strconv.Atoi(value); err == nil {
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	if date, err := http.ParseTime(value); err == nil {
+		return time.Until(date), true
+	}
+
+	return 0, false
 }

--- a/pkg/certmanager/acme_errors.go
+++ b/pkg/certmanager/acme_errors.go
@@ -23,6 +23,7 @@ package certmanager
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -72,11 +73,6 @@ func (e *ACMEError) Is(target error) bool {
 	return e != nil && e.rateLimited && target == ErrACMERateLimited
 }
 
-// RetryAfter returns how long callers should wait before retrying.
-// For rate-limited errors it honors the ACME Retry-After value whenever the
-// header is present and parseable — including a zero (or past) value, which the
-// CA uses to permit an immediate retry. It falls back to defaultCooldown only
-// when the header is absent or invalid. Non-rate-limited errors return 0.
 func (e *ACMEError) RetryAfter() time.Duration {
 	if e == nil || !e.rateLimited {
 		return 0
@@ -131,10 +127,6 @@ func newACMEError(op string, err error) *ACMEError {
 	if _, ok := acme.RateLimit(acmeErr); ok {
 		out.rateLimited = true
 
-		// acme.RateLimit collapses "Retry-After: 0", an invalid header, and a
-		// missing header all to a zero duration, so inspect the header directly
-		// to tell an explicit zero (immediate retry) apart from an absent one
-		// (fall back to defaultCooldown in RetryAfter).
 		if retryAfter, ok := parseRetryAfter(acmeErr.Header); ok {
 			out.retryAfter = retryAfter
 			out.retryAfterSet = true
@@ -158,7 +150,17 @@ func parseRetryAfter(header http.Header) (time.Duration, bool) {
 		return 0, false
 	}
 
-	if seconds, err := strconv.Atoi(value); err == nil {
+	// The delta-seconds form is an unsigned decimal integer (RFC 9110 §10.2.3).
+	// Parsing it as unsigned rejects negative or otherwise malformed values so
+	// they fall back to the caller's default cooldown instead of collapsing to a
+	// zero/negative duration that would disable the rate-limit cooldown. A value
+	// larger than time.Duration can hold is clamped to the maximum duration.
+	if seconds, err := strconv.ParseUint(value, 10, 64); err == nil {
+		maxSeconds := uint64(math.MaxInt64 / int64(time.Second))
+		if seconds > maxSeconds {
+			return time.Duration(math.MaxInt64), true
+		}
+
 		return time.Duration(seconds) * time.Second, true
 	}
 

--- a/pkg/certmanager/acme_test.go
+++ b/pkg/certmanager/acme_test.go
@@ -52,7 +52,7 @@ func TestNewMetrics_SharedRegistererDoesNotPanic(t *testing.T) {
 	assert.Same(t, first.provisionSteps, second.provisionSteps)
 	assert.Same(t, first.acmeErrors, second.acmeErrors)
 	assert.Same(t, first.stepDuration, second.stepDuration)
-	assert.Equal(t, first.acmeCooldown, second.acmeCooldown)
+	assert.Same(t, first.acmeCooldown, second.acmeCooldown)
 }
 
 func TestNewACMEError_RateLimited(t *testing.T) {

--- a/pkg/certmanager/acme_test.go
+++ b/pkg/certmanager/acme_test.go
@@ -43,6 +43,7 @@ func TestNewMetrics_SharedRegistererDoesNotPanic(t *testing.T) {
 	// A second ACMEService sharing the registerer re-registers fixed-name
 	// collectors; this must reuse the existing ones instead of panicking.
 	var second *metrics
+
 	require.NotPanics(t, func() {
 		second = newMetrics(registerer)
 	})

--- a/pkg/certmanager/acme_test.go
+++ b/pkg/certmanager/acme_test.go
@@ -26,10 +26,33 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/acme"
 )
+
+func TestNewMetrics_SharedRegistererDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	registerer := prometheus.NewRegistry()
+
+	first := newMetrics(registerer)
+	require.NotNil(t, first)
+
+	// A second ACMEService sharing the registerer re-registers fixed-name
+	// collectors; this must reuse the existing ones instead of panicking.
+	var second *metrics
+	require.NotPanics(t, func() {
+		second = newMetrics(registerer)
+	})
+	require.NotNil(t, second)
+
+	assert.Same(t, first.provisionSteps, second.provisionSteps)
+	assert.Same(t, first.acmeErrors, second.acmeErrors)
+	assert.Same(t, first.stepDuration, second.stepDuration)
+	assert.Equal(t, first.acmeCooldown, second.acmeCooldown)
+}
 
 func TestNewACMEError_RateLimited(t *testing.T) {
 	t.Parallel()
@@ -60,6 +83,41 @@ func TestNewACMEError_RateLimitedDefaultCooldown(t *testing.T) {
 
 	require.NotNil(t, err)
 	assert.ErrorIs(t, err, ErrACMERateLimited)
+	assert.Equal(t, defaultCooldown, err.RetryAfter())
+}
+
+func TestNewACMEError_RateLimitedRetryAfterZero(t *testing.T) {
+	t.Parallel()
+
+	err := newACMEError(
+		"cannot create order",
+		&acme.Error{
+			ProblemType: "urn:ietf:params:acme:error:rateLimited",
+			Header:      http.Header{"Retry-After": []string{"0"}},
+		},
+	)
+
+	require.NotNil(t, err)
+	assert.ErrorIs(t, err, ErrACMERateLimited)
+	// An explicit Retry-After: 0 permits an immediate retry and must not be
+	// promoted to the one-hour default cooldown.
+	assert.Equal(t, time.Duration(0), err.RetryAfter())
+}
+
+func TestNewACMEError_RateLimitedRetryAfterInvalid(t *testing.T) {
+	t.Parallel()
+
+	err := newACMEError(
+		"cannot create order",
+		&acme.Error{
+			ProblemType: "urn:ietf:params:acme:error:rateLimited",
+			Header:      http.Header{"Retry-After": []string{"not-a-date"}},
+		},
+	)
+
+	require.NotNil(t, err)
+	assert.ErrorIs(t, err, ErrACMERateLimited)
+	// An unparseable header falls back to the default cooldown.
 	assert.Equal(t, defaultCooldown, err.RetryAfter())
 }
 

--- a/pkg/certmanager/acme_test.go
+++ b/pkg/certmanager/acme_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package certmanager
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/acme"
+)
+
+func TestNewACMEError_RateLimited(t *testing.T) {
+	t.Parallel()
+
+	err := newACMEError(
+		"cannot create order",
+		&acme.Error{
+			ProblemType: "urn:ietf:params:acme:error:rateLimited",
+			Detail:      "too many requests",
+			Header:      http.Header{"Retry-After": []string{"120"}},
+		},
+	)
+
+	require.NotNil(t, err)
+	assert.ErrorIs(t, err, ErrACMERateLimited)
+	assert.Equal(t, 2*time.Minute, err.RetryAfter())
+	assert.Equal(t, "urn:ietf:params:acme:error:rateLimited", err.problemType)
+	assert.Equal(t, "too many requests", err.detail)
+}
+
+func TestNewACMEError_RateLimitedDefaultCooldown(t *testing.T) {
+	t.Parallel()
+
+	err := newACMEError(
+		"cannot create order",
+		&acme.Error{ProblemType: "URN:IETF:PARAMS:ACME:ERROR:RATELIMITED"},
+	)
+
+	require.NotNil(t, err)
+	assert.ErrorIs(t, err, ErrACMERateLimited)
+	assert.Equal(t, defaultCooldown, err.RetryAfter())
+}
+
+func TestNewACMEError_NonRateLimited(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("network timeout")
+	err := newACMEError("cannot get order", cause)
+
+	require.NotNil(t, err)
+	assert.False(t, errors.Is(err, ErrACMERateLimited))
+	assert.ErrorIs(t, err, cause)
+	assert.Equal(t, time.Duration(0), err.RetryAfter())
+}

--- a/pkg/certmanager/metrics.go
+++ b/pkg/certmanager/metrics.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package certmanager
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type (
+	provisionPhase  string
+	provisionResult string
+)
+
+const (
+	provisionPhaseCreateOrder provisionPhase = "create_order"
+	provisionPhasePollOrder   provisionPhase = "poll_order"
+	provisionPhaseIssueCert   provisionPhase = "issue_cert"
+	provisionPhaseDNSCheck    provisionPhase = "dns_check"
+
+	provisionResultOK          provisionResult = "ok"
+	provisionResultNotReady    provisionResult = "not_ready"
+	provisionResultError       provisionResult = "error"
+	provisionResultRateLimited provisionResult = "rate_limited"
+	provisionResultDNSError    provisionResult = "dns_error"
+)
+
+type metrics struct {
+	provisionSteps *prometheus.CounterVec
+	acmeErrors     *prometheus.CounterVec
+	acmeCooldown   prometheus.Gauge
+	stepDuration   *prometheus.HistogramVec
+}
+
+func newMetrics(registerer prometheus.Registerer) *metrics {
+	if registerer == nil {
+		registerer = prometheus.DefaultRegisterer
+	}
+
+	m := &metrics{
+		provisionSteps: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: "certmanager",
+				Name:      "certificate_provision_steps_total",
+				Help:      "Certificate provisioning steps by phase and result.",
+			},
+			[]string{"phase", "result"},
+		),
+		acmeErrors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: "certmanager",
+				Name:      "certificate_acme_errors_total",
+				Help:      "ACME errors by problem type.",
+			},
+			[]string{"problem_type"},
+		),
+		acmeCooldown: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Subsystem: "certmanager",
+				Name:      "certificate_acme_cooldown",
+				Help:      "1 while the ACME client is in a global rate-limit cooldown.",
+			},
+		),
+		stepDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Subsystem: "certmanager",
+				Name:      "certificate_provision_step_duration_seconds",
+				Help:      "Duration of certificate provisioning steps in seconds.",
+			},
+			[]string{"phase"},
+		),
+	}
+
+	registerer.MustRegister(
+		m.provisionSteps,
+		m.acmeErrors,
+		m.acmeCooldown,
+		m.stepDuration,
+	)
+
+	return m
+}
+
+func (m *metrics) observeStep(phase provisionPhase, result provisionResult, started time.Time) {
+	m.provisionSteps.WithLabelValues(string(phase), string(result)).Inc()
+	m.stepDuration.WithLabelValues(string(phase)).Observe(time.Since(started).Seconds())
+}
+
+func (m *metrics) recordACMEError(problemType string) {
+	if problemType == "" {
+		problemType = "unknown"
+	}
+
+	m.acmeErrors.WithLabelValues(problemType).Inc()
+}
+
+func (m *metrics) setCooldown(active bool) {
+	if active {
+		m.acmeCooldown.Set(1)
+		return
+	}
+
+	m.acmeCooldown.Set(0)
+}

--- a/pkg/certmanager/metrics.go
+++ b/pkg/certmanager/metrics.go
@@ -22,6 +22,7 @@ package certmanager
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -127,11 +128,49 @@ func (m *metrics) observeStep(phase provisionPhase, result provisionResult, star
 }
 
 func (m *metrics) recordACMEError(problemType string) {
-	if problemType == "" {
-		problemType = "unknown"
+	m.acmeErrors.WithLabelValues(normalizeProblemType(problemType)).Inc()
+}
+
+const acmeProblemTypePrefix = "urn:ietf:params:acme:error:"
+
+var knownACMEProblemTypes = map[string]struct{}{
+	"accountdoesnotexist":     {},
+	"alreadyrevoked":          {},
+	"badcsr":                  {},
+	"badnonce":                {},
+	"badpublickey":            {},
+	"badrevocationreason":     {},
+	"badsignaturealgorithm":   {},
+	"caa":                     {},
+	"compound":                {},
+	"connection":              {},
+	"dns":                     {},
+	"externalaccountrequired": {},
+	"incorrectresponse":       {},
+	"invalidcontact":          {},
+	"malformed":               {},
+	"ordernotready":           {},
+	"ratelimited":             {},
+	"rejectedidentifier":      {},
+	"serverinternal":          {},
+	"tls":                     {},
+	"unauthorized":            {},
+	"unsupportedcontact":      {},
+	"unsupportedidentifier":   {},
+	"useractionrequired":      {},
+}
+
+func normalizeProblemType(problemType string) string {
+	suffix, ok := strings.CutPrefix(strings.ToLower(problemType), acmeProblemTypePrefix)
+	if !ok {
+		return "unknown"
 	}
 
-	m.acmeErrors.WithLabelValues(problemType).Inc()
+	if _, ok := knownACMEProblemTypes[suffix]; !ok {
+		return "unknown"
+	}
+
+	return suffix
 }
 
 func (m *metrics) setCooldown(active bool) {

--- a/pkg/certmanager/metrics.go
+++ b/pkg/certmanager/metrics.go
@@ -21,6 +21,7 @@
 package certmanager
 
 import (
+	"errors"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -56,48 +57,68 @@ func newMetrics(registerer prometheus.Registerer) *metrics {
 		registerer = prometheus.DefaultRegisterer
 	}
 
-	m := &metrics{
-		provisionSteps: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Subsystem: "certmanager",
-				Name:      "certificate_provision_steps_total",
-				Help:      "Certificate provisioning steps by phase and result.",
-			},
-			[]string{"phase", "result"},
+	return &metrics{
+		provisionSteps: registerCollector(
+			registerer,
+			prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Subsystem: "certmanager",
+					Name:      "certificate_provision_steps_total",
+					Help:      "Certificate provisioning steps by phase and result.",
+				},
+				[]string{"phase", "result"},
+			),
 		),
-		acmeErrors: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Subsystem: "certmanager",
-				Name:      "certificate_acme_errors_total",
-				Help:      "ACME errors by problem type.",
-			},
-			[]string{"problem_type"},
+		acmeErrors: registerCollector(
+			registerer,
+			prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Subsystem: "certmanager",
+					Name:      "certificate_acme_errors_total",
+					Help:      "ACME errors by problem type.",
+				},
+				[]string{"problem_type"},
+			),
 		),
-		acmeCooldown: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Subsystem: "certmanager",
-				Name:      "certificate_acme_cooldown",
-				Help:      "1 while the ACME client is in a global rate-limit cooldown.",
-			},
+		acmeCooldown: registerCollector(
+			registerer,
+			prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Subsystem: "certmanager",
+					Name:      "certificate_acme_cooldown",
+					Help:      "1 while the ACME client is in a global rate-limit cooldown.",
+				},
+			),
 		),
-		stepDuration: prometheus.NewHistogramVec(
-			prometheus.HistogramOpts{
-				Subsystem: "certmanager",
-				Name:      "certificate_provision_step_duration_seconds",
-				Help:      "Duration of certificate provisioning steps in seconds.",
-			},
-			[]string{"phase"},
+		stepDuration: registerCollector(
+			registerer,
+			prometheus.NewHistogramVec(
+				prometheus.HistogramOpts{
+					Subsystem: "certmanager",
+					Name:      "certificate_provision_step_duration_seconds",
+					Help:      "Duration of certificate provisioning steps in seconds.",
+				},
+				[]string{"phase"},
+			),
 		),
 	}
+}
 
-	registerer.MustRegister(
-		m.provisionSteps,
-		m.acmeErrors,
-		m.acmeCooldown,
-		m.stepDuration,
-	)
+func registerCollector[T prometheus.Collector](
+	registerer prometheus.Registerer,
+	collector T,
+) T {
+	if err := registerer.Register(collector); err != nil {
+		if already, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); ok {
+			if existing, ok := already.ExistingCollector.(T); ok {
+				return existing
+			}
+		}
 
-	return m
+		panic(err)
+	}
+
+	return collector
 }
 
 func (m *metrics) observeStep(phase provisionPhase, result provisionResult, started time.Time) {

--- a/pkg/certmanager/provision_worker.go
+++ b/pkg/certmanager/provision_worker.go
@@ -43,6 +43,10 @@ const (
 	maxProvisioningRetries = 3
 	dnsExchangeTimeout     = 10 * time.Second
 	processTickTimeout     = 90 * time.Second
+	// persistFailureTimeout bounds the retry-outcome write-back. It runs on a
+	// context detached from the process tick deadline so a timed-out attempt can
+	// still record its failure.
+	persistFailureTimeout = 15 * time.Second
 
 	tracerName = "go.probo.inc/probo/pkg/certmanager"
 )
@@ -404,6 +408,15 @@ func (h *provisionHandler) persistFailure(
 ) error {
 	errorCode := classifyProvisioningError(provisionErr)
 
+	// Process runs each tick under processTickTimeout. When that deadline fires
+	// mid-attempt, the same expired context reaches here, and the write-back
+	// silently fails — so the retry budget never advances and the certificate
+	// stays retriable forever. Detach from the tick deadline (and cancellation)
+	// and bound the write with its own timeout so repeated timeouts still make
+	// progress toward FAILED.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), persistFailureTimeout)
+	defer cancel()
+
 	return h.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
@@ -731,7 +744,8 @@ func (h *provisionHandler) checkCAARecords(ctx context.Context, hostname string)
 	}
 
 	return fmt.Errorf(
-		"caa records for domain %q do not permit issuance by %q",
+		"%w: domain %q by %q",
+		ErrCAANotPermitted,
 		hostname,
 		h.caaIssuerDomain,
 	)

--- a/pkg/certmanager/provision_worker.go
+++ b/pkg/certmanager/provision_worker.go
@@ -25,23 +25,48 @@ import (
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
 	"go.gearno.de/kit/worker"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/crypto/cipher"
 	"go.probo.inc/probo/pkg/gid"
 )
 
-const maxProvisioningRetries = 3
+const (
+	// maxProvisioningRetries is the failure budget for ordinary transient ACME
+	// errors. Rate limits do not consume this budget; they use the in-process
+	// ACME cooldown instead. Claim SQL still caps the exponential backoff
+	// exponent at 5 (LEAST(ssl_retry_count, 5)), so normal retries only reach
+	// exponents 0–2 before FAILED.
+	maxProvisioningRetries = 3
+	dnsExchangeTimeout     = 10 * time.Second
+	processTickTimeout     = 90 * time.Second
 
-type provisionHandler struct {
-	pg                *pg.Client
-	acmeService       *ACMEService
-	encryptionKey     cipher.EncryptionKey
-	cnameTarget       string
-	caaIssuerDomain   string
-	resolverAddr      string
-	managedBaseDomain string
-	logger            *log.Logger
-}
+	tracerName = "go.probo.inc/probo/pkg/certmanager"
+)
+
+type (
+	provisionHandler struct {
+		pg                *pg.Client
+		acmeService       *ACMEService
+		encryptionKey     cipher.EncryptionKey
+		cnameTarget       string
+		caaIssuerDomain   string
+		resolverAddr      string
+		managedBaseDomain string
+		logger            *log.Logger
+		tracer            trace.Tracer
+	}
+
+	provisioningOutcome struct {
+		status         coredata.CertificateStatus
+		retryCount     int
+		clearACMEState bool
+		errorCode      string
+	}
+)
 
 var (
 	_ worker.Handler[coredata.Certificate] = (*provisionHandler)(nil)
@@ -68,7 +93,10 @@ func NewProvisionWorker(
 		resolverAddr:      resolverAddr,
 		managedBaseDomain: managedBaseDomain,
 		logger:            logger,
+		tracer:            otel.Tracer(tracerName),
 	}
+
+	opts = append(opts, worker.WithMaxConcurrency(1))
 
 	return worker.New(
 		"certificate-provision-worker",
@@ -79,6 +107,10 @@ func NewProvisionWorker(
 }
 
 func (h *provisionHandler) Claim(ctx context.Context) (coredata.Certificate, error) {
+	if h.acmeService.InCooldown() {
+		return coredata.Certificate{}, worker.ErrNoTask
+	}
+
 	var certificate coredata.Certificate
 
 	if err := h.pg.WithTx(
@@ -86,6 +118,13 @@ func (h *provisionHandler) Claim(ctx context.Context) (coredata.Certificate, err
 		func(ctx context.Context, tx pg.Tx) error {
 			if err := certificate.LoadNextForProvisioningForUpdateSkipLocked(ctx, tx); err != nil {
 				return err
+			}
+
+			now := time.Now()
+			certificate.SSLLastAttemptAt = &now
+
+			if err := certificate.Update(ctx, tx, coredata.NewNoScope()); err != nil {
+				return fmt.Errorf("cannot stamp certificate claim: %w", err)
 			}
 
 			return nil
@@ -102,57 +141,372 @@ func (h *provisionHandler) Claim(ctx context.Context) (coredata.Certificate, err
 }
 
 func (h *provisionHandler) Process(ctx context.Context, certificate coredata.Certificate) error {
-	challengeInitiated, err := h.runProvisionCertificate(ctx, certificate.ID)
-	if err != nil {
-		h.logger.ErrorCtx(
-			ctx,
-			"cannot provision certificate",
-			log.String("hostname", certificate.Hostname),
-			log.Error(err),
-		)
+	ctx, cancel := context.WithTimeout(ctx, processTickTimeout)
+	defer cancel()
 
-		return err
-	}
-
-	if !challengeInitiated {
+	switch certificate.Status {
+	case coredata.CertificateStatusPending, coredata.CertificateStatusRenewing:
+		return h.processBeginChallenge(ctx, certificate)
+	case coredata.CertificateStatusProvisioning:
+		return h.processPollOrder(ctx, certificate)
+	default:
 		return nil
 	}
+}
 
-	if _, err := h.runProvisionCertificate(ctx, certificate.ID); err != nil {
-		h.logger.ErrorCtx(
-			ctx,
-			"cannot complete certificate challenge",
-			log.String("hostname", certificate.Hostname),
-			log.Error(err),
-		)
+func (h *provisionHandler) processBeginChallenge(
+	ctx context.Context,
+	certificate coredata.Certificate,
+) error {
+	ctx, span := h.tracer.Start(ctx, "certmanager.create_order")
+	defer span.End()
 
+	h.setCertificateSpanAttributes(span, certificate)
+
+	skipDNSChecks, err := h.loadSkipDNSChecks(ctx, certificate.Hostname)
+	if err != nil {
+		h.recordSpanError(span, err, "")
 		return err
 	}
 
-	return nil
-}
+	if !skipDNSChecks {
+		dnsCtx, dnsSpan := h.tracer.Start(ctx, "certmanager.dns_check")
+		dnsStarted := time.Now()
 
-func (h *provisionHandler) runProvisionCertificate(
-	ctx context.Context,
-	certificateID gid.GID,
-) (bool, error) {
-	var challengeInitiated bool
+		if err := h.checkDNSConfiguration(dnsCtx, certificate.Hostname); err != nil {
+			h.acmeService.metrics.observeStep(provisionPhaseDNSCheck, provisionResultDNSError, dnsStarted)
+			h.recordSpanError(dnsSpan, err, classifyProvisioningError(err))
+			dnsSpan.End()
+			h.recordSpanError(span, err, classifyProvisioningError(err))
+			// DNS/CAA misconfig is intentionally non-terminal: retry forever so a
+			// customer DNS fix auto-recovers without marking the domain FAILED.
+			return h.persistFailure(ctx, certificate.ID, err)
+		}
 
-	err := h.pg.WithTx(
-		ctx,
-		func(ctx context.Context, tx pg.Tx) error {
-			var err error
+		if err := h.checkCAARecords(dnsCtx, certificate.Hostname); err != nil {
+			h.acmeService.metrics.observeStep(provisionPhaseDNSCheck, provisionResultDNSError, dnsStarted)
+			h.recordSpanError(dnsSpan, err, classifyProvisioningError(err))
+			dnsSpan.End()
+			h.recordSpanError(span, err, classifyProvisioningError(err))
+			// DNS/CAA misconfig is intentionally non-terminal (see above).
+			return h.persistFailure(ctx, certificate.ID, err)
+		}
 
-			challengeInitiated, err = h.provisionCertificate(ctx, tx, certificateID)
-
-			return err
-		},
-	)
-	if err != nil {
-		return false, err
+		h.acmeService.metrics.observeStep(provisionPhaseDNSCheck, provisionResultOK, dnsStarted)
+		dnsSpan.End()
 	}
 
-	return challengeInitiated, nil
+	challenge, err := h.acmeService.StartHTTPChallenge(ctx, certificate.Hostname)
+	if err != nil {
+		errorCode := classifyProvisioningError(err)
+		h.logACMEOutcome(ctx, certificate, provisionPhaseCreateOrder, err, errorCode)
+		h.recordSpanError(span, err, errorCode)
+
+		return h.persistFailure(ctx, certificate.ID, err)
+	}
+
+	return h.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			row := &coredata.Certificate{}
+			if err := row.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), certificate.ID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return nil
+				}
+
+				return fmt.Errorf("cannot load certificate %q: %w", certificate.ID, err)
+			}
+
+			if row.Status != coredata.CertificateStatusPending &&
+				row.Status != coredata.CertificateStatusRenewing {
+				return nil
+			}
+
+			row.HTTPChallengeToken = &challenge.Token
+			row.HTTPChallengeKeyAuth = &challenge.KeyAuth
+			row.HTTPChallengeURL = &challenge.URL
+			row.HTTPOrderURL = &challenge.OrderURL
+			row.Status = coredata.CertificateStatusProvisioning
+			row.ProvisioningError = nil
+
+			if err := row.Update(ctx, tx, coredata.NewNoScope()); err != nil {
+				return fmt.Errorf("cannot update certificate with challenge: %w", err)
+			}
+
+			h.logger.InfoCtx(
+				ctx,
+				"HTTP challenge accepted, waiting for order validation",
+				log.String("hostname", row.Hostname),
+				log.String("certificate_id", row.ID.String()),
+			)
+
+			return nil
+		},
+	)
+}
+
+func (h *provisionHandler) processPollOrder(
+	ctx context.Context,
+	certificate coredata.Certificate,
+) error {
+	ctx, span := h.tracer.Start(ctx, "certmanager.poll_order")
+	defer span.End()
+
+	h.setCertificateSpanAttributes(span, certificate)
+
+	if certificate.HTTPOrderURL == nil {
+		return h.persistFailure(
+			ctx,
+			certificate.ID,
+			fmt.Errorf("provisioning certificate missing order URL"),
+		)
+	}
+
+	challenge := &HTTPChallenge{
+		Domain:   certificate.Hostname,
+		Token:    stringValue(certificate.HTTPChallengeToken),
+		KeyAuth:  stringValue(certificate.HTTPChallengeKeyAuth),
+		URL:      stringValue(certificate.HTTPChallengeURL),
+		OrderURL: *certificate.HTTPOrderURL,
+	}
+
+	poll, err := h.acmeService.PollOrder(ctx, *certificate.HTTPOrderURL)
+	if err != nil {
+		errorCode := classifyProvisioningError(err)
+		h.logACMEOutcome(ctx, certificate, provisionPhasePollOrder, err, errorCode)
+		h.recordSpanError(span, err, errorCode)
+
+		return h.persistFailure(ctx, certificate.ID, err)
+	}
+
+	switch poll.Status {
+	case OrderPollStatusNotReady:
+		h.logger.InfoCtx(
+			ctx,
+			"ACME order not ready yet, will poll again",
+			log.String("hostname", certificate.Hostname),
+			log.String("certificate_id", certificate.ID.String()),
+			log.String("order_status", poll.Order.Status),
+		)
+
+		return nil
+	case OrderPollStatusInvalid:
+		err := ErrOrderInvalid
+		errorCode := classifyProvisioningError(err)
+		h.logACMEOutcome(ctx, certificate, provisionPhasePollOrder, err, errorCode)
+		h.recordSpanError(span, err, errorCode)
+
+		return h.persistFailure(ctx, certificate.ID, err)
+	case OrderPollStatusReady, OrderPollStatusValid:
+		return h.issueCertificate(ctx, certificate, challenge, poll)
+	default:
+		return nil
+	}
+}
+
+func (h *provisionHandler) issueCertificate(
+	ctx context.Context,
+	certificate coredata.Certificate,
+	challenge *HTTPChallenge,
+	poll *OrderPollResult,
+) error {
+	ctx, span := h.tracer.Start(ctx, "certmanager.issue_cert")
+	defer span.End()
+
+	h.setCertificateSpanAttributes(span, certificate)
+
+	cert, err := h.acmeService.IssueCertificate(ctx, challenge, poll)
+	if err != nil {
+		if errors.Is(err, ErrOrderNotReady) {
+			h.logger.InfoCtx(
+				ctx,
+				"ACME order not ready to issue yet, will poll again",
+				log.String("hostname", certificate.Hostname),
+				log.String("certificate_id", certificate.ID.String()),
+			)
+
+			return nil
+		}
+
+		errorCode := classifyProvisioningError(err)
+		h.logACMEOutcome(ctx, certificate, provisionPhaseIssueCert, err, errorCode)
+		h.recordSpanError(span, err, errorCode)
+
+		return h.persistFailure(ctx, certificate.ID, err)
+	}
+
+	return h.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			row := &coredata.Certificate{}
+			if err := row.LoadByIDForUpdate(ctx, tx, coredata.NewNoScope(), certificate.ID); err != nil {
+				return fmt.Errorf("cannot load certificate %q: %w", certificate.ID, err)
+			}
+
+			h.logger.InfoCtx(
+				ctx,
+				"certificate obtained successfully",
+				log.String("hostname", row.Hostname),
+				log.String("certificate_id", row.ID.String()),
+				log.Time("expires_at", cert.ExpiresAt),
+			)
+
+			row.ProvisioningError = nil
+			row.SSLCertificatePEM = cert.CertPEM
+
+			if err := row.EncryptPrivateKey(cert.KeyPEM, h.encryptionKey); err != nil {
+				return fmt.Errorf("cannot encrypt private key: %w", err)
+			}
+
+			chainStr := string(cert.ChainPEM)
+			row.SSLCertificateChain = &chainStr
+			row.SSLExpiresAt = &cert.ExpiresAt
+			row.Status = coredata.CertificateStatusActive
+			row.SSLRetryCount = 0
+			row.SSLLastAttemptAt = nil
+			row.HTTPChallengeToken = nil
+			row.HTTPChallengeKeyAuth = nil
+			row.HTTPChallengeURL = nil
+			row.HTTPOrderURL = nil
+
+			if err := row.Update(ctx, tx, coredata.NewNoScope()); err != nil {
+				return fmt.Errorf("cannot update certificate: %w", err)
+			}
+
+			cache := &coredata.CachedCertificate{
+				Domain:           row.Hostname,
+				CertificatePEM:   string(cert.CertPEM),
+				PrivateKeyPEM:    string(cert.KeyPEM),
+				CertificateChain: &chainStr,
+				ExpiresAt:        cert.ExpiresAt,
+				CachedAt:         time.Now(),
+				CertificateID:    row.ID,
+			}
+
+			if err := cache.Upsert(ctx, tx); err != nil {
+				h.logger.ErrorCtx(
+					ctx,
+					"cannot update certificate cache",
+					log.String("hostname", row.Hostname),
+					log.Error(err),
+				)
+			}
+
+			return nil
+		},
+	)
+}
+
+func (h *provisionHandler) persistFailure(
+	ctx context.Context,
+	certificateID gid.GID,
+	provisionErr error,
+) error {
+	errorCode := classifyProvisioningError(provisionErr)
+
+	return h.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			row := &coredata.Certificate{}
+			if err := row.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), certificateID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return nil
+				}
+
+				return fmt.Errorf("cannot load certificate %q: %w", certificateID, err)
+			}
+
+			outcome := decideProvisioningOutcome(row, errorCode)
+
+			row.ProvisioningError = provisioningErrorCodePtr(outcome.errorCode)
+			now := time.Now()
+			row.SSLLastAttemptAt = &now
+			row.Status = outcome.status
+			row.SSLRetryCount = outcome.retryCount
+
+			if outcome.clearACMEState {
+				row.HTTPChallengeToken = nil
+				row.HTTPChallengeKeyAuth = nil
+				row.HTTPChallengeURL = nil
+				row.HTTPOrderURL = nil
+			}
+
+			if err := row.Update(ctx, tx, coredata.NewNoScope()); err != nil {
+				return fmt.Errorf("cannot update certificate with provisioning error: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+// decideProvisioningOutcome computes status/retry/clear policy for a failed step.
+//
+// Two backoff regimes:
+//   - Normal transient errors: ssl_retry_count increments; at maxProvisioningRetries
+//     the domain becomes FAILED.
+//   - Rate limits: never increment ssl_retry_count and never mark FAILED; the
+//     in-process ACME cooldown gates Claim. When an order URL is present
+//     it is preserved so the next tick resumes polling instead of minting a new
+//     order.
+//
+// DNS/CAA misconfig is intentionally non-terminal so customer DNS fixes
+// auto-recover on the claim backoff schedule.
+func decideProvisioningOutcome(
+	certificate *coredata.Certificate,
+	errorCode string,
+) provisioningOutcome {
+	retryCount := certificate.SSLRetryCount
+	hasResumableOrder := certificate.HTTPOrderURL != nil && *certificate.HTTPOrderURL != ""
+
+	switch errorCode {
+	case ProvisioningErrorACMERateLimited:
+		status := coredata.CertificateStatusPending
+		if hasResumableOrder {
+			status = coredata.CertificateStatusProvisioning
+		}
+
+		return provisioningOutcome{
+			status:         status,
+			retryCount:     retryCount,
+			clearACMEState: false,
+			errorCode:      errorCode,
+		}
+
+	case ProvisioningErrorDNSCNAME, ProvisioningErrorDNSCAA:
+		return provisioningOutcome{
+			status:         coredata.CertificateStatusPending,
+			retryCount:     retryCount,
+			clearACMEState: true,
+			errorCode:      errorCode,
+		}
+	}
+
+	retryCount++
+	if retryCount >= maxProvisioningRetries {
+		return provisioningOutcome{
+			status:         coredata.CertificateStatusFailed,
+			retryCount:     retryCount,
+			clearACMEState: true,
+			errorCode:      ProvisioningErrorACMEFailed,
+		}
+	}
+
+	if errorCode == ProvisioningErrorACMEInvalidOrder || !hasResumableOrder {
+		return provisioningOutcome{
+			status:         coredata.CertificateStatusPending,
+			retryCount:     retryCount,
+			clearACMEState: true,
+			errorCode:      errorCode,
+		}
+	}
+
+	return provisioningOutcome{
+		status:         coredata.CertificateStatusProvisioning,
+		retryCount:     retryCount,
+		clearACMEState: false,
+		errorCode:      errorCode,
+	}
 }
 
 func (h *provisionHandler) RecoverStale(ctx context.Context) error {
@@ -186,7 +540,103 @@ func (h *provisionHandler) RecoverStale(ctx context.Context) error {
 	)
 }
 
-func (h *provisionHandler) checkDNSConfiguration(hostname string) error {
+func (h *provisionHandler) logACMEOutcome(
+	ctx context.Context,
+	certificate coredata.Certificate,
+	phase provisionPhase,
+	err error,
+	errorCode string,
+) {
+	var (
+		problemType string
+		detail      string
+	)
+	if acmeErr, ok := errors.AsType[*ACMEError](err); ok {
+		problemType = acmeErr.ProblemType()
+		detail = acmeErr.Detail()
+	}
+
+	level := h.logger.WarnCtx
+
+	if errorCode == ProvisioningErrorACMETemporary {
+		level = h.logger.ErrorCtx
+	}
+
+	level(
+		ctx,
+		"certificate provisioning step failed",
+		log.String("hostname", certificate.Hostname),
+		log.String("certificate_id", certificate.ID.String()),
+		log.String("phase", string(phase)),
+		log.String("error_code", errorCode),
+		log.String("acme_problem_type", problemType),
+		log.String("acme_detail", detail),
+		log.Int("retry_count", certificate.SSLRetryCount),
+		log.Time("cool_down_until", h.acmeService.CooldownUntil()),
+		log.Error(err),
+	)
+}
+
+func (h *provisionHandler) setCertificateSpanAttributes(span trace.Span, certificate coredata.Certificate) {
+	span.SetAttributes(
+		attribute.String("certificate.id", certificate.ID.String()),
+		attribute.String("certificate.hostname", certificate.Hostname),
+		attribute.String("certificate.status", string(certificate.Status)),
+	)
+}
+
+func (h *provisionHandler) recordSpanError(span trace.Span, err error, errorCode string) {
+	if err == nil {
+		return
+	}
+
+	var (
+		problemType string
+		detail      string
+	)
+	if acmeErr, ok := errors.AsType[*ACMEError](err); ok {
+		problemType = acmeErr.ProblemType()
+		detail = acmeErr.Detail()
+	}
+
+	span.RecordError(err)
+	span.SetStatus(codes.Error, errorCode)
+	span.SetAttributes(
+		attribute.String("provisioning.error_code", errorCode),
+		attribute.String("acme.problem_type", problemType),
+		attribute.String("acme.detail", detail),
+	)
+}
+
+func (h *provisionHandler) loadSkipDNSChecks(ctx context.Context, hostname string) (bool, error) {
+	var skip bool
+
+	err := h.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var err error
+
+			skip, err = h.skipsDNSChecks(ctx, conn, hostname)
+
+			return err
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	return skip, nil
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+
+	return *value
+}
+
+func (h *provisionHandler) checkDNSConfiguration(ctx context.Context, hostname string) error {
 	customerFQDN := hostname
 	if !strings.HasSuffix(customerFQDN, ".") {
 		customerFQDN = customerFQDN + "."
@@ -200,9 +650,12 @@ func (h *provisionHandler) checkDNSConfiguration(hostname string) error {
 	msg := &dns.Msg{MsgHeader: dns.MsgHeader{ID: dns.ID(), RecursionDesired: true}}
 	msg.Question = []dns.RR{&dns.CNAME{Hdr: dns.Header{Name: customerFQDN, Class: dns.ClassINET}}}
 
+	dnsCtx, cancel := context.WithTimeout(ctx, dnsExchangeTimeout)
+	defer cancel()
+
 	client := dns.NewClient()
 
-	resp, _, err := client.Exchange(context.Background(), msg, "udp", h.resolverAddr)
+	resp, _, err := client.Exchange(dnsCtx, msg, "udp", h.resolverAddr)
 	if err != nil {
 		return fmt.Errorf("cannot exchange dns message: %w", err)
 	}
@@ -232,7 +685,7 @@ func (h *provisionHandler) checkDNSConfiguration(hostname string) error {
 	return nil
 }
 
-func (h *provisionHandler) checkCAARecords(hostname string) error {
+func (h *provisionHandler) checkCAARecords(ctx context.Context, hostname string) error {
 	fqdn := hostname
 	if !strings.HasSuffix(fqdn, ".") {
 		fqdn = fqdn + "."
@@ -241,10 +694,13 @@ func (h *provisionHandler) checkCAARecords(hostname string) error {
 	msg := &dns.Msg{MsgHeader: dns.MsgHeader{ID: dns.ID(), RecursionDesired: true}}
 	msg.Question = []dns.RR{&dns.CAA{Hdr: dns.Header{Name: fqdn, Class: dns.ClassINET}}}
 
+	dnsCtx, cancel := context.WithTimeout(ctx, dnsExchangeTimeout)
+	defer cancel()
+
 	client := dns.NewClient()
 
 	resp, _, err := client.Exchange(
-		context.Background(),
+		dnsCtx,
 		msg,
 		"udp",
 		h.resolverAddr,
@@ -357,216 +813,4 @@ func (h *provisionHandler) resetStaleCertificate(
 	}
 
 	return nil
-}
-
-func (h *provisionHandler) provisionCertificate(
-	ctx context.Context,
-	tx pg.Tx,
-	certificateID gid.GID,
-) (bool, error) {
-	certificate := &coredata.Certificate{}
-	if err := certificate.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), certificateID); err != nil {
-		if errors.Is(err, coredata.ErrResourceNotFound) {
-			return false, nil
-		}
-
-		return false, fmt.Errorf("cannot load by id for update %q certificate: %w", certificateID, err)
-	}
-
-	if certificate.Status == coredata.CertificateStatusPending || certificate.Status == coredata.CertificateStatusRenewing {
-		skipDNSChecks, err := h.skipsDNSChecks(ctx, tx, certificate.Hostname)
-		if err != nil {
-			return false, fmt.Errorf("cannot check managed domain: %w", err)
-		}
-
-		if !skipDNSChecks {
-			if err := h.checkDNSConfiguration(certificate.Hostname); err != nil {
-				h.logger.WarnCtx(
-					ctx,
-					"dns configuration check failed",
-					log.String("hostname", certificate.Hostname),
-					log.Error(err),
-				)
-
-				errMsg := err.Error()
-
-				certificate.ProvisioningError = &errMsg
-				if err := certificate.Update(ctx, tx, coredata.NewNoScope()); err != nil {
-					return false, fmt.Errorf("cannot update certificate with provisioning error: %w", err)
-				}
-
-				return false, nil
-			}
-
-			if err := h.checkCAARecords(certificate.Hostname); err != nil {
-				h.logger.WarnCtx(
-					ctx,
-					"caa record check failed",
-					log.String("hostname", certificate.Hostname),
-					log.Error(err),
-				)
-
-				errMsg := err.Error()
-
-				certificate.ProvisioningError = &errMsg
-				if err := certificate.Update(ctx, tx, coredata.NewNoScope()); err != nil {
-					return false, fmt.Errorf("cannot update certificate with provisioning error: %w", err)
-				}
-
-				return false, nil
-			}
-		}
-
-		certificate.ProvisioningError = nil
-		if err := certificate.Update(ctx, tx, coredata.NewNoScope()); err != nil {
-			return false, fmt.Errorf("cannot clear provisioning error: %w", err)
-		}
-
-		h.logger.InfoCtx(ctx, "DNS configuration verified, initiating HTTP challenge for hostname", log.String("hostname", certificate.Hostname))
-
-		challenge, err := h.acmeService.GetHTTPChallenge(ctx, certificate.Hostname)
-		if err != nil {
-			h.logger.ErrorCtx(
-				ctx,
-				"cannot get HTTP challenge",
-				log.String("hostname", certificate.Hostname),
-				log.Error(err),
-			)
-
-			return false, err
-		}
-
-		certificate.HTTPChallengeToken = &challenge.Token
-		certificate.HTTPChallengeKeyAuth = &challenge.KeyAuth
-		certificate.HTTPChallengeURL = &challenge.URL
-		certificate.HTTPOrderURL = &challenge.OrderURL
-		certificate.Status = coredata.CertificateStatusProvisioning
-
-		if err := certificate.Update(ctx, tx, coredata.NewNoScope()); err != nil {
-			return false, fmt.Errorf("cannot update certificate with challenge: %w", err)
-		}
-
-		h.logger.InfoCtx(
-			ctx,
-			"HTTP challenge initiated, completing in same cycle",
-			log.String("hostname", certificate.Hostname),
-			log.String("token", challenge.Token),
-		)
-
-		return true, nil
-	}
-
-	if certificate.HTTPChallengeToken == nil ||
-		certificate.HTTPChallengeKeyAuth == nil ||
-		certificate.HTTPChallengeURL == nil ||
-		certificate.HTTPOrderURL == nil {
-		certificate.Status = coredata.CertificateStatusPending
-
-		if err := certificate.Update(ctx, tx, coredata.NewNoScope()); err != nil {
-			return false, fmt.Errorf("cannot reset certificate without challenge data: %w", err)
-		}
-
-		return false, nil
-	}
-
-	challenge := &HTTPChallenge{
-		Domain:   certificate.Hostname,
-		Token:    *certificate.HTTPChallengeToken,
-		KeyAuth:  *certificate.HTTPChallengeKeyAuth,
-		URL:      *certificate.HTTPChallengeURL,
-		OrderURL: *certificate.HTTPOrderURL,
-	}
-
-	cert, err := h.acmeService.CompleteHTTPChallenge(ctx, challenge)
-	if err != nil {
-		h.logger.WarnCtx(
-			ctx,
-			"cannot complete HTTP challenge",
-			log.String("hostname", certificate.Hostname),
-			log.Int("retry_count", certificate.SSLRetryCount),
-			log.Error(err),
-		)
-
-		errMsg := err.Error()
-		certificate.ProvisioningError = &errMsg
-		certificate.SSLRetryCount = certificate.SSLRetryCount + 1
-		now := time.Now()
-		certificate.SSLLastAttemptAt = &now
-
-		certificate.HTTPChallengeToken = nil
-		certificate.HTTPChallengeKeyAuth = nil
-		certificate.HTTPChallengeURL = nil
-		certificate.HTTPOrderURL = nil
-
-		if certificate.SSLRetryCount >= maxProvisioningRetries {
-			h.logger.ErrorCtx(
-				ctx,
-				"certificate has exceeded max retry attempts, marking as failed",
-				log.String("hostname", certificate.Hostname),
-				log.Int("retry_count", certificate.SSLRetryCount),
-			)
-
-			certificate.Status = coredata.CertificateStatusFailed
-		} else {
-			certificate.Status = coredata.CertificateStatusPending
-		}
-
-		if err := certificate.Update(ctx, tx, coredata.NewNoScope()); err != nil {
-			return false, fmt.Errorf("cannot update certificate: %w", err)
-		}
-
-		return false, nil
-	}
-
-	h.logger.InfoCtx(
-		ctx,
-		"certificate obtained successfully",
-		log.String("hostname", certificate.Hostname),
-		log.Time("expires_at", cert.ExpiresAt),
-	)
-
-	certificate.ProvisioningError = nil
-
-	certificate.SSLCertificatePEM = cert.CertPEM
-	if err := certificate.EncryptPrivateKey(cert.KeyPEM, h.encryptionKey); err != nil {
-		return false, fmt.Errorf("cannot encrypt private key: %w", err)
-	}
-
-	chainStr := string(cert.ChainPEM)
-	certificate.SSLCertificateChain = &chainStr
-	certificate.SSLExpiresAt = &cert.ExpiresAt
-	certificate.Status = coredata.CertificateStatusActive
-
-	certificate.SSLRetryCount = 0
-	certificate.SSLLastAttemptAt = nil
-
-	certificate.HTTPChallengeToken = nil
-	certificate.HTTPChallengeKeyAuth = nil
-	certificate.HTTPChallengeURL = nil
-	certificate.HTTPOrderURL = nil
-
-	if err := certificate.Update(ctx, tx, coredata.NewNoScope()); err != nil {
-		return false, fmt.Errorf("cannot update certificate: %w", err)
-	}
-
-	cache := &coredata.CachedCertificate{
-		Domain:           certificate.Hostname,
-		CertificatePEM:   string(cert.CertPEM),
-		PrivateKeyPEM:    string(cert.KeyPEM),
-		CertificateChain: &chainStr,
-		ExpiresAt:        cert.ExpiresAt,
-		CachedAt:         time.Now(),
-		CertificateID:    certificate.ID,
-	}
-
-	if err := cache.Upsert(ctx, tx); err != nil {
-		h.logger.ErrorCtx(
-			ctx,
-			"cannot update certificate cache",
-			log.String("hostname", certificate.Hostname),
-			log.Error(err),
-		)
-	}
-
-	return false, nil
 }

--- a/pkg/certmanager/provision_worker.go
+++ b/pkg/certmanager/provision_worker.go
@@ -43,10 +43,14 @@ const (
 	maxProvisioningRetries = 3
 	dnsExchangeTimeout     = 10 * time.Second
 	processTickTimeout     = 90 * time.Second
-	// persistFailureTimeout bounds the retry-outcome write-back. It runs on a
-	// context detached from the process tick deadline so a timed-out attempt can
-	// still record its failure.
-	persistFailureTimeout = 15 * time.Second
+	persistFailureTimeout  = 15 * time.Second
+
+	// provisioningPollLease is how long a claimed PROVISIONING row with an open
+	// order stays ineligible for re-claim after each attempt. It must exceed
+	// processTickTimeout: the claim's row lock is released before Process runs,
+	// so a lease shorter than the maximum processing window would let another
+	// worker claim and process the same row concurrently.
+	provisioningPollLease = processTickTimeout + 30*time.Second
 
 	tracerName = "go.probo.inc/probo/pkg/certmanager"
 )
@@ -120,7 +124,7 @@ func (h *provisionHandler) Claim(ctx context.Context) (coredata.Certificate, err
 	if err := h.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := certificate.LoadNextForProvisioningForUpdateSkipLocked(ctx, tx); err != nil {
+			if err := certificate.LoadNextForProvisioningForUpdateSkipLocked(ctx, tx, provisioningPollLease); err != nil {
 				return err
 			}
 
@@ -209,11 +213,57 @@ func (h *provisionHandler) processBeginChallenge(
 		return h.persistFailure(ctx, certificate.ID, err)
 	}
 
-	return h.pg.WithTx(
+	persisted, err := h.persistChallenge(ctx, certificate, challenge)
+	if err != nil {
+		h.recordSpanError(span, err, classifyProvisioningError(err))
+		return err
+	}
+
+	if !persisted {
+		return nil
+	}
+
+	// The key authorization is now committed and served by the challenge
+	// handler, so it is safe to ask the CA to begin validation. Accepting
+	// earlier risks the CA hitting the token before this instance can serve it,
+	// yielding a 404 and an invalid order.
+	if err := h.acmeService.AcceptHTTPChallenge(ctx, challenge); err != nil {
+		errorCode := classifyProvisioningError(err)
+		h.logACMEOutcome(ctx, certificate, provisionPhaseCreateOrder, err, errorCode)
+		h.recordSpanError(span, err, errorCode)
+
+		return h.persistFailure(ctx, certificate.ID, err)
+	}
+
+	h.logger.InfoCtx(
+		ctx,
+		"HTTP challenge accepted, waiting for order validation",
+		log.String("hostname", certificate.Hostname),
+		log.String("certificate_id", certificate.ID.String()),
+	)
+
+	return nil
+}
+
+// persistChallenge stores the HTTP-01 challenge metadata and flips the row to
+// PROVISIONING. It takes a blocking write-back lock so the metadata is persisted
+// once any competing transaction commits; a genuinely deleted row is the only
+// no-op. It reports whether the row was persisted (false when the row is gone or
+// has moved on to another status).
+func (h *provisionHandler) persistChallenge(
+	ctx context.Context,
+	certificate coredata.Certificate,
+	challenge *HTTPChallenge,
+) (bool, error) {
+	persisted := false
+
+	err := h.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
+			persisted = false
+
 			row := &coredata.Certificate{}
-			if err := row.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), certificate.ID); err != nil {
+			if err := row.LoadByIDForUpdate(ctx, tx, coredata.NewNoScope(), certificate.ID); err != nil {
 				if errors.Is(err, coredata.ErrResourceNotFound) {
 					return nil
 				}
@@ -237,16 +287,16 @@ func (h *provisionHandler) processBeginChallenge(
 				return fmt.Errorf("cannot update certificate with challenge: %w", err)
 			}
 
-			h.logger.InfoCtx(
-				ctx,
-				"HTTP challenge accepted, waiting for order validation",
-				log.String("hostname", row.Hostname),
-				log.String("certificate_id", row.ID.String()),
-			)
+			persisted = true
 
 			return nil
 		},
 	)
+	if err != nil {
+		return false, err
+	}
+
+	return persisted, nil
 }
 
 func (h *provisionHandler) processPollOrder(
@@ -301,11 +351,66 @@ func (h *provisionHandler) processPollOrder(
 		h.recordSpanError(span, err, errorCode)
 
 		return h.persistFailure(ctx, certificate.ID, err)
-	case OrderPollStatusReady, OrderPollStatusValid:
+	case OrderPollStatusReady:
 		return h.issueCertificate(ctx, certificate, challenge, poll)
+	case OrderPollStatusValid:
+		// A VALID order observed while polling means a previous attempt already
+		// finalized it at the CA but the certificate/private-key write never
+		// landed (crash or a failed transaction). The private key generated for
+		// that finalize is gone, so fetching the issued certificate now would
+		// pair it with a freshly generated key and break TLS loading. Abandon
+		// the unrecoverable order and start a new one.
+		return h.abandonRecoveredValidOrder(ctx, span, certificate)
 	default:
 		return nil
 	}
+}
+
+// abandonRecoveredValidOrder clears the ACME order state and returns the row to
+// PENDING so the next tick mints a fresh order (and a matching private key).
+func (h *provisionHandler) abandonRecoveredValidOrder(
+	ctx context.Context,
+	span trace.Span,
+	certificate coredata.Certificate,
+) error {
+	h.logger.WarnCtx(
+		ctx,
+		"abandoning recovered valid ACME order without a matching private key, restarting provisioning",
+		log.String("hostname", certificate.Hostname),
+		log.String("certificate_id", certificate.ID.String()),
+	)
+	span.AddEvent("abandoned recovered valid order without matching private key")
+
+	return h.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			row := &coredata.Certificate{}
+			if err := row.LoadByIDForUpdate(ctx, tx, coredata.NewNoScope(), certificate.ID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return nil
+				}
+
+				return fmt.Errorf("cannot load certificate %q: %w", certificate.ID, err)
+			}
+
+			if row.Status != coredata.CertificateStatusProvisioning {
+				return nil
+			}
+
+			row.HTTPChallengeToken = nil
+			row.HTTPChallengeKeyAuth = nil
+			row.HTTPChallengeURL = nil
+			row.HTTPOrderURL = nil
+			row.ProvisioningError = nil
+			row.Status = coredata.CertificateStatusPending
+
+			if err := row.Update(ctx, tx, coredata.NewNoScope()); err != nil {
+				return fmt.Errorf("cannot reset certificate after abandoning valid order: %w", err)
+			}
+
+			return nil
+		},
+	)
 }
 
 func (h *provisionHandler) issueCertificate(
@@ -408,12 +513,6 @@ func (h *provisionHandler) persistFailure(
 ) error {
 	errorCode := classifyProvisioningError(provisionErr)
 
-	// Process runs each tick under processTickTimeout. When that deadline fires
-	// mid-attempt, the same expired context reaches here, and the write-back
-	// silently fails — so the retry budget never advances and the certificate
-	// stays retriable forever. Detach from the tick deadline (and cancellation)
-	// and bound the write with its own timeout so repeated timeouts still make
-	// progress toward FAILED.
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), persistFailureTimeout)
 	defer cancel()
 
@@ -527,7 +626,7 @@ func (h *provisionHandler) RecoverStale(ctx context.Context) error {
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			var certificates coredata.Certificates
-			if err := certificates.ListStaleProvisioning(ctx, tx, coredata.NewNoScope()); err != nil {
+			if err := certificates.ListStaleProvisioning(ctx, tx, coredata.NewNoScope(), ProvisioningErrorACMERateLimited); err != nil {
 				return fmt.Errorf("cannot load stale provisioning certificates: %w", err)
 			}
 

--- a/pkg/certmanager/provision_worker.go
+++ b/pkg/certmanager/provision_worker.go
@@ -335,6 +335,20 @@ func (h *provisionHandler) processPollOrder(
 
 	switch poll.Status {
 	case OrderPollStatusNotReady:
+		// Re-accept best-effort: if a prior tick committed the challenge but its
+		// Accept never reached the CA, the order would otherwise stay pending
+		// forever since this path only polls. Re-accepting a pending challenge
+		// starts validation; one already processing is a no-op at the CA.
+		if err := h.acmeService.AcceptHTTPChallenge(ctx, challenge); err != nil {
+			h.logger.WarnCtx(
+				ctx,
+				"re-accepting HTTP challenge for not-ready order failed, will poll again",
+				log.String("hostname", certificate.Hostname),
+				log.String("certificate_id", certificate.ID.String()),
+				log.Error(err),
+			)
+		}
+
 		h.logger.InfoCtx(
 			ctx,
 			"ACME order not ready yet, will poll again",
@@ -531,10 +545,18 @@ func (h *provisionHandler) persistFailure(
 			outcome := decideProvisioningOutcome(row, errorCode)
 
 			row.ProvisioningError = provisioningErrorCodePtr(outcome.errorCode)
-			now := time.Now()
-			row.SSLLastAttemptAt = &now
 			row.Status = outcome.status
 			row.SSLRetryCount = outcome.retryCount
+
+			if isImmediateRetryRateLimit(provisionErr) {
+				// Retry-After: 0 permits an immediate retry; clearing the
+				// timestamp exempts the row from the claim query's backoff gates
+				// that would otherwise hold it despite the zero cooldown.
+				row.SSLLastAttemptAt = nil
+			} else {
+				now := time.Now()
+				row.SSLLastAttemptAt = &now
+			}
 
 			if outcome.clearACMEState {
 				row.HTTPChallengeToken = nil
@@ -550,6 +572,17 @@ func (h *provisionHandler) persistFailure(
 			return nil
 		},
 	)
+}
+
+// isImmediateRetryRateLimit reports whether err is an ACME rate limit with an
+// explicit Retry-After of zero, i.e. the CA permits an immediate retry.
+func isImmediateRetryRateLimit(err error) bool {
+	acmeErr, ok := errors.AsType[*ACMEError](err)
+	if !ok {
+		return false
+	}
+
+	return errors.Is(acmeErr, ErrACMERateLimited) && acmeErr.RetryAfter() == 0
 }
 
 // decideProvisioningOutcome computes status/retry/clear policy for a failed step.

--- a/pkg/certmanager/provision_worker_test.go
+++ b/pkg/certmanager/provision_worker_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package certmanager
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestClassifyProvisioningError(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, ProvisioningErrorACMERateLimited, classifyProvisioningError(ErrACMERateLimited))
+	assert.Equal(t, ProvisioningErrorACMEInvalidOrder, classifyProvisioningError(ErrOrderInvalid))
+	assert.Equal(t, ProvisioningErrorDNSCNAME, classifyProvisioningError(errors.New("cname target mismatch")))
+	assert.Equal(t, ProvisioningErrorDNSCAA, classifyProvisioningError(errors.New("caa records for domain")))
+	assert.Equal(t, ProvisioningErrorACMETemporary, classifyProvisioningError(errors.New("network timeout")))
+}
+
+func TestDecideProvisioningOutcome_RateLimitKeepsRetryCountAndOrder(t *testing.T) {
+	t.Parallel()
+
+	orderURL := "https://acme.example/order/1"
+	certificate := &coredata.Certificate{
+		Status:        coredata.CertificateStatusProvisioning,
+		SSLRetryCount: 2,
+		HTTPOrderURL:  &orderURL,
+	}
+
+	outcome := decideProvisioningOutcome(certificate, ProvisioningErrorACMERateLimited)
+
+	assert.Equal(t, coredata.CertificateStatusProvisioning, outcome.status)
+	assert.Equal(t, 2, outcome.retryCount)
+	assert.False(t, outcome.clearACMEState)
+	assert.Equal(t, ProvisioningErrorACMERateLimited, outcome.errorCode)
+}
+
+func TestDecideProvisioningOutcome_RateLimitThenTransientDoesNotFail(t *testing.T) {
+	t.Parallel()
+
+	orderURL := "https://acme.example/order/1"
+	certificate := &coredata.Certificate{
+		Status:        coredata.CertificateStatusProvisioning,
+		SSLRetryCount: 0,
+		HTTPOrderURL:  &orderURL,
+	}
+
+	rateLimited := decideProvisioningOutcome(certificate, ProvisioningErrorACMERateLimited)
+	certificate.SSLRetryCount = rateLimited.retryCount
+	certificate.Status = rateLimited.status
+
+	// Previously rate-limit floored ssl_retry_count to 5, so the next transient
+	// immediately crossed maxProvisioningRetries and marked FAILED.
+	transient := decideProvisioningOutcome(certificate, ProvisioningErrorACMETemporary)
+
+	assert.Equal(t, coredata.CertificateStatusProvisioning, transient.status)
+	assert.Equal(t, 1, transient.retryCount)
+	assert.False(t, transient.clearACMEState)
+	assert.NotEqual(t, coredata.CertificateStatusFailed, transient.status)
+}
+
+func TestDecideProvisioningOutcome_MarksFailedAfterMaxRetries(t *testing.T) {
+	t.Parallel()
+
+	certificate := &coredata.Certificate{
+		Status:        coredata.CertificateStatusProvisioning,
+		SSLRetryCount: maxProvisioningRetries - 1,
+	}
+
+	outcome := decideProvisioningOutcome(certificate, ProvisioningErrorACMEInvalidOrder)
+
+	assert.Equal(t, coredata.CertificateStatusFailed, outcome.status)
+	assert.Equal(t, maxProvisioningRetries, outcome.retryCount)
+	assert.True(t, outcome.clearACMEState)
+	assert.Equal(t, ProvisioningErrorACMEFailed, outcome.errorCode)
+}
+
+func TestDecideProvisioningOutcome_TransientPreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	orderURL := "https://acme.example/order/1"
+	certificate := &coredata.Certificate{
+		Status:        coredata.CertificateStatusProvisioning,
+		SSLRetryCount: 0,
+		HTTPOrderURL:  &orderURL,
+	}
+
+	outcome := decideProvisioningOutcome(certificate, ProvisioningErrorACMETemporary)
+
+	assert.Equal(t, coredata.CertificateStatusProvisioning, outcome.status)
+	assert.Equal(t, 1, outcome.retryCount)
+	assert.False(t, outcome.clearACMEState)
+	assert.Equal(t, ProvisioningErrorACMETemporary, outcome.errorCode)
+}
+
+func TestDecideProvisioningOutcome_InvalidOrderClearsState(t *testing.T) {
+	t.Parallel()
+
+	orderURL := "https://acme.example/order/1"
+	certificate := &coredata.Certificate{
+		Status:        coredata.CertificateStatusProvisioning,
+		SSLRetryCount: 0,
+		HTTPOrderURL:  &orderURL,
+	}
+
+	outcome := decideProvisioningOutcome(certificate, ProvisioningErrorACMEInvalidOrder)
+
+	assert.Equal(t, coredata.CertificateStatusPending, outcome.status)
+	assert.Equal(t, 1, outcome.retryCount)
+	assert.True(t, outcome.clearACMEState)
+	assert.Equal(t, ProvisioningErrorACMEInvalidOrder, outcome.errorCode)
+}
+
+func TestDecideProvisioningOutcome_DNSIsNonTerminal(t *testing.T) {
+	t.Parallel()
+
+	certificate := &coredata.Certificate{
+		Status:        coredata.CertificateStatusPending,
+		SSLRetryCount: 0,
+	}
+
+	outcome := decideProvisioningOutcome(certificate, ProvisioningErrorDNSCNAME)
+
+	assert.Equal(t, coredata.CertificateStatusPending, outcome.status)
+	assert.Equal(t, 0, outcome.retryCount)
+	assert.True(t, outcome.clearACMEState)
+	assert.Equal(t, ProvisioningErrorDNSCNAME, outcome.errorCode)
+}
+
+func TestDecideProvisioningOutcome_RateLimitWithoutOrderStaysPending(t *testing.T) {
+	t.Parallel()
+
+	certificate := &coredata.Certificate{
+		Status:        coredata.CertificateStatusPending,
+		SSLRetryCount: 1,
+	}
+
+	outcome := decideProvisioningOutcome(certificate, ProvisioningErrorACMERateLimited)
+
+	require.Equal(t, coredata.CertificateStatusPending, outcome.status)
+	assert.Equal(t, 1, outcome.retryCount)
+	assert.False(t, outcome.clearACMEState)
+}

--- a/pkg/certmanager/provision_worker_test.go
+++ b/pkg/certmanager/provision_worker_test.go
@@ -22,6 +22,7 @@ package certmanager
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,8 +36,11 @@ func TestClassifyProvisioningError(t *testing.T) {
 	assert.Equal(t, ProvisioningErrorACMERateLimited, classifyProvisioningError(ErrACMERateLimited))
 	assert.Equal(t, ProvisioningErrorACMEInvalidOrder, classifyProvisioningError(ErrOrderInvalid))
 	assert.Equal(t, ProvisioningErrorDNSCNAME, classifyProvisioningError(errors.New("cname target mismatch")))
-	assert.Equal(t, ProvisioningErrorDNSCAA, classifyProvisioningError(errors.New("caa records for domain")))
+	assert.Equal(t, ProvisioningErrorDNSCAA, classifyProvisioningError(fmt.Errorf("%w: domain %q", ErrCAANotPermitted, "example.com")))
 	assert.Equal(t, ProvisioningErrorACMETemporary, classifyProvisioningError(errors.New("network timeout")))
+	// A CAA resolver/transport failure shares the "caa records" wording with a
+	// real CAA misconfiguration but must consume the normal retry budget.
+	assert.Equal(t, ProvisioningErrorACMETemporary, classifyProvisioningError(errors.New("cannot exchange dns message for caa records: i/o timeout")))
 }
 
 func TestDecideProvisioningOutcome_RateLimitKeepsRetryCountAndOrder(t *testing.T) {

--- a/pkg/certmanager/provisioning_error.go
+++ b/pkg/certmanager/provisioning_error.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package certmanager
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	ProvisioningErrorDNSCNAME         = "DNS_CNAME"
+	ProvisioningErrorDNSCAA           = "DNS_CAA"
+	ProvisioningErrorACMERateLimited  = "ACME_RATE_LIMITED"
+	ProvisioningErrorACMEInvalidOrder = "ACME_INVALID_ORDER"
+	ProvisioningErrorACMETemporary    = "ACME_TEMPORARY"
+	ProvisioningErrorACMEFailed       = "ACME_FAILED"
+)
+
+func classifyProvisioningError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	if errors.Is(err, ErrACMERateLimited) {
+		return ProvisioningErrorACMERateLimited
+	}
+
+	if errors.Is(err, ErrOrderInvalid) {
+		return ProvisioningErrorACMEInvalidOrder
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "cname"):
+		return ProvisioningErrorDNSCNAME
+	case strings.Contains(msg, "caa record"):
+		return ProvisioningErrorDNSCAA
+	case strings.Contains(msg, "status: invalid"), strings.Contains(msg, "order is in unexpected status \"invalid\""):
+		return ProvisioningErrorACMEInvalidOrder
+	default:
+		return ProvisioningErrorACMETemporary
+	}
+}
+
+func provisioningErrorCodePtr(code string) *string {
+	if code == "" {
+		return nil
+	}
+
+	return &code
+}

--- a/pkg/certmanager/provisioning_error.go
+++ b/pkg/certmanager/provisioning_error.go
@@ -34,6 +34,13 @@ const (
 	ProvisioningErrorACMEFailed       = "ACME_FAILED"
 )
 
+// ErrCAANotPermitted marks a CAA policy that actively forbids issuance by our
+// CA. This is a customer-side misconfiguration and is intentionally
+// non-terminal. It must stay distinct from a CAA resolver/transport failure,
+// which shares the "caa records" wording but is a transient error that has to
+// consume the normal retry budget instead of retrying forever.
+var ErrCAANotPermitted = errors.New("caa records do not permit issuance")
+
 func classifyProvisioningError(err error) string {
 	if err == nil {
 		return ""
@@ -47,12 +54,14 @@ func classifyProvisioningError(err error) string {
 		return ProvisioningErrorACMEInvalidOrder
 	}
 
+	if errors.Is(err, ErrCAANotPermitted) {
+		return ProvisioningErrorDNSCAA
+	}
+
 	msg := strings.ToLower(err.Error())
 	switch {
 	case strings.Contains(msg, "cname"):
 		return ProvisioningErrorDNSCNAME
-	case strings.Contains(msg, "caa record"):
-		return ProvisioningErrorDNSCAA
 	case strings.Contains(msg, "status: invalid"), strings.Contains(msg, "order is in unexpected status \"invalid\""):
 		return ProvisioningErrorACMEInvalidOrder
 	default:

--- a/pkg/certmanager/service.go
+++ b/pkg/certmanager/service.go
@@ -141,42 +141,6 @@ func (s *Service) EnsureCertificate(
 	return certificate, nil
 }
 
-// UpdateHostname renames a certificate and resets its lifecycle so a fresh
-// certificate is provisioned for the new hostname. It returns the certificate
-// unchanged when the hostname already matches.
-func (s *Service) UpdateHostname(
-	ctx context.Context,
-	tx pg.Tx,
-	scope coredata.Scoper,
-	certificateID gid.GID,
-	newHostname string,
-) (*coredata.Certificate, error) {
-	certificate := &coredata.Certificate{}
-	if err := certificate.LoadByID(ctx, tx, scope, certificateID); err != nil {
-		return nil, fmt.Errorf("cannot load certificate: %w", err)
-	}
-
-	if certificate.Hostname == newHostname {
-		return certificate, nil
-	}
-
-	certificate.Hostname = newHostname
-	certificate.Status = coredata.CertificateStatusPending
-	certificate.SSLRetryCount = 0
-	certificate.SSLLastAttemptAt = nil
-	certificate.ProvisioningError = nil
-	certificate.HTTPChallengeToken = nil
-	certificate.HTTPChallengeKeyAuth = nil
-	certificate.HTTPChallengeURL = nil
-	certificate.HTTPOrderURL = nil
-
-	if err := certificate.Update(ctx, tx, scope); err != nil {
-		return nil, fmt.Errorf("cannot update certificate: %w", err)
-	}
-
-	return certificate, nil
-}
-
 // Get returns a certificate by ID.
 func (s *Service) Get(
 	ctx context.Context,

--- a/pkg/coredata/certificate.go
+++ b/pkg/coredata/certificate.go
@@ -220,7 +220,7 @@ FOR UPDATE SKIP LOCKED
 
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
-	args := pgx.NamedArgs{"id": certificateID}
+	args := pgx.StrictNamedArgs{"id": certificateID}
 	maps.Copy(args, scope.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)
@@ -280,7 +280,7 @@ FOR UPDATE
 
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
-	args := pgx.NamedArgs{"id": certificateID}
+	args := pgx.StrictNamedArgs{"id": certificateID}
 	maps.Copy(args, scope.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)

--- a/pkg/coredata/certificate.go
+++ b/pkg/coredata/certificate.go
@@ -242,6 +242,66 @@ FOR UPDATE SKIP LOCKED
 	return nil
 }
 
+// LoadByIDForUpdate locks the row with a blocking FOR UPDATE. Prefer this for
+// write-backs that must not be dropped (e.g. persisting a freshly issued cert).
+// Use LoadByIDForUpdateSkipLocked when skipping a locked row is acceptable.
+func (c *Certificate) LoadByIDForUpdate(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	certificateID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	hostname,
+	http_challenge_token,
+	http_challenge_key_auth,
+	http_challenge_url,
+	http_order_url,
+	ssl_certificate,
+	encrypted_ssl_private_key,
+	ssl_certificate_chain,
+	status,
+	ssl_expires_at,
+	ssl_retry_count,
+	ssl_last_attempt_at,
+	provisioning_error,
+	created_at,
+	updated_at
+FROM
+	certificates
+WHERE
+	%s
+	AND id = @id
+LIMIT 1
+FOR UPDATE
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.NamedArgs{"id": certificateID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query certificate for update: %w", err)
+	}
+
+	certificate, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[Certificate])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect certificate: %w", err)
+	}
+
+	*c = certificate
+
+	return nil
+}
+
 func (c *Certificate) LoadByHostname(
 	ctx context.Context,
 	conn pg.Querier,
@@ -772,7 +832,7 @@ FROM
 WHERE
 	%s
 	AND (
-		(status IN (@provisioning_status, @renewing_status) AND updated_at < CURRENT_TIMESTAMP - INTERVAL '4 hours')
+		(status IN (@provisioning_status, @renewing_status) AND updated_at < CURRENT_TIMESTAMP - INTERVAL '10 minutes')
 		OR
 		(ssl_retry_count > 0 AND ssl_last_attempt_at < CURRENT_TIMESTAMP - INTERVAL '24 hours')
 	)
@@ -809,6 +869,11 @@ func (c *Certificate) LoadNextForProvisioningForUpdateSkipLocked(
 	ctx context.Context,
 	tx pg.Tx,
 ) error {
+	// PROVISIONING rows with an open order poll every ~30s. Pending/Renewing
+	// rows (and provisioning rows without an order) use exponential backoff
+	// from ssl_last_attempt_at: 15m * 2^min(retry,5). Ordinary failures only
+	// reach retry counts 0–2 before FAILED; higher exponents are unused by the
+	// current failure budget but keep the SQL ceiling defensive.
 	q := `
 SELECT
 	id,
@@ -831,6 +896,23 @@ FROM
 	certificates
 WHERE
 	status = ANY(@statuses)
+	AND (
+		ssl_last_attempt_at IS NULL
+		OR (
+			status = @provisioning_status
+			AND http_order_url IS NOT NULL
+			AND ssl_last_attempt_at < CURRENT_TIMESTAMP - INTERVAL '30 seconds'
+		)
+		OR (
+			NOT (
+				status = @provisioning_status
+				AND http_order_url IS NOT NULL
+			)
+			AND ssl_last_attempt_at < CURRENT_TIMESTAMP - (
+				INTERVAL '15 minutes' * (POWER(2, LEAST(ssl_retry_count, 5))::int)
+			)
+		)
+	)
 ORDER BY
 	updated_at ASC
 LIMIT 1
@@ -846,6 +928,7 @@ FOR UPDATE SKIP LOCKED
 				string(CertificateStatusProvisioning),
 				string(CertificateStatusRenewing),
 			},
+			"provisioning_status": string(CertificateStatusProvisioning),
 		},
 	)
 	if err != nil {

--- a/pkg/coredata/certificate.go
+++ b/pkg/coredata/certificate.go
@@ -808,7 +808,14 @@ func (certificates *Certificates) ListStaleProvisioning(
 	ctx context.Context,
 	conn pg.Querier,
 	scope Scoper,
+	rateLimitedErrorCode string,
 ) error {
+	// Rate-limited rows are intentionally left in PROVISIONING with their order
+	// URL preserved so the next attempt resumes the same order once the ACME
+	// cooldown (up to an hour) elapses. Resetting them at the 10-minute stale
+	// threshold would discard that resumable order and mint a new one straight
+	// into the same rate limit, so exclude them from that branch. They are still
+	// recoverable via the 24-hour safety net if they get truly stuck.
 	q := `
 SELECT
 	id,
@@ -832,7 +839,11 @@ FROM
 WHERE
 	%s
 	AND (
-		(status IN (@provisioning_status, @renewing_status) AND updated_at < CURRENT_TIMESTAMP - INTERVAL '10 minutes')
+		(
+			status IN (@provisioning_status, @renewing_status)
+			AND updated_at < CURRENT_TIMESTAMP - INTERVAL '10 minutes'
+			AND (provisioning_error IS NULL OR provisioning_error != @rate_limited_error_code)
+		)
 		OR
 		(ssl_retry_count > 0 AND ssl_last_attempt_at < CURRENT_TIMESTAMP - INTERVAL '24 hours')
 	)
@@ -843,10 +854,11 @@ WHERE
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
 	args := pgx.NamedArgs{
-		"provisioning_status": string(CertificateStatusProvisioning),
-		"renewing_status":     string(CertificateStatusRenewing),
-		"failed_status":       string(CertificateStatusFailed),
-		"active_status":       string(CertificateStatusActive),
+		"provisioning_status":     string(CertificateStatusProvisioning),
+		"renewing_status":         string(CertificateStatusRenewing),
+		"failed_status":           string(CertificateStatusFailed),
+		"active_status":           string(CertificateStatusActive),
+		"rate_limited_error_code": rateLimitedErrorCode,
 	}
 	maps.Copy(args, scope.SQLArguments())
 
@@ -868,12 +880,17 @@ WHERE
 func (c *Certificate) LoadNextForProvisioningForUpdateSkipLocked(
 	ctx context.Context,
 	tx pg.Tx,
+	pollLease time.Duration,
 ) error {
-	// PROVISIONING rows with an open order poll every ~30s. Pending/Renewing
-	// rows (and provisioning rows without an order) use exponential backoff
-	// from ssl_last_attempt_at: 15m * 2^min(retry,5). Ordinary failures only
-	// reach retry counts 0–2 before FAILED; higher exponents are unused by the
-	// current failure budget but keep the SQL ceiling defensive.
+	// PROVISIONING rows with an open order become eligible again only after
+	// pollLease elapses since the last attempt. The caller sizes pollLease to
+	// exceed the maximum Process window: the claim's FOR UPDATE lock is released
+	// before Process runs, so a shorter interval would let another worker claim
+	// the same row while its poll/issue is still in flight. Pending/Renewing
+	// rows (and provisioning rows without an order) use exponential backoff from
+	// ssl_last_attempt_at: 15m * 2^min(retry,5). Ordinary failures only reach
+	// retry counts 0–2 before FAILED; higher exponents are unused by the current
+	// failure budget but keep the SQL ceiling defensive.
 	q := `
 SELECT
 	id,
@@ -901,7 +918,7 @@ WHERE
 		OR (
 			status = @provisioning_status
 			AND http_order_url IS NOT NULL
-			AND ssl_last_attempt_at < CURRENT_TIMESTAMP - INTERVAL '30 seconds'
+			AND ssl_last_attempt_at < CURRENT_TIMESTAMP - make_interval(secs => @poll_lease_seconds)
 		)
 		OR (
 			NOT (
@@ -929,6 +946,7 @@ FOR UPDATE SKIP LOCKED
 				string(CertificateStatusRenewing),
 			},
 			"provisioning_status": string(CertificateStatusProvisioning),
+			"poll_lease_seconds":  pollLease.Seconds(),
 		},
 	)
 	if err != nil {

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -524,6 +524,7 @@ func (impl *Implm) Run(
 		accountKey,
 		rootCAs,
 		l,
+		r,
 	)
 	if err != nil {
 		return fmt.Errorf("cannot initialize ACME service: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Strengthened certificate provisioning with a begin → poll → issue flow, a global ACME cooldown, and safer write-backs so transient errors and rate limits don’t mark domains FAILED. Centralized failure outcomes, honored Retry‑After: 0, added robust metrics/tracing, and clearer user messages in the console.

### Tests **`+304`** **`-0`**
- Covered Retry‑After parsing (incl. 0), Prometheus collector reuse, ACME error typing, and outcome/backoff decisions (rate limits preserve retries; DNS/CAA vs transient).

### Coredata **`+107`** **`-6`**
- Added LoadByIDForUpdate (blocking writes) and switched to `pgx.StrictNamedArgs`.
- Claim/backoff: poll‑lease gating for PROVISIONING orders; exponential backoff for others; 10‑minute stale reset skips `ACME_RATE_LIMITED`.

### Service **`+1256`** **`-328`**
- ACME: split StartHTTPChallenge/AcceptHTTPChallenge, PollOrder, IssueCertificate; direct Retry‑After parse (0 = immediate) with cooldown; normalized Prometheus problem_type; shared‑registerer collector reuse.
- Worker: single concurrency; 90s per‑tick timeout; persist failures on a detached context; stamp `ssl_last_attempt_at` on Claim; persist challenge under blocking FOR UPDATE before accepting; block on FOR UPDATE for issued cert write‑back; abandon recovered VALID orders; DNS and CAA checks with timeouts (distinguish CAA policy denial vs resolver errors); centralized failure outcomes and resumable orders.
- Metrics/tracing: counters/histograms and cooldown gauge; OpenTelemetry spans with stable error codes.

### App: console **`+14`** **`-6`**
- Show localized provisioning messages in the domain card and dialog via `getCertificateProvisioningErrorMessage`.

### Package: helpers **`+32`** **`-0`**
- Added and exported `getCertificateProvisioningErrorMessage` via `@probo/helpers`.

<sup>Written for commit 9f6a0c1d406c5f61879b77b5a4d5d51a18be71c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

