### PR TITLE
Fix crash on third-party details when country is GLOBAL

### DIFF
--- a/apps/console/src/components/form/CountriesField.tsx
+++ b/apps/console/src/components/form/CountriesField.tsx
@@ -63,8 +63,16 @@ type CountriesFieldInputProps = {
 };
 
 function CountriesFieldInput(props: CountriesFieldInputProps) {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [animateBadge, setAnimateBadge] = useState(false);
+
+  const countryLabel = (code: CountryCode) => {
+    // GLOBAL is not a valid Intl region code; use the translated label.
+    if (code === "GLOBAL") {
+      return t("country.GLOBAL");
+    }
+    return getCountryName(i18n.language, code);
+  };
 
   const addCountry = (code: string) => {
     setAnimateBadge(true);
@@ -94,7 +102,7 @@ function CountriesFieldInput(props: CountriesFieldInputProps) {
                     && "starting:opacity-0 starting:w-0 w-max transition-all duration-500 starting:bg-accent",
                   )}
                 >
-                  {getCountryName(i18n.language, countryCode as CountryCode)}
+                  {countryLabel(countryCode as CountryCode)}
                   <div className="w-0 overflow-hidden group-hover:w-4 duration-200">
                     <IconCrossLargeX size={12} />
                   </div>
@@ -110,6 +118,7 @@ function CountriesFieldInput(props: CountriesFieldInputProps) {
             (c: CountryCode) => !props.value.includes(c),
           )}
           onAdd={addCountry}
+          countryLabel={countryLabel}
         />
       )}
     </div>
@@ -119,15 +128,16 @@ function CountriesFieldInput(props: CountriesFieldInputProps) {
 type CountryInputProps = {
   availableCountries: readonly CountryCode[];
   onAdd: (code: string) => void;
+  countryLabel: (code: CountryCode) => string;
 };
 
-function CountryInput({ availableCountries, onAdd }: CountryInputProps) {
-  const { t, i18n } = useTranslation();
+function CountryInput({ availableCountries, onAdd, countryLabel }: CountryInputProps) {
+  const { t } = useTranslation();
   const [search, setSearch] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const countryOptions = availableCountries.map(code => ({
     value: code,
-    label: getCountryName(i18n.language, code),
+    label: countryLabel(code),
   }));
 
   useEffect(() => {

--- a/packages/helpers/src/countries.test.ts
+++ b/packages/helpers/src/countries.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { describe, it, expect } from "vitest";
+import { getCountryName, getCountryOptions } from "./countries";
+
+describe("getCountryName", () => {
+    it("returns a label for the GLOBAL pseudo-region", () => {
+        expect(getCountryName("en", "GLOBAL")).toBe("Global");
+    });
+
+    it("returns localized names for ISO country codes", () => {
+        expect(getCountryName("en", "US")).toBe("United States");
+        expect(getCountryName("en", "EU")).toBe("European Union");
+    });
+});
+
+describe("getCountryOptions", () => {
+    it("includes GLOBAL without throwing", () => {
+        const options = getCountryOptions("en");
+        expect(options.find(option => option.value === "GLOBAL")).toEqual({
+            value: "GLOBAL",
+            label: "Global",
+        });
+    });
+});

--- a/packages/helpers/src/countries.ts
+++ b/packages/helpers/src/countries.ts
@@ -50,8 +50,22 @@ export const countries = [
 
 export type CountryCode = typeof countries[number];
 
+// Pseudo-regions accepted by our CountryCode enum but not by Intl.DisplayNames.
+const pseudoRegionNames: Partial<Record<CountryCode, string>> = {
+    GLOBAL: "Global",
+};
+
 export function getCountryName(language: string, code: CountryCode): string {
-    return new Intl.DisplayNames(language, { type: "region" }).of(code) ?? code;
+    const pseudoName = pseudoRegionNames[code];
+    if (pseudoName) {
+        return pseudoName;
+    }
+
+    try {
+        return new Intl.DisplayNames(language, { type: "region" }).of(code) ?? code;
+    } catch {
+        return code;
+    }
 }
 
 export function getCountryOptions(lang: string) {


### PR DESCRIPTION
Intl.DisplayNames rejects the GLOBAL pseudo-region, so label resolution now handles it explicitly before rendering the picker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the third‑party details view when country is GLOBAL by resolving the pseudo‑region label before rendering. Adds tests and updates `helpers` to safely localize region names and include GLOBAL without errors.

### Tests **`+43`** **`-0`**
- Added unit tests for `getCountryName` and `getCountryOptions` covering GLOBAL and ISO codes.
- Ensure GLOBAL appears in options without errors.

### Package: `helpers` **`+15`** **`-1`**
- Added pseudo‑region map for GLOBAL with a default label (“Global”).
- Wrapped Intl.DisplayNames in try/catch and fallback to the code on failure.

### App: console **`+15`** **`-5`**
- Introduced a `countryLabel` helper to return `country.GLOBAL` and fall back to resolved names.
- Passed `countryLabel` into the country picker to avoid runtime errors when GLOBAL is selected.

<sup>Written for commit 88ceb68c17909e9df7874090cd0fcb60bf051232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

