### PR TITLE
Preserve continue URL on auth error re-login

### DIFF
--- a/apps/console/src/pages/iam/auth/AuthErrorPage.tsx
+++ b/apps/console/src/pages/iam/auth/AuthErrorPage.tsx
@@ -75,6 +75,11 @@ export default function AuthErrorPage() {
   const [searchParams] = useSearchParams();
   const content = useAuthErrorContent(searchParams.get("error"));
 
+  const continueParam = searchParams.get("continue");
+  const loginSearch = continueParam
+    ? `?${new URLSearchParams({ continue: continueParam }).toString()}`
+    : "";
+
   usePageTitle(content.title);
 
   return (
@@ -83,7 +88,13 @@ export default function AuthErrorPage() {
         <h1 className="text-2xl font-bold">{content.title}</h1>
         <p className="text-txt-tertiary">{content.description}</p>
       </div>
-      <Button className="w-full h-10" to="/auth/login">
+      <Button
+        className="w-full h-10"
+        to={{
+          pathname: "/auth/login",
+          search: loginSearch,
+        }}
+      >
         {t("auth.actions.signIn")}
       </Button>
     </div>

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -670,6 +670,15 @@ func (s AuthService) GetMagicLinkEmail(ctx context.Context, tokenString string) 
 	return payload.Data.Email, nil
 }
 
+func (s AuthService) MagicLinkContinueFromToken(tokenString string) (*string, error) {
+	payload, err := statelesstoken.ValidateTokenAllowExpired[MagicLinkData](s.tokenSecret, TokenTypeMagicLink, tokenString)
+	if err != nil {
+		return nil, err
+	}
+
+	return payload.Data.Continue, nil
+}
+
 func (s AuthService) OpenSessionWithMagicLink(ctx context.Context, tokenString string) (*coredata.Identity, *coredata.Session, *string, error) {
 	var (
 		now      = time.Now()

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -671,7 +671,12 @@ func (s AuthService) GetMagicLinkEmail(ctx context.Context, tokenString string) 
 }
 
 func (s AuthService) MagicLinkContinueFromToken(tokenString string) (*string, error) {
-	payload, err := statelesstoken.ValidateTokenAllowExpired[MagicLinkData](s.tokenSecret, TokenTypeMagicLink, tokenString)
+	payload, err := statelesstoken.ValidateToken[MagicLinkData](
+		s.tokenSecret,
+		TokenTypeMagicLink,
+		tokenString,
+		statelesstoken.AllowExpired(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/iam/oidc/service.go
+++ b/pkg/iam/oidc/service.go
@@ -381,6 +381,53 @@ func (s *Service) InitiateLogin(
 	return authURL, nil
 }
 
+// ContinueURLFromCallbackState loads and removes a pending login state and returns
+// its continue URL. Used when the IdP callback fails before an authorization code
+// is exchanged (user denied consent, cancelled login, etc.).
+func (s *Service) ContinueURLFromCallbackState(
+	ctx context.Context,
+	provider coredata.OIDCProvider,
+	stateParam string,
+) (string, error) {
+	if stateParam == "" {
+		return "", NewInvalidStateError()
+	}
+
+	var oidcState coredata.OIDCState
+
+	err := s.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			if err := oidcState.LoadByIDForUpdate(ctx, tx, stateParam); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return NewInvalidStateError()
+				}
+
+				return fmt.Errorf("cannot load oidc state: %w", err)
+			}
+
+			if err := oidcState.Delete(ctx, tx); err != nil {
+				return fmt.Errorf("cannot delete oidc state: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	if time.Now().After(oidcState.ExpiresAt) {
+		return "", NewInvalidStateError()
+	}
+
+	if oidcState.Provider != provider {
+		return "", NewInvalidStateError()
+	}
+
+	return oidcState.ContinueURL, nil
+}
+
 func (s *Service) HandleCallback(
 	ctx context.Context,
 	provider coredata.OIDCProvider,
@@ -417,11 +464,11 @@ func (s *Service) HandleCallback(
 	}
 
 	if time.Now().After(oidcState.ExpiresAt) {
-		return nil, "", nil, NewInvalidStateError()
+		return nil, oidcState.ContinueURL, nil, NewInvalidStateError()
 	}
 
 	if oidcState.Provider != provider {
-		return nil, "", nil, NewInvalidStateError()
+		return nil, oidcState.ContinueURL, nil, NewInvalidStateError()
 	}
 
 	token, err := info.oauth2Config.Exchange(
@@ -430,26 +477,26 @@ func (s *Service) HandleCallback(
 		oauth2.SetAuthURLParam("code_verifier", oidcState.CodeVerifier),
 	)
 	if err != nil {
-		return nil, "", nil, NewCodeExchangeError(err)
+		return nil, oidcState.ContinueURL, nil, NewCodeExchangeError(err)
 	}
 
 	rawIDToken, ok := token.Extra("id_token").(string)
 	if !ok {
-		return nil, "", nil, NewIDTokenMissingError()
+		return nil, oidcState.ContinueURL, nil, NewIDTokenMissingError()
 	}
 
 	claims, err := s.verifyAndParseIDToken(ctx, info, rawIDToken, oidcState.Nonce)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("cannot verify id token: %w", err)
+		return nil, oidcState.ContinueURL, nil, fmt.Errorf("cannot verify id token: %w", err)
 	}
 
 	if err := validateIDTokenClaims(info, claims); err != nil {
-		return nil, "", nil, err
+		return nil, oidcState.ContinueURL, nil, err
 	}
 
 	email, err := mail.ParseAddr(claims.Email)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("cannot parse email from id token: %w", err)
+		return nil, oidcState.ContinueURL, nil, fmt.Errorf("cannot parse email from id token: %w", err)
 	}
 
 	var identity *coredata.Identity
@@ -496,7 +543,7 @@ func (s *Service) HandleCallback(
 		},
 	)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, oidcState.ContinueURL, nil, err
 	}
 
 	return identity, oidcState.ContinueURL, oidcState.OrganizationID, nil

--- a/pkg/server/api/connect/v1/auth_error.go
+++ b/pkg/server/api/connect/v1/auth_error.go
@@ -35,9 +35,13 @@ const (
 	authErrorMagicLinkInvalid          = "magic_link_invalid"
 )
 
-func redirectAuthError(w http.ResponseWriter, r *http.Request, code string) {
+func redirectAuthError(w http.ResponseWriter, r *http.Request, code string, continueURL string) {
 	q := url.Values{}
 	q.Set("error", code)
+
+	if continueURL != "" {
+		q.Set("continue", continueURL)
+	}
 
 	redirectURL := url.URL{
 		Path:     "/auth/error",

--- a/pkg/server/api/connect/v1/auth_error_test.go
+++ b/pkg/server/api/connect/v1/auth_error_test.go
@@ -35,11 +35,29 @@ func TestRedirectAuthError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/connect/v1/oidc/google/callback", nil)
 	rec := httptest.NewRecorder()
 
-	redirectAuthError(rec, req, authErrorPersonalAccountNotAllowed)
+	redirectAuthError(rec, req, authErrorPersonalAccountNotAllowed, "")
 
 	assert.Equal(t, http.StatusFound, rec.Code)
 	location, err := rec.Result().Location()
 	require.NoError(t, err)
 	assert.Equal(t, "/auth/error", location.Path)
 	assert.Equal(t, authErrorPersonalAccountNotAllowed, location.Query().Get("error"))
+	assert.Empty(t, location.Query().Get("continue"))
+}
+
+func TestRedirectAuthErrorWithContinue(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/connect/v1/oidc/google/callback", nil)
+	rec := httptest.NewRecorder()
+
+	continueURL := "/overview"
+	redirectAuthError(rec, req, authErrorAuthenticationFailed, continueURL)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+	location, err := rec.Result().Location()
+	require.NoError(t, err)
+	assert.Equal(t, "/auth/error", location.Path)
+	assert.Equal(t, authErrorAuthenticationFailed, location.Query().Get("error"))
+	assert.Equal(t, continueURL, location.Query().Get("continue"))
 }

--- a/pkg/server/api/connect/v1/oidc_handler.go
+++ b/pkg/server/api/connect/v1/oidc_handler.go
@@ -21,6 +21,7 @@
 package connect_v1
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -58,6 +59,31 @@ func NewOIDCHandler(
 		logger:        logger,
 		safeRedirect:  saferedirect.New(allowedHost),
 	}
+}
+
+func (h *OIDCHandler) redirectAuthError(w http.ResponseWriter, r *http.Request, code string, continueURL string) {
+	safeContinue := ""
+
+	if continueURL != "" {
+		if validated, ok := h.safeRedirect.Validate(r.Context(), continueURL); ok {
+			safeContinue = validated
+		}
+	}
+
+	redirectAuthError(w, r, code, safeContinue)
+}
+
+func (h *OIDCHandler) continueURLFromCallbackState(
+	ctx context.Context,
+	provider coredata.OIDCProvider,
+	stateParam string,
+) string {
+	continueURL, err := h.iam.OIDCService.ContinueURLFromCallbackState(ctx, provider, stateParam)
+	if err != nil {
+		return ""
+	}
+
+	return continueURL
 }
 
 func (h *OIDCHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
@@ -116,7 +142,8 @@ func (h *OIDCHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 			log.String("error", errParam),
 			log.String("error_description", r.URL.Query().Get("error_description")),
 		)
-		redirectAuthError(w, r, authErrorAuthenticationFailed)
+		continueURL := h.continueURLFromCallbackState(ctx, provider, r.URL.Query().Get("state"))
+		h.redirectAuthError(w, r, authErrorAuthenticationFailed, continueURL)
 
 		return
 	}
@@ -125,7 +152,12 @@ func (h *OIDCHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 
 	if stateParam == "" || code == "" {
-		redirectAuthError(w, r, authErrorInvalidState)
+		continueURL := ""
+		if stateParam != "" {
+			continueURL = h.continueURLFromCallbackState(ctx, provider, stateParam)
+		}
+
+		h.redirectAuthError(w, r, authErrorInvalidState, continueURL)
 
 		return
 	}
@@ -133,25 +165,25 @@ func (h *OIDCHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	identity, continueURL, organizationID, err := h.iam.OIDCService.HandleCallback(ctx, provider, stateParam, code)
 	if err != nil {
 		if _, ok := errors.AsType[*oidc.ErrPersonalAccountNotAllowed](err); ok {
-			redirectAuthError(w, r, authErrorPersonalAccountNotAllowed)
+			h.redirectAuthError(w, r, authErrorPersonalAccountNotAllowed, continueURL)
 
 			return
 		}
 
 		if _, ok := errors.AsType[*oidc.ErrEmailNotVerified](err); ok {
-			redirectAuthError(w, r, authErrorEmailNotVerified)
+			h.redirectAuthError(w, r, authErrorEmailNotVerified, continueURL)
 
 			return
 		}
 
 		if _, ok := errors.AsType[*oidc.ErrInvalidState](err); ok {
-			redirectAuthError(w, r, authErrorInvalidState)
+			h.redirectAuthError(w, r, authErrorInvalidState, continueURL)
 
 			return
 		}
 
 		h.logger.ErrorCtx(ctx, "cannot handle OIDC callback", log.Error(err))
-		redirectAuthError(w, r, authErrorAuthenticationFailed)
+		h.redirectAuthError(w, r, authErrorAuthenticationFailed, continueURL)
 
 		return
 	}
@@ -259,6 +291,21 @@ func NewMagicLinkHandler(
 	}
 }
 
+func (h *MagicLinkHandler) redirectAuthError(w http.ResponseWriter, r *http.Request, code string, token string) {
+	safeContinue := ""
+
+	if token != "" {
+		continueURL, err := h.iam.AuthService.MagicLinkContinueFromToken(token)
+		if err == nil && continueURL != nil && *continueURL != "" {
+			if validated, ok := h.safeRedirect.Validate(r.Context(), *continueURL); ok {
+				safeContinue = validated
+			}
+		}
+	}
+
+	redirectAuthError(w, r, code, safeContinue)
+}
+
 func (h *MagicLinkHandler) SendHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -313,29 +360,33 @@ func (h *MagicLinkHandler) VerifyHandler(w http.ResponseWriter, r *http.Request)
 
 	token := r.URL.Query().Get("token")
 	if token == "" {
-		redirectAuthError(w, r, authErrorMagicLinkInvalid)
+		h.redirectAuthError(w, r, authErrorMagicLinkInvalid, "")
+
 		return
 	}
 
 	identity, session, continueURL, err := h.iam.AuthService.OpenSessionWithMagicLink(ctx, token)
 	if err != nil {
 		if _, ok := errors.AsType[*iam.ErrExpiredToken](err); ok {
-			redirectAuthError(w, r, authErrorMagicLinkExpired)
+			h.redirectAuthError(w, r, authErrorMagicLinkExpired, token)
+
 			return
 		}
 
 		if _, ok := errors.AsType[*iam.ErrTokenAlreadyUsed](err); ok {
-			redirectAuthError(w, r, authErrorMagicLinkAlreadyUsed)
+			h.redirectAuthError(w, r, authErrorMagicLinkAlreadyUsed, token)
+
 			return
 		}
 
 		if _, ok := errors.AsType[*iam.ErrInvalidToken](err); ok {
-			redirectAuthError(w, r, authErrorMagicLinkInvalid)
+			h.redirectAuthError(w, r, authErrorMagicLinkInvalid, token)
+
 			return
 		}
 
 		h.logger.ErrorCtx(ctx, "cannot open session with magic link", log.Error(err))
-		redirectAuthError(w, r, authErrorAuthenticationFailed)
+		h.redirectAuthError(w, r, authErrorAuthenticationFailed, token)
 
 		return
 	}

--- a/pkg/server/api/connect/v1/saml_handler.go
+++ b/pkg/server/api/connect/v1/saml_handler.go
@@ -21,6 +21,7 @@
 package connect_v1
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -59,9 +60,28 @@ func (h *SAMLHandler) renderInternalServerError(w http.ResponseWriter) {
 	httpserver.RenderError(w, http.StatusInternalServerError, errors.New("internal server error"))
 }
 
-func (h *SAMLHandler) renderAssertionError(w http.ResponseWriter, r *http.Request, err error) {
+func (h *SAMLHandler) continueURLFromRelayState(ctx context.Context, relayState string) string {
+	if len(relayState) <= gid.EncodedGIDSize {
+		return ""
+	}
+
+	unescapedContinueURL, err := url.QueryUnescape(relayState[gid.EncodedGIDSize:])
+	if err != nil {
+		return ""
+	}
+
+	safeContinue, ok := h.safeRedirect.Validate(ctx, unescapedContinueURL)
+	if !ok {
+		return ""
+	}
+
+	return safeContinue
+}
+
+func (h *SAMLHandler) renderAssertionError(w http.ResponseWriter, r *http.Request, relayState string, err error) {
 	h.logger.ErrorCtx(r.Context(), "cannot handle SAML assertion", log.Error(err))
-	redirectAuthError(w, r, authErrorAuthenticationFailed)
+	continueURL := h.continueURLFromRelayState(r.Context(), relayState)
+	redirectAuthError(w, r, authErrorAuthenticationFailed, continueURL)
 }
 
 func (h *SAMLHandler) MetadataHandler(w http.ResponseWriter, r *http.Request) {
@@ -106,7 +126,8 @@ func (h *SAMLHandler) ConsumeHandler(w http.ResponseWriter, r *http.Request) {
 
 	user, membership, err := h.iam.SAMLService.HandleAssertion(ctx, samlResponse, configID)
 	if err != nil {
-		h.renderAssertionError(w, r, err)
+		h.renderAssertionError(w, r, relayState, err)
+
 		return
 	}
 

--- a/pkg/statelesstoken/statelesstoken.go
+++ b/pkg/statelesstoken/statelesstoken.go
@@ -58,6 +58,13 @@ type (
 	ErrExpiredToken struct {
 		message string
 	}
+
+	validateOptions struct {
+		allowExpired bool
+	}
+
+	// ValidateOption configures token validation.
+	ValidateOption func(*validateOptions)
 )
 
 var (
@@ -71,6 +78,14 @@ func (e ErrInvalidToken) Error() string {
 
 func (e ErrExpiredToken) Error() string {
 	return e.message
+}
+
+// AllowExpired skips the expiration check while still verifying signature and type.
+// Use only when recovering non-sensitive metadata (e.g. post-auth redirect URLs).
+func AllowExpired() ValidateOption {
+	return func(o *validateOptions) {
+		o.allowExpired = true
+	}
 }
 
 func NewToken[T any](secret string, tokenType string, expirationTime time.Duration, data T) (string, error) {
@@ -125,25 +140,30 @@ func DecodePayload[T any](tokenString string) (*Payload[T], error) {
 	return &payload, nil
 }
 
-// ValidateToken validates a token and unmarshals the payload
-// It returns an error if the token is invalid or expired
-func ValidateToken[T any](secret string, tokenType string, tokenString string) (*Payload[T], error) {
+// ValidateToken validates a token and unmarshals the payload.
+// By default it returns an error if the token is invalid or expired.
+func ValidateToken[T any](
+	secret string,
+	tokenType string,
+	tokenString string,
+	opts ...ValidateOption,
+) (*Payload[T], error) {
+	var options validateOptions
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	payload, err := parseSignedToken[T](secret, tokenType, tokenString)
 	if err != nil {
 		return nil, err
 	}
 
-	if time.Now().After(payload.ExpiresAt) {
+	if !options.allowExpired && time.Now().After(payload.ExpiresAt) {
 		return nil, &ErrExpiredToken{message: "token has expired"}
 	}
 
 	return payload, nil
-}
-
-// ValidateTokenAllowExpired validates signature and type but ignores expiration.
-// Use only when recovering non-sensitive metadata (e.g. post-auth redirect URLs).
-func ValidateTokenAllowExpired[T any](secret string, tokenType string, tokenString string) (*Payload[T], error) {
-	return parseSignedToken[T](secret, tokenType, tokenString)
 }
 
 func parseSignedToken[T any](secret string, tokenType string, tokenString string) (*Payload[T], error) {

--- a/pkg/statelesstoken/statelesstoken.go
+++ b/pkg/statelesstoken/statelesstoken.go
@@ -128,6 +128,25 @@ func DecodePayload[T any](tokenString string) (*Payload[T], error) {
 // ValidateToken validates a token and unmarshals the payload
 // It returns an error if the token is invalid or expired
 func ValidateToken[T any](secret string, tokenType string, tokenString string) (*Payload[T], error) {
+	payload, err := parseSignedToken[T](secret, tokenType, tokenString)
+	if err != nil {
+		return nil, err
+	}
+
+	if time.Now().After(payload.ExpiresAt) {
+		return nil, &ErrExpiredToken{message: "token has expired"}
+	}
+
+	return payload, nil
+}
+
+// ValidateTokenAllowExpired validates signature and type but ignores expiration.
+// Use only when recovering non-sensitive metadata (e.g. post-auth redirect URLs).
+func ValidateTokenAllowExpired[T any](secret string, tokenType string, tokenString string) (*Payload[T], error) {
+	return parseSignedToken[T](secret, tokenType, tokenString)
+}
+
+func parseSignedToken[T any](secret string, tokenType string, tokenString string) (*Payload[T], error) {
 	parts := strings.Split(tokenString, ".")
 	if len(parts) != 2 {
 		return nil, &ErrInvalidToken{message: "invalid token format"}
@@ -152,10 +171,6 @@ func ValidateToken[T any](secret string, tokenType string, tokenString string) (
 	var payload Payload[T]
 	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal token payload: %w", err)
-	}
-
-	if time.Now().After(payload.ExpiresAt) {
-		return nil, &ErrExpiredToken{message: "token has expired"}
 	}
 
 	if payload.Type != tokenType {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When sign-in failed (OIDC, magic link, or SAML), users landed on `/auth/error` with a **Sign in** button that always linked to `/auth/login` without the original `continue` destination.

## Changes

- **Backend:** `redirectAuthError` accepts an optional validated `continue` query parameter.
- **OIDC:** Return stored continue URL from `HandleCallback` on failures after state is loaded.
- **Magic link:** Recover continue from the signed token (including expired links) on error redirect.
- **SAML:** Parse continue from `RelayState` on assertion failures.
- **Console:** `AuthErrorPage` forwards `continue` to `/auth/login`.

Reopened on a fresh branch after the previous PR branch was overwritten on the remote.

## Test plan

- [ ] OAuth authorize flow + recoverable auth error → **Sign in** preserves `continue` and retry completes authorize.
- [ ] Expired magic link with continue target → error page **Sign in** preserves `continue`.
- [ ] SAML assertion failure with continue in RelayState → re-login preserves intent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9d6a-6fe4-75d9-a880-31288c38e614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9d6a-6fe4-75d9-a880-31288c38e614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve the original continue URL on OIDC, magic link, and SAML auth failures so re-sign-in returns users to the intended page. The continue value is validated end-to-end with `safeRedirect`, and the console error page forwards it to `/auth/login`.

### GraphQL API **`+91`** **`-15`**
- `redirectAuthError` now accepts an optional validated `continue`.
- OIDC: recover `continue` from callback state on IdP/invalid-state/code errors and include it in redirects.
- Magic link: extract `continue` from the token (even if expired), validate, and pass to error redirects.
- SAML: parse `continue` from `RelayState`, validate, and include on assertion errors.

### Service **`+111`** **`-15`**
- OIDC: added `ContinueURLFromCallbackState`; `HandleCallback` returns `continue` on failure paths.
- Magic link: new `MagicLinkContinueFromToken` using `statelesstoken.ValidateToken(..., AllowExpired())`.
- `statelesstoken`: unified validation via options; replaced the allow-expired variant with `ValidateToken` + `AllowExpired()`.

### App: console **`+12`** **`-1`**
- `AuthErrorPage` forwards `continue` to `/auth/login`.

### Tests **`+19`** **`-1`**
- Added coverage for the `continue` parameter in auth error redirects.

<sup>Written for commit 144cddadf5280136280e4c17d266400b257d7bb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

