### PR TITLE
Ship signed Windows MSI via Azure Trusted Signing

### DIFF
--- a/.github/workflows/release-probo-agent.yaml
+++ b/.github/workflows/release-probo-agent.yaml
@@ -20,8 +20,6 @@ jobs:
         include:
           - { goos: linux, goarch: amd64 }
           - { goos: linux, goarch: arm64 }
-          - { goos: windows, goarch: amd64 }
-          - { goos: windows, goarch: arm64 }
           - { goos: freebsd, goarch: amd64 }
           - { goos: freebsd, goarch: arm64 }
     steps:
@@ -39,11 +37,9 @@ jobs:
           GOARCH: "${{ matrix.goarch }}"
         run: |
           VERSION="${GITHUB_REF_NAME##*/v}"
-          EXT=""
-          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
 
           go build -ldflags "-s -w -X 'main.version=${VERSION}'" \
-            -gcflags="-e" -o "dist/probo-agent${EXT}" ./cmd/probo-agent
+            -gcflags="-e" -o "dist/probo-agent" ./cmd/probo-agent
       - name: "Create archive"
         env:
           GOOS: "${{ matrix.goos }}"
@@ -51,31 +47,134 @@ jobs:
         run: |
           case "$GOOS" in
             linux)   OS="Linux" ;;
-            windows) OS="Windows" ;;
             freebsd) OS="Freebsd" ;;
           esac
           case "$GOARCH" in
             amd64) ARCH="x86_64" ;;
             *)     ARCH="$GOARCH" ;;
           esac
-          EXT=""
-          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
 
           mkdir -p archives
           AGENT_DIR="probo-agent_${OS}_${ARCH}"
           mkdir -p "staging/${AGENT_DIR}"
-          cp "dist/probo-agent${EXT}" README.md LICENSE "staging/${AGENT_DIR}/"
+          cp "dist/probo-agent" README.md LICENSE "staging/${AGENT_DIR}/"
           if [ -f cmd/probo-agent/CHANGELOG.md ]; then
             cp cmd/probo-agent/CHANGELOG.md "staging/${AGENT_DIR}/"
           fi
-          if [ "$GOOS" = "windows" ]; then
-            (cd staging && zip -r "../archives/${AGENT_DIR}.zip" "${AGENT_DIR}")
-          else
-            tar -czf "archives/${AGENT_DIR}.tar.gz" -C staging "${AGENT_DIR}"
-          fi
+          tar -czf "archives/${AGENT_DIR}.tar.gz" -C staging "${AGENT_DIR}"
       - uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7
         with:
           name: "archive-${{ matrix.goos }}-${{ matrix.goarch }}"
+          path: "archives/"
+          retention-days: 1
+
+  build-windows:
+    name: "windows (${{ matrix.goarch }})"
+    runs-on: "windows-latest"
+    environment: "probo-agent-release"
+    permissions:
+      contents: "read"
+      id-token: "write"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { goarch: amd64, arch_label: x86_64, wix_arch: amd64 }
+          - { goarch: arm64, arch_label: arm64, wix_arch: arm64 }
+    steps:
+      - uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v6
+        with:
+          submodules: recursive
+      - uses: "./.github/actions/setup"
+        with:
+          node: "false"
+      - name: "Install WiX"
+        shell: "pwsh"
+        run: |
+          dotnet tool install --global wix --version 6.0.2
+          "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          & "$env:USERPROFILE\.dotnet\tools\wix.exe" --version
+      - name: "Build binary"
+        shell: "pwsh"
+        env:
+          CGO_ENABLED: "0"
+          GOOS: "windows"
+          GOARCH: "${{ matrix.goarch }}"
+        run: |
+          $ErrorActionPreference = "Stop"
+          $Version = $env:GITHUB_REF_NAME -replace '^.*\/v', ''
+          New-Item -ItemType Directory -Force -Path dist, archives | Out-Null
+          $ldflags = "-s -w -X 'main.version=$Version'"
+          go build -ldflags $ldflags -gcflags="-e" -o dist/probo-agent.exe ./cmd/probo-agent
+          if ($LASTEXITCODE -ne 0) { throw "go build failed" }
+      - name: "Azure login"
+        uses: "azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43" # v3.0.0
+        with:
+          client-id: "${{ secrets.AZURE_CLIENT_ID }}"
+          tenant-id: "${{ secrets.AZURE_TENANT_ID }}"
+          subscription-id: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+      - name: "Sign probo-agent.exe"
+        uses: "azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82" # v2.0.0
+        with:
+          endpoint: "${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}"
+          signing-account-name: "${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT }}"
+          certificate-profile-name: "${{ vars.AZURE_TRUSTED_SIGNING_PROFILE }}"
+          files: "${{ github.workspace }}/dist/probo-agent.exe"
+          file-digest: "SHA256"
+          timestamp-rfc3161: "http://timestamp.acs.microsoft.com"
+          timestamp-digest: "SHA256"
+          description: "Probo Agent"
+          description-url: "https://probo.com"
+      - name: "Build MSI"
+        id: "msi"
+        shell: "pwsh"
+        run: |
+          $ErrorActionPreference = "Stop"
+          $Version = $env:GITHUB_REF_NAME -replace '^.*\/v', ''
+          $ArchLabel = "${{ matrix.arch_label }}"
+          New-Item -ItemType Directory -Force -Path archives | Out-Null
+          $Msi = Join-Path $PWD "archives/probo-agent_${Version}_windows_${ArchLabel}.msi"
+          & ./cmd/probo-agent/installer/windows/build.ps1 `
+            -Binary ./dist/probo-agent.exe `
+            -Version $Version `
+            -Arch "${{ matrix.wix_arch }}" `
+            -Output $Msi
+          "msi_path=$Msi" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+      - name: "Sign MSI"
+        uses: "azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82" # v2.0.0
+        with:
+          endpoint: "${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}"
+          signing-account-name: "${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT }}"
+          certificate-profile-name: "${{ vars.AZURE_TRUSTED_SIGNING_PROFILE }}"
+          files: "${{ steps.msi.outputs.msi_path }}"
+          file-digest: "SHA256"
+          timestamp-rfc3161: "http://timestamp.acs.microsoft.com"
+          timestamp-digest: "SHA256"
+          description: "Probo Agent"
+          description-url: "https://probo.com"
+      - name: "Create zip archive"
+        shell: "pwsh"
+        run: |
+          $ErrorActionPreference = "Stop"
+          $ArchLabel = "${{ matrix.arch_label }}"
+          $AgentDir = "probo-agent_Windows_$ArchLabel"
+          $StagingRoot = Join-Path $PWD "staging"
+          $Staging = Join-Path $StagingRoot $AgentDir
+          New-Item -ItemType Directory -Force -Path $Staging, archives | Out-Null
+          Copy-Item dist/probo-agent.exe $Staging/
+          Copy-Item README.md, LICENSE $Staging/
+          if (Test-Path cmd/probo-agent/CHANGELOG.md) {
+            Copy-Item cmd/probo-agent/CHANGELOG.md $Staging/
+          }
+          $Zip = Join-Path $PWD "archives/$AgentDir.zip"
+          if (Test-Path $Zip) { Remove-Item $Zip }
+          # Prefer tar so zip entry paths use forward slashes (Go updater
+          # matches with path.Clean, not filepath).
+          & tar.exe -a -c -f $Zip -C $StagingRoot $AgentDir
+          if ($LASTEXITCODE -ne 0) { throw "tar zip failed" }
+      - uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7
+        with:
+          name: "archive-windows-${{ matrix.goarch }}"
           path: "archives/"
           retention-days: 1
 
@@ -174,7 +273,7 @@ jobs:
 
   github-release:
     name: "github-release"
-    needs: [build-binary, build-macos]
+    needs: [build-binary, build-windows, build-macos]
     runs-on: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64/extras=s3-cache"
     permissions:
       contents: "write"
@@ -194,7 +293,7 @@ jobs:
       - name: "Generate checksums and sign"
         run: |
           cd archives
-          sha256sum *.tar.gz *.zip *.pkg > checksums.txt
+          sha256sum *.tar.gz *.zip *.pkg *.msi > checksums.txt
           cosign sign-blob --bundle="checksums.txt.bundle" checksums.txt --yes
       - name: "Inject release checksums into install.sh"
         run: |
@@ -238,12 +337,12 @@ jobs:
       - name: "Attest SBOM for archives"
         uses: "actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e" # v4
         with:
-          subject-path: "archives/*.tar.gz, archives/*.zip, archives/*.pkg"
+          subject-path: "archives/*.tar.gz, archives/*.zip, archives/*.pkg, archives/*.msi"
           sbom-path: "sbom.json"
       - name: "Attest build provenance for archives"
         uses: "actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373" # v4
         with:
-          subject-path: "archives/*.tar.gz, archives/*.zip, archives/*.pkg"
+          subject-path: "archives/*.tar.gz, archives/*.zip, archives/*.pkg, archives/*.msi"
       - name: "Extract release notes"
         run: |
           VERSION="${GITHUB_REF_NAME##*/v}"

--- a/cmd/probo-agent/installer/windows/Package.wxs
+++ b/cmd/probo-agent/installer/windows/Package.wxs
@@ -1,0 +1,75 @@
+<!-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. -->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+	<!--
+		Builds the per-machine Probo Agent MSI.
+
+		Preprocessor variables (passed by build.ps1 via wix -d):
+		  Version   Product version, e.g. 0.3.0  → $(var.Version)
+		  AgentExe  Absolute path to probo-agent.exe → $(var.AgentExe)
+	-->
+	<Package
+		Name="Probo Agent"
+		Manufacturer="Probo Inc"
+		Version="$(var.Version)"
+		UpgradeCode="71b7d5c8-733b-4fd7-887e-bdffa6a6c0d8"
+		Scope="perMachine"
+	>
+		<MajorUpgrade
+			DowngradeErrorMessage="A newer version of Probo Agent is already installed."
+		/>
+
+		<StandardDirectory Id="ProgramFiles64Folder">
+			<Directory Id="INSTALLFOLDER" Name="Probo" />
+		</StandardDirectory>
+
+		<ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+			<Component Guid="62994ec7-7696-4513-92ab-0cb41cadfc0a">
+				<File
+					Id="ProboAgentExe"
+					Source="$(var.AgentExe)"
+					Name="probo-agent.exe"
+					KeyPath="yes"
+				/>
+			</Component>
+
+			<Component Guid="6603ee19-ddba-42f1-8961-5cd945374657">
+				<RegistryKey Root="HKLM" Key="Software\Classes\probo">
+					<RegistryValue
+						Type="string"
+						Value="URL:Probo Enrollment Protocol"
+						KeyPath="yes"
+					/>
+					<RegistryValue Name="URL Protocol" Type="string" Value="" />
+					<RegistryKey Key="shell\open\command">
+						<RegistryValue
+							Type="string"
+							Value="&quot;[INSTALLFOLDER]probo-agent.exe&quot; &quot;%1&quot;"
+						/>
+					</RegistryKey>
+				</RegistryKey>
+			</Component>
+		</ComponentGroup>
+
+		<Feature Id="Main" Title="Probo Agent" Level="1">
+			<ComponentGroupRef Id="ProductComponents" />
+		</Feature>
+	</Package>
+</Wix>

--- a/cmd/probo-agent/installer/windows/build.ps1
+++ b/cmd/probo-agent/installer/windows/build.ps1
@@ -1,0 +1,130 @@
+# Copyright (c) 2026 Probo Inc <hello@probo.com>.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+  Build the Probo Agent Windows MSI with WiX.
+
+.DESCRIPTION
+  Packages a pre-built probo-agent.exe into
+  probo-agent_<version>_windows_<arch>.msi. Prefer passing an
+  Authenticode-signed binary so the nested exe remains signed.
+
+  Requires the WiX CLI (`wix`) on PATH (dotnet tool install --global wix).
+
+.PARAMETER Binary
+  Path to probo-agent.exe.
+
+.PARAMETER Version
+  Product version (X.Y.Z). Defaults to cmd/probo-agent/VERSION.
+
+.PARAMETER Arch
+  Target architecture: amd64, x86_64, x64, or arm64.
+
+.PARAMETER Output
+  Output .msi path. Defaults next to the script under dist/.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Binary,
+
+    [string]$Version = "",
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("amd64", "x86_64", "x64", "arm64")]
+    [string]$Arch,
+
+    [string]$Output = ""
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = $PSScriptRoot
+$RepoRoot = (Resolve-Path (Join-Path $ScriptDir "..\..\..\..")).Path
+$PackageWxs = Join-Path $ScriptDir "Package.wxs"
+
+if (-not (Test-Path -LiteralPath $Binary)) {
+    throw "error: --binary / -Binary path not found: $Binary"
+}
+
+$Binary = (Resolve-Path -LiteralPath $Binary).Path
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $VersionFile = Join-Path $RepoRoot "cmd\probo-agent\VERSION"
+    if (-not (Test-Path -LiteralPath $VersionFile)) {
+        throw "error: VERSION file missing at $VersionFile; pass -Version"
+    }
+    $Version = (Get-Content -LiteralPath $VersionFile -Raw).Trim()
+}
+
+if ($Version -notmatch '^\d+\.\d+\.\d+') {
+    throw "error: version must look like X.Y.Z (got '$Version')"
+}
+
+switch ($Arch) {
+    { $_ -in @("amd64", "x86_64", "x64") } {
+        $WixArch = "x64"
+        $ArchLabel = "x86_64"
+    }
+    "arm64" {
+        $WixArch = "arm64"
+        $ArchLabel = "arm64"
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($Output)) {
+    $DistDir = Join-Path $RepoRoot "dist"
+    New-Item -ItemType Directory -Force -Path $DistDir | Out-Null
+    $Output = Join-Path $DistDir "probo-agent_${Version}_windows_${ArchLabel}.msi"
+} else {
+    $outDir = Split-Path -Parent $Output
+    if ($outDir) {
+        New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+    }
+}
+
+$wix = Get-Command wix -ErrorAction SilentlyContinue
+if (-not $wix) {
+    throw "error: wix CLI not found on PATH (install with: dotnet tool install --global wix)"
+}
+
+Write-Host "Building MSI: binary=$Binary arch=$WixArch version=$Version output=$Output"
+
+& wix build `
+    -arch $WixArch `
+    -d "Version=$Version" `
+    -d "AgentExe=$Binary" `
+    -o $Output `
+    $PackageWxs
+
+if ($LASTEXITCODE -ne 0) {
+    throw "error: wix build failed with exit code $LASTEXITCODE"
+}
+
+if (-not (Test-Path -LiteralPath $Output)) {
+    throw "error: expected MSI was not produced at $Output"
+}
+
+Write-Host "Wrote $Output"

--- a/contrib/claude/release/README.md
+++ b/contrib/claude/release/README.md
@@ -11,7 +11,7 @@ changelog entry, commit, tag, push.
 | Server (`probod` group) | `probod/v*`                    | [probod.md](./probod.md)         |
 | `probod-bootstrap`      | `probod-bootstrap/v*`          | [probod-bootstrap.md](./probod-bootstrap.md) |
 | `proboctl`              | `proboctl/v*`                  | [proboctl.md](./proboctl.md)     |
-| `probo-agent`           | `probo-agent/v*`               | [probo-agent.md](./probo-agent.md) |
+| `probo-agent`           | `probo-agent/v*`               | [probo-agent.md](./probo-agent.md) ([Windows signing setup](./probo-agent-windows-signing.md)) |
 | `@probo/n8n-nodes-probo` | `@probo/n8n-nodes-probo/v*`   | [n8n-nodes-probo.md](./n8n-nodes-probo.md) |
 | `@probo/cookie-banner`  | `@probo/cookie-banner/v*`      | [cookie-banner.md](./cookie-banner.md) |
 | `@probo/skills`         | `@probo/skills/v*`             | [skills.md](./skills.md)           |

--- a/contrib/claude/release/probo-agent-windows-signing.md
+++ b/contrib/claude/release/probo-agent-windows-signing.md
@@ -1,0 +1,299 @@
+# Set up Azure Trusted Signing for `probo-agent`
+
+This guide walks through everything needed before the first
+Authenticode-signed Windows release. The release workflow
+(`.github/workflows/release-probo-agent.yaml`) builds on `windows-latest`,
+signs `probo-agent.exe` and the MSI with **Azure Artifact Signing**
+(formerly Trusted Signing), then publishes zip + MSI.
+
+Official Microsoft docs:
+
+- [Quickstart: Set up Artifact Signing](https://learn.microsoft.com/en-us/azure/trusted-signing/quickstart)
+- [Connect GitHub Actions to Azure with OIDC](https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure)
+- [Artifact Signing roles](https://learn.microsoft.com/en-us/azure/trusted-signing/concept-resources-roles)
+
+Naming note: Azure UI/docs increasingly say **Artifact Signing**; older
+pages still say **Trusted Signing**. Same service (`Microsoft.CodeSigning`).
+
+## What you will create
+
+| Azure / GitHub object | Purpose |
+|-----------------------|---------|
+| Azure subscription + billing | Pays for Artifact Signing (~Basic SKU) |
+| Resource provider `Microsoft.CodeSigning` | Enables the service on the subscription |
+| Artifact Signing account | Container for identity + certificate profile |
+| Organization **Public** identity validation | Publisher name on the certificate (Probo Inc) |
+| Certificate profile (`PublicTrust`) | Profile the CI job signs with |
+| Entra app registration + service principal | Identity GitHub Actions assumes via OIDC |
+| Federated credential → GitHub Environment | No client secret; tag-triggered releases can sign |
+| GitHub Environment `probo-agent-release` | Scopes OIDC (tag wildcards are not supported) |
+| GitHub secrets + variables | Wired into `build-windows` |
+
+Suggested concrete names (adjust if they collide globally):
+
+| Item | Suggested value |
+|------|-----------------|
+| Resource group | `rg-probo-codesigning` |
+| Artifact Signing account | `probo-codesigning` (3–24 chars, globally unique) |
+| Certificate profile | `probo-agent` |
+| Region / endpoint | e.g. East US → `https://eus.codesigning.azure.net/` |
+| Entra app | `github-probo-agent-codesign` |
+| GitHub Environment | `probo-agent-release` (must match the workflow) |
+
+Region → endpoint map (pick the region of the account):
+
+| Region | Endpoint |
+|--------|----------|
+| East US | `https://eus.codesigning.azure.net/` |
+| West Europe | `https://weu.codesigning.azure.net/` |
+| North Europe | `https://neu.codesigning.azure.net/` |
+| West US 2 | `https://wus2.codesigning.azure.net/` |
+| … | See [quickstart region table](https://learn.microsoft.com/en-us/azure/trusted-signing/quickstart) |
+
+Public Trust is available to organizations in supported countries (US,
+Canada, EU, UK, and others listed in Microsoft’s docs). Confirm Probo’s
+legal entity qualifies before starting.
+
+## 1. Azure subscription and resource provider
+
+1. Sign in to [Azure Portal](https://portal.azure.com) with an account that
+   can create resources and assign roles on the target subscription.
+2. Open **Subscriptions** → select the subscription → **Resource providers**.
+3. Find **`Microsoft.CodeSigning`** → **Register**.
+4. Note the **Subscription ID** (GUID). You will store it as
+   `AZURE_SUBSCRIPTION_ID`.
+
+Optional CLI:
+
+```shell
+az login
+az account set --subscription '<subscription-id>'
+az provider register --namespace Microsoft.CodeSigning
+az provider show --namespace Microsoft.CodeSigning --query registrationState
+az extension add --name artifact-signing   # or trustedsigning on older CLIs
+```
+
+## 2. Create the Artifact Signing account
+
+Portal:
+
+1. Search for **Artifact Signing Accounts** → **Create**.
+2. Subscription + new resource group (e.g. `rg-probo-codesigning`).
+3. Account name (e.g. `probo-codesigning`).
+4. Region that supports Artifact Signing (see table above).
+5. Pricing: **Basic** is enough for typical release volume; use Premium
+   only if you need multiple accounts / higher quotas.
+6. **Review + create** → open the resource.
+
+CLI sketch:
+
+```shell
+az group create --name rg-probo-codesigning --location eastus
+az artifact-signing create \
+  -n probo-codesigning \
+  -g rg-probo-codesigning \
+  -l eastus \
+  --sku Basic
+```
+
+Save:
+
+- Account name → GitHub variable `AZURE_TRUSTED_SIGNING_ACCOUNT`
+- Endpoint for that region → `AZURE_TRUSTED_SIGNING_ENDPOINT`
+
+## 3. Grant yourself Identity Verifier (once)
+
+Identity validation can only be started by a principal with the
+**Artifact Signing Identity Verifier** role (portal may still show the
+older “Trusted Signing Identity Verifier” name).
+
+1. Open the Artifact Signing account → **Access control (IAM)**.
+2. **Add** → **Add role assignment**.
+3. Role: **Artifact Signing Identity Verifier**.
+4. Assign to your user (the human who will submit Probo Inc’s docs).
+5. **Review + assign**.
+
+Without this role, **New identity** stays disabled.
+
+## 4. Organization public identity validation (Probo Inc)
+
+This is the long pole (often **1–20 business days**). Do it before
+relying on a release tag.
+
+1. Artifact Signing account → **Identity validations**.
+2. Choose **Organization** → **New identity** → **Public**
+   (required for Public Trust profiles used for public downloads).
+3. Fill fields carefully — they drive the certificate subject preview:
+   - Legal organization name (as it should appear as publisher)
+   - Website URL owned by the entity (e.g. `https://probo.com`)
+   - Primary + secondary emails (primary receives verification links;
+     links expire in ~7 days)
+   - Business identifier / registration details as requested
+   - Legal business address
+   - First/last name of the individual who will complete ID proofing
+     (must match government ID)
+4. Preview the certificate subject → **Create**.
+5. When status is **Action Required**, complete email verification and
+   the individual ID proofing flow (third-party verifier + Authenticator
+   Verified ID) linked from the portal / email.
+6. Wait until status is **Completed**. Failed email verification means
+   start a **new** request.
+
+Tips:
+
+- Keep public company records and domain registration in sync with what
+  you submit.
+- Billing account type for the subscription should be compatible with
+  **organization** validation (individual billing accounts cannot
+  validate an organization identity).
+- Do not expect street address on the public certificate unless you
+  explicitly include it later on the profile.
+
+## 5. Create a Public Trust certificate profile
+
+1. Artifact Signing account → **Certificate profiles** → **Create**.
+2. Type: **Public Trust** (not Private Trust; Private is for internal-only).
+3. Profile name (e.g. `probo-agent`) → GitHub variable
+   `AZURE_TRUSTED_SIGNING_PROFILE`.
+4. Select the **Completed** organization identity for CN/O.
+5. Leave street / postal off unless you intentionally want them on the
+   cert.
+6. Create the profile.
+
+Leaf certificates issued under the profile are short-lived (~days). CI
+always timestamps with `http://timestamp.acs.microsoft.com` so signatures
+remain valid after the leaf rotates. You never download a long-lived PFX.
+
+## 6. Entra app registration for GitHub OIDC
+
+Prefer **federated credentials** (no long-lived client secret).
+
+### 6.1 Register the app
+
+1. Azure Portal → **Microsoft Entra ID** → **App registrations** →
+   **New registration**.
+2. Name: e.g. `github-probo-agent-codesign`.
+3. Supported account types: **Single tenant**.
+4. Redirect URI: leave empty.
+5. **Register**.
+6. Note:
+   - **Application (client) ID** → `AZURE_CLIENT_ID`
+   - **Directory (tenant) ID** → `AZURE_TENANT_ID`
+
+### 6.2 Federated credential (GitHub Environment)
+
+Tag name wildcards (`probo-agent/v*`) are **not** supported in Entra
+federated credentials. The release workflow therefore uses the GitHub
+Environment `probo-agent-release`.
+
+1. On the app → **Certificates & secrets** → **Federated credentials** →
+   **Add credential**.
+2. Scenario: **GitHub Actions deploying Azure resources**.
+3. Organization: `getprobo`
+4. Repository: `probo`
+5. Entity type: **Environment**
+6. Environment name: `probo-agent-release` (exact match)
+7. Name the credential (e.g. `github-probo-agent-release`)
+8. Audience: leave default (`api://AzureADTokenExchange`)
+
+Expected subject (for debugging):
+
+```text
+repo:getprobo/probo:environment:probo-agent-release
+```
+
+### 6.3 Grant signing permission
+
+1. Artifact Signing account → **Access control (IAM)** → **Add role assignment**.
+2. Role: **Artifact Signing Certificate Profile Signer**
+   (legacy name: Trusted Signing Certificate Profile Signer).
+3. Assign to **User, group, or service principal**.
+4. Search by the **app registration name** (apps often do not appear until
+   you type the name).
+5. **Review + assign**.
+
+Do **not** give the GitHub app the Identity Verifier role. Keep verifier
+on humans only.
+
+## 7. GitHub repository configuration
+
+### 7.1 Environment
+
+1. GitHub repo **Settings** → **Environments** → **New environment**.
+2. Name: `probo-agent-release`.
+3. Optional but recommended: required reviewers, and restrict to tags
+   matching `probo-agent/v*` if your plan supports deployment branch/tag
+   policies.
+
+The `build-windows` job already sets `environment: probo-agent-release`.
+
+### 7.2 Secrets
+
+Repo (or org) **Settings** → **Secrets and variables** → **Actions** →
+**Secrets**:
+
+| Secret | Value |
+|--------|-------|
+| `AZURE_CLIENT_ID` | Entra Application (client) ID |
+| `AZURE_TENANT_ID` | Entra Directory (tenant) ID |
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription GUID |
+
+### 7.3 Variables
+
+Same page → **Variables**:
+
+| Variable | Example |
+|----------|---------|
+| `AZURE_TRUSTED_SIGNING_ENDPOINT` | `https://eus.codesigning.azure.net/` |
+| `AZURE_TRUSTED_SIGNING_ACCOUNT` | `probo-codesigning` |
+| `AZURE_TRUSTED_SIGNING_PROFILE` | `probo-agent` |
+
+Endpoint **must** match the account’s region.
+
+## 8. Verify end-to-end
+
+1. Confirm identity validation status is **Completed** and the Public
+   Trust profile exists.
+2. Push a prerelease tag, e.g. `probo-agent/v0.0.0-rc.signing-test`
+   (after the usual version/changelog process, or a disposable test tag
+   on a branch that contains the workflow).
+3. Watch **Release probo-agent** → **windows (amd64)** / **windows (arm64)**:
+   - Azure login succeeds (OIDC)
+   - Sign `probo-agent.exe` succeeds
+   - WiX MSI build succeeds
+   - Sign MSI succeeds
+4. Download an MSI / unzip the Windows archive and check
+   Properties → Digital Signatures (publisher should show the validated
+   organization name; timestamp present).
+
+### Common failures
+
+| Symptom | Likely cause |
+|---------|----------------|
+| Azure login 401 / federated token rejected | Environment name mismatch, wrong org/repo, or federated credential subject |
+| Artifact Signing 403 | Missing **Certificate Profile Signer** on the app, or wrong account/profile name |
+| Identity validation blocked | Missing **Identity Verifier** on your user |
+| Wrong endpoint / region errors | Variable endpoint does not match account region |
+| Sign works but SmartScreen still warns | Expected for new publishers until reputation builds; not a signing failure |
+
+## 9. What this does *not* cover
+
+- Local unsigned MSI layout testing (see
+  [probo-agent.md](./probo-agent.md) — WiX `build.ps1` without Azure).
+- Buying a traditional DigiCert/Sectigo EV PFX (out of scope; CI uses
+  Artifact Signing only).
+- MSI-based auto-update (zip remains the update channel).
+
+## Checklist
+
+- [ ] `Microsoft.CodeSigning` registered on the subscription
+- [ ] Artifact Signing account created; endpoint noted
+- [ ] Identity Verifier role on the human operator
+- [ ] Organization Public identity validation **Completed**
+- [ ] Public Trust certificate profile created
+- [ ] Entra app + federated credential for Environment `probo-agent-release`
+- [ ] Certificate Profile Signer role on the Entra app
+- [ ] GitHub Environment `probo-agent-release` exists
+- [ ] Secrets `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID`
+- [ ] Vars `AZURE_TRUSTED_SIGNING_ENDPOINT` / `_ACCOUNT` / `_PROFILE`
+- [ ] Prerelease tag signed successfully for both Windows arches

--- a/contrib/claude/release/probo-agent.md
+++ b/contrib/claude/release/probo-agent.md
@@ -34,20 +34,22 @@ and FreeBSD builds stay pure Go (no tray).
 
 ## Notes
 
-CI builds binaries for linux, windows, and freebsd (amd64/arm64) on
-Linux runners, and builds **CGO-enabled** darwin archives plus a
-signed/notarized fat `.pkg` on a macOS runner. The GitHub
-Release includes those archives, `probo-agent_*_darwin.pkg`,
-`install.sh`, signed checksums, SBOM, and build attestations. The agent
-auto-update path downloads the matching archive plus `checksums.txt` and
-verifies the cosign bundle before installing.
+CI builds linux and freebsd (amd64/arm64) on Linux runners, builds
+**CGO-enabled** darwin archives plus a signed/notarized fat `.pkg` on a
+macOS runner, and builds **Windows** zip archives plus Authenticode-signed
+MSIs on `windows-latest` (Azure Trusted Signing). The GitHub Release
+includes those archives, `probo-agent_*_darwin.pkg`,
+`probo-agent_*_windows_*.msi`, `install.sh`, signed checksums, SBOM, and
+build attestations. The agent auto-update path downloads the matching
+archive plus `checksums.txt` and verifies the cosign bundle before
+installing.
 
 The menu bar / tray enrollment flow is **macOS and Windows only**.
 Linux and FreeBSD use `probo-agent install --server …
 --enrollment-token …` from the shell, or the curl-to-sh installer
-documented below. Windows release binaries are cross-compiled from
-Linux with `CGO_ENABLED=0` (tray is pure Go). macOS release binaries
-and the `.pkg` are built on macOS with `CGO_ENABLED=1`.
+documented below. Windows release binaries are built natively on
+Windows runners with `CGO_ENABLED=0` (tray is pure Go). macOS release
+binaries and the `.pkg` are built on macOS with `CGO_ENABLED=1`.
 
 ### macOS `.pkg` (MDM / GUI install)
 
@@ -143,15 +145,70 @@ export APPLE_ID_PASSWORD="app-specific-password"
 # optional: NOTARYTOOL_KEYCHAIN_PROFILE=probo-agent-notary (default)
 ```
 
+### Windows MSI (MDM / GUI install)
+
+Release builds use `cmd/probo-agent/installer/windows/build.ps1` (WiX)
+on `windows-latest`. The MSI installs `probo-agent.exe` under
+`C:\Program Files\Probo\` and registers a machine-wide `probo://`
+handler (HKLM). It does **not** create the Windows service — enrollment
+(`probo-agent install` / deep link) still owns `sc.exe create`, same
+idea as the macOS LaunchDaemon-after-enroll flow.
+
+Published assets per arch:
+
+| Artifact | Role |
+|----------|------|
+| `probo-agent_*_windows_*.msi` | Initial install (double-click or `msiexec /i … /qn`) |
+| `probo-agent_Windows_*.zip` | Auto-update only (unchanged updater contract) |
+
+Both the nested `probo-agent.exe` and the MSI are Authenticode-signed
+with **Azure Trusted Signing** before upload. Local unsigned MSI builds
+(no signing) are fine for layout testing:
+
+```powershell
+# Requires: go, and `dotnet tool install --global wix`
+$Version = Get-Content cmd/probo-agent/VERSION -Raw
+$Version = $Version.Trim()
+go build -ldflags "-X 'main.version=$Version'" -o dist/probo-agent.exe ./cmd/probo-agent
+./cmd/probo-agent/installer/windows/build.ps1 `
+  -Binary dist/probo-agent.exe `
+  -Version $Version `
+  -Arch amd64
+```
+
+For per-user protocol registration without the MSI (dev machines),
+`cmd/probo-agent/installer/windows/register-protocol.ps1` still writes
+an HKCU handler pointing at `%ProgramFiles%\Probo\probo-agent.exe`.
+
+### Azure Trusted Signing (GitHub)
+
+The `build-windows` job signs with Azure Artifact Signing (Trusted
+Signing) only — no PFX in repository secrets. The job uses the GitHub
+Environment `probo-agent-release` and OIDC (no client secret).
+
+**Full setup guide:**
+[`probo-agent-windows-signing.md`](./probo-agent-windows-signing.md)
+
+Quick reference (names must match the guide and workflow):
+
+| Name | Kind | Purpose |
+|------|------|---------|
+| `AZURE_CLIENT_ID` | secret | Entra app (federated credential) |
+| `AZURE_TENANT_ID` | secret | Entra tenant |
+| `AZURE_SUBSCRIPTION_ID` | secret | Azure subscription |
+| `AZURE_TRUSTED_SIGNING_ENDPOINT` | variable | e.g. `https://eus.codesigning.azure.net/` |
+| `AZURE_TRUSTED_SIGNING_ACCOUNT` | variable | Artifact Signing account name |
+| `AZURE_TRUSTED_SIGNING_PROFILE` | variable | Certificate profile name |
+
+Timestamps use Microsoft ACS (`http://timestamp.acs.microsoft.com`).
+Leaf certificates are short-lived; the RFC3161 timestamp is required.
+
 Windows enrollment is browser-driven: the console issues a
 `probo://enroll?server=...&token=...` deep link handled by
 `Probo Agent.app` on macOS (PKG-installed helper + XPC) or
-`probo-agent enroll-url` on Windows. After install, register the protocol for the
-current user with
-`cmd/probo-agent/installer/windows/register-protocol.ps1` (per-user
-`HKCU` handler pointing at `probo-agent.exe`). The system tray helper
-(`probo-agent tray`) shows enrollment status; enrollment itself happens
-in the browser.
+`probo-agent enroll-url` on Windows (MSI-registered protocol). The
+system tray helper (`probo-agent tray`) shows enrollment status;
+enrollment itself happens in the browser.
 
 Region labels and console URLs for the macOS installer HTML live in
 `cmd/probo-agent/installer/regions.json`. A Go test keeps US/EU URLs in


### PR DESCRIPTION
Move Windows release builds onto windows-latest and publish an Authenticode-signed MSI for initial install alongside the existing zip used for auto-update. Sign the agent exe and MSI with Azure Trusted Signing so the private key never leaves Microsoft’s HSM.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships a Windows MSI for Probo Agent, signed via Azure Trusted Signing, and moves Windows builds to `windows-latest`. Updates the release pipeline to include MSI artifacts in checksums, SBOM, and provenance while keeping the zip for auto-update.

### Other **`+322`** **`-18`**
- Add WiX-based installer: `Package.wxs` and `build.ps1` to build a per-machine MSI installing to `C:\Program Files\Probo\` and registering the `probo://` protocol (HKLM).
- New `build-windows` job on `windows-latest` (amd64, arm64): build `probo-agent.exe`, sign with `azure/login` + `azure/artifact-signing-action`, build MSI with WiX, sign MSI, and publish MSI + zip.
- Remove Windows from the Linux matrix; Linux/FreeBSD stay `.tar.gz`. Windows zips are built on Windows runners.
- Release depends on Windows builds and includes `.msi` in checksums, SBOM, and build attestations.

### Agents **`+373`** **`-17`**
- Add full Azure Trusted Signing setup guide for `probo-agent` (Entra OIDC, roles, env, secrets/vars, verification).
- Update release docs for Windows MSI usage, local unsigned MSI builds with WiX, and that MSI registers `probo://` but does not create the service; zip remains the update channel.
- Link the signing guide from the release README and clarify Windows builds now run on `windows-latest`.

<sup>Written for commit edb1651b097341e01d80d0d53de37a45c9f7a8fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

