### PR TITLE
Gate password sign-in on email verification

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1287,6 +1287,17 @@
     "sent": { "title": "Check your email", "description": "We've sent password reset instructions to your email address", "didNotReceive": "Didn't receive the email?" },
     "actions": { "tryAgain": "Try again", "backToLogin": "Back to login", "sendingInstructions": "Sending instructions...", "sendInstructions": "Send reset instructions" }
   },
+  "resendVerificationEmailPage": {
+    "pageTitle": "Verify your email",
+    "title": "Verify your email",
+    "description": "Your email address has not been verified yet. Enter your email and we'll send you a new verification link",
+    "alreadyVerified": "Already verified?",
+    "messages": { "verificationSent": "Verification email sent" },
+    "errors": { "requestFailed": "Request failed", "sendVerification": "Failed to send verification email" },
+    "fields": { "email": "Email", "emailPlaceholder": "name@example.com" },
+    "sent": { "title": "Check your email", "description": "We've sent a verification link to your email address", "didNotReceive": "Didn't receive the email?" },
+    "actions": { "tryAgain": "Try again", "backToLogin": "Back to login", "sendingVerification": "Sending verification email...", "sendVerification": "Send verification email" }
+  },
   "resetPasswordPage": {
     "pageTitle": "Reset password",
     "title": "Reset password",

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -2072,6 +2072,34 @@
       "sendInstructions": "Envoyer les instructions de réinitialisation"
     }
   },
+  "resendVerificationEmailPage": {
+    "pageTitle": "Vérifiez votre e-mail",
+    "title": "Vérifiez votre e-mail",
+    "description": "Votre adresse e-mail n’a pas encore été vérifiée. Saisissez votre e-mail et nous vous enverrons un nouveau lien de vérification",
+    "alreadyVerified": "Déjà vérifié ?",
+    "messages": {
+      "verificationSent": "E-mail de vérification envoyé"
+    },
+    "errors": {
+      "requestFailed": "La requête a échoué",
+      "sendVerification": "Échec de l’envoi de l’e-mail de vérification"
+    },
+    "fields": {
+      "email": "E-mail",
+      "emailPlaceholder": "name@example.com"
+    },
+    "sent": {
+      "title": "Consultez votre e-mail",
+      "description": "Nous avons envoyé un lien de vérification à votre adresse e-mail",
+      "didNotReceive": "Vous n’avez pas reçu l’e-mail ?"
+    },
+    "actions": {
+      "tryAgain": "Réessayer",
+      "backToLogin": "Retour à la connexion",
+      "sendingVerification": "Envoi de l’e-mail de vérification...",
+      "sendVerification": "Envoyer l’e-mail de vérification"
+    }
+  },
   "resetPasswordPage": {
     "pageTitle": "Réinitialiser le mot de passe",
     "title": "Réinitialiser le mot de passe",

--- a/apps/console/src/pages/iam/auth/ForgotPasswordPage.tsx
+++ b/apps/console/src/pages/iam/auth/ForgotPasswordPage.tsx
@@ -56,11 +56,12 @@ export default function ForgotPasswordPage() {
     },
   });
 
-  const [sendInstructions] = useMutation<ForgotPasswordPageMutation>(
-    sendInstructionsMutation,
-  );
+  const [sendInstructions, isSendingInstructions]
+    = useMutation<ForgotPasswordPageMutation>(sendInstructionsMutation);
 
   const onSubmit = handleSubmit(({ email }) => {
+    if (isSendingInstructions) return;
+
     sendInstructions({
       variables: {
         input: { email },
@@ -154,9 +155,9 @@ export default function ForgotPasswordPage() {
             <Button
               type="submit"
               className="w-xs h-10 mx-auto mt-6"
-              disabled={formState.isSubmitting}
+              disabled={isSendingInstructions}
             >
-              {formState.isSubmitting
+              {isSendingInstructions
                 ? t("forgotPasswordPage.actions.sendingInstructions")
                 : t("forgotPasswordPage.actions.sendInstructions")}
             </Button>

--- a/apps/console/src/pages/iam/auth/ResendVerificationEmailPage.tsx
+++ b/apps/console/src/pages/iam/auth/ResendVerificationEmailPage.tsx
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { formatError } from "@probo/helpers";
+import { usePageTitle } from "@probo/hooks";
+import { Button, Field, useToast } from "@probo/ui";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useMutation } from "react-relay";
+import { Link, useSearchParams } from "react-router";
+import { graphql } from "relay-runtime";
+import { z } from "zod";
+
+import type { ResendVerificationEmailPageMutation } from "#/__generated__/iam/ResendVerificationEmailPageMutation.graphql";
+import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+
+const resendVerificationEmailMutation = graphql`
+  mutation ResendVerificationEmailPageMutation($input: ResendVerificationEmailInput!) {
+    resendVerificationEmail(input: $input) {
+      success
+    }
+  }
+`;
+
+const schema = z.object({
+  email: z.email(),
+});
+
+export default function ResendVerificationEmailPage() {
+  const { toast } = useToast();
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+
+  usePageTitle(t("resendVerificationEmailPage.pageTitle"));
+
+  const [emailSent, setEmailSent] = useState<boolean>();
+  const { register, handleSubmit, formState } = useFormWithSchema(schema, {
+    defaultValues: {
+      email: searchParams.get("email") ?? "",
+    },
+  });
+
+  const [resendVerificationEmail] = useMutation<ResendVerificationEmailPageMutation>(
+    resendVerificationEmailMutation,
+  );
+
+  const onSubmit = handleSubmit(({ email }) => {
+    resendVerificationEmail({
+      variables: {
+        input: { email },
+      },
+      onError: (e: Error) => {
+        toast({
+          title: t("resendVerificationEmailPage.errors.requestFailed"),
+          description: e.message,
+          variant: "error",
+        });
+      },
+      onCompleted: (_, e) => {
+        if (e) {
+          toast({
+            title: t("resendVerificationEmailPage.errors.requestFailed"),
+            description: formatError(
+              t("resendVerificationEmailPage.errors.sendVerification"),
+              e,
+            ),
+            variant: "error",
+          });
+          return;
+        }
+
+        toast({
+          title: t("common.success"),
+          description: t("resendVerificationEmailPage.messages.verificationSent"),
+          variant: "success",
+        });
+        setEmailSent(true);
+      },
+    });
+  });
+
+  return emailSent
+    ? (
+        <div className="space-y-6 w-full max-w-md mx-auto pt-8">
+          <div className="space-y-2 text-center">
+            <h1 className="text-3xl font-bold">{t("resendVerificationEmailPage.sent.title")}</h1>
+            <p className="text-txt-tertiary">
+              {t("resendVerificationEmailPage.sent.description")}
+            </p>
+          </div>
+
+          <div className="text-center">
+            <p className="text-sm text-txt-tertiary">
+              {t("resendVerificationEmailPage.sent.didNotReceive")}
+              {" "}
+              <button
+                onClick={() => setEmailSent(false)}
+                className="underline text-txt-primary hover:text-txt-secondary"
+              >
+                {t("resendVerificationEmailPage.actions.tryAgain")}
+              </button>
+            </p>
+          </div>
+
+          <div className="text-center">
+            <p className="text-sm text-txt-tertiary">
+              {t("resendVerificationEmailPage.alreadyVerified")}
+              {" "}
+              <Link
+                to="/auth/login"
+                className="underline text-txt-primary hover:text-txt-secondary"
+              >
+                {t("resendVerificationEmailPage.actions.backToLogin")}
+              </Link>
+            </p>
+          </div>
+        </div>
+      )
+    : (
+        <div className="space-y-6 w-full max-w-md mx-auto pt-8">
+          <div className="space-y-2 text-center">
+            <h1 className="text-3xl font-bold">{t("resendVerificationEmailPage.title")}</h1>
+            <p className="text-txt-tertiary">
+              {t("resendVerificationEmailPage.description")}
+            </p>
+          </div>
+
+          <form onSubmit={e => void onSubmit(e)} className="space-y-4">
+            <Field
+              label={t("resendVerificationEmailPage.fields.email")}
+              type="email"
+              placeholder={t("resendVerificationEmailPage.fields.emailPlaceholder")}
+              {...register("email")}
+              required
+              error={formState.errors.email?.message}
+            />
+
+            <Button
+              type="submit"
+              className="w-xs h-10 mx-auto mt-6"
+              disabled={formState.isSubmitting}
+            >
+              {formState.isSubmitting
+                ? t("resendVerificationEmailPage.actions.sendingVerification")
+                : t("resendVerificationEmailPage.actions.sendVerification")}
+            </Button>
+          </form>
+
+          <div className="text-center">
+            <p className="text-sm text-txt-tertiary">
+              {t("resendVerificationEmailPage.alreadyVerified")}
+              {" "}
+              <Link
+                to="/auth/login"
+                className="underline text-txt-primary hover:text-txt-secondary"
+              >
+                {t("resendVerificationEmailPage.actions.backToLogin")}
+              </Link>
+            </p>
+          </div>
+        </div>
+      );
+}

--- a/apps/console/src/pages/iam/auth/ResendVerificationEmailPage.tsx
+++ b/apps/console/src/pages/iam/auth/ResendVerificationEmailPage.tsx
@@ -57,11 +57,12 @@ export default function ResendVerificationEmailPage() {
     },
   });
 
-  const [resendVerificationEmail] = useMutation<ResendVerificationEmailPageMutation>(
-    resendVerificationEmailMutation,
-  );
+  const [resendVerificationEmail, isResending]
+    = useMutation<ResendVerificationEmailPageMutation>(resendVerificationEmailMutation);
 
   const onSubmit = handleSubmit(({ email }) => {
+    if (isResending) return;
+
     resendVerificationEmail({
       variables: {
         input: { email },
@@ -155,9 +156,9 @@ export default function ResendVerificationEmailPage() {
             <Button
               type="submit"
               className="w-xs h-10 mx-auto mt-6"
-              disabled={formState.isSubmitting}
+              disabled={isResending}
             >
-              {formState.isSubmitting
+              {isResending
                 ? t("resendVerificationEmailPage.actions.sendingVerification")
                 : t("resendVerificationEmailPage.actions.sendVerification")}
             </Button>

--- a/apps/console/src/pages/iam/auth/sign-in/PasswordSignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/PasswordSignInPage.tsx
@@ -18,12 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { formatError } from "@probo/helpers";
+import { formatError, type GraphQLError } from "@probo/helpers";
 import { Button, Field, IconChevronLeft, useToast } from "@probo/ui";
 import type { FormEventHandler } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
-import { Link, matchPath, useLocation } from "react-router";
+import { Link, matchPath, useLocation, useNavigate } from "react-router";
 import { graphql } from "relay-runtime";
 
 import type { PasswordSignInPageMutation } from "#/__generated__/iam/PasswordSignInPageMutation.graphql";
@@ -41,6 +41,7 @@ const signInMutation = graphql`
 
 export default function PasswordSignInPage() {
   const location = useLocation();
+  const navigate = useNavigate();
   const postAuthRedirectUrl = usePostAuthRedirectUrl();
 
   const { t } = useTranslation();
@@ -73,6 +74,16 @@ export default function PasswordSignInPage() {
       },
       onCompleted: (_, error) => {
         if (error) {
+          const errors = Array.isArray(error) ? error : [error];
+          const emailNotVerified = errors.some(
+            e => (e as GraphQLError).extensions?.code === "EMAIL_NOT_VERIFIED",
+          );
+          if (emailNotVerified) {
+            const search = new URLSearchParams({ email: emailValue }).toString();
+            void navigate(`/auth/resend-verification-email?${search}`);
+            return;
+          }
+
           toast({
             title: t("common.error"),
             description: formatError(

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -86,6 +86,12 @@ const routes = [
         Component: lazy(() => import("./pages/iam/auth/VerifyEmailPage")),
       },
       {
+        path: "resend-verification-email",
+        Component: lazy(
+          () => import("./pages/iam/auth/ResendVerificationEmailPage"),
+        ),
+      },
+      {
         path: "activate-account",
         Component: lazy(
           () => import("./pages/iam/auth/ActivateAccountPage"),

--- a/contrib/helm/charts/probo/templates/deployment.yaml
+++ b/contrib/helm/charts/probo/templates/deployment.yaml
@@ -122,6 +122,8 @@ spec:
               value: {{ .Values.probo.auth.disableSignup | quote }}
             - name: PROBOD_AUTH_INVITATION_TOKEN_VALIDITY
               value: {{ .Values.probo.auth.invitationTokenValidity | quote }}
+            - name: PROBOD_AUTH_EMAIL_CONFIRMATION_TOKEN_VALIDITY
+              value: {{ .Values.probo.auth.emailConfirmationTokenValidity | quote }}
             - name: PROBOD_AUTH_COOKIE_NAME
               value: {{ .Values.probo.auth.cookieName | quote }}
             - name: PROBOD_AUTH_COOKIE_DOMAIN

--- a/contrib/helm/charts/probo/values.yaml
+++ b/contrib/helm/charts/probo/values.yaml
@@ -225,6 +225,8 @@ probo:
   auth:
     disableSignup: false
     invitationTokenValidity: 3600
+    # Email confirmation token validity in seconds (default: 3600 = 1 hour)
+    emailConfirmationTokenValidity: 3600
     cookieName: "SSID"
     cookieDomain: "probo.example.com"
     # REQUIRED: Generate with openssl rand -base64 32

--- a/e2e/console/email_verification_test.go
+++ b/e2e/console/email_verification_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package console_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+func TestEmailVerification_PasswordSignInRequiresVerifiedEmail(t *testing.T) {
+	t.Parallel()
+
+	client := testutil.NewUnauthenticatedClient(t)
+
+	uniqueID := fmt.Sprintf("%d", time.Now().UnixNano())
+	email := fmt.Sprintf("unverified-%s@e2e.probo.test", uniqueID)
+	password := "TestPassword123!"
+	fullName := fmt.Sprintf("Unverified User %s", uniqueID)
+
+	const signUpMutation = `
+		mutation($input: SignUpInput!) {
+			signUp(input: $input) {
+				identity { id }
+			}
+		}
+	`
+
+	var signUpResult struct {
+		SignUp struct {
+			Identity struct {
+				ID string `json:"id"`
+			} `json:"identity"`
+		} `json:"signUp"`
+	}
+
+	err := client.ExecuteConnect(signUpMutation, map[string]any{
+		"input": map[string]any{
+			"email":    email,
+			"password": password,
+			"fullName": fullName,
+		},
+	}, &signUpResult)
+	require.NoError(t, err, "signUp should succeed for unverified identity")
+	require.NotEmpty(t, signUpResult.SignUp.Identity.ID)
+
+	client.SignOut()
+
+	err = client.SignIn(email, password)
+	testutil.RequireErrorCode(t, err, "EMAIL_NOT_VERIFIED")
+
+	client.ResendVerificationEmail(email)
+
+	token := client.GetEmailConfirmationToken(email)
+	require.NotEmpty(t, token)
+
+	const verifyMutation = `
+		mutation($input: VerifyEmailInput!) {
+			verifyEmail(input: $input) {
+				success
+			}
+		}
+	`
+
+	var verifyResult struct {
+		VerifyEmail struct {
+			Success bool `json:"success"`
+		} `json:"verifyEmail"`
+	}
+
+	err = client.ExecuteConnect(verifyMutation, map[string]any{
+		"input": map[string]any{
+			"token": token,
+		},
+	}, &verifyResult)
+	require.NoError(t, err, "verifyEmail should succeed")
+	assert.True(t, verifyResult.VerifyEmail.Success)
+
+	err = client.SignIn(email, password)
+	require.NoError(t, err, "signIn should succeed after email verification")
+}
+
+func TestEmailVerification_ResendIsEnumerationSafe(t *testing.T) {
+	t.Parallel()
+
+	client := testutil.NewUnauthenticatedClient(t)
+
+	client.ResendVerificationEmail(fmt.Sprintf("missing-%d@e2e.probo.test", time.Now().UnixNano()))
+}

--- a/e2e/console/oauth2_test.go
+++ b/e2e/console/oauth2_test.go
@@ -2515,8 +2515,8 @@ func TestOAuth2_IDTokenClaims(t *testing.T) {
 				"ID token must contain email when email scope is requested")
 			require.NotNil(t, claims.EmailVerified,
 				"ID token must contain email_verified when email scope is requested")
-			assert.False(t, *claims.EmailVerified,
-				"email_verified must be false for unverified e2e test identity")
+			assert.True(t, *claims.EmailVerified,
+				"email_verified must reflect the verified e2e test identity")
 			assert.NotEmpty(t, claims.Name,
 				"ID token must contain name when profile scope is requested")
 		},
@@ -2607,8 +2607,8 @@ func TestOAuth2_IDTokenClaims(t *testing.T) {
 				"refresh ID token must contain email when email scope is present")
 			require.NotNil(t, claims.EmailVerified,
 				"refresh ID token must contain email_verified when email scope is present")
-			assert.False(t, *claims.EmailVerified,
-				"email_verified must be false for unverified e2e test identity")
+			assert.True(t, *claims.EmailVerified,
+				"email_verified must reflect the verified e2e test identity")
 			assert.NotEmpty(t, claims.Name,
 				"refresh ID token must contain name when profile scope is present")
 		},

--- a/e2e/internal/testutil/client.go
+++ b/e2e/internal/testutil/client.go
@@ -127,6 +127,9 @@ func (c *Client) setupTestUser() {
 	// Sign up
 	c.userID = c.signUp(email, password, fullName)
 
+	// Confirm email so password sign-in works for later re-authentication.
+	c.verifyEmail(c.GetEmailConfirmationToken(email))
+
 	// Create organization (this makes the user an OWNER)
 	orgName := fmt.Sprintf("Test Org %s", uniqueID)
 	c.organizationID = c.createOrganization(orgName)
@@ -197,28 +200,7 @@ func (c *Client) signUp(email, password, fullName string) gid.GID {
 }
 
 func (c *Client) signIn(email string, password string) {
-	const query = `
-		mutation($input: SignInInput!) {
-			signIn(input: $input) {
-				identity { id }
-			}
-		}
-	`
-
-	var result struct {
-		SignIn struct {
-			Identity struct {
-				ID string `json:"id"`
-			} `json:"identity"`
-		} `json:"signIn"`
-	}
-
-	err := c.ExecuteConnect(query, map[string]any{
-		"input": map[string]any{
-			"email":    email,
-			"password": password,
-		},
-	}, &result)
+	err := c.SignIn(email, password)
 	require.NoError(c.T, err, "signIn mutation failed")
 }
 
@@ -415,6 +397,129 @@ func (c *Client) inviteUser(profileID gid.GID) {
 
 func (c *Client) getActivationToken(email string) string {
 	return c.pollForLinkToken(fmt.Sprintf("to:%s subject:\"Invitation to join\"", email))
+}
+
+func (c *Client) GetEmailConfirmationToken(email string) string {
+	c.T.Helper()
+
+	return c.pollForLinkToken(fmt.Sprintf("to:%s subject:\"Confirm your email address\"", email))
+}
+
+func (c *Client) verifyEmail(token string) {
+	const query = `
+		mutation($input: VerifyEmailInput!) {
+			verifyEmail(input: $input) {
+				success
+			}
+		}
+	`
+
+	var result struct {
+		VerifyEmail struct {
+			Success bool `json:"success"`
+		} `json:"verifyEmail"`
+	}
+
+	err := c.ExecuteConnect(query, map[string]any{
+		"input": map[string]any{
+			"token": token,
+		},
+	}, &result)
+	require.NoError(c.T, err, "verifyEmail mutation failed")
+	require.True(c.T, result.VerifyEmail.Success, "verifyEmail should succeed")
+}
+
+func (c *Client) ResendVerificationEmail(email string) {
+	c.T.Helper()
+
+	const query = `
+		mutation($input: ResendVerificationEmailInput!) {
+			resendVerificationEmail(input: $input) {
+				success
+			}
+		}
+	`
+
+	var result struct {
+		ResendVerificationEmail struct {
+			Success bool `json:"success"`
+		} `json:"resendVerificationEmail"`
+	}
+
+	err := c.ExecuteConnect(query, map[string]any{
+		"input": map[string]any{
+			"email": email,
+		},
+	}, &result)
+	require.NoError(c.T, err, "resendVerificationEmail mutation failed")
+	require.True(c.T, result.ResendVerificationEmail.Success, "resendVerificationEmail should succeed")
+}
+
+func (c *Client) SignOut() {
+	c.T.Helper()
+
+	const query = `
+		mutation {
+			signOut {
+				success
+			}
+		}
+	`
+
+	var result struct {
+		SignOut struct {
+			Success bool `json:"success"`
+		} `json:"signOut"`
+	}
+
+	err := c.ExecuteConnect(query, nil, &result)
+	require.NoError(c.T, err, "signOut mutation failed")
+}
+
+// SignIn attempts password sign-in and returns any GraphQL/transport error.
+func (c *Client) SignIn(email string, password string) error {
+	c.T.Helper()
+
+	const query = `
+		mutation($input: SignInInput!) {
+			signIn(input: $input) {
+				identity { id }
+			}
+		}
+	`
+
+	var result struct {
+		SignIn struct {
+			Identity struct {
+				ID string `json:"id"`
+			} `json:"identity"`
+		} `json:"signIn"`
+	}
+
+	return c.ExecuteConnect(query, map[string]any{
+		"input": map[string]any{
+			"email":    email,
+			"password": password,
+		},
+	}, &result)
+}
+
+// NewUnauthenticatedClient returns a Connect client with no session cookie.
+func NewUnauthenticatedClient(t testing.TB) *Client {
+	t.Helper()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err, "cannot create cookie jar")
+
+	return &Client{
+		T:              t,
+		baseURL:        GetBaseURL(),
+		mailpitBaseURL: GetMailpitBaseURL(),
+		httpClient: &http.Client{
+			Jar:     jar,
+			Timeout: 30 * time.Second,
+		},
+	}
 }
 
 // pollForLinkToken polls mailpit for a message matching searchQuery and

--- a/packages/emails/emails.go
+++ b/packages/emails/emails.go
@@ -100,7 +100,7 @@ func NewPresenter(baseURL string, fullName string) *Presenter {
 }
 
 const (
-	subjectConfirmEmail                           = "Confirm your email address"
+	SubjectConfirmEmail                           = "Confirm your email address"
 	subjectPasswordReset                          = "Reset your password"
 	subjectInvitation                             = "Invitation to join %s on Probo"
 	subjectDocumentApproval                       = "Action Required – Please review and approve %s compliance documents"
@@ -185,7 +185,7 @@ func (p *Presenter) RenderConfirmEmail(ctx context.Context, confirmationURLPath 
 
 	textBody, htmlBody, err = renderEmail(confirmEmailTextTemplate, confirmEmailHTMLTemplate, data)
 
-	return subjectConfirmEmail, textBody, htmlBody, err
+	return SubjectConfirmEmail, textBody, htmlBody, err
 }
 
 func (p *Presenter) RenderPasswordReset(ctx context.Context, resetPasswordURLPath string, resetPasswordToken string) (subject string, textBody string, htmlBody *string, err error) {

--- a/packages/emails/emails.go
+++ b/packages/emails/emails.go
@@ -100,7 +100,7 @@ func NewPresenter(baseURL string, fullName string) *Presenter {
 }
 
 const (
-	SubjectConfirmEmail                           = "Confirm your email address"
+	subjectConfirmEmail                           = "Confirm your email address"
 	subjectPasswordReset                          = "Reset your password"
 	subjectInvitation                             = "Invitation to join %s on Probo"
 	subjectDocumentApproval                       = "Action Required – Please review and approve %s compliance documents"
@@ -185,7 +185,7 @@ func (p *Presenter) RenderConfirmEmail(ctx context.Context, confirmationURLPath 
 
 	textBody, htmlBody, err = renderEmail(confirmEmailTextTemplate, confirmEmailHTMLTemplate, data)
 
-	return SubjectConfirmEmail, textBody, htmlBody, err
+	return subjectConfirmEmail, textBody, htmlBody, err
 }
 
 func (p *Presenter) RenderPasswordReset(ctx context.Context, resetPasswordURLPath string, resetPasswordToken string) (subject string, textBody string, htmlBody *string, err error) {

--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -111,6 +111,7 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 				InvitationConfirmationTokenValidity: b.resolver.getEnvIntOrDefault("PROBOD_AUTH_INVITATION_TOKEN_VALIDITY", 3600),
 				PasswordResetTokenValidity:          b.resolver.getEnvIntOrDefault("PROBOD_AUTH_PASSWORD_RESET_TOKEN_VALIDITY", 3600),
 				MagicLinkTokenValidity:              b.resolver.getEnvIntOrDefault("PROBOD_AUTH_MAGIC_LINK_TOKEN_VALIDITY", 900),
+				EmailConfirmationTokenValidity:      b.resolver.getEnvIntOrDefault("PROBOD_AUTH_EMAIL_CONFIRMATION_TOKEN_VALIDITY", 3600),
 				Cookie: probodconfig.CookieConfig{
 					Name:     b.resolver.getEnv("PROBOD_AUTH_COOKIE_NAME"),
 					Domain:   b.resolver.getEnv("PROBOD_AUTH_COOKIE_DOMAIN"),

--- a/pkg/bootstrap/builder_test.go
+++ b/pkg/bootstrap/builder_test.go
@@ -175,6 +175,7 @@ func TestBuilder_Build_Defaults(t *testing.T) {
 	assert.Equal(t, 3600, cfg.Probod.Auth.InvitationConfirmationTokenValidity)
 	assert.Equal(t, 3600, cfg.Probod.Auth.PasswordResetTokenValidity)
 	assert.Equal(t, 900, cfg.Probod.Auth.MagicLinkTokenValidity)
+	assert.Equal(t, 3600, cfg.Probod.Auth.EmailConfirmationTokenValidity)
 	assert.Empty(t, cfg.Probod.Auth.Cookie.Name)
 	assert.Empty(t, cfg.Probod.Auth.Cookie.Domain)
 	assert.Equal(t, 24, cfg.Probod.Auth.Cookie.Duration)
@@ -331,6 +332,7 @@ func TestBuilder_Build_CustomValues(t *testing.T) {
 	env["PROBOD_AUTH_INVITATION_TOKEN_VALIDITY"] = "7200"
 	env["PROBOD_AUTH_PASSWORD_RESET_TOKEN_VALIDITY"] = "1800"
 	env["PROBOD_AUTH_MAGIC_LINK_TOKEN_VALIDITY"] = "600"
+	env["PROBOD_AUTH_EMAIL_CONFIRMATION_TOKEN_VALIDITY"] = "43200"
 	env["PROBOD_AUTH_COOKIE_DOMAIN"] = ".example.com"
 	env["PROBOD_AUTH_COOKIE_DURATION"] = "48"
 	// SAML
@@ -466,6 +468,7 @@ func TestBuilder_Build_CustomValues(t *testing.T) {
 	assert.Equal(t, 7200, cfg.Probod.Auth.InvitationConfirmationTokenValidity)
 	assert.Equal(t, 1800, cfg.Probod.Auth.PasswordResetTokenValidity)
 	assert.Equal(t, 600, cfg.Probod.Auth.MagicLinkTokenValidity)
+	assert.Equal(t, 43200, cfg.Probod.Auth.EmailConfirmationTokenValidity)
 	assert.Equal(t, ".example.com", cfg.Probod.Auth.Cookie.Domain)
 	assert.Equal(t, 48, cfg.Probod.Auth.Cookie.Duration)
 	// SAML

--- a/pkg/coredata/email.go
+++ b/pkg/coredata/email.go
@@ -319,6 +319,39 @@ WHERE id = @id
 	return err
 }
 
+// ExistsByRecipientSubjectCreatedAfter reports whether an email with the given
+// recipient and subject was created at or after createdAfter.
+func ExistsByRecipientSubjectCreatedAfter(
+	ctx context.Context,
+	conn pg.Querier,
+	recipientEmail mail.Addr,
+	subject string,
+	createdAfter time.Time,
+) (bool, error) {
+	q := `
+SELECT EXISTS (
+	SELECT 1
+	FROM emails
+	WHERE recipient_email = @recipient_email
+		AND subject = @subject
+		AND created_at >= @created_after
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"recipient_email": recipientEmail.String(),
+		"subject":         subject,
+		"created_after":   createdAfter,
+	}
+
+	var exists bool
+	if err := conn.QueryRow(ctx, q, args).Scan(&exists); err != nil {
+		return false, fmt.Errorf("cannot check recent email: %w", err)
+	}
+
+	return exists, nil
+}
+
 func ResetStaleProcessingEmails(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/coredata/email.go
+++ b/pkg/coredata/email.go
@@ -319,39 +319,6 @@ WHERE id = @id
 	return err
 }
 
-// ExistsByRecipientSubjectCreatedAfter reports whether an email with the given
-// recipient and subject was created at or after createdAfter.
-func ExistsByRecipientSubjectCreatedAfter(
-	ctx context.Context,
-	conn pg.Querier,
-	recipientEmail mail.Addr,
-	subject string,
-	createdAfter time.Time,
-) (bool, error) {
-	q := `
-SELECT EXISTS (
-	SELECT 1
-	FROM emails
-	WHERE recipient_email = @recipient_email
-		AND subject = @subject
-		AND created_at >= @created_after
-)
-`
-
-	args := pgx.StrictNamedArgs{
-		"recipient_email": recipientEmail.String(),
-		"subject":         subject,
-		"created_after":   createdAfter,
-	}
-
-	var exists bool
-	if err := conn.QueryRow(ctx, q, args).Scan(&exists); err != nil {
-		return false, fmt.Errorf("cannot check recent email: %w", err)
-	}
-
-	return exists, nil
-}
-
 func ResetStaleProcessingEmails(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/iam/account_service.go
+++ b/pkg/iam/account_service.go
@@ -76,11 +76,6 @@ var SupportedIdentityLocales = []string{
 
 const (
 	TokenTypeEmailConfirmation = "email_confirmation"
-
-	// emailConfirmationResendCooldown is the minimum time between confirmation
-	// emails for the same address. Resend requests inside this window succeed
-	// without enqueueing another message (anti-enumeration + anti-abuse).
-	emailConfirmationResendCooldown = time.Minute
 )
 
 func NewAccountService(svc *Service) *AccountService {
@@ -246,20 +241,6 @@ func (s AccountService) ResendVerificationEmail(ctx context.Context, email mail.
 
 			if identity.EmailAddressVerified {
 				return nil // Don't leak information about already-verified identities
-			}
-
-			recent, err := coredata.ExistsByRecipientSubjectCreatedAfter(
-				ctx,
-				tx,
-				identity.EmailAddress,
-				emails.SubjectConfirmEmail,
-				time.Now().Add(-emailConfirmationResendCooldown),
-			)
-			if err != nil {
-				return fmt.Errorf("cannot check recent confirmation email: %w", err)
-			}
-			if recent {
-				return nil // Cooldown: avoid flooding the recipient / mail queue
 			}
 
 			confirmationToken, err := statelesstoken.NewToken(

--- a/pkg/iam/account_service.go
+++ b/pkg/iam/account_service.go
@@ -76,6 +76,11 @@ var SupportedIdentityLocales = []string{
 
 const (
 	TokenTypeEmailConfirmation = "email_confirmation"
+
+	// emailConfirmationResendCooldown is the minimum time between confirmation
+	// emails for the same address. Resend requests inside this window succeed
+	// without enqueueing another message (anti-enumeration + anti-abuse).
+	emailConfirmationResendCooldown = time.Minute
 )
 
 func NewAccountService(svc *Service) *AccountService {
@@ -241,6 +246,20 @@ func (s AccountService) ResendVerificationEmail(ctx context.Context, email mail.
 
 			if identity.EmailAddressVerified {
 				return nil // Don't leak information about already-verified identities
+			}
+
+			recent, err := coredata.ExistsByRecipientSubjectCreatedAfter(
+				ctx,
+				tx,
+				identity.EmailAddress,
+				emails.SubjectConfirmEmail,
+				time.Now().Add(-emailConfirmationResendCooldown),
+			)
+			if err != nil {
+				return fmt.Errorf("cannot check recent confirmation email: %w", err)
+			}
+			if recent {
+				return nil // Cooldown: avoid flooding the recipient / mail queue
 			}
 
 			confirmationToken, err := statelesstoken.NewToken(

--- a/pkg/iam/account_service.go
+++ b/pkg/iam/account_service.go
@@ -120,7 +120,7 @@ func (s AccountService) ChangeEmail(ctx context.Context, identityID gid.GID, req
 	confirmationToken, err := statelesstoken.NewToken(
 		s.tokenSecret,
 		TokenTypeEmailConfirmation,
-		24*time.Hour,
+		s.emailConfirmationTokenValidity,
 		EmailConfirmationData{IdentityID: identityID, Email: req.NewEmail},
 	)
 	if err != nil {
@@ -219,6 +219,58 @@ func (s AccountService) VerifyEmail(ctx context.Context, token string) error {
 			err = identity.Update(ctx, tx)
 			if err != nil {
 				return fmt.Errorf("cannot update identity: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+func (s AccountService) ResendVerificationEmail(ctx context.Context, email mail.Addr) error {
+	return s.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			identity := &coredata.Identity{}
+			if err := identity.LoadByEmail(ctx, tx, email); err != nil {
+				if err == coredata.ErrResourceNotFound {
+					return nil // Don't leak information about non-existent identities
+				}
+
+				return fmt.Errorf("cannot load identity: %w", err)
+			}
+
+			if identity.EmailAddressVerified {
+				return nil // Don't leak information about already-verified identities
+			}
+
+			confirmationToken, err := statelesstoken.NewToken(
+				s.tokenSecret,
+				TokenTypeEmailConfirmation,
+				s.emailConfirmationTokenValidity,
+				EmailConfirmationData{IdentityID: identity.ID, Email: identity.EmailAddress},
+			)
+			if err != nil {
+				return fmt.Errorf("cannot generate confirmation token: %w", err)
+			}
+
+			emailPresenter := emails.NewPresenter(s.baseURL, identity.FullName)
+
+			subject, textBody, htmlBody, err := emailPresenter.RenderConfirmEmail(ctx, "/auth/verify-email", confirmationToken)
+			if err != nil {
+				return fmt.Errorf("cannot render confirmation email: %w", err)
+			}
+
+			confirmationEmail := coredata.NewEmail(
+				identity.FullName,
+				identity.EmailAddress,
+				subject,
+				textBody,
+				htmlBody,
+				nil,
+			)
+
+			if err := confirmationEmail.Insert(ctx, tx); err != nil {
+				return fmt.Errorf("cannot insert confirmation email: %w", err)
 			}
 
 			return nil

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -726,6 +726,13 @@ func (s AuthService) OpenSessionWithMagicLink(ctx context.Context, tokenString s
 				} else {
 					return fmt.Errorf("cannot load identity by email: %w", err)
 				}
+			} else if !identity.EmailAddressVerified {
+				identity.EmailAddressVerified = true
+				identity.UpdatedAt = now
+
+				if err := identity.Update(ctx, tx); err != nil {
+					return fmt.Errorf("cannot update identity: %w", err)
+				}
 			}
 
 			session = coredata.NewRootSession(identity.ID, coredata.AuthMethodMagicLink, s.sessionDuration)

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -388,7 +388,7 @@ func (s AuthService) CreateIdentityWithPassword(
 	confirmationToken, err := statelesstoken.NewToken(
 		s.tokenSecret,
 		TokenTypeEmailConfirmation,
-		24*time.Hour,
+		s.emailConfirmationTokenValidity,
 		EmailConfirmationData{IdentityID: identity.ID, Email: identity.EmailAddress},
 	)
 	if err != nil {

--- a/pkg/iam/errors.go
+++ b/pkg/iam/errors.go
@@ -108,6 +108,16 @@ func (e ErrEmailAlreadyVerified) Error() string {
 	return e.message
 }
 
+type ErrEmailNotVerified struct{ message string }
+
+func NewEmailNotVerifiedError() error {
+	return &ErrEmailNotVerified{"email address not verified"}
+}
+
+func (e ErrEmailNotVerified) Error() string {
+	return e.message
+}
+
 type ErrIdentityNotFound struct{ IdentityID gid.GID }
 
 func NewIdentityNotFoundError(identityID gid.GID) error {

--- a/pkg/iam/service.go
+++ b/pkg/iam/service.go
@@ -50,23 +50,24 @@ import (
 
 type (
 	Service struct {
-		pg                         *pg.Client
-		fm                         *filemanager.Service
-		hp                         *passwdhash.Profile
-		dummyHash                  []byte
-		baseURL                    string
-		tokenSecret                string
-		disableSignup              bool
-		invitationTokenValidity    time.Duration
-		passwordResetTokenValidity time.Duration
-		magicLinkTokenValidity     time.Duration
-		sessionDuration            time.Duration
-		bucket                     string
-		compliancePortalBaseDomain string
-		certManager                *certmanager.Service
-		certificate                *x509.Certificate
-		privateKey                 *rsa.PrivateKey
-		logger                     *log.Logger
+		pg                             *pg.Client
+		fm                             *filemanager.Service
+		hp                             *passwdhash.Profile
+		dummyHash                      []byte
+		baseURL                        string
+		tokenSecret                    string
+		disableSignup                  bool
+		invitationTokenValidity        time.Duration
+		passwordResetTokenValidity     time.Duration
+		magicLinkTokenValidity         time.Duration
+		emailConfirmationTokenValidity time.Duration
+		sessionDuration                time.Duration
+		bucket                         string
+		compliancePortalBaseDomain     string
+		certManager                    *certmanager.Service
+		certificate                    *x509.Certificate
+		privateKey                     *rsa.PrivateKey
+		logger                         *log.Logger
 
 		AccountService      *AccountService
 		OrganizationService *OrganizationService
@@ -88,6 +89,7 @@ type (
 		InvitationTokenValidity        time.Duration
 		PasswordResetTokenValidity     time.Duration
 		MagicLinkTokenValidity         time.Duration
+		EmailConfirmationTokenValidity time.Duration
 		SessionDuration                time.Duration
 		Bucket                         string
 		TokenSecret                    string
@@ -154,23 +156,24 @@ func NewService(
 	}
 
 	svc := &Service{
-		pg:                         pgClient,
-		fm:                         fm,
-		hp:                         hp,
-		dummyHash:                  mustHashDummy(hp),
-		baseURL:                    cfg.BaseURL.String(),
-		tokenSecret:                cfg.TokenSecret,
-		disableSignup:              cfg.DisableSignup,
-		invitationTokenValidity:    cfg.InvitationTokenValidity,
-		passwordResetTokenValidity: cfg.PasswordResetTokenValidity,
-		magicLinkTokenValidity:     cfg.MagicLinkTokenValidity,
-		sessionDuration:            cfg.SessionDuration,
-		bucket:                     cfg.Bucket,
-		compliancePortalBaseDomain: cfg.CompliancePortalBaseDomain,
-		certManager:                cfg.CertManager,
-		certificate:                cfg.Certificate,
-		privateKey:                 cfg.PrivateKey,
-		logger:                     cfg.Logger,
+		pg:                             pgClient,
+		fm:                             fm,
+		hp:                             hp,
+		dummyHash:                      mustHashDummy(hp),
+		baseURL:                        cfg.BaseURL.String(),
+		tokenSecret:                    cfg.TokenSecret,
+		disableSignup:                  cfg.DisableSignup,
+		invitationTokenValidity:        cfg.InvitationTokenValidity,
+		passwordResetTokenValidity:     cfg.PasswordResetTokenValidity,
+		magicLinkTokenValidity:         cfg.MagicLinkTokenValidity,
+		emailConfirmationTokenValidity: cfg.EmailConfirmationTokenValidity,
+		sessionDuration:                cfg.SessionDuration,
+		bucket:                         cfg.Bucket,
+		compliancePortalBaseDomain:     cfg.CompliancePortalBaseDomain,
+		certManager:                    cfg.CertManager,
+		certificate:                    cfg.Certificate,
+		privateKey:                     cfg.PrivateKey,
+		logger:                         cfg.Logger,
 	}
 
 	svc.AccountService = NewAccountService(svc)

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -139,6 +139,7 @@ func New() *Implm {
 				InvitationConfirmationTokenValidity: 3600,
 				PasswordResetTokenValidity:          3600,
 				MagicLinkTokenValidity:              900,
+				EmailConfirmationTokenValidity:      3600,
 				SAML: SAMLConfig{
 					SessionDuration:                   604800,
 					CleanupIntervalSeconds:            86400,
@@ -569,6 +570,7 @@ func (impl *Implm) Run(
 			InvitationTokenValidity:        time.Duration(impl.cfg.Auth.InvitationConfirmationTokenValidity) * time.Second,
 			PasswordResetTokenValidity:     time.Duration(impl.cfg.Auth.PasswordResetTokenValidity) * time.Second,
 			MagicLinkTokenValidity:         time.Duration(impl.cfg.Auth.MagicLinkTokenValidity) * time.Second,
+			EmailConfirmationTokenValidity: time.Duration(impl.cfg.Auth.EmailConfirmationTokenValidity) * time.Second,
 			SessionDuration:                time.Duration(impl.cfg.Auth.Cookie.Duration) * time.Hour,
 			Bucket:                         impl.cfg.AWS.Bucket,
 			TokenSecret:                    impl.cfg.Auth.Cookie.Secret,

--- a/pkg/probodconfig/auth_config.go
+++ b/pkg/probodconfig/auth_config.go
@@ -32,6 +32,7 @@ type AuthConfig struct {
 	InvitationConfirmationTokenValidity int                `json:"invitation-confirmation-token-validity"`
 	PasswordResetTokenValidity          int                `json:"password-reset-token-validity"`
 	MagicLinkTokenValidity              int                `json:"magic-link-token-validity"`
+	EmailConfirmationTokenValidity      int                `json:"email-confirmation-token-validity"`
 	SAML                                SAMLConfig         `json:"saml"`
 	Google                              OIDCProviderConfig `json:"google,omitzero"`
 	Microsoft                           OIDCProviderConfig `json:"microsoft,omitzero"`

--- a/pkg/server/api/connect/v1/graphql/session.graphql
+++ b/pkg/server/api/connect/v1/graphql/session.graphql
@@ -17,6 +17,9 @@ extend type Mutation {
     @authentication(required: NONE)
   verifyEmail(input: VerifyEmailInput!): VerifyEmailPayload
     @authentication(required: OPTIONAL)
+  resendVerificationEmail(
+    input: ResendVerificationEmailInput!
+  ): ResendVerificationEmailPayload @authentication(required: NONE)
   changePassword(input: ChangePasswordInput!): ChangePasswordPayload
     @authentication(required: PRESENT) @sessionOnly
   changeEmail(input: ChangeEmailInput!): ChangeEmailPayload
@@ -102,6 +105,10 @@ input VerifyEmailInput {
   token: String!
 }
 
+input ResendVerificationEmailInput {
+  email: EmailAddr!
+}
+
 input ChangePasswordInput {
   currentPassword: String!
   newPassword: String!
@@ -149,6 +156,10 @@ type ResetPasswordPayload {
 }
 
 type VerifyEmailPayload {
+  success: Boolean!
+}
+
+type ResendVerificationEmailPayload {
   success: Boolean!
 }
 

--- a/pkg/server/api/connect/v1/magic_link_handler.go
+++ b/pkg/server/api/connect/v1/magic_link_handler.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package connect_v1
+
+import (
+	"errors"
+	"net/http"
+
+	"go.gearno.de/kit/httpserver"
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/baseurl"
+	"go.probo.inc/probo/pkg/iam"
+	"go.probo.inc/probo/pkg/mail"
+	"go.probo.inc/probo/pkg/saferedirect"
+	"go.probo.inc/probo/pkg/securecookie"
+	"go.probo.inc/probo/pkg/server/api/authn"
+)
+
+type MagicLinkHandler struct {
+	iam           *iam.Service
+	proboBaseURL  *baseurl.BaseURL
+	sessionCookie *authn.Cookie
+	safeRedirect  *saferedirect.SafeRedirect
+	logger        *log.Logger
+}
+
+func NewMagicLinkHandler(
+	iamSvc *iam.Service,
+	proboBaseURL *baseurl.BaseURL,
+	cookieConfig securecookie.Config,
+	logger *log.Logger,
+	allowedHost saferedirect.AllowedHostFunc,
+) *MagicLinkHandler {
+	return &MagicLinkHandler{
+		iam:           iamSvc,
+		proboBaseURL:  proboBaseURL,
+		sessionCookie: authn.NewCookie(&cookieConfig),
+		safeRedirect:  saferedirect.New(allowedHost),
+		logger:        logger,
+	}
+}
+
+func (h *MagicLinkHandler) redirectAuthError(w http.ResponseWriter, r *http.Request, code string, token string) {
+	safeContinue := ""
+
+	if token != "" {
+		continueURL, err := h.iam.AuthService.MagicLinkContinueFromToken(token)
+		if err == nil && continueURL != nil && *continueURL != "" {
+			if validated, ok := h.safeRedirect.Validate(r.Context(), *continueURL); ok {
+				safeContinue = validated
+			}
+		}
+	}
+
+	redirectAuthError(w, r, code, safeContinue)
+}
+
+func (h *MagicLinkHandler) SendHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if err := r.ParseForm(); err != nil {
+		httpserver.RenderError(w, http.StatusBadRequest, errors.New("invalid form data"))
+		return
+	}
+
+	emailAddr, err := mail.ParseAddr(r.FormValue("email"))
+	if err != nil {
+		httpserver.RenderError(w, http.StatusBadRequest, errors.New("invalid email"))
+		return
+	}
+
+	continueParam := r.FormValue("continue")
+	if continueParam == "" {
+		httpserver.RenderError(w, http.StatusBadRequest, errors.New("invalid magic link parameters"))
+		return
+	}
+
+	safeContinue, ok := h.safeRedirect.Validate(ctx, continueParam)
+	if !ok {
+		httpserver.RenderError(w, http.StatusBadRequest, errors.New("invalid continue URL"))
+		return
+	}
+
+	proboURL := h.proboBaseURL.String()
+
+	req := &iam.SendMagicLinkRequest{
+		Email:            emailAddr,
+		URLPath:          "/api/connect/v1/magic-link/verify",
+		MagicLinkBaseURL: &proboURL,
+		Continue:         &safeContinue,
+	}
+
+	if clientID := oauth2ClientIDFromContinueURL(safeContinue); clientID != "" {
+		req.OAuth2ClientIDRaw = &clientID
+	}
+
+	if err := h.iam.AuthService.SendMagicLink(ctx, req); err != nil {
+		h.logger.ErrorCtx(ctx, "cannot send magic link", log.Error(err))
+		httpserver.RenderError(w, http.StatusInternalServerError, errors.New("internal server error"))
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *MagicLinkHandler) VerifyHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		h.redirectAuthError(w, r, authErrorMagicLinkInvalid, "")
+
+		return
+	}
+
+	identity, session, continueURL, err := h.iam.AuthService.OpenSessionWithMagicLink(ctx, token)
+	if err != nil {
+		if _, ok := errors.AsType[*iam.ErrExpiredToken](err); ok {
+			h.redirectAuthError(w, r, authErrorMagicLinkExpired, token)
+
+			return
+		}
+
+		if _, ok := errors.AsType[*iam.ErrTokenAlreadyUsed](err); ok {
+			h.redirectAuthError(w, r, authErrorMagicLinkAlreadyUsed, token)
+
+			return
+		}
+
+		if _, ok := errors.AsType[*iam.ErrInvalidToken](err); ok {
+			h.redirectAuthError(w, r, authErrorMagicLinkInvalid, token)
+
+			return
+		}
+
+		h.logger.ErrorCtx(ctx, "cannot open session with magic link", log.Error(err))
+		h.redirectAuthError(w, r, authErrorAuthenticationFailed, token)
+
+		return
+	}
+
+	_ = identity
+
+	h.sessionCookie.Set(w, session)
+
+	metadata := OAuth2ServerMetadata(
+		h.proboBaseURL,
+		h.iam.OAuth2ScopeRegistry.RegisteredScopes(),
+	)
+
+	redirectURL := metadata.AuthorizationEndpoint.String()
+	if continueURL != nil && *continueURL != "" {
+		redirectURL = *continueURL
+	}
+
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}

--- a/pkg/server/api/connect/v1/oidc_handler.go
+++ b/pkg/server/api/connect/v1/oidc_handler.go
@@ -29,12 +29,10 @@ import (
 	"github.com/go-chi/chi/v5"
 	"go.gearno.de/kit/httpserver"
 	"go.gearno.de/kit/log"
-	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/iam/oidc"
-	"go.probo.inc/probo/pkg/mail"
 	"go.probo.inc/probo/pkg/saferedirect"
 	"go.probo.inc/probo/pkg/securecookie"
 	"go.probo.inc/probo/pkg/server/api/authn"
@@ -265,145 +263,4 @@ func parseOIDCProvider(s string) (coredata.OIDCProvider, error) {
 	default:
 		return "", errors.New("unknown provider")
 	}
-}
-
-type MagicLinkHandler struct {
-	iam           *iam.Service
-	proboBaseURL  *baseurl.BaseURL
-	sessionCookie *authn.Cookie
-	safeRedirect  *saferedirect.SafeRedirect
-	logger        *log.Logger
-}
-
-func NewMagicLinkHandler(
-	iamSvc *iam.Service,
-	proboBaseURL *baseurl.BaseURL,
-	cookieConfig securecookie.Config,
-	logger *log.Logger,
-	allowedHost saferedirect.AllowedHostFunc,
-) *MagicLinkHandler {
-	return &MagicLinkHandler{
-		iam:           iamSvc,
-		proboBaseURL:  proboBaseURL,
-		sessionCookie: authn.NewCookie(&cookieConfig),
-		safeRedirect:  saferedirect.New(allowedHost),
-		logger:        logger,
-	}
-}
-
-func (h *MagicLinkHandler) redirectAuthError(w http.ResponseWriter, r *http.Request, code string, token string) {
-	safeContinue := ""
-
-	if token != "" {
-		continueURL, err := h.iam.AuthService.MagicLinkContinueFromToken(token)
-		if err == nil && continueURL != nil && *continueURL != "" {
-			if validated, ok := h.safeRedirect.Validate(r.Context(), *continueURL); ok {
-				safeContinue = validated
-			}
-		}
-	}
-
-	redirectAuthError(w, r, code, safeContinue)
-}
-
-func (h *MagicLinkHandler) SendHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	if err := r.ParseForm(); err != nil {
-		httpserver.RenderError(w, http.StatusBadRequest, errors.New("invalid form data"))
-		return
-	}
-
-	emailAddr, err := mail.ParseAddr(r.FormValue("email"))
-	if err != nil {
-		httpserver.RenderError(w, http.StatusBadRequest, errors.New("invalid email"))
-		return
-	}
-
-	continueParam := r.FormValue("continue")
-	if continueParam == "" {
-		httpserver.RenderError(w, http.StatusBadRequest, errors.New("invalid magic link parameters"))
-		return
-	}
-
-	safeContinue, ok := h.safeRedirect.Validate(ctx, continueParam)
-	if !ok {
-		httpserver.RenderError(w, http.StatusBadRequest, errors.New("invalid continue URL"))
-		return
-	}
-
-	proboURL := h.proboBaseURL.String()
-
-	req := &iam.SendMagicLinkRequest{
-		Email:            emailAddr,
-		URLPath:          "/api/connect/v1/magic-link/verify",
-		MagicLinkBaseURL: &proboURL,
-		Continue:         &safeContinue,
-	}
-
-	if clientID := oauth2ClientIDFromContinueURL(safeContinue); clientID != "" {
-		req.OAuth2ClientIDRaw = &clientID
-	}
-
-	if err := h.iam.AuthService.SendMagicLink(ctx, req); err != nil {
-		h.logger.ErrorCtx(ctx, "cannot send magic link", log.Error(err))
-		httpserver.RenderError(w, http.StatusInternalServerError, errors.New("internal server error"))
-
-		return
-	}
-
-	w.WriteHeader(http.StatusNoContent)
-}
-
-func (h *MagicLinkHandler) VerifyHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	token := r.URL.Query().Get("token")
-	if token == "" {
-		h.redirectAuthError(w, r, authErrorMagicLinkInvalid, "")
-
-		return
-	}
-
-	identity, session, continueURL, err := h.iam.AuthService.OpenSessionWithMagicLink(ctx, token)
-	if err != nil {
-		if _, ok := errors.AsType[*iam.ErrExpiredToken](err); ok {
-			h.redirectAuthError(w, r, authErrorMagicLinkExpired, token)
-
-			return
-		}
-
-		if _, ok := errors.AsType[*iam.ErrTokenAlreadyUsed](err); ok {
-			h.redirectAuthError(w, r, authErrorMagicLinkAlreadyUsed, token)
-
-			return
-		}
-
-		if _, ok := errors.AsType[*iam.ErrInvalidToken](err); ok {
-			h.redirectAuthError(w, r, authErrorMagicLinkInvalid, token)
-
-			return
-		}
-
-		h.logger.ErrorCtx(ctx, "cannot open session with magic link", log.Error(err))
-		h.redirectAuthError(w, r, authErrorAuthenticationFailed, token)
-
-		return
-	}
-
-	_ = identity
-
-	h.sessionCookie.Set(w, session)
-
-	metadata := OAuth2ServerMetadata(
-		h.proboBaseURL,
-		h.iam.OAuth2ScopeRegistry.RegisteredScopes(),
-	)
-
-	redirectURL := metadata.AuthorizationEndpoint.String()
-	if continueURL != nil && *continueURL != "" {
-		redirectURL = *continueURL
-	}
-
-	http.Redirect(w, r, redirectURL, http.StatusFound)
 }

--- a/pkg/server/api/connect/v1/session_resolvers.go
+++ b/pkg/server/api/connect/v1/session_resolvers.go
@@ -40,6 +40,15 @@ func (r *mutationResolver) SignIn(ctx context.Context, input types.SignInInput) 
 		return nil, gqlutils.Internal(ctx)
 	}
 
+	if !identity.EmailAddressVerified {
+		return nil, &gqlerror.Error{
+			Message: iam.NewEmailNotVerifiedError().Error(),
+			Extensions: map[string]any{
+				"code": "EMAIL_NOT_VERIFIED",
+			},
+		}
+	}
+
 	session := authn.SessionFromContext(ctx)
 
 	switch {
@@ -307,6 +316,19 @@ func (r *mutationResolver) VerifyEmail(ctx context.Context, input types.VerifyEm
 	}
 
 	return &types.VerifyEmailPayload{
+		Success: true,
+	}, nil
+}
+
+// ResendVerificationEmail is the resolver for the resendVerificationEmail field.
+func (r *mutationResolver) ResendVerificationEmail(ctx context.Context, input types.ResendVerificationEmailInput) (*types.ResendVerificationEmailPayload, error) {
+	err := r.iam.AccountService.ResendVerificationEmail(ctx, input.Email)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot resend verification email", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return &types.ResendVerificationEmailPayload{
 		Success: true,
 	}, nil
 }


### PR DESCRIPTION
Closes ENG-401

Unverified password identities were able to open sessions after signing out. Reject sign-in with EMAIL_NOT_VERIFIED and add a resend-confirmation flow so users can complete verification.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Password sign-in now requires a verified email. Unverified attempts return EMAIL_NOT_VERIFIED and redirect to a resend‑verification page; completing a magic link now verifies the address.

### GraphQL API **`+209`** **`-143`**
- Block signIn when EmailAddressVerified is false; return EMAIL_NOT_VERIFIED.
- Add resendVerificationEmail mutation and resolver.
- Extract MagicLinkHandler from the OIDC handler.

### Service **`+112`** **`-36`**
- Implement resend verification email in AccountService; enumeration‑safe.
- Make email confirmation token validity configurable; apply in signup and change‑email.
- Magic link completion marks the email verified for existing identities.
- Add ErrEmailNotVerified; wire auth config through builder, `probod`, and config structs.

### App: console **`+245`** **`-7`**
- Add Resend Verification page at `/auth/resend-verification-email`.
- Redirect from password sign-in to the resend page on EMAIL_NOT_VERIFIED (preserves email).
- Disable submit buttons while mutations run on resend and forgot-password; add i18n strings (en‑US, fr‑FR).

### Tests **`+245`** **`-26`**
- Add e2e tests for verified‑email requirement, resend flow, and enumeration safety.
- Test client: add sign‑in/sign‑out helpers, resend + token fetch, and verify email in setup; update OAuth2 ID token tests to expect email_verified true.

### Other **`+4`** **`-0`**
- Helm chart: add `PROBOD_AUTH_EMAIL_CONFIRMATION_TOKEN_VALIDITY` env and default.

<sup>Written for commit 6e11886365f66e71267f6bbd685ff961ece78eda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



