### PR TITLE
Cookie banner - Allow integrations in discovery mode

### DIFF
--- a/packages/cookie-banner/CHANGELOG.md
+++ b/packages/cookie-banner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `@probo/cookie-banner` SDK will be documented in this
 
 ## Unreleased
 
+### Fixed
+
+- Grant all Google Consent Mode types when the banner config is unavailable (discovery mode), so GTM-managed tags can fire and be detected instead of staying blocked by the eager deny-all bootstrap
+
 ## [0.10.0] - 2026-06-19
 
 ### Changed

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -98,6 +98,12 @@ export class CookieBannerClient {
     try {
       config = await fetchJSON<BannerConfig>(configUrl);
     } catch {
+      // Discovery mode: no published banner config, but detectors still run
+      // so admins can inventory trackers. Grant GCM so GTM-managed tags can
+      // fire; otherwise bootstrap's deny-all would hide them from discovery.
+      for (const integration of this.integrations) {
+        integration.grantAll();
+      }
       this.startDetector();
       if (this.observer) {
         this.observer.disconnect();

--- a/packages/cookie-banner/src/integrations/gcm.ts
+++ b/packages/cookie-banner/src/integrations/gcm.ts
@@ -45,17 +45,32 @@ export class GoogleConsentModeIntegration implements ConsentIntegration {
     };
   }
 
+  private static readonly ALL_TYPES = [
+    "ad_storage",
+    "ad_user_data",
+    "ad_personalization",
+    "analytics_storage",
+    "functionality_storage",
+    "personalization_storage",
+    "security_storage",
+  ] as const;
+
   bootstrap(): void {
     const consentFn = this.getConsentFn();
-    consentFn("consent", "default", {
-      ad_storage: "denied",
-      ad_user_data: "denied",
-      ad_personalization: "denied",
-      analytics_storage: "denied",
-      functionality_storage: "denied",
-      personalization_storage: "denied",
-      security_storage: "denied",
-    });
+    const defaults: Record<string, string> = {};
+    for (const type of GoogleConsentModeIntegration.ALL_TYPES) {
+      defaults[type] = "denied";
+    }
+    consentFn("consent", "default", defaults);
+  }
+
+  grantAll(): void {
+    const consentFn = this.getConsentFn();
+    const update: Record<string, string> = {};
+    for (const type of GoogleConsentModeIntegration.ALL_TYPES) {
+      update[type] = "granted";
+    }
+    consentFn("consent", "update", update);
   }
 
   setDefaults(categories: Category[]): void {

--- a/packages/cookie-banner/src/integrations/integration.ts
+++ b/packages/cookie-banner/src/integrations/integration.ts
@@ -24,6 +24,12 @@ export interface ConsentIntegration {
   /** Called eagerly before config fetch to deny all tracking by default. */
   bootstrap(): void;
 
+  /**
+   * Called when the banner config is unavailable (discovery mode).
+   * Grants all consent types so trackers can fire and be detected.
+   */
+  grantAll(): void;
+
   /** Called once after config is loaded, before any consent is applied. */
   setDefaults(categories: Category[]): void;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables discovery mode in `@probo/cookie-banner`: when no banner config is available, the client grants all consent types for supported integrations (Google Consent Mode) so GTM-managed tags can fire for detection. The deny-all bootstrap remains the default until a config is published.

### Package: cookie-banner **`+40`** **`-9`**
- Client: on config fetch failure, call `grantAll()` on integrations and start detectors.
- Integrations: add `grantAll()` to `ConsentIntegration`; implement for Google Consent Mode via a single `ALL_TYPES` list.
- GCM: keep bootstrap default as all denied; `grantAll()` updates all types to granted.
- Docs: add CHANGELOG entry for discovery-mode behavior.

<sup>Written for commit 85bdcffdbb070ef3b1fbd1367bc341508a20e849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

