### PR TITLE
Fix access review campaign source review findings

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/accessReview/loadAccessReviewSourceOptions.ts
+++ b/packages/n8n-node/nodes/Probo/actions/accessReview/loadAccessReviewSourceOptions.ts
@@ -22,15 +22,19 @@ import type { IDataObject, ILoadOptionsFunctions, INodePropertyOptions } from 'n
 import { proboApiRequest } from '../../GenericFunctions';
 
 const organizationSourcesQuery = `
-	query AccessReviewSources($organizationId: ID!) {
+	query AccessReviewSources($organizationId: ID!, $after: CursorKey) {
 		organization: node(id: $organizationId) {
 			... on Organization {
-				accessReviewSources(first: 500) {
+				accessReviewSources(first: 100, after: $after) {
 					edges {
 						node {
 							id
 							name
 						}
+					}
+					pageInfo {
+						hasNextPage
+						endCursor
 					}
 				}
 			}
@@ -51,10 +55,9 @@ const campaignOrganizationQuery = `
 `;
 
 function mapSources(responseData: IDataObject): INodePropertyOptions[] {
-	const data = responseData.data as IDataObject | undefined;
-	const organization = data?.organization as IDataObject | undefined;
-	const accessReviewSources = organization?.accessReviewSources as IDataObject | undefined;
-	const edges = accessReviewSources?.edges as Array<{ node: IDataObject }> | undefined;
+	const edges = getAccessReviewSourcesConnection(responseData)?.edges as
+		| Array<{ node: IDataObject }>
+		| undefined;
 
 	return (edges ?? [])
 		.map((edge) => edge.node)
@@ -63,6 +66,24 @@ function mapSources(responseData: IDataObject): INodePropertyOptions[] {
 			name: String(node.name ?? node.id),
 			value: String(node.id),
 		}));
+}
+
+function getAccessReviewSourcesConnection(responseData: IDataObject): IDataObject | undefined {
+	const data = responseData.data as IDataObject | undefined;
+	const organization = data?.organization as IDataObject | undefined;
+
+	return organization?.accessReviewSources as IDataObject | undefined;
+}
+
+function getPageInfo(responseData: IDataObject): { hasNextPage: boolean; endCursor?: string } {
+	const pageInfo = getAccessReviewSourcesConnection(responseData)?.pageInfo as
+		| IDataObject
+		| undefined;
+
+	return {
+		hasNextPage: pageInfo?.hasNextPage === true,
+		endCursor: typeof pageInfo?.endCursor === 'string' ? pageInfo.endCursor : undefined,
+	};
 }
 
 async function resolveOrganizationId(
@@ -96,9 +117,20 @@ export async function getAccessReviewSources(
 		return [];
 	}
 
-	const responseData = await proboApiRequest.call(this, organizationSourcesQuery, {
-		organizationId,
-	});
+	const options: INodePropertyOptions[] = [];
+	let after: string | undefined;
 
-	return mapSources(responseData);
+	do {
+		const responseData = await proboApiRequest.call(this, organizationSourcesQuery, {
+			organizationId,
+			after,
+		});
+
+		options.push(...mapSources(responseData));
+
+		const pageInfo = getPageInfo(responseData);
+		after = pageInfo.hasNextPage ? pageInfo.endCursor : undefined;
+	} while (after);
+
+	return options;
 }

--- a/pkg/accessreview/campaign_service.go
+++ b/pkg/accessreview/campaign_service.go
@@ -59,16 +59,16 @@ func (s *Service) CreateCampaign(
 				return fmt.Errorf("cannot insert access review campaign: %w", err)
 			}
 
-			for _, sourceID := range req.AccessReviewSourceIDs {
-				source := &coredata.AccessReviewSource{}
-				if err := source.LoadByID(ctx, conn, scope, sourceID); err != nil {
-					if errors.Is(err, coredata.ErrResourceNotFound) {
-						return coredata.ErrResourceNotFound
-					}
-
-					return fmt.Errorf("cannot load access source: %w", err)
+			var sources coredata.AccessReviewSources
+			if err := sources.LoadByIDs(ctx, conn, scope, req.AccessReviewSourceIDs); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return coredata.ErrResourceNotFound
 				}
 
+				return fmt.Errorf("cannot load access sources: %w", err)
+			}
+
+			for _, source := range sources {
 				if err := s.upsertCampaignSource(ctx, conn, scope, campaign.ID, source); err != nil {
 					return fmt.Errorf("cannot snapshot scope source: %w", err)
 				}
@@ -308,12 +308,17 @@ func (s *Service) syncCampaignSources(
 	campaign *coredata.AccessReviewCampaign,
 	sourceIDs []gid.GID,
 ) error {
-	var campaignSources coredata.AccessReviewCampaignSources
-	if err := campaignSources.MergeByCampaignID(ctx, conn, scope, campaign.ID, sourceIDs); err != nil {
+	var sources coredata.AccessReviewSources
+	if err := sources.LoadByIDs(ctx, conn, scope, sourceIDs); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return coredata.ErrResourceNotFound
 		}
 
+		return fmt.Errorf("cannot load access sources: %w", err)
+	}
+
+	var campaignSources coredata.AccessReviewCampaignSources
+	if err := campaignSources.MergeByCampaignID(ctx, conn, scope, campaign.ID, sources); err != nil {
 		return fmt.Errorf("cannot merge campaign sources: %w", err)
 	}
 

--- a/pkg/coredata/access_review_campaign_source.go
+++ b/pkg/coredata/access_review_campaign_source.go
@@ -149,21 +149,40 @@ RETURNING id
 	return nil
 }
 
-// MergeByCampaignID syncs scoped access-review source snapshots for a campaign:
-// upserts snapshots for the given live source IDs and deletes snapshots no
-// longer in the set.
+// MergeByCampaignID syncs scoped campaign source snapshots against the given,
+// already-loaded and validated live access sources: upserts a snapshot for
+// each source and deletes snapshots no longer in the set. Callers are
+// responsible for resolving accessReviewSources (existence, tenant, and
+// organization checks) before calling this method.
 func (sources *AccessReviewCampaignSources) MergeByCampaignID(
 	ctx context.Context,
 	conn pg.Tx,
 	scope Scoper,
 	campaignID gid.GID,
-	accessReviewSourceIDs []gid.GID,
+	accessReviewSources AccessReviewSources,
 ) error {
-	sourceIDs := gid.NewSet(accessReviewSourceIDs...)
+	ids := make([]string, 0, len(accessReviewSources))
+	organizationIDs := make([]string, 0, len(accessReviewSources))
+	names := make([]string, 0, len(accessReviewSources))
+	connectorIDs := make([]*string, 0, len(accessReviewSources))
 
-	sourceIDStrings := make([]string, 0, len(sourceIDs))
-	for id := range sourceIDs {
-		sourceIDStrings = append(sourceIDStrings, id.String())
+	seen := make(map[gid.GID]struct{}, len(accessReviewSources))
+	for _, source := range accessReviewSources {
+		if _, ok := seen[source.ID]; ok {
+			continue
+		}
+		seen[source.ID] = struct{}{}
+
+		var connectorID *string
+		if source.ConnectorID != nil {
+			s := source.ConnectorID.String()
+			connectorID = &s
+		}
+
+		ids = append(ids, source.ID.String())
+		organizationIDs = append(organizationIDs, source.OrganizationID.String())
+		names = append(names, source.Name)
+		connectorIDs = append(connectorIDs, connectorID)
 	}
 
 	now := time.Now()
@@ -175,10 +194,12 @@ WITH desired_sources AS (
 		organization_id,
 		name,
 		connector_id
-	FROM access_review_sources
-	WHERE
-		%s
-		AND id = ANY(@access_review_source_ids::text[])
+	FROM unnest(
+		@access_review_source_ids::text[],
+		@organization_ids::text[],
+		@names::text[],
+		@connector_ids::text[]
+	) AS t(id, organization_id, name, connector_id)
 )
 MERGE INTO access_review_campaign_sources AS target
 USING desired_sources AS source
@@ -220,11 +241,14 @@ WHEN NOT MATCHED BY SOURCE
 	DELETE
 `
 
-	q = fmt.Sprintf(q, scope.SQLFragment(), scope.SQLFragment(), scope.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
-		"access_review_campaign_id":                 campaignID,
-		"access_review_source_ids":                  sourceIDStrings,
+		"access_review_campaign_id": campaignID,
+		"access_review_source_ids":  ids,
+		"organization_ids":          organizationIDs,
+		"names":                     names,
+		"connector_ids":             connectorIDs,
 		"access_review_campaign_source_entity_type": AccessReviewCampaignSourceEntityType,
 		"tenant_id": scope.GetTenantID(),
 		"now":       now,

--- a/pkg/coredata/access_review_campaign_source.go
+++ b/pkg/coredata/access_review_campaign_source.go
@@ -149,11 +149,6 @@ RETURNING id
 	return nil
 }
 
-// MergeByCampaignID syncs scoped campaign source snapshots against the given,
-// already-loaded and validated live access sources: upserts a snapshot for
-// each source and deletes snapshots no longer in the set. Callers are
-// responsible for resolving accessReviewSources (existence, tenant, and
-// organization checks) before calling this method.
 func (sources *AccessReviewCampaignSources) MergeByCampaignID(
 	ctx context.Context,
 	conn pg.Tx,

--- a/pkg/coredata/access_review_campaign_source.go
+++ b/pkg/coredata/access_review_campaign_source.go
@@ -166,9 +166,11 @@ func (sources *AccessReviewCampaignSources) MergeByCampaignID(
 		if _, ok := seen[source.ID]; ok {
 			continue
 		}
+
 		seen[source.ID] = struct{}{}
 
 		var connectorID *string
+
 		if source.ConnectorID != nil {
 			s := source.ConnectorID.String()
 			connectorID = &s

--- a/pkg/coredata/access_review_source.go
+++ b/pkg/coredata/access_review_source.go
@@ -144,6 +144,52 @@ LIMIT 1;
 	return nil
 }
 
+func (sources *AccessReviewSources) LoadByIDs(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	ids []gid.GID,
+) error {
+	q := `
+SELECT
+    id,
+    organization_id,
+    connector_id,
+    name,
+    csv_data,
+    name_synced_at,
+    created_at,
+    updated_at
+FROM
+    access_review_sources
+WHERE
+    %s
+    AND id = ANY(@ids)
+`
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"ids": ids}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query access_review_sources: %w", err)
+	}
+
+	result, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[AccessReviewSource])
+	if err != nil {
+		return fmt.Errorf("cannot collect access_review_sources: %w", err)
+	}
+
+	*sources = result
+
+	if len(result) != len(gid.NewSet(ids...)) {
+		return ErrResourceNotFound
+	}
+
+	return nil
+}
+
 func (as *AccessReviewSource) Insert(
 	ctx context.Context,
 	conn pg.Tx,


### PR DESCRIPTION
## Summary
- Paginate the n8n access review source loader (`accessReviewSources`) instead of a hardcoded `first: 500`, so organizations with more than 500 sources can select sources past the first page in Create/Update.
- Fix `MergeByCampaignID` silently dropping unrecognized/out-of-scope source IDs instead of erroring — in the worst case (all IDs invalid) it deleted every existing campaign source, and `syncCampaignSources`'s `ErrResourceNotFound` handling was unreachable dead code.
- Add `AccessReviewSources.LoadByIDs` (matching the existing scoped `LoadByIDs` pattern elsewhere) and have `CreateCampaign`, `AddCampaignSource`, and `syncCampaignSources` resolve/validate sources in one batched query before merging.
- `MergeByCampaignID` now takes already-loaded sources and builds its desired-state CTE from `unnest()` of their values instead of joining `access_review_sources` directly, keeping the merge inside the campaign-source entity boundary.

## Test plan
- [x] `go build ./pkg/coredata/...` and `./pkg/accessreview/...`
- [x] `go vet ./pkg/coredata/... ./pkg/accessreview/...`
- [x] `go test ./pkg/coredata/... -run TestAccessReview` (includes a live-DB test exercising the rewritten `MergeByCampaignID` SQL)
- [x] `npx tsc --noEmit` in `packages/n8n-node`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes access review campaign source handling and pagination. The `packages/n8n-node` loader now fetches all sources via cursors, and the backend validates sources upfront and merges safely to prevent accidental deletions.

### Coredata **`+82`** **`-15`**
- Added `AccessReviewSources.LoadByIDs` with scoped lookup and count check; returns `ErrResourceNotFound` for invalid or out-of-scope IDs.
- Refactored `MergeByCampaignID` to accept preloaded sources and build desired state via `unnest()`; dedupes inputs and avoids dropping invalid IDs.
- Minor cleanups: removed a redundant comment and fixed `wsl_v5` spacing.

### Service **`+15`** **`-10`**
- `CreateCampaign` and `syncCampaignSources` batch-load and validate sources with `LoadByIDs`, surface `ErrResourceNotFound`, and pass the resolved set to `MergeByCampaignID`.

### Package: n8n-node **`+42`** **`-10`**
- Paginated `accessReviewSources` query (`first: 100`, `after`) and loop until `hasNextPage` is false.
- Added helpers to read `pageInfo` and map options; returns all sources, not just the first page.

<sup>Written for commit 364bda3826c3b0d8bd797771d79db7b0b22b5f35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

