### PR TITLE
Fix n8n Get User organization selection

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/user/getUser.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/user/getUser.operation.ts
@@ -61,7 +61,7 @@ export async function execute(
 					createdAt
 					updatedAt
 					identity { id email fullName emailVerified }
-					organization { id name email }
+					organization { id name }
 					membership { id role createdAt }
 				}
 			}


### PR DESCRIPTION
Connect Organization has no email field. Requesting it made the Get User GraphQL query fail; align with list/create/update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the n8n Get User action by removing the nonexistent `organization.email` field from the GraphQL selection to prevent query failures and align with list/create/update.

### Package: `n8n-node` **`+1`** **`-1`**
- Updated `getUser.operation.ts` to request `organization { id name }` instead of `organization { id name email }`.

<sup>Written for commit a9e3044b478b792f6186b4e89cd6c8500a48488c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

