### PR TITLE
Limit third party selectors to first-level parties

### DIFF
--- a/apps/console/src/components/form/ThirdPartiesMultiSelectField.tsx
+++ b/apps/console/src/components/form/ThirdPartiesMultiSelectField.tsx
@@ -49,7 +49,11 @@ const thirdPartiesQuery = graphql`
   query ThirdPartiesMultiSelectFieldQuery($organizationId: ID!) {
     organization: node(id: $organizationId) {
       ... on Organization {
-        thirdParties(first: 100, orderBy: { direction: ASC, field: NAME }) {
+        thirdParties(
+          first: 100
+          orderBy: { direction: ASC, field: NAME }
+          filter: { level: 1 }
+        ) {
           edges {
             node {
               id

--- a/apps/console/src/components/table/ThirdPartiesCell.tsx
+++ b/apps/console/src/components/table/ThirdPartiesCell.tsx
@@ -32,6 +32,7 @@ const thirdPartiesCellQuery = graphql`
         thirdParties(
           first: 100
           orderBy: { direction: ASC, field: NAME }
+          filter: { level: 1 }
         ) {
           edges {
             node {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Limit third‑party selectors in the console to only first‑level parties. Multi‑selects and table cells now show level 1 entries only.

### App: console **`+6`** **`-1`**
- Added `filter: { level: 1 }` to `thirdParties` queries in `ThirdPartiesMultiSelectField.tsx` and `ThirdPartiesCell.tsx`.

<sup>Written for commit edb67743ae57ef7102cf3651898053e2ba2d306d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

