### PR TITLE
Link the 19 API-key access-review connector docs

### DIFF
--- a/pkg/connector/provider/better_stack.go
+++ b/pkg/connector/provider/better_stack.go
@@ -38,10 +38,11 @@ import (
 // name that scopes the team-members listing.
 func betterStackRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderBetterStack,
-		DisplayName:    "Better Stack",
-		SupportsAPIKey: true,
-		ProbeURL:       "https://betterstack.com/api/v2/team-members",
+		Provider:         coredata.ConnectorProviderBetterStack,
+		DisplayName:      "Better Stack",
+		DocumentationURL: accessReviewDocsURL("better-stack"),
+		SupportsAPIKey:   true,
+		ProbeURL:         "https://betterstack.com/api/v2/team-members",
 		APIKeyExtraSettings: []ExtraSetting{
 			{Key: "teamName", Label: "Team Name", Required: true},
 		},

--- a/pkg/connector/provider/brevo.go
+++ b/pkg/connector/provider/brevo.go
@@ -31,9 +31,10 @@ import (
 
 func brevoRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderBrevo,
-		DisplayName:    "Brevo",
-		SupportsAPIKey: true,
+		Provider:         coredata.ConnectorProviderBrevo,
+		DisplayName:      "Brevo",
+		DocumentationURL: accessReviewDocsURL("brevo"),
+		SupportsAPIKey:   true,
 		// Brevo authenticates with an API key sent in the api-key header
 		// rather than Authorization: Bearer. APIKeyHeader makes the
 		// APIKeyConnection send api-key instead and omit Authorization. There

--- a/pkg/connector/provider/clickhouse.go
+++ b/pkg/connector/provider/clickhouse.go
@@ -31,9 +31,10 @@ import (
 
 func clickhouseRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderClickHouse,
-		DisplayName:    "ClickHouse Cloud",
-		SupportsAPIKey: true,
+		Provider:         coredata.ConnectorProviderClickHouse,
+		DisplayName:      "ClickHouse Cloud",
+		DocumentationURL: accessReviewDocsURL("clickhouse"),
+		SupportsAPIKey:   true,
 		// ClickHouse Cloud's control-plane API authenticates with HTTP Basic
 		// auth where the credential is keyId:keySecret. APIKeyBasicAuthUserPass
 		// makes the APIKeyConnection base64 the verbatim "keyId:keySecret"

--- a/pkg/connector/provider/grafana.go
+++ b/pkg/connector/provider/grafana.go
@@ -34,10 +34,11 @@ import (
 
 func grafanaRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderGrafana,
-		DisplayName:    "Grafana",
-		SupportsAPIKey: true,
-		BuildProbeURL:  buildGrafanaProbeURL,
+		Provider:         coredata.ConnectorProviderGrafana,
+		DisplayName:      "Grafana",
+		DocumentationURL: accessReviewDocsURL("grafana"),
+		SupportsAPIKey:   true,
+		BuildProbeURL:    buildGrafanaProbeURL,
 		APIKeyExtraSettings: []ExtraSetting{
 			{Key: "baseUrl", Label: "Base URL", Required: true},
 		},

--- a/pkg/connector/provider/incidentio.go
+++ b/pkg/connector/provider/incidentio.go
@@ -31,9 +31,10 @@ import (
 
 func incidentioRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderIncidentIO,
-		DisplayName:    "incident.io",
-		SupportsAPIKey: true,
+		Provider:         coredata.ConnectorProviderIncidentIO,
+		DisplayName:      "incident.io",
+		DocumentationURL: accessReviewDocsURL("incident-io"),
+		SupportsAPIKey:   true,
 		// incident.io publishes an OAuth2 flow, but it is outbound-only (for
 		// incident.io to call other apps), so access review authenticates
 		// with an API key presented as Authorization: Bearer, the default

--- a/pkg/connector/provider/langfuse.go
+++ b/pkg/connector/provider/langfuse.go
@@ -34,9 +34,10 @@ import (
 
 func langfuseRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderLangfuse,
-		DisplayName:    "Langfuse",
-		SupportsAPIKey: true,
+		Provider:         coredata.ConnectorProviderLangfuse,
+		DisplayName:      "Langfuse",
+		DocumentationURL: accessReviewDocsURL("langfuse"),
+		SupportsAPIKey:   true,
 		// Langfuse's organization-scoped public API authenticates with HTTP
 		// Basic auth where the credential is publicKey:secretKey.
 		// APIKeyBasicAuthUserPass base64s the verbatim "publicKey:secretKey" the

--- a/pkg/connector/provider/mercury.go
+++ b/pkg/connector/provider/mercury.go
@@ -31,9 +31,10 @@ import (
 
 func mercuryRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderMercury,
-		DisplayName:    "Mercury",
-		SupportsAPIKey: true,
+		Provider:         coredata.ConnectorProviderMercury,
+		DisplayName:      "Mercury",
+		DocumentationURL: accessReviewDocsURL("mercury"),
+		SupportsAPIKey:   true,
 		// Mercury authenticates with a self-serve API token presented as
 		// Authorization: Bearer, the default APIKeyConnection scheme. There
 		// is no third-party OAuth2 flow for the Users API. The token is

--- a/pkg/connector/provider/metabase.go
+++ b/pkg/connector/provider/metabase.go
@@ -34,11 +34,12 @@ import (
 
 func metabaseRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderMetabase,
-		DisplayName:    "Metabase",
-		SupportsAPIKey: true,
-		APIKeyHeader:   "x-api-key",
-		BuildProbeURL:  buildMetabaseProbeURL,
+		Provider:         coredata.ConnectorProviderMetabase,
+		DisplayName:      "Metabase",
+		DocumentationURL: accessReviewDocsURL("metabase"),
+		SupportsAPIKey:   true,
+		APIKeyHeader:     "x-api-key",
+		BuildProbeURL:    buildMetabaseProbeURL,
 		APIKeyExtraSettings: []ExtraSetting{
 			{Key: "instanceUrl", Label: "Instance URL", Required: true},
 		},

--- a/pkg/connector/provider/neon.go
+++ b/pkg/connector/provider/neon.go
@@ -32,8 +32,9 @@ import (
 
 func neonRegistration() *Registration {
 	return &Registration{
-		Provider:    coredata.ConnectorProviderNeon,
-		DisplayName: "Neon",
+		Provider:         coredata.ConnectorProviderNeon,
+		DisplayName:      "Neon",
+		DocumentationURL: accessReviewDocsURL("neon"),
 		// Neon's API authenticates with an API key (napi_...) presented
 		// as Authorization: Bearer, the default APIKeyConnection scheme.
 		// Neon's OAuth is partner-gated (manual application), so the

--- a/pkg/connector/provider/okta.go
+++ b/pkg/connector/provider/okta.go
@@ -41,6 +41,7 @@ func oktaRegistration() *Registration {
 	return &Registration{
 		Provider:         coredata.ConnectorProviderOkta,
 		DisplayName:      "Okta",
+		DocumentationURL: accessReviewDocsURL("okta"),
 		SupportsAPIKey:   true,
 		APIKeyAuthScheme: "SSWS",
 		BuildProbeURL:    buildOktaProbeURL,

--- a/pkg/connector/provider/one_password.go
+++ b/pkg/connector/provider/one_password.go
@@ -35,6 +35,7 @@ func onePasswordRegistration() *Registration {
 	return &Registration{
 		Provider:                  coredata.ConnectorProviderOnePassword,
 		DisplayName:               "1Password",
+		DocumentationURL:          accessReviewDocsURL("one-password"),
 		ProbeURL:                  "https://events.1password.com/api/v1/auditevents",
 		SupportsAPIKey:            true,
 		SupportsClientCredentials: true,

--- a/pkg/connector/provider/pylon.go
+++ b/pkg/connector/provider/pylon.go
@@ -31,9 +31,10 @@ import (
 
 func pylonRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderPylon,
-		DisplayName:    "Pylon",
-		SupportsAPIKey: true,
+		Provider:         coredata.ConnectorProviderPylon,
+		DisplayName:      "Pylon",
+		DocumentationURL: accessReviewDocsURL("pylon"),
+		SupportsAPIKey:   true,
 		// Pylon authenticates with an account API token presented as
 		// Authorization: Bearer, the default APIKeyConnection scheme. There
 		// is no third-party OAuth2 flow for the Users API. The token is bound

--- a/pkg/connector/provider/qovery.go
+++ b/pkg/connector/provider/qovery.go
@@ -34,6 +34,7 @@ func qoveryRegistration() *Registration {
 	return &Registration{
 		Provider:         coredata.ConnectorProviderQovery,
 		DisplayName:      "Qovery",
+		DocumentationURL: accessReviewDocsURL("qovery"),
 		SupportsAPIKey:   true,
 		APIKeyAuthScheme: "Token",
 		BuildProbeURL:    buildQoveryProbeURL,

--- a/pkg/connector/provider/render.go
+++ b/pkg/connector/provider/render.go
@@ -39,10 +39,11 @@ import (
 // omitted.
 func renderRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderRender,
-		DisplayName:    "Render",
-		SupportsAPIKey: true,
-		BuildProbeURL:  buildRenderProbeURL,
+		Provider:         coredata.ConnectorProviderRender,
+		DisplayName:      "Render",
+		DocumentationURL: accessReviewDocsURL("render"),
+		SupportsAPIKey:   true,
+		BuildProbeURL:    buildRenderProbeURL,
 		APIKeyExtraSettings: []ExtraSetting{
 			{Key: "workspaceId", Label: "Workspace ID", Required: true},
 		},

--- a/pkg/connector/provider/sendgrid.go
+++ b/pkg/connector/provider/sendgrid.go
@@ -31,10 +31,11 @@ import (
 
 func sendgridRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderSendGrid,
-		DisplayName:    "SendGrid",
-		ProbeURL:       "https://api.sendgrid.com/v3/teammates?limit=1&offset=0",
-		SupportsAPIKey: true,
+		Provider:         coredata.ConnectorProviderSendGrid,
+		DisplayName:      "SendGrid",
+		DocumentationURL: accessReviewDocsURL("sendgrid"),
+		ProbeURL:         "https://api.sendgrid.com/v3/teammates?limit=1&offset=0",
+		SupportsAPIKey:   true,
 		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, logger *log.Logger) (drivers.Driver, error) {
 			return drivers.NewSendGridDriver(c, logger.Named("sendgrid")), nil
 		},

--- a/pkg/connector/provider/signoz.go
+++ b/pkg/connector/provider/signoz.go
@@ -34,11 +34,12 @@ import (
 
 func signozRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderSigNoz,
-		DisplayName:    "SigNoz",
-		SupportsAPIKey: true,
-		APIKeyHeader:   "SIGNOZ-API-KEY",
-		BuildProbeURL:  buildSigNozProbeURL,
+		Provider:         coredata.ConnectorProviderSigNoz,
+		DisplayName:      "SigNoz",
+		DocumentationURL: accessReviewDocsURL("signoz"),
+		SupportsAPIKey:   true,
+		APIKeyHeader:     "SIGNOZ-API-KEY",
+		BuildProbeURL:    buildSigNozProbeURL,
 		APIKeyExtraSettings: []ExtraSetting{
 			{Key: "baseUrl", Label: "Base URL", Required: true},
 		},

--- a/pkg/connector/provider/supabase.go
+++ b/pkg/connector/provider/supabase.go
@@ -32,10 +32,11 @@ import (
 
 func supabaseRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderSupabase,
-		DisplayName:    "Supabase",
-		ProbeURL:       "https://api.supabase.com/v1/organizations",
-		SupportsAPIKey: true,
+		Provider:         coredata.ConnectorProviderSupabase,
+		DisplayName:      "Supabase",
+		DocumentationURL: accessReviewDocsURL("supabase"),
+		ProbeURL:         "https://api.supabase.com/v1/organizations",
+		SupportsAPIKey:   true,
 		APIKeyExtraSettings: []ExtraSetting{
 			{Key: "organizationSlug", Label: "Organization Slug", Required: true},
 		},

--- a/pkg/connector/provider/tailscale.go
+++ b/pkg/connector/provider/tailscale.go
@@ -31,10 +31,11 @@ import (
 
 func tailscaleRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderTailscale,
-		DisplayName:    "Tailscale",
-		SupportsAPIKey: true,
-		ProbeURL:       "https://api.tailscale.com/api/v2/tailnet/-/users",
+		Provider:         coredata.ConnectorProviderTailscale,
+		DisplayName:      "Tailscale",
+		DocumentationURL: accessReviewDocsURL("tailscale"),
+		SupportsAPIKey:   true,
+		ProbeURL:         "https://api.tailscale.com/api/v2/tailnet/-/users",
 		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger) (drivers.Driver, error) {
 			return drivers.NewTailscaleDriver(c), nil
 		},

--- a/pkg/connector/provider/tally.go
+++ b/pkg/connector/provider/tally.go
@@ -32,10 +32,11 @@ import (
 
 func tallyRegistration() *Registration {
 	return &Registration{
-		Provider:       coredata.ConnectorProviderTally,
-		DisplayName:    "Tally",
-		ProbeURL:       "https://api.tally.so/me",
-		SupportsAPIKey: true,
+		Provider:         coredata.ConnectorProviderTally,
+		DisplayName:      "Tally",
+		DocumentationURL: accessReviewDocsURL("tally"),
+		ProbeURL:         "https://api.tally.so/me",
+		SupportsAPIKey:   true,
 		APIKeyExtraSettings: []ExtraSetting{
 			{Key: "organizationId", Label: "Organization ID", Required: true},
 		},


### PR DESCRIPTION
## What

Sets `DocumentationURL` on the 19 access-review connector registrations that ship an API-key path and a driver but had no docs page until now: Better Stack, Brevo, ClickHouse Cloud, Grafana, incident.io, Langfuse, Mercury, Metabase, Neon, Okta, 1Password, Pylon, Qovery, Render, SendGrid, SigNoz, Supabase, Tailscale and Tally.

## Why

`DocumentationURL` is what makes the console render the "how do I get this token" link on the connect dialog. All 19 were empty, so a customer connecting Okta or SigNoz got a bare API-key field and no guidance on which token to mint or what role it needs. Several of these need more than a key (an org ID, a base URL, a region), which is exactly the case where the link matters most.

Slugs are passed explicitly rather than derived from the enum, per `accessReviewDocsURL`'s contract, so `BETTER_STACK` maps to `better-stack` and `INCIDENT_IO` to `incident-io`.

## Merge order

The pages land in getprobo/probo.com first. Until that ships, these URLs 404.

## Test plan

- [x] `go build ./...` (clean apart from the pre-existing `pattern dist:` frontend-embed errors)
- [x] `go test ./pkg/connector/...` passes
- [x] `gofmt` clean

## Note

Writing these pages surfaced two connect-flow defects, fixed separately on `aureliensibiril/fix-connector-extra-settings`: Langfuse is missing from `mapAPIKeyExtraSettingToField` so its required Base URL is dropped, and 1Password's `ExtraSettings` is protocol-blind so the API-key dialog renders Account ID and Region instead of the SCIM Bridge URL its driver needs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Link docs for 19 API-key access-review connectors so the console shows a “How to get this token” link in the connect dialog. This reduces setup friction, especially for providers that need extra inputs like org IDs or base URLs.

### Service **`+77`** **`-58`**
- Added `DocumentationURL` to Registration definitions for 19 API-key providers via `accessReviewDocsURL("<slug>")`.
- Passed explicit slugs for enum names (e.g., `BETTER_STACK` -> `better-stack`, `INCIDENT_IO` -> `incident-io`).
- No auth or driver logic changes; only surfaces the docs link in the UI.
- Note: links will 404 until the docs pages deploy on probo.com.

<sup>Written for commit 4e1ecd41c22e9aca255496e22d118d45cd9c80cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

