### PR TITLE
Add Risk Accepted status to finding forms

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -348,12 +348,12 @@
     "breadcrumbs": { "findings": "Findings" },
     "unknown": "Unknown finding",
     "kinds": { "minor_nonconformity": "Minor nonconformity", "major_nonconformity": "Major nonconformity", "observation": "Observation", "exception": "Exception" },
-    "status": { "open": "Open", "in_progress": "In progress", "closed": "Closed", "mitigated": "Mitigated", "false_positive": "False positive" },
+    "status": { "open": "Open", "in_progress": "In progress", "closed": "Closed", "risk_accepted": "Risk accepted", "mitigated": "Mitigated", "false_positive": "False positive" },
     "priority": { "low": "Low", "medium": "Medium", "high": "High" },
     "messages": { "successTitle": "Success", "deleted": "Finding deleted successfully", "updated": "Finding updated successfully" },
     "errors": { "title": "Error", "delete": "Failed to delete finding", "update": "Failed to update finding" },
     "deleteConfirmation": "This will permanently delete the finding {{referenceId}}. This action cannot be undone.",
-    "fields": { "description": "Description", "source": "Source", "owner": "Owner", "status": "Status", "priority": "Priority", "dateIdentified": "Date identified", "dueDate": "Due date", "rootCause": "Root cause", "correctiveAction": "Corrective action", "effectivenessCheck": "Effectiveness check" },
+    "fields": { "description": "Description", "source": "Source", "owner": "Owner", "status": "Status", "priority": "Priority", "acceptedRisk": "Accepted risk", "dateIdentified": "Date identified", "dueDate": "Due date", "rootCause": "Root cause", "correctiveAction": "Corrective action", "effectivenessCheck": "Effectiveness check" },
     "placeholders": { "description": "Enter description", "source": "Enter source", "rootCause": "Enter root cause", "correctiveAction": "Enter corrective action", "effectivenessCheck": "Enter effectiveness check details" },
     "actions": { "delete": "Delete", "updating": "Updating...", "update": "Update" }
   },
@@ -374,11 +374,11 @@
   "createFindingDialog": {
     "breadcrumbs": { "findings": "Findings", "create": "Create" },
     "kinds": { "minorNonconformity": "Minor nonconformity", "majorNonconformity": "Major nonconformity", "observation": "Observation", "exception": "Exception" },
-    "status": { "open": "Open", "in_progress": "In progress", "closed": "Closed", "mitigated": "Mitigated", "false_positive": "False positive" },
+    "status": { "open": "Open", "in_progress": "In progress", "closed": "Closed", "risk_accepted": "Risk accepted", "mitigated": "Mitigated", "false_positive": "False positive" },
     "priority": { "low": "Low", "medium": "Medium", "high": "High" },
     "messages": { "successTitle": "Success", "created": "Finding created successfully" },
     "errors": { "title": "Error", "create": "Failed to create finding" },
-    "fields": { "kind": "Kind", "description": "Description", "source": "Source", "owner": "Owner", "status": "Status", "priority": "Priority", "dateIdentified": "Date identified", "dueDate": "Due date", "rootCause": "Root cause", "correctiveAction": "Corrective action", "effectivenessCheck": "Effectiveness check" },
+    "fields": { "kind": "Kind", "description": "Description", "source": "Source", "owner": "Owner", "status": "Status", "priority": "Priority", "acceptedRisk": "Accepted risk", "dateIdentified": "Date identified", "dueDate": "Due date", "rootCause": "Root cause", "correctiveAction": "Corrective action", "effectivenessCheck": "Effectiveness check" },
     "placeholders": { "selectKind": "Select kind", "description": "Brief description of the finding...", "source": "Enter source", "selectStatus": "Select status", "rootCause": "Detailed analysis of the root cause...", "correctiveAction": "Proposed corrective actions...", "effectivenessCheck": "Assessment of corrective action effectiveness..." },
     "actions": { "creating": "Creating...", "create": "Create finding" }
   },
@@ -608,6 +608,10 @@
   },
   "peopleSelectField": {
     "placeholder": "Select an owner",
+    "none": "None"
+  },
+  "riskSelectField": {
+    "placeholder": "Select a risk",
     "none": "None"
   },
   "processingActivityEnumOptions": {

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -728,6 +728,7 @@
       "open": "Ouvert",
       "in_progress": "En cours",
       "closed": "Fermé",
+      "risk_accepted": "Risque accepté",
       "mitigated": "Atténué",
       "false_positive": "Faux positif"
     },
@@ -753,6 +754,7 @@
       "owner": "Propriétaire",
       "status": "Statut",
       "priority": "Priorité",
+      "acceptedRisk": "Risque accepté",
       "dateIdentified": "Date d’identification",
       "dueDate": "Date d’échéance",
       "rootCause": "Cause racine",
@@ -852,6 +854,7 @@
       "open": "Ouvert",
       "in_progress": "En cours",
       "closed": "Fermé",
+      "risk_accepted": "Risque accepté",
       "mitigated": "Atténué",
       "false_positive": "Faux positif"
     },
@@ -875,6 +878,7 @@
       "owner": "Propriétaire",
       "status": "Statut",
       "priority": "Priorité",
+      "acceptedRisk": "Risque accepté",
       "dateIdentified": "Date d’identification",
       "dueDate": "Date d’échéance",
       "rootCause": "Cause racine",
@@ -1135,6 +1139,10 @@
   },
   "peopleSelectField": {
     "placeholder": "Sélectionner un propriétaire",
+    "none": "Aucun"
+  },
+  "riskSelectField": {
+    "placeholder": "Sélectionner un risque",
     "none": "Aucun"
   },
   "processingActivityEnumOptions": {

--- a/apps/console/src/components/form/RiskSelectField.tsx
+++ b/apps/console/src/components/form/RiskSelectField.tsx
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { Combobox, ComboboxItem, Field, InfiniteScrollTrigger } from "@probo/ui";
+import { type ComponentProps, Suspense, useCallback, useMemo, useState } from "react";
+import {
+  type Control,
+  Controller,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useDebounceCallback } from "usehooks-ts";
+
+import { usePaginatedRisks } from "#/hooks/graph/usePaginatedRisks";
+
+type SelectedRisk = {
+  id: string;
+  name: string;
+};
+
+type Props<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  organizationId: string;
+  control: Control<TFieldValues>;
+  name: TName;
+  label?: string;
+  error?: string;
+  disabled?: boolean;
+  optional?: boolean;
+  selectedRisk?: SelectedRisk | null;
+} & ComponentProps<typeof Field>;
+
+export function RiskSelectField<TFieldValues extends FieldValues = FieldValues>({
+  organizationId,
+  control,
+  disabled,
+  optional,
+  selectedRisk,
+  ...props
+}: Props<TFieldValues>) {
+  const { t } = useTranslation();
+
+  return (
+    <Field {...props}>
+      <Suspense
+        fallback={(
+          <Combobox
+            onSearch={() => {}}
+            placeholder={t("riskSelectField.placeholder")}
+            disabled
+          >
+            <div />
+          </Combobox>
+        )}
+      >
+        <RiskSelectWithQuery<TFieldValues>
+          organizationId={organizationId}
+          control={control}
+          name={props.name}
+          disabled={disabled}
+          optional={optional}
+          selectedRisk={selectedRisk}
+        />
+      </Suspense>
+    </Field>
+  );
+}
+
+function RiskSelectWithQuery<TFieldValues extends FieldValues = FieldValues>(
+  props: Pick<
+    Props<TFieldValues>,
+    | "organizationId"
+    | "control"
+    | "name"
+    | "disabled"
+    | "optional"
+    | "selectedRisk"
+  >,
+) {
+  const { t } = useTranslation();
+  const { name, organizationId, control, disabled, optional, selectedRisk }
+    = props;
+  const { data, loadNext, hasNext, isLoadingNext, refetch }
+    = usePaginatedRisks(organizationId);
+  const [search, setSearch] = useState("");
+
+  const refetchSearch = useDebounceCallback(
+    useCallback(
+      (query: string) => {
+        refetch(
+          {
+            first: 50,
+            filter: { query: query || null },
+          },
+          { fetchPolicy: "network-only" },
+        );
+      },
+      [refetch],
+    ),
+    300,
+  );
+
+  const handleSearch = (query: string) => {
+    setSearch(query);
+    refetchSearch(query);
+  };
+
+  const risks = useMemo(() => {
+    return data?.risks.edges?.map(edge => edge.node) ?? [];
+  }, [data?.risks.edges]);
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field }) => {
+        const selectedFromList = field.value
+          ? risks.find(risk => risk.id === field.value)
+          : null;
+        const selected
+          = selectedFromList
+            ?? (selectedRisk && selectedRisk.id === field.value
+              ? selectedRisk
+              : null);
+
+        return (
+          <Combobox
+            id={name}
+            name={field.name}
+            ref={field.ref}
+            onBlur={field.onBlur}
+            placeholder={t("riskSelectField.placeholder")}
+            value={search || selected?.name || ""}
+            onSearch={handleSearch}
+            disabled={disabled}
+          >
+            {optional && (
+              <ComboboxItem
+                onClick={() => {
+                  field.onChange(null);
+                  setSearch("");
+                  refetchSearch("");
+                }}
+              >
+                {t("riskSelectField.none")}
+              </ComboboxItem>
+            )}
+            {risks.map(risk => (
+              <ComboboxItem
+                key={risk.id}
+                onClick={() => {
+                  field.onChange(risk.id);
+                  setSearch(risk.name);
+                }}
+              >
+                <div className="space-y-1 text-start min-w-0">
+                  <div className="max-w-75 ellipsis overflow-hidden whitespace-pre-wrap">
+                    {risk.name}
+                  </div>
+                  {risk.category && (
+                    <div className="text-sm text-txt-secondary">
+                      {risk.category}
+                    </div>
+                  )}
+                </div>
+              </ComboboxItem>
+            ))}
+            {hasNext && (
+              <InfiniteScrollTrigger
+                loading={isLoadingNext}
+                onView={() => loadNext(50)}
+              />
+            )}
+          </Combobox>
+        );
+      }}
+    />
+  );
+}

--- a/apps/console/src/hooks/graph/usePaginatedRisks.ts
+++ b/apps/console/src/hooks/graph/usePaginatedRisks.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay";
+
+import type { usePaginatedRisksFragment$key } from "#/__generated__/core/usePaginatedRisksFragment.graphql";
+import type { usePaginatedRisksQuery } from "#/__generated__/core/usePaginatedRisksQuery.graphql";
+import type { usePaginatedRisksQuery_fragment } from "#/__generated__/core/usePaginatedRisksQuery_fragment.graphql";
+
+/* eslint-disable relay/unused-fields */
+
+const risksQuery = graphql`
+  query usePaginatedRisksQuery($organizationId: ID!) {
+    organization: node(id: $organizationId) {
+      id
+      ... on Organization {
+        ...usePaginatedRisksFragment
+      }
+    }
+  }
+`;
+
+const risksFragment = graphql`
+  fragment usePaginatedRisksFragment on Organization
+  @refetchable(queryName: "usePaginatedRisksQuery_fragment")
+  @argumentDefinitions(
+    first: { type: "Int", defaultValue: 50 }
+    order: { type: "RiskOrder", defaultValue: null }
+    after: { type: "CursorKey", defaultValue: null }
+    before: { type: "CursorKey", defaultValue: null }
+    last: { type: "Int", defaultValue: null }
+    filter: { type: "RiskFilter", defaultValue: null }
+  ) {
+    risks(
+      first: $first
+      after: $after
+      last: $last
+      before: $before
+      orderBy: $order
+      filter: $filter
+    ) @connection(key: "usePaginatedRisksQuery_risks", filters: ["filter"]) {
+      edges {
+        node {
+          id
+          name
+          category
+          description
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Hook to retrieve risks paginated (used for risk selectors)
+ */
+export function usePaginatedRisks(organizationId: string) {
+  const query = useLazyLoadQuery<usePaginatedRisksQuery>(
+    risksQuery,
+    {
+      organizationId,
+    },
+    { fetchPolicy: "network-only" },
+  );
+  return usePaginationFragment<usePaginatedRisksQuery_fragment, usePaginatedRisksFragment$key>(
+    risksFragment,
+    query.organization as usePaginatedRisksFragment$key,
+  );
+}

--- a/apps/console/src/pages/organizations/findings/FindingDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/findings/FindingDetailsPage.tsx
@@ -40,6 +40,7 @@ import {
   useConfirm,
   useToast,
 } from "@probo/ui";
+import { useEffect } from "react";
 import { Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {
@@ -56,6 +57,7 @@ import type { FindingDetailsPageQuery } from "#/__generated__/core/FindingDetail
 import type { FindingDetailsPageUpdateMutation } from "#/__generated__/core/FindingDetailsPageUpdateMutation.graphql";
 import { ControlledField } from "#/components/form/ControlledField";
 import { PeopleSelectField } from "#/components/form/PeopleSelectField";
+import { RiskSelectField } from "#/components/form/RiskSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 
@@ -79,6 +81,10 @@ export const findingDetailsPageQuery = graphql`
         effectivenessCheck
         owner {
           id
+        }
+        risk {
+          id
+          name
         }
         canUpdate: permission(action: "core:finding:update")
         canDelete: permission(action: "core:finding:delete")
@@ -107,6 +113,10 @@ const updateFindingMutation = graphql`
           id
           fullName
         }
+        risk {
+          id
+          name
+        }
         updatedAt
       }
     }
@@ -124,18 +134,34 @@ const deleteFindingMutation = graphql`
   }
 `;
 
-const updateFindingSchema = z.object({
-  description: z.string().optional(),
-  source: z.string().optional(),
-  identifiedOn: z.string().optional(),
-  dueDate: z.string().optional(),
-  rootCause: z.string().optional(),
-  correctiveAction: z.string().optional(),
-  effectivenessCheck: z.string().optional(),
-  status: z.enum(["OPEN", "IN_PROGRESS", "CLOSED", "MITIGATED", "FALSE_POSITIVE", "RISK_ACCEPTED"]),
-  priority: z.enum(["LOW", "MEDIUM", "HIGH"]),
-  ownerId: z.string().nullable().optional(),
-});
+const updateFindingSchema = z
+  .object({
+    description: z.string().optional(),
+    source: z.string().optional(),
+    identifiedOn: z.string().optional(),
+    dueDate: z.string().optional(),
+    rootCause: z.string().optional(),
+    correctiveAction: z.string().optional(),
+    effectivenessCheck: z.string().optional(),
+    status: z.enum([
+      "OPEN",
+      "IN_PROGRESS",
+      "CLOSED",
+      "MITIGATED",
+      "FALSE_POSITIVE",
+      "RISK_ACCEPTED",
+    ]),
+    priority: z.enum(["LOW", "MEDIUM", "HIGH"]),
+    ownerId: z.string().nullable().optional(),
+    riskId: z.string().nullable().optional(),
+  })
+  .refine(
+    data => data.status !== "RISK_ACCEPTED" || Boolean(data.riskId),
+    {
+      message: "A risk is required when status is Risk Accepted",
+      path: ["riskId"],
+    },
+  );
 
 type Props = {
   queryRef: PreloadedQuery<FindingDetailsPageQuery>;
@@ -230,7 +256,7 @@ export default function FindingDetailsPage(props: Props) {
     );
   };
 
-  const { control, formState, handleSubmit, register, reset }
+  const { control, formState, handleSubmit, register, reset, watch, setValue }
     = useFormWithSchema(updateFindingSchema, {
       defaultValues: {
         description: finding.description || "",
@@ -243,8 +269,17 @@ export default function FindingDetailsPage(props: Props) {
         status: finding.status || "OPEN",
         priority: finding.priority || "MEDIUM",
         ownerId: finding.owner?.id ?? null,
+        riskId: finding.risk?.id ?? null,
       },
     });
+
+  const status = watch("status");
+
+  useEffect(() => {
+    if (status !== "RISK_ACCEPTED") {
+      setValue("riskId", null);
+    }
+  }, [status, setValue]);
 
   const onSubmit = handleSubmit((formData) => {
     if (!finding.id) return;
@@ -263,6 +298,9 @@ export default function FindingDetailsPage(props: Props) {
           status: formData.status,
           priority: formData.priority,
           ownerId: formData.ownerId || undefined,
+          riskId: formData.status === "RISK_ACCEPTED"
+            ? formData.riskId || null
+            : null,
         },
       },
       onCompleted() {
@@ -286,8 +324,7 @@ export default function FindingDetailsPage(props: Props) {
     });
   });
 
-  const statusOptions = ["OPEN", "IN_PROGRESS", "CLOSED", "MITIGATED", "FALSE_POSITIVE"] as const;
-
+  const statusOptions = ["OPEN", "IN_PROGRESS", "CLOSED", "RISK_ACCEPTED", "MITIGATED", "FALSE_POSITIVE"] as const;
   const priorityOptions = [
     { value: "LOW", label: t("findingDetails.priority.low") },
     { value: "MEDIUM", label: t("findingDetails.priority.medium") },
@@ -426,6 +463,18 @@ export default function FindingDetailsPage(props: Props) {
                 )}
               />
             </div>
+
+            {status === "RISK_ACCEPTED" && (
+              <RiskSelectField
+                organizationId={organizationId}
+                control={control}
+                name="riskId"
+                label={t("findingDetails.fields.acceptedRisk")}
+                error={formState.errors.riskId?.message}
+                selectedRisk={finding.risk}
+                required
+              />
+            )}
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <Field label={t("findingDetails.fields.dateIdentified")}>

--- a/apps/console/src/pages/organizations/findings/dialogs/CreateFindingDialog.tsx
+++ b/apps/console/src/pages/organizations/findings/dialogs/CreateFindingDialog.tsx
@@ -37,7 +37,7 @@ import {
   useDialogRef,
   useToast,
 } from "@probo/ui";
-import { type ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
 import { Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { graphql, useMutation } from "react-relay";
@@ -45,6 +45,7 @@ import { z } from "zod";
 
 import type { CreateFindingDialogMutation } from "#/__generated__/core/CreateFindingDialogMutation.graphql";
 import { PeopleSelectField } from "#/components/form/PeopleSelectField";
+import { RiskSelectField } from "#/components/form/RiskSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 
 const createFindingMutation = graphql`
@@ -71,6 +72,10 @@ const createFindingMutation = graphql`
             id
             fullName
           }
+          risk {
+            id
+            name
+          }
           createdAt
           canUpdate: permission(action: "core:finding:update")
           canDelete: permission(action: "core:finding:delete")
@@ -80,19 +85,35 @@ const createFindingMutation = graphql`
   }
 `;
 
-const schema = z.object({
-  kind: z.enum(["MINOR_NONCONFORMITY", "MAJOR_NONCONFORMITY", "OBSERVATION", "EXCEPTION"]),
-  description: z.string().optional(),
-  source: z.string().optional(),
-  identifiedOn: z.string().optional(),
-  rootCause: z.string().optional(),
-  correctiveAction: z.string().optional(),
-  ownerId: z.string().nullable().optional(),
-  dueDate: z.string().optional(),
-  status: z.enum(["OPEN", "IN_PROGRESS", "CLOSED", "MITIGATED", "FALSE_POSITIVE"]),
-  priority: z.enum(["LOW", "MEDIUM", "HIGH"]),
-  effectivenessCheck: z.string().optional(),
-});
+const schema = z
+  .object({
+    kind: z.enum(["MINOR_NONCONFORMITY", "MAJOR_NONCONFORMITY", "OBSERVATION", "EXCEPTION"]),
+    description: z.string().optional(),
+    source: z.string().optional(),
+    identifiedOn: z.string().optional(),
+    rootCause: z.string().optional(),
+    correctiveAction: z.string().optional(),
+    ownerId: z.string().nullable().optional(),
+    dueDate: z.string().optional(),
+    status: z.enum([
+      "OPEN",
+      "IN_PROGRESS",
+      "CLOSED",
+      "MITIGATED",
+      "FALSE_POSITIVE",
+      "RISK_ACCEPTED",
+    ]),
+    priority: z.enum(["LOW", "MEDIUM", "HIGH"]),
+    riskId: z.string().nullable().optional(),
+    effectivenessCheck: z.string().optional(),
+  })
+  .refine(
+    data => data.status !== "RISK_ACCEPTED" || Boolean(data.riskId),
+    {
+      message: "A risk is required when status is Risk Accepted",
+      path: ["riskId"],
+    },
+  );
 
 type FormData = z.infer<typeof schema>;
 
@@ -111,8 +132,7 @@ export function CreateFindingDialog({
   const { toast } = useToast();
   const dialogRef = useDialogRef();
   const [createFinding] = useMutation<CreateFindingDialogMutation>(createFindingMutation);
-  const statusOptions = ["OPEN", "IN_PROGRESS", "CLOSED", "MITIGATED", "FALSE_POSITIVE"] as const;
-
+  const statusOptions = ["OPEN", "IN_PROGRESS", "CLOSED", "RISK_ACCEPTED", "MITIGATED", "FALSE_POSITIVE"] as const;
   const kindOptions = [
     { value: "MINOR_NONCONFORMITY", label: t("createFindingDialog.kinds.minorNonconformity") },
     { value: "MAJOR_NONCONFORMITY", label: t("createFindingDialog.kinds.majorNonconformity") },
@@ -126,7 +146,7 @@ export function CreateFindingDialog({
     { value: "HIGH", label: t("createFindingDialog.priority.high") },
   ];
 
-  const { register, handleSubmit, formState, reset, control } = useFormWithSchema(schema, {
+  const { register, handleSubmit, formState, reset, control, watch, setValue } = useFormWithSchema(schema, {
     defaultValues: {
       kind: "MINOR_NONCONFORMITY" as const,
       description: "",
@@ -138,9 +158,18 @@ export function CreateFindingDialog({
       dueDate: "",
       status: "OPEN" as const,
       priority: "MEDIUM" as const,
+      riskId: null,
       effectivenessCheck: "",
     },
   });
+
+  const status = watch("status");
+
+  useEffect(() => {
+    if (status !== "RISK_ACCEPTED") {
+      setValue("riskId", null);
+    }
+  }, [status, setValue]);
 
   const onSubmit = (formData: FormData) => {
     createFinding({
@@ -157,6 +186,9 @@ export function CreateFindingDialog({
           dueDate: formatDatetime(formData.dueDate),
           status: formData.status,
           priority: formData.priority,
+          riskId: formData.status === "RISK_ACCEPTED"
+            ? formData.riskId || undefined
+            : undefined,
           effectivenessCheck: formData.effectivenessCheck || undefined,
         },
         connections: connectionIds ?? [],
@@ -297,6 +329,17 @@ export function CreateFindingDialog({
               )}
             />
           </div>
+
+          {status === "RISK_ACCEPTED" && (
+            <RiskSelectField
+              organizationId={organizationId}
+              control={control}
+              name="riskId"
+              label={t("createFindingDialog.fields.acceptedRisk")}
+              error={formState.errors.riskId?.message}
+              required
+            />
+          )}
 
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Findings create and update views excluded `RISK_ACCEPTED` from the status dropdown, even though the backend supports it and requires a linked risk.

## Changes

- Restore `RISK_ACCEPTED` in the finding create dialog and details (update) form
- Add a reusable searchable, cursor-paginated `RiskSelectField`
- Require `riskId` when status is Risk Accepted; clear it when status changes away
- Include linked `risk` in create/update GraphQL selections so edit can prefill it
- Refetch risks with `RiskFilter.query` on search; prefer the active query over the selected label
- Add English and French locale keys for the new status, field, and risk picker

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4428d6fb-0e86-4596-802d-81505a628ea3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4428d6fb-0e86-4596-802d-81505a628ea3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Risk Accepted status in finding create/edit forms and requires linking a risk when selected. Adds a searchable, paginated risk picker and clears stale links when status changes.

### App: console **`+425`** **`-36`**
- Restore `RISK_ACCEPTED` in status options; require `riskId`; clear when status changes; prefill on edit.
- Add `RiskSelectField` with server search, debounced refetch, and infinite scroll; shown only for `RISK_ACCEPTED`.
- Introduce `usePaginatedRisks` (Relay) and update GraphQL queries/mutations to include `risk`/`riskId`.
- Update i18n (EN/FR) for “Risk accepted”, “Accepted risk”, and risk picker placeholders.

<sup>Written for commit 0fa2dad15ee7bb3475ab781f013b224ada57a0cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

