### PR TITLE
Fix n8n Organization queries for moved compliance portal fields

### DIFF
--- a/packages/n8n-node/CHANGELOG.md
+++ b/packages/n8n-node/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the `@probo/n8n-nodes-probo` package will be documented i
 
 ## Unreleased
 
+### Fixed
+
+- Organization Get/Get Many/Create no longer query removed Connect `Organization` profile fields (`description`, `websiteUrl`, `email`, `headquarterAddress`), which broke Organization Get Many. Use Compliance Portal Get/Update for those fields instead
+- Compliance Portal Get now returns `entityName`, `description`, `websiteUrl`, `email`, and `headquarterAddress`, matching Compliance Portal Update, and selects `logo`/`darkLogo`/`nda` as File objects instead of removed URL scalars
+
 ## [0.206.0] - 2026-07-22
 
 ### Changed

--- a/packages/n8n-node/nodes/Probo/actions/compliancePortal/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/compliancePortal/get.operation.ts
@@ -52,10 +52,26 @@ export async function execute(
 						id
 						active
 						searchEngineIndexing
-						logoFileUrl
-						darkLogoFileUrl
-						ndaFileName
-						ndaFileUrl
+						entityName
+						description
+						websiteUrl
+						email
+						headquarterAddress
+						logo {
+							id
+							fileName
+							downloadUrl
+						}
+						darkLogo {
+							id
+							fileName
+							downloadUrl
+						}
+						nda {
+							id
+							fileName
+							downloadUrl
+						}
 						createdAt
 						updatedAt
 					}

--- a/packages/n8n-node/nodes/Probo/actions/organization/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/organization/create.operation.ts
@@ -50,10 +50,6 @@ export async function execute(
 				organization {
 					id
 					name
-					description
-					websiteUrl
-					email
-					headquarterAddress
 					logo {
 						id
 						fileName
@@ -71,17 +67,14 @@ export async function execute(
 		}
 	`;
 
-	const variables = {
+	const responseData = await proboConnectApiRequest.call(this, query, {
 		input: {
 			name,
 		},
-	};
-
-	const responseData = await proboConnectApiRequest.call(this, query, variables);
+	});
 
 	return {
 		json: responseData,
 		pairedItem: { item: itemIndex },
 	};
 }
-

--- a/packages/n8n-node/nodes/Probo/actions/organization/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/organization/get.operation.ts
@@ -50,10 +50,6 @@ export async function execute(
 				... on Organization {
 					id
 					name
-					description
-					websiteUrl
-					email
-					headquarterAddress
 					logo {
 						id
 						fileName
@@ -71,15 +67,12 @@ export async function execute(
 		}
 	`;
 
-	const variables = {
+	const responseData = await proboConnectApiRequest.call(this, query, {
 		organizationId,
-	};
-
-	const responseData = await proboConnectApiRequest.call(this, query, variables);
+	});
 
 	return {
 		json: responseData,
 		pairedItem: { item: itemIndex },
 	};
 }
-

--- a/packages/n8n-node/nodes/Probo/actions/organization/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/organization/getAll.operation.ts
@@ -70,10 +70,6 @@ export async function execute(
 							organization {
 								id
 								name
-								description
-								websiteUrl
-								email
-								headquarterAddress
 								logo {
 									id
 									fileName
@@ -125,4 +121,3 @@ export async function execute(
 		pairedItem: { item: itemIndex },
 	};
 }
-


### PR DESCRIPTION
Drop removed Connect Organization profile fields that break Get Many, and return those fields from Compliance Portal Get.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken Organization queries in updated regions by removing deprecated Connect `Organization` profile fields. Moves those fields to Compliance Portal Get and returns file objects instead of URL scalars.

### Package: n8n-node **`+29`** **`-27`**
- Compliance Portal Get: returns `entityName`, `description`, `websiteUrl`, `email`, `headquarterAddress`; `logo`/`darkLogo`/`nda` as File objects (`id`, `fileName`, `downloadUrl`).
- Organization Create/Get/Get Many: stop querying removed fields to prevent Get Many failures; inline variables in API calls.
- Updated `@probo/n8n-nodes-probo` changelog.

<sup>Written for commit 6313278c0df1b315690c75070c200b3f802818a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



