### PR TITLE
Rename My Signatures menu label to Employee Portal

### DIFF
--- a/apps/console/src/pages/iam/organizations/_components/ViewerMembershipDropdown.tsx
+++ b/apps/console/src/pages/iam/organizations/_components/ViewerMembershipDropdown.tsx
@@ -122,7 +122,7 @@ export function ViewerMembershipDropdown(props: {
       <UserDropdownItem
         to={`/organizations/${organizationId}/employee`}
         icon={IconPageTextLine}
-        label={__("My Signatures")}
+        label={__("Employee Portal")}
       />
       <UserDropdownItem
         to="mailto:support@probo.com"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the My Signatures menu label to Employee Portal in the console user dropdown. Clarifies the destination without changing navigation.

### App: console **`+1`** **`-1`**
- Updated `ViewerMembershipDropdown` to label the `UserDropdownItem` as “Employee Portal”.
- Kept the route `/organizations/:organizationId/employee` unchanged.

<sup>Written for commit 501c26c19a866b189855214fc80d5fe1a1f5e151. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

