### PR TITLE
Fix npm audit findings in postcss and react-router

### DIFF
--- a/apps/compliance-portal/package.json
+++ b/apps/compliance-portal/package.json
@@ -23,7 +23,7 @@
     "react-i18next": "^17.0.10",
     "react-pdf": "^10.3.0",
     "react-relay": "^21.0.1",
-    "react-router": "^8.1.0",
+    "react-router": "^8.3.0",
     "relay-runtime": "^21.0.1"
   },
   "devDependencies": {

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -31,7 +31,7 @@
     "react-i18next": "^17.0.10",
     "react-pdf": "^10.3.0",
     "react-relay": "^21.0.1",
-    "react-router": "^8.1.0",
+    "react-router": "^8.3.0",
     "relay-runtime": "^21.0.1",
     "use-debounce": "^10.0.5",
     "usehooks-ts": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react-i18next": "^17.0.10",
         "react-pdf": "^10.3.0",
         "react-relay": "^21.0.1",
-        "react-router": "^8.1.0",
+        "react-router": "^8.3.0",
         "relay-runtime": "^21.0.1"
       },
       "devDependencies": {
@@ -326,7 +326,7 @@
         "react-i18next": "^17.0.10",
         "react-pdf": "^10.3.0",
         "react-relay": "^21.0.1",
-        "react-router": "^8.1.0",
+        "react-router": "^8.3.0",
         "relay-runtime": "^21.0.1",
         "use-debounce": "^10.0.5",
         "usehooks-ts": "^3.1.1",
@@ -16673,9 +16673,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -16693,7 +16693,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -16716,9 +16716,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -17443,9 +17443,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.1.0.tgz",
-      "integrity": "sha512-Mdfi61uObuvWNN9OhChOC0HV6YWOIfKRzEWOvCHRSuQg8IM+Nv10edaM/2HE8ZixBpUTdQbruyWqC3sDkkh9vw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^3.1.1"
@@ -20824,7 +20824,7 @@
       "peerDependencies": {
         "react": "^19.2.7",
         "react-relay": "^21.0.1",
-        "react-router": "^8.1.0",
+        "react-router": "^8.3.0",
         "relay-runtime": "^21.0.1"
       }
     },
@@ -20839,7 +20839,7 @@
       "peerDependencies": {
         "react": "^19.2.7",
         "react-relay": "^21.0.1",
-        "react-router": "^8.1.0",
+        "react-router": "^8.3.0",
         "relay-runtime": "^21.0.1"
       }
     },
@@ -20910,7 +20910,7 @@
         "react": "^19.2.7",
         "react-docgen": "^8.0.3",
         "react-dom": "^19.2.7",
-        "react-router": "^8.1.0",
+        "react-router": "^8.3.0",
         "storybook": "^10.2.10",
         "typescript": "~6.0.3",
         "vite": "^8.1.2",
@@ -20919,7 +20919,7 @@
       "peerDependencies": {
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-router": "^8.1.0"
+        "react-router": "^8.3.0"
       }
     },
     "packages/ui/node_modules/@vitest/browser": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   "overrides": {
     "uuid": "^14.0.0",
     "js-yaml": "^4.2.0",
-    "glob": "^13.0.6"
+    "glob": "^13.0.6",
+    "postcss": "8.5.23",
+    "react-router": "^8.3.0"
   },
   "allowScripts": {
     "esbuild": true,

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "react": "^19.2.7",
     "react-relay": "^21.0.1",
-    "react-router": "^8.1.0",
+    "react-router": "^8.3.0",
     "relay-runtime": "^21.0.1"
   },
   "dependencies": {

--- a/packages/routes/package.json
+++ b/packages/routes/package.json
@@ -17,7 +17,7 @@
   "peerDependencies": {
     "react": "^19.2.7",
     "react-relay": "^21.0.1",
-    "react-router": "^8.1.0",
+    "react-router": "^8.3.0",
     "relay-runtime": "^21.0.1"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,7 +66,7 @@
     "react": "^19.2.7",
     "react-docgen": "^8.0.3",
     "react-dom": "^19.2.7",
-    "react-router": "^8.1.0",
+    "react-router": "^8.3.0",
     "storybook": "^10.2.10",
     "typescript": "~6.0.3",
     "vite": "^8.1.2",
@@ -75,7 +75,7 @@
   "peerDependencies": {
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-router": "^8.1.0"
+    "react-router": "^8.3.0"
   },
   "volta": {
     "node": "24.4.0"


### PR DESCRIPTION
Bump postcss to 8.5.23 and react-router to 8.3.0 to clear their high-severity advisories. Leave nested brace-expansion issues for a follow-up that won't break older minimatch consumers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix high-severity npm audit alerts by upgrading `postcss` to 8.5.23 and `react-router` to ^8.3.0 across the repo. Dependency-only changes; `brace-expansion` stays as-is for a follow-up to avoid breaking older `minimatch`.

### App: compliance-portal **`+1`** **`-1`**
- Update `react-router` to ^8.3.0.

### App: console **`+1`** **`-1`**
- Update `react-router` to ^8.3.0.

### Package: relay **`+1`** **`-1`**
- Raise peer dependency on `react-router` to ^8.3.0.

### Package: routes **`+1`** **`-1`**
- Raise peer dependency on `react-router` to ^8.3.0.

### Package: ui **`+2`** **`-2`**
- Bump `react-router` to ^8.3.0 in dev and peer deps.

### Other **`+19`** **`-17`**
- Pin `postcss` 8.5.23 and `react-router` ^8.3.0 in root `overrides`; refresh lockfile to resolve advisories and pull `nanoid` 3.3.16 transitively.

<sup>Written for commit 5c9c9e3888dfed4ad19503d8fecf4fd853a0d6f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

