### PR TITLE
Split inactive profile state - allow pending user to be assigned to resources

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1371,7 +1371,7 @@
     "columns": { "name": "Name", "status": "Status", "email": "Email", "role": "Role", "createdOn": "Created on" },
     "empty": "No people",
     "searchPlaceholder": "Search people...",
-    "filters": { "allStatuses": "All statuses", "active": "Active", "inactive": "Inactive", "allRoles": "All roles", "allTypes": "All types" }
+    "filters": { "allStatuses": "All statuses", "pending": "Pending", "active": "Active", "deactivated": "Deactivated", "allRoles": "All roles", "allTypes": "All types" }
   },
   "peopleListItem": {
     "messages": { "invitationSent": "Invitation sent successfully", "roleUpdated": "Role updated successfully", "archived": "Person archived successfully", "removed": "Person removed successfully" },

--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1371,7 +1371,7 @@
     "columns": { "name": "Name", "status": "Status", "email": "Email", "role": "Role", "createdOn": "Created on" },
     "empty": "No people",
     "searchPlaceholder": "Search people...",
-    "filters": { "allStatuses": "All statuses", "pending": "Pending", "active": "Active", "deactivated": "Deactivated", "allRoles": "All roles", "allTypes": "All types" }
+    "filters": { "allStatuses": "All statuses", "status": "Status", "pending": "Pending", "active": "Active", "deactivated": "Deactivated", "allRoles": "All roles", "allTypes": "All types" }
   },
   "peopleListItem": {
     "messages": { "invitationSent": "Invitation sent successfully", "roleUpdated": "Role updated successfully", "deactivated": "Person deactivated successfully", "removed": "Person removed successfully" },

--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1361,10 +1361,10 @@
   "peoplePage": { "title": "People", "actions": { "add": "Add Person" } },
   "personPage": {
     "breadcrumb": { "people": "People" },
-    "messages": { "archived": "Person archived successfully", "removed": "Person removed successfully" },
-    "errors": { "archive": "Failed to archive person", "remove": "Failed to remove person" },
-    "confirmations": { "archive": "Are you sure you want to archive {{name}}?", "remove": "Are you sure you want to remove {{name}}?" },
-    "actions": { "archive": "Archive", "remove": "Remove" }
+    "messages": { "deactivated": "Person deactivated successfully", "removed": "Person removed successfully" },
+    "errors": { "deactivate": "Failed to deactivate person", "remove": "Failed to remove person" },
+    "confirmations": { "deactivate": "Are you sure you want to deactivate {{name}}?", "remove": "Are you sure you want to remove {{name}}?" },
+    "actions": { "deactivate": "Deactivate", "remove": "Remove" }
   },
   "addPersonDialog": { "title": "Add Person" },
   "peopleList": {
@@ -1374,10 +1374,10 @@
     "filters": { "allStatuses": "All statuses", "pending": "Pending", "active": "Active", "deactivated": "Deactivated", "allRoles": "All roles", "allTypes": "All types" }
   },
   "peopleListItem": {
-    "messages": { "invitationSent": "Invitation sent successfully", "roleUpdated": "Role updated successfully", "archived": "Person archived successfully", "removed": "Person removed successfully" },
-    "errors": { "sendInvitation": "Failed to send invitation", "updateRole": "Failed to update role", "archive": "Failed to archive person", "remove": "Failed to remove person" },
-    "confirmations": { "sendActivationEmail": "Send the activation email to {{name}}?", "archive": "Are you sure you want to archive {{name}}?", "remove": "Are you sure you want to remove {{name}}?" },
-    "actions": { "send": "Send", "sendActivationMail": "Send activation mail", "resendActivationMail": "Resend activation mail", "archivePerson": "Archive person", "removePerson": "Remove person" }
+    "messages": { "invitationSent": "Invitation sent successfully", "roleUpdated": "Role updated successfully", "deactivated": "Person deactivated successfully", "removed": "Person removed successfully" },
+    "errors": { "sendInvitation": "Failed to send invitation", "updateRole": "Failed to update role", "deactivate": "Failed to deactivate person", "remove": "Failed to remove person" },
+    "confirmations": { "sendActivationEmail": "Send the activation email to {{name}}?", "deactivate": "Are you sure you want to deactivate {{name}}?", "remove": "Are you sure you want to remove {{name}}?" },
+    "actions": { "send": "Send", "sendActivationMail": "Send activation mail", "resendActivationMail": "Resend activation mail", "deactivatePerson": "Deactivate person", "removePerson": "Remove person" }
   },
   "personForm": {
     "messages": { "created": "Person created successfully.", "updated": "Person updated successfully." },

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -2458,8 +2458,9 @@
     "searchPlaceholder": "Rechercher des personnes...",
     "filters": {
       "allStatuses": "Tous les statuts",
+      "pending": "En attente",
       "active": "Actif",
-      "inactive": "Inactif",
+      "deactivated": "Désactivé",
       "allRoles": "Tous les rôles",
       "allTypes": "Tous les types"
     }

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -2458,6 +2458,7 @@
     "searchPlaceholder": "Rechercher des personnes...",
     "filters": {
       "allStatuses": "Tous les statuts",
+      "status": "Statut",
       "pending": "En attente",
       "active": "Actif",
       "deactivated": "Désactivé",

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -2427,19 +2427,19 @@
       "people": "Personnes"
     },
     "messages": {
-      "archived": "Personne archivée avec succès",
+      "deactivated": "Personne désactivée avec succès",
       "removed": "Personne supprimée avec succès"
     },
     "errors": {
-      "archive": "Échec de l’archivage de la personne",
+      "deactivate": "Échec de la désactivation de la personne",
       "remove": "Échec de la suppression de la personne"
     },
     "confirmations": {
-      "archive": "Voulez-vous vraiment archiver {{name}} ?",
+      "deactivate": "Voulez-vous vraiment désactiver {{name}} ?",
       "remove": "Voulez-vous vraiment supprimer {{name}} ?"
     },
     "actions": {
-      "archive": "Archiver",
+      "deactivate": "Désactiver",
       "remove": "Supprimer"
     }
   },
@@ -2469,25 +2469,25 @@
     "messages": {
       "invitationSent": "Invitation envoyée avec succès",
       "roleUpdated": "Rôle mis à jour avec succès",
-      "archived": "Personne archivée avec succès",
+      "deactivated": "Personne désactivée avec succès",
       "removed": "Personne supprimée avec succès"
     },
     "errors": {
       "sendInvitation": "Échec de l’envoi de l’invitation",
       "updateRole": "Échec de la mise à jour du rôle",
-      "archive": "Échec de l’archivage de la personne",
+      "deactivate": "Échec de la désactivation de la personne",
       "remove": "Échec de la suppression de la personne"
     },
     "confirmations": {
       "sendActivationEmail": "Envoyer l’e-mail d’activation à {{name}} ?",
-      "archive": "Voulez-vous vraiment archiver {{name}} ?",
+      "deactivate": "Voulez-vous vraiment désactiver {{name}} ?",
       "remove": "Voulez-vous vraiment supprimer {{name}} ?"
     },
     "actions": {
       "send": "Envoyer",
       "sendActivationMail": "Envoyer l’e-mail d’activation",
       "resendActivationMail": "Renvoyer l’e-mail d’activation",
-      "archivePerson": "Archiver la personne",
+      "deactivatePerson": "Désactiver la personne",
       "removePerson": "Supprimer la personne"
     }
   },

--- a/apps/console/src/components/table/PeopleCell.tsx
+++ b/apps/console/src/components/table/PeopleCell.tsx
@@ -37,7 +37,7 @@ export function PeopleCell(props: Props) {
       query={peopleQuery}
       variables={{
         organizationId: props.organizationId,
-        filter: { contractEnded: false },
+        filter: { contractEnded: false, states: ["ACTIVE", "PENDING"] },
       }}
       items={data =>
         data.organization?.profiles?.edges.map(edge => edge.node) ?? []}

--- a/apps/console/src/hooks/graph/PeopleGraph.ts
+++ b/apps/console/src/hooks/graph/PeopleGraph.ts
@@ -24,7 +24,7 @@ import {
 } from "react-relay";
 import { graphql } from "relay-runtime";
 
-import type { PeopleGraphQuery } from "#/__generated__/core/PeopleGraphQuery.graphql";
+import type { PeopleGraphQuery, ProfileFilter } from "#/__generated__/core/PeopleGraphQuery.graphql";
 
 /* eslint-disable relay/unused-fields */
 
@@ -57,11 +57,15 @@ export function usePeople(
   organizationId: string,
   { contractEnded }: { contractEnded?: boolean } = {},
 ) {
+  const filter: ProfileFilter = contractEnded !== undefined
+    ? { contractEnded, states: ["ACTIVE", "PENDING"] }
+    : { states: ["ACTIVE", "PENDING"] };
+
   const data = useLazyLoadQuery<PeopleGraphQuery>(
     peopleQuery,
     {
       organizationId: organizationId,
-      filter: contractEnded !== undefined ? { contractEnded } : null,
+      filter,
     },
     { fetchPolicy: "network-only" },
   );

--- a/apps/console/src/pages/iam/enroll/EnrollDevicePage.tsx
+++ b/apps/console/src/pages/iam/enroll/EnrollDevicePage.tsx
@@ -43,7 +43,7 @@ export const enrollDevicePageQuery = graphql`
       profiles(
         first: 1000
         orderBy: { direction: ASC, field: ORGANIZATION_NAME }
-        filter: { state: ACTIVE }
+        filter: { states: [ACTIVE] }
       ) @required(action: THROW) {
         edges @required(action: THROW) {
           node @required(action: THROW) {

--- a/apps/console/src/pages/iam/memberships/MembershipsPage.tsx
+++ b/apps/console/src/pages/iam/memberships/MembershipsPage.tsx
@@ -41,7 +41,7 @@ export const membershipsPageQuery = graphql`
       profiles(
         first: 1000
         orderBy: { direction: ASC, field: ORGANIZATION_NAME }
-        filter: { state: ACTIVE }
+        filter: { states: [ACTIVE] }
       )
         @connection(key: "MembershipsPage_profiles")
         @required(action: THROW) {

--- a/apps/console/src/pages/iam/organizations/_components/MembershipsDropdownMenu.tsx
+++ b/apps/console/src/pages/iam/organizations/_components/MembershipsDropdownMenu.tsx
@@ -34,7 +34,7 @@ export const membershipsDropdownMenuQuery = graphql`
       profiles(
         first: 1000
         orderBy: { direction: ASC, field: ORGANIZATION_NAME }
-        filter: { state: ACTIVE }
+        filter: { states: [ACTIVE] }
       ) @required(action: THROW) {
         edges @required(action: THROW) {
           node @required(action: THROW) {

--- a/apps/console/src/pages/iam/organizations/people/PersonPage.tsx
+++ b/apps/console/src/pages/iam/organizations/people/PersonPage.tsx
@@ -139,7 +139,7 @@ export function PersonPage(props: { queryRef: PreloadedQuery<PersonPageQuery> })
     );
   };
 
-  const canArchive = person.canDelete && person.source !== "SCIM" && person.state !== "INACTIVE";
+  const canArchive = person.canDelete && person.source !== "SCIM" && person.state !== "DEACTIVATED";
   const canRemove = person.canRemoveMember && person.source !== "SCIM";
 
   return (

--- a/apps/console/src/pages/iam/organizations/people/PersonPage.tsx
+++ b/apps/console/src/pages/iam/organizations/people/PersonPage.tsx
@@ -40,7 +40,7 @@ export const personPageQuery = graphql`
         emailAddress
         source
         state
-        canDelete: permission(action: "iam:membership-profile:delete")
+        canDeactivate: permission(action: "iam:membership-profile:deactivate")
         canRemoveMember: permission(action: "iam:membership:delete")
         ...PersonFormFragment
       }
@@ -58,12 +58,12 @@ const removeUserMutation = graphql`
   }
 `;
 
-const archiveUserMutation = graphql`
-  mutation PersonPage_archiveMutation(
-    $input: ArchiveUserInput!
+const deactivateUserMutation = graphql`
+  mutation PersonPage_deactivateMutation(
+    $input: DeactivateUserInput!
   ) {
-    archiveUser(input: $input) {
-      archivedProfileId
+    deactivateUser(input: $input) {
+      success
     }
   }
 `;
@@ -81,11 +81,11 @@ export function PersonPage(props: { queryRef: PreloadedQuery<PersonPageQuery> })
     throw new Error("invalid type for node");
   }
 
-  const [archiveUser, isArchiving] = useMutationWithToasts(
-    archiveUserMutation,
+  const [deactivateUser, isDeactivating] = useMutationWithToasts(
+    deactivateUserMutation,
     {
-      successMessage: t("personPage.messages.archived"),
-      errorMessage: t("personPage.errors.archive"),
+      successMessage: t("personPage.messages.deactivated"),
+      errorMessage: t("personPage.errors.deactivate"),
     },
   );
   const [removeUser, isRemoving] = useMutationWithToasts(
@@ -95,12 +95,12 @@ export function PersonPage(props: { queryRef: PreloadedQuery<PersonPageQuery> })
       errorMessage: t("personPage.errors.remove"),
     },
   );
-  const isMutating = isArchiving || isRemoving;
+  const isMutating = isDeactivating || isRemoving;
 
-  const handleArchive = () => {
+  const handleDeactivate = () => {
     confirm(
       () => {
-        return archiveUser({
+        return deactivateUser({
           variables: {
             input: {
               profileId: person.id,
@@ -113,7 +113,7 @@ export function PersonPage(props: { queryRef: PreloadedQuery<PersonPageQuery> })
         });
       },
       {
-        message: t("personPage.confirmations.archive", { name: person.fullName }),
+        message: t("personPage.confirmations.deactivate", { name: person.fullName }),
       },
     );
   };
@@ -139,7 +139,7 @@ export function PersonPage(props: { queryRef: PreloadedQuery<PersonPageQuery> })
     );
   };
 
-  const canArchive = person.canDelete && person.source !== "SCIM" && person.state !== "DEACTIVATED";
+  const canDeactivate = person.canDeactivate && person.source !== "SCIM" && person.state !== "DEACTIVATED";
   const canRemove = person.canRemoveMember && person.source !== "SCIM";
 
   return (
@@ -166,15 +166,15 @@ export function PersonPage(props: { queryRef: PreloadedQuery<PersonPageQuery> })
             <div className="text-lg text-txt-secondary">{person.emailAddress}</div>
           </div>
         </div>
-        {(canArchive || canRemove) && (
+        {(canDeactivate || canRemove) && (
           <ActionDropdown variant="secondary">
-            {canArchive && (
+            {canDeactivate && (
               <DropdownItem
                 icon={IconArchive}
-                onClick={handleArchive}
+                onClick={handleDeactivate}
                 disabled={isMutating}
               >
-                {t("personPage.actions.archive")}
+                {t("personPage.actions.deactivate")}
               </DropdownItem>
             )}
             {canRemove && (

--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleList.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleList.tsx
@@ -231,8 +231,9 @@ export function PeopleList(props: {
           onValueChange={handleStateFilterChange}
         >
           <Option value="ALL">{t("peopleList.filters.allStatuses")}</Option>
+          <Option value="PENDING">{t("peopleList.filters.pending")}</Option>
           <Option value="ACTIVE">{t("peopleList.filters.active")}</Option>
-          <Option value="INACTIVE">{t("peopleList.filters.inactive")}</Option>
+          <Option value="DEACTIVATED">{t("peopleList.filters.deactivated")}</Option>
         </Select>
         <Select
           value={roleFilter ?? "ALL"}

--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleList.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleList.tsx
@@ -20,6 +20,7 @@
 
 import { getAssignableRoles, getMembershipRoles, peopleRoles } from "@probo/helpers";
 import {
+  Checkbox,
   IconMagnifyingGlass,
   Input,
   Option,
@@ -89,10 +90,12 @@ const fragment = graphql`
 
 type PeopleFilter = {
   query: string | null;
-  state: ProfileState | null;
+  states: ProfileState[];
   role: MembershipRole | null;
   kind: string | null;
 };
+
+const PROFILE_STATES: ProfileState[] = ["PENDING", "ACTIVE", "DEACTIVATED"];
 
 export function PeopleList(props: {
   fKey: PeopleListFragment$key;
@@ -105,7 +108,7 @@ export function PeopleList(props: {
   const canManageRoles = getAssignableRoles(role).length > 0;
 
   const [queryFilter, setQueryFilter] = useState<string | null>(null);
-  const [stateFilter, setStateFilter] = useState<ProfileState | null>(null);
+  const [statesFilter, setStatesFilter] = useState<ProfileState[]>([]);
   const [roleFilter, setRoleFilter] = useState<MembershipRole | null>(null);
   const [kindFilter, setKindFilter] = useState<string | null>(null);
   const [order, setOrder] = useState<Order>({
@@ -127,7 +130,7 @@ export function PeopleList(props: {
 
   const currentFilter = (overrides: Partial<PeopleFilter> = {}): PeopleFilter => ({
     query: queryFilter,
-    state: stateFilter,
+    states: statesFilter,
     role: roleFilter,
     kind: kindFilter,
     ...overrides,
@@ -135,7 +138,7 @@ export function PeopleList(props: {
 
   const connectionFilter = (filter: PeopleFilter) => ({
     query: filter.query,
-    state: filter.state,
+    states: filter.states.length > 0 ? filter.states : null,
     role: filter.role,
     kind: filter.kind,
     contractEnded: null,
@@ -170,7 +173,7 @@ export function PeopleList(props: {
               },
               filter: {
                 query: newQuery,
-                state: stateFilter,
+                states: statesFilter.length > 0 ? statesFilter : null,
                 role: roleFilter,
                 kind: kindFilter,
                 contractEnded: null,
@@ -180,7 +183,7 @@ export function PeopleList(props: {
           );
         });
       },
-      [peoplePagination, order, stateFilter, roleFilter, kindFilter],
+      [peoplePagination, order, statesFilter, roleFilter, kindFilter],
     ),
     SEARCH_DEBOUNCE_MS,
   );
@@ -190,10 +193,12 @@ export function PeopleList(props: {
     debouncedRefetchQuery(value);
   };
 
-  const handleStateFilterChange = (value: string) => {
-    const newState = value === "ALL" ? null : (value as ProfileState);
-    setStateFilter(newState);
-    refetchPeople({ state: newState });
+  const handleStateFilterToggle = (state: ProfileState) => {
+    const newStates = statesFilter.includes(state)
+      ? statesFilter.filter(s => s !== state)
+      : [...statesFilter, state];
+    setStatesFilter(newStates);
+    refetchPeople({ states: newStates });
   };
 
   const handleRoleFilterChange = (value: string) => {
@@ -226,15 +231,18 @@ export function PeopleList(props: {
           value={queryFilter ?? ""}
           onValueChange={handleQueryFilterChange}
         />
-        <Select
-          value={stateFilter ?? "ALL"}
-          onValueChange={handleStateFilterChange}
-        >
-          <Option value="ALL">{t("peopleList.filters.allStatuses")}</Option>
-          <Option value="PENDING">{t("peopleList.filters.pending")}</Option>
-          <Option value="ACTIVE">{t("peopleList.filters.active")}</Option>
-          <Option value="DEACTIVATED">{t("peopleList.filters.deactivated")}</Option>
-        </Select>
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-txt-secondary">{t("peopleList.filters.status")}</span>
+          {PROFILE_STATES.map(state => (
+            <label key={state} className="flex items-center gap-2 text-sm cursor-pointer">
+              <Checkbox
+                checked={statesFilter.includes(state)}
+                onChange={() => handleStateFilterToggle(state)}
+              />
+              {t(`peopleList.filters.${state.toLowerCase()}`)}
+            </label>
+          ))}
+        </div>
         <Select
           value={roleFilter ?? "ALL"}
           onValueChange={handleRoleFilterChange}

--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleList.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleList.tsx
@@ -20,7 +20,10 @@
 
 import { getAssignableRoles, getMembershipRoles, peopleRoles } from "@probo/helpers";
 import {
-  Checkbox,
+  Button,
+  Dropdown,
+  DropdownCheckboxItem,
+  IconChevronDown,
   IconMagnifyingGlass,
   Input,
   Option,
@@ -192,14 +195,20 @@ export function PeopleList(props: {
     debouncedRefetchQuery(value);
   };
 
-  const handleStateFilterToggle = (state: ProfileState) => {
+  const handleStateFilterChange = (state: ProfileState, checked: boolean) => {
     debouncedRefetchQuery.cancel();
-    const newStates = statesFilter.includes(state)
-      ? statesFilter.filter(s => s !== state)
-      : [...statesFilter, state];
+    const newStates = checked
+      ? [...statesFilter, state]
+      : statesFilter.filter(s => s !== state);
     setStatesFilter(newStates);
     refetchPeople({ states: newStates });
   };
+
+  const statusFilterLabel = statesFilter.length === 0
+    ? t("peopleList.filters.allStatuses")
+    : statesFilter
+        .map(state => t(`peopleList.filters.${state.toLowerCase()}`))
+        .join(", ");
 
   const handleRoleFilterChange = (value: string) => {
     debouncedRefetchQuery.cancel();
@@ -234,18 +243,24 @@ export function PeopleList(props: {
           value={queryFilter ?? ""}
           onValueChange={handleQueryFilterChange}
         />
-        <div className="flex items-center gap-3">
-          <span className="text-sm text-txt-secondary">{t("peopleList.filters.status")}</span>
+        <Dropdown
+          toggle={(
+            <Button variant="secondary" className="min-w-40 justify-between gap-2">
+              <span className="truncate">{statusFilterLabel}</span>
+              <IconChevronDown size={12} className="shrink-0" />
+            </Button>
+          )}
+        >
           {PROFILE_STATES.map(state => (
-            <label key={state} className="flex items-center gap-2 text-sm cursor-pointer">
-              <Checkbox
-                checked={statesFilter.includes(state)}
-                onChange={() => handleStateFilterToggle(state)}
-              />
+            <DropdownCheckboxItem
+              key={state}
+              checked={statesFilter.includes(state)}
+              onCheckedChange={(checked: boolean) => handleStateFilterChange(state, checked)}
+            >
               {t(`peopleList.filters.${state.toLowerCase()}`)}
-            </label>
+            </DropdownCheckboxItem>
           ))}
-        </div>
+        </Dropdown>
         <Select
           value={roleFilter ?? "ALL"}
           onValueChange={handleRoleFilterChange}

--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleList.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleList.tsx
@@ -163,7 +163,6 @@ export function PeopleList(props: {
   const debouncedRefetchQuery = useDebounceCallback(
     useCallback(
       (value: string) => {
-        const newQuery = value === "" ? null : value;
         startTransition(() => {
           peoplePagination.refetch(
             {
@@ -172,7 +171,7 @@ export function PeopleList(props: {
                 field: order.field as ProfileOrderField,
               },
               filter: {
-                query: newQuery,
+                query: value === "" ? null : value,
                 states: statesFilter.length > 0 ? statesFilter : null,
                 role: roleFilter,
                 kind: kindFilter,
@@ -194,6 +193,7 @@ export function PeopleList(props: {
   };
 
   const handleStateFilterToggle = (state: ProfileState) => {
+    debouncedRefetchQuery.cancel();
     const newStates = statesFilter.includes(state)
       ? statesFilter.filter(s => s !== state)
       : [...statesFilter, state];
@@ -202,12 +202,14 @@ export function PeopleList(props: {
   };
 
   const handleRoleFilterChange = (value: string) => {
+    debouncedRefetchQuery.cancel();
     const newRole = value === "ALL" ? null : (value as MembershipRole);
     setRoleFilter(newRole);
     refetchPeople({ role: newRole });
   };
 
   const handleKindFilterChange = (value: string) => {
+    debouncedRefetchQuery.cancel();
     const newKind = value === "ALL" ? null : value;
     setKindFilter(newKind);
     refetchPeople({ kind: newKind });
@@ -218,6 +220,7 @@ export function PeopleList(props: {
   };
 
   const refetchWithFilters: ComponentProps<typeof SortableTable>["refetch"] = ({ order: nextOrder }) => {
+    debouncedRefetchQuery.cancel();
     setOrder(nextOrder);
     refetchPeople({}, nextOrder);
   };

--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
@@ -145,10 +145,11 @@ export function PeopleListItem(props: {
     ? availableRoles
     : [...availableRoles, profile.membership.role];
 
-  const isInactive = profile.state === "INACTIVE";
+  const isActive = profile.state === "ACTIVE";
+  const isInactive = !isActive;
 
-  const canSendActivationMail = isInactive && profile.source !== "SCIM" && profile.canInvite;
-  const canArchive = profile.canDelete && profile.source !== "SCIM" && profile.state !== "INACTIVE";
+  const canSendActivationMail = !isActive && profile.source !== "SCIM" && profile.canInvite;
+  const canArchive = profile.canDelete && profile.source !== "SCIM" && profile.state !== "DEACTIVATED";
   const canRemove = profile.canRemoveMember && profile.source !== "SCIM";
 
   const [inviteUser]
@@ -262,7 +263,7 @@ export function PeopleListItem(props: {
         <span className="font-semibold">{profile.fullName}</span>
       </Td>
       <Td>
-        <Badge variant={profile.state === "INACTIVE" ? "neutral" : "success"}>{profile.state}</Badge>
+        <Badge variant={isActive ? "success" : "neutral"}>{profile.state}</Badge>
       </Td>
       <Td className={clsx(
         isMutating && "opacity-60 pointer-events-none",

--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
@@ -146,7 +146,7 @@ export function PeopleListItem(props: {
     : [...availableRoles, profile.membership.role];
 
   const isActive = profile.state === "ACTIVE";
-  const isInactive = !isActive;
+  const isInactive = profile.state === "DEACTIVATED";
 
   const canSendActivationMail = !isActive && profile.source !== "SCIM" && profile.canInvite;
   const canDeactivate = profile.canDeactivate && profile.source !== "SCIM" && profile.state !== "DEACTIVATED";

--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
@@ -191,6 +191,11 @@ export function PeopleListItem(props: {
             },
             connections: [profile.lastInvitation.__id],
           },
+          updater: (store) => {
+            // Inviting a deactivated user marks the profile pending server-side;
+            // the payload only returns the invitation edge, so update state here.
+            store.get(profile.id)?.setValue("PENDING", "state");
+          },
         });
       },
       {

--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
@@ -71,7 +71,7 @@ const fragment = graphql`
     createdAt
     canUpdate: permission(action: "iam:membership-profile:update")
     canInvite: permission(action: "iam:invitation:create")
-    canDelete: permission(action: "iam:membership-profile:delete")
+    canDeactivate: permission(action: "iam:membership-profile:deactivate")
     canRemoveMember: permission(action: "iam:membership:delete")
   }
 `;
@@ -116,10 +116,10 @@ const removeUserMutation = graphql`
   }
 `;
 
-const archiveUserMutation = graphql`
-  mutation PeopleListItem_archiveMutation($input: ArchiveUserInput!) {
-    archiveUser(input: $input) {
-      archivedProfileId
+const deactivateUserMutation = graphql`
+  mutation PeopleListItem_deactivateMutation($input: DeactivateUserInput!) {
+    deactivateUser(input: $input) {
+      success
     }
   }
 `;
@@ -149,7 +149,7 @@ export function PeopleListItem(props: {
   const isInactive = !isActive;
 
   const canSendActivationMail = !isActive && profile.source !== "SCIM" && profile.canInvite;
-  const canArchive = profile.canDelete && profile.source !== "SCIM" && profile.state !== "DEACTIVATED";
+  const canDeactivate = profile.canDeactivate && profile.source !== "SCIM" && profile.state !== "DEACTIVATED";
   const canRemove = profile.canRemoveMember && profile.source !== "SCIM";
 
   const [inviteUser]
@@ -164,11 +164,11 @@ export function PeopleListItem(props: {
       errorMessage: t("peopleListItem.errors.updateRole"),
     },
   );
-  const [archiveUser, isArchiving] = useMutationWithToasts(
-    archiveUserMutation,
+  const [deactivateUser, isDeactivating] = useMutationWithToasts(
+    deactivateUserMutation,
     {
-      successMessage: t("peopleListItem.messages.archived"),
-      errorMessage: t("peopleListItem.errors.archive"),
+      successMessage: t("peopleListItem.messages.deactivated"),
+      errorMessage: t("peopleListItem.errors.deactivate"),
     },
   );
   const [removeUser, isRemoving] = useMutationWithToasts(
@@ -178,7 +178,7 @@ export function PeopleListItem(props: {
       errorMessage: t("peopleListItem.errors.remove"),
     },
   );
-  const isMutating = isArchiving || isRemoving;
+  const isMutating = isDeactivating || isRemoving;
 
   const handleInvite = () => {
     confirm(
@@ -211,10 +211,10 @@ export function PeopleListItem(props: {
       },
     });
   };
-  const handleArchive = () => {
+  const handleDeactivate = () => {
     confirm(
       () => {
-        return archiveUser({
+        return deactivateUser({
           variables: {
             input: {
               profileId: profile.id,
@@ -227,7 +227,7 @@ export function PeopleListItem(props: {
         });
       },
       {
-        message: t("peopleListItem.confirmations.archive", { name: profile.fullName }),
+        message: t("peopleListItem.confirmations.deactivate", { name: profile.fullName }),
       },
     );
   };
@@ -307,7 +307,7 @@ export function PeopleListItem(props: {
         {dateFormat(i18n.language, profile.createdAt)}
       </Td>
       <Td noLink width={160} className="text-end">
-        {(canSendActivationMail || canArchive || canRemove) && (
+        {(canSendActivationMail || canDeactivate || canRemove) && (
           <ActionDropdown>
             {canSendActivationMail && (
               <DropdownItem
@@ -317,12 +317,12 @@ export function PeopleListItem(props: {
                 {lastInvitation ? t("peopleListItem.actions.resendActivationMail") : t("peopleListItem.actions.sendActivationMail")}
               </DropdownItem>
             )}
-            {canArchive && (
+            {canDeactivate && (
               <DropdownItem
-                onClick={handleArchive}
+                onClick={handleDeactivate}
                 icon={IconArchive}
               >
-                {t("peopleListItem.actions.archivePerson")}
+                {t("peopleListItem.actions.deactivatePerson")}
               </DropdownItem>
             )}
             {canRemove && (

--- a/apps/console/src/pages/organizations/documents/DocumentLayout.tsx
+++ b/apps/console/src/pages/organizations/documents/DocumentLayout.tsx
@@ -46,10 +46,10 @@ export const documentLayoutQuery = graphql`
         ...DocumentTitleFormFragment
         ...DocumentActionsDropdown_versionFragment
         ...DocumentDetailsCard_versionFragment
-        signatures(first: 0 filter: { activeContract: true, profileState: ACTIVE }) {
+        signatures(first: 0 filter: { activeContract: true, profileStates: [ACTIVE] }) {
           totalCount
         }
-        signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, profileState: ACTIVE }) {
+        signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, profileStates: [ACTIVE] }) {
           totalCount
         }
         approvalQuorums(first: 1, orderBy: { field: CREATED_AT, direction: DESC }) {
@@ -91,10 +91,10 @@ export const documentLayoutQuery = graphql`
               ...DocumentTitleFormFragment
               ...DocumentActionsDropdown_versionFragment
               ...DocumentDetailsCard_versionFragment
-              signatures(first: 0 filter: { activeContract: true, profileState: ACTIVE }) {
+              signatures(first: 0 filter: { activeContract: true, profileStates: [ACTIVE] }) {
                 totalCount
               }
-              signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, profileState: ACTIVE }) {
+              signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, profileStates: [ACTIVE] }) {
                 totalCount
               }
               approvalQuorums(first: 1, orderBy: { field: CREATED_AT, direction: DESC }) {

--- a/apps/console/src/pages/organizations/documents/_components/DocumentListItem.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/DocumentListItem.tsx
@@ -79,10 +79,10 @@ const fragment = graphql`
               }
             }
           }
-          signatures(first: 0 filter: { activeContract: true, profileState: ACTIVE }) {
+          signatures(first: 0 filter: { activeContract: true, profileStates: [ACTIVE] }) {
             totalCount
           }
-          signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, profileState: ACTIVE }) {
+          signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, profileStates: [ACTIVE] }) {
             totalCount
           }
         }

--- a/apps/console/src/pages/organizations/documents/_components/SignatureDocumentsDialog.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/SignatureDocumentsDialog.tsx
@@ -210,7 +210,7 @@ function PeopleList({
     signatureDocumentsDialogPeopleQuery,
     {
       organizationId,
-      filter: { contractEnded: false, state: "ACTIVE" },
+      filter: { contractEnded: false, states: ["ACTIVE"] },
     },
   );
   const {

--- a/apps/console/src/pages/organizations/documents/signatures/DocumentSignaturesPage.tsx
+++ b/apps/console/src/pages/organizations/documents/signatures/DocumentSignaturesPage.tsx
@@ -33,7 +33,7 @@ export const documentSignaturesPageQuery = graphql`
   query DocumentSignaturesPageQuery($documentId: ID! $organizationId: ID! $versionId: ID! $versionSpecified: Boolean!) {
     organization: node(id: $organizationId) {
       __typename
-      ...DocumentSignatureList_peopleFragment @arguments(filter: { contractEnded: false, state: ACTIVE })
+      ...DocumentSignatureList_peopleFragment @arguments(filter: { contractEnded: false, states: [ACTIVE] })
     }
     # We use this on /documents/:documentId
     document: node(id: $documentId) @skip(if: $versionSpecified) {

--- a/apps/console/src/pages/organizations/documents/signatures/_components/DocumentSignatureList.tsx
+++ b/apps/console/src/pages/organizations/documents/signatures/_components/DocumentSignatureList.tsx
@@ -35,7 +35,7 @@ const versionFragment = graphql`
   @argumentDefinitions(
     count: { type: "Int", defaultValue: 1000 }
     cursor: { type: "CursorKey" }
-    signatureFilter: { type: "DocumentVersionSignatureFilter", defaultValue: { activeContract: true, profileState: ACTIVE } }
+    signatureFilter: { type: "DocumentVersionSignatureFilter", defaultValue: { activeContract: true, profileStates: [ACTIVE] } }
   ) {
     ...DocumentSignaturePlaceholder_versionFragment
     signatures(first: $count, after: $cursor, filter: $signatureFilter)
@@ -110,7 +110,7 @@ export function DocumentSignatureList(props: {
 
     const filter = {
       activeContract: true,
-      profileState: "ACTIVE" as const,
+      profileStates: ["ACTIVE" as const],
       ...(selectedStates.length > 0 ? { states: selectedStates } : {}),
     };
 

--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -704,7 +704,7 @@ func TestUser_ArchiveUser(t *testing.T) {
 	}
 
 	require.NotEmpty(t, archivedUserState, "Should still find archived user")
-	assert.Equal(t, "INACTIVE", archivedUserState)
+	assert.Equal(t, "DEACTIVATED", archivedUserState)
 }
 
 func TestUser_DeactivateUserCancelsSignatureRequests(t *testing.T) {

--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -605,13 +605,13 @@ func TestUser_RemoveUser_ProfileInUse(t *testing.T) {
 	assert.Contains(t, gqlErrors[0].Message, "referenced by other resources")
 }
 
-func TestUser_ArchiveUser(t *testing.T) {
+func TestUser_DeactivateUser(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 
-	// Create a user to archive.
-	userToArchive := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
-	_ = userToArchive
+	// Create a user to deactivate.
+	userToDeactivate := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+	_ = userToDeactivate
 
 	query := `
 		query($id: ID!) {
@@ -666,17 +666,17 @@ func TestUser_ArchiveUser(t *testing.T) {
 	require.NotEmpty(t, userID, "Should find viewer member")
 
 	mutation := `
-		mutation($input: ArchiveUserInput!) {
-			archiveUser(input: $input) {
-				archivedProfileId
+		mutation($input: DeactivateUserInput!) {
+			deactivateUser(input: $input) {
+				success
 			}
 		}
 	`
 
 	var mutationResult struct {
-		ArchiveUser struct {
-			ArchivedProfileID string `json:"archivedProfileId"`
-		} `json:"archiveUser"`
+		DeactivateUser struct {
+			Success bool `json:"success"`
+		} `json:"deactivateUser"`
 	}
 
 	err = owner.ExecuteConnect(mutation, map[string]any{
@@ -687,24 +687,24 @@ func TestUser_ArchiveUser(t *testing.T) {
 	}, &mutationResult)
 	require.NoError(t, err)
 
-	assert.Equal(t, userID, mutationResult.ArchiveUser.ArchivedProfileID)
+	assert.True(t, mutationResult.DeactivateUser.Success)
 
 	err = owner.ExecuteConnect(query, map[string]any{
 		"id": owner.GetOrganizationID().String(),
 	}, &result)
 	require.NoError(t, err)
 
-	var archivedUserState string
+	var deactivatedUserState string
 
 	for _, edge := range result.Node.Profiles.Edges {
 		if edge.Node.ID == userID {
-			archivedUserState = edge.Node.State
+			deactivatedUserState = edge.Node.State
 			break
 		}
 	}
 
-	require.NotEmpty(t, archivedUserState, "Should still find archived user")
-	assert.Equal(t, "DEACTIVATED", archivedUserState)
+	require.NotEmpty(t, deactivatedUserState, "Should still find deactivated user")
+	assert.Equal(t, "DEACTIVATED", deactivatedUserState)
 }
 
 func TestUser_DeactivateUserCancelsSignatureRequests(t *testing.T) {

--- a/packages/n8n-node/nodes/Probo/actions/document/getAllSignatures.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/getAllSignatures.operation.ts
@@ -98,13 +98,12 @@ export const description: INodeProperties[] = [
 				description: 'Whether to filter by active contract status',
 			},
 			{
-				displayName: 'Profile State',
+				displayName: 'Profile States',
 				name: 'state',
-				type: 'options',
-				default: '',
-				description: 'Filter by signatory profile state',
+				type: 'multiOptions',
+				default: [],
+				description: 'Filter by signatory profile states',
 				options: [
-					{ name: 'Any', value: '' },
 					{ name: 'Pending', value: 'PENDING' },
 					{ name: 'Active', value: 'ACTIVE' },
 					{ name: 'Deactivated', value: 'DEACTIVATED' },
@@ -126,7 +125,7 @@ export async function execute(
 	const filter: IDataObject = {};
 	if ((filters.states as string[])?.length) filter.states = filters.states;
 	if (filters.activeContract !== undefined) filter.activeContract = filters.activeContract;
-	if (filters.state) filter.profileState = filters.state;
+	if ((filters.state as string[])?.length) filter.profileStates = filters.state;
 
 	const hasFilter = Object.keys(filter).length > 0;
 

--- a/packages/n8n-node/nodes/Probo/actions/document/getAllSignatures.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/getAllSignatures.operation.ts
@@ -105,8 +105,9 @@ export const description: INodeProperties[] = [
 				description: 'Filter by signatory profile state',
 				options: [
 					{ name: 'Any', value: '' },
+					{ name: 'Pending', value: 'PENDING' },
 					{ name: 'Active', value: 'ACTIVE' },
-					{ name: 'Inactive', value: 'INACTIVE' },
+					{ name: 'Deactivated', value: 'DEACTIVATED' },
 				],
 			},
 		],

--- a/packages/n8n-node/nodes/Probo/actions/user/deactivateUser.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/user/deactivateUser.operation.ts
@@ -29,7 +29,7 @@ export const description: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['user'],
-				operation: ['archiveUser'],
+				operation: ['deactivateUser'],
 			},
 		},
 		default: '',
@@ -43,11 +43,11 @@ export const description: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['user'],
-				operation: ['archiveUser'],
+				operation: ['deactivateUser'],
 			},
 		},
 		default: '',
-		description: 'The ID of the user (profile) to archive in the organization',
+		description: 'The ID of the user (profile) to deactivate in the organization',
 		required: true,
 	},
 ];
@@ -60,9 +60,9 @@ export async function execute(
 	const userId = this.getNodeParameter('userId', itemIndex) as string;
 
 	const query = `
-		mutation ArchiveUser($input: ArchiveUserInput!) {
-			archiveUser(input: $input) {
-				archivedProfileId
+		mutation DeactivateUser($input: DeactivateUserInput!) {
+			deactivateUser(input: $input) {
+				success
 			}
 		}
 	`;

--- a/packages/n8n-node/nodes/Probo/actions/user/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/user/index.ts
@@ -19,7 +19,7 @@
 // SOFTWARE.
 
 import type { INodeProperties } from 'n8n-workflow';
-import * as archiveUserOp from './archiveUser.operation';
+import * as deactivateUserOp from './deactivateUser.operation';
 import * as listUsersOp from './listUsers.operation';
 import * as getUserOp from './getUser.operation';
 import * as createUserOp from './createUser.operation';
@@ -41,16 +41,16 @@ export const description: INodeProperties[] = [
 		},
 		options: [
 			{
-				name: 'Archive',
-				value: 'archiveUser',
-				description: 'Archive a user in the organization',
-				action: 'Archive a user',
-			},
-			{
 				name: 'Create',
 				value: 'createUser',
 				description: 'Create a new user in the organization',
 				action: 'Create a user',
+			},
+			{
+				name: 'Deactivate',
+				value: 'deactivateUser',
+				description: 'Deactivate a user in the organization',
+				action: 'Deactivate a user',
 			},
 			{
 				name: 'Get',
@@ -91,7 +91,7 @@ export const description: INodeProperties[] = [
 		],
 		default: 'listUsers',
 	},
-	...archiveUserOp.description,
+	...deactivateUserOp.description,
 	...listUsersOp.description,
 	...getUserOp.description,
 	...createUserOp.description,
@@ -102,7 +102,7 @@ export const description: INodeProperties[] = [
 ];
 
 export {
-	archiveUserOp as archiveUser,
+	deactivateUserOp as deactivateUser,
 	listUsersOp as listUsers,
 	getUserOp as getUser,
 	createUserOp as createUser,

--- a/packages/n8n-node/nodes/Probo/actions/user/listUsers.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/user/listUsers.operation.ts
@@ -85,9 +85,9 @@ export const description: INodeProperties[] = [
 		description: 'Search users by full name or email address',
 	},
 	{
-		displayName: 'State',
+		displayName: 'States',
 		name: 'state',
-		type: 'options',
+		type: 'multiOptions',
 		displayOptions: {
 			show: {
 				resource: ['user'],
@@ -96,12 +96,11 @@ export const description: INodeProperties[] = [
 		},
 		options: [
 			{ name: 'Active', value: 'ACTIVE' },
-			{ name: 'All', value: '' },
 			{ name: 'Deactivated', value: 'DEACTIVATED' },
 			{ name: 'Pending', value: 'PENDING' },
 		],
-		default: '',
-		description: 'Filter by profile state',
+		default: [],
+		description: 'Filter by profile states',
 	},
 	{
 		displayName: 'Role',
@@ -153,7 +152,7 @@ export async function execute(
 	const returnAll = this.getNodeParameter('returnAll', itemIndex) as boolean;
 	const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
 	const query = this.getNodeParameter('query', itemIndex, '') as string;
-	const state = this.getNodeParameter('state', itemIndex, '') as string;
+	const state = this.getNodeParameter('state', itemIndex, []) as string[];
 	const role = this.getNodeParameter('role', itemIndex, '') as string;
 	const kind = this.getNodeParameter('kind', itemIndex, '') as string;
 
@@ -194,8 +193,8 @@ export async function execute(
 	if (query) {
 		filter.query = query;
 	}
-	if (state) {
-		filter.state = state;
+	if (state.length > 0) {
+		filter.states = state;
 	}
 	if (role) {
 		filter.role = role;

--- a/packages/n8n-node/nodes/Probo/actions/user/listUsers.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/user/listUsers.operation.ts
@@ -97,7 +97,8 @@ export const description: INodeProperties[] = [
 		options: [
 			{ name: 'Active', value: 'ACTIVE' },
 			{ name: 'All', value: '' },
-			{ name: 'Inactive', value: 'INACTIVE' },
+			{ name: 'Deactivated', value: 'DEACTIVATED' },
+			{ name: 'Pending', value: 'PENDING' },
 		],
 		default: '',
 		description: 'Filter by profile state',

--- a/packages/ui/src/Atoms/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/Atoms/Dropdown/Dropdown.tsx
@@ -158,13 +158,18 @@ export function DropdownCheckboxItem({
       checked={checked}
       onCheckedChange={value => onCheckedChange(value === true)}
       disabled={disabled}
-      className={clsx(dropdownItem(), "rounded-lg outline-none", className)}
+      className={clsx(
+        dropdownItem(),
+        "rounded-lg outline-none",
+        "data-disabled:opacity-50 data-disabled:cursor-not-allowed data-disabled:pointer-events-none",
+        "data-disabled:hover:bg-transparent data-disabled:active:bg-transparent data-disabled:data-active-item:bg-transparent",
+        className,
+      )}
     >
       <span
         className={clsx(
           "size-4 border border-border-mid relative rounded-sm flex items-center justify-center flex-none",
           checked && "bg-accent text-invert",
-          disabled && "opacity-50",
         )}
       >
         <DropdownMenu.ItemIndicator>

--- a/packages/ui/src/Atoms/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/Atoms/Dropdown/Dropdown.tsx
@@ -24,7 +24,7 @@ import type { ComponentProps, FC, PropsWithChildren, ReactNode } from "react";
 import { tv } from "tailwind-variants";
 
 import { Button } from "../Button/Button";
-import { IconDotGrid1x3Horizontal } from "../Icons";
+import { IconCheckmark1, IconDotGrid1x3Horizontal } from "../Icons";
 import type { IconProps } from "../Icons/type";
 
 type Props = PropsWithChildren<{
@@ -136,5 +136,42 @@ export function DropdownItem({
             </>
           )}
     </DropdownMenu.Item>
+  );
+}
+
+type DropdownCheckboxItemProps = PropsWithChildren<{
+  className?: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+}>;
+
+export function DropdownCheckboxItem({
+  className,
+  checked,
+  onCheckedChange,
+  disabled,
+  children,
+}: DropdownCheckboxItemProps) {
+  return (
+    <DropdownMenu.CheckboxItem
+      checked={checked}
+      onCheckedChange={value => onCheckedChange(value === true)}
+      disabled={disabled}
+      className={clsx(dropdownItem(), "rounded-lg outline-none", className)}
+    >
+      <span
+        className={clsx(
+          "size-4 border border-border-mid relative rounded-sm flex items-center justify-center flex-none",
+          checked && "bg-accent text-invert",
+          disabled && "opacity-50",
+        )}
+      >
+        <DropdownMenu.ItemIndicator>
+          <IconCheckmark1 size={12} />
+        </DropdownMenu.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenu.CheckboxItem>
   );
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -43,6 +43,7 @@ export { Spinner } from "./Atoms/Spinner/Spinner";
 export {
   ActionDropdown,
   Dropdown,
+  DropdownCheckboxItem,
   DropdownItem,
   DropdownSeparator,
 } from "./Atoms/Dropdown/Dropdown";

--- a/pkg/cmd/user/deactivate/deactivate.go
+++ b/pkg/cmd/user/deactivate/deactivate.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package archive
+package deactivate
 
 import (
 	"fmt"
@@ -29,34 +29,34 @@ import (
 	"go.probo.inc/probo/pkg/cmd/cmdutil"
 )
 
-const archiveMutation = `
-mutation($input: ArchiveUserInput!) {
-  archiveUser(input: $input) {
-    archivedProfileId
+const deactivateMutation = `
+mutation($input: DeactivateUserInput!) {
+  deactivateUser(input: $input) {
+    success
   }
 }
 `
 
-func NewCmdArchive(f *cmdutil.Factory) *cobra.Command {
+func NewCmdDeactivate(f *cmdutil.Factory) *cobra.Command {
 	var (
 		flagOrg string
 		flagYes bool
 	)
 
 	cmd := &cobra.Command{
-		Use:   "archive <id>",
-		Short: "Archive a user",
+		Use:   "deactivate <id>",
+		Short: "Deactivate a user",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !flagYes {
 				if !f.IOStreams.IsInteractive() {
-					return fmt.Errorf("cannot archive user: confirmation required, use --yes to confirm")
+					return fmt.Errorf("cannot deactivate user: confirmation required, use --yes to confirm")
 				}
 
 				var confirmed bool
 
 				err := huh.NewConfirm().
-					Title(fmt.Sprintf("Archive user %s?", args[0])).
+					Title(fmt.Sprintf("Deactivate user %s?", args[0])).
 					Value(&confirmed).
 					Run()
 				if err != nil {
@@ -95,7 +95,7 @@ func NewCmdArchive(f *cmdutil.Factory) *cobra.Command {
 			)
 
 			_, err = client.Do(
-				archiveMutation,
+				deactivateMutation,
 				map[string]any{
 					"input": map[string]any{
 						"organizationId": flagOrg,
@@ -107,7 +107,7 @@ func NewCmdArchive(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
-			_, _ = fmt.Fprintf(f.IOStreams.Out, "Archived user %s\n", args[0])
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Deactivated user %s\n", args[0])
 
 			return nil
 		},

--- a/pkg/cmd/user/list/list.go
+++ b/pkg/cmd/user/list/list.go
@@ -158,7 +158,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if flagState != "" {
-				if err := cmdutil.ValidateEnum("state", flagState, []string{"ACTIVE", "INACTIVE"}); err != nil {
+				if err := cmdutil.ValidateEnum("state", flagState, []string{"PENDING", "ACTIVE", "DEACTIVATED"}); err != nil {
 					return err
 				}
 
@@ -273,7 +273,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagOrder, "order-by", "", "Order by field (FULL_NAME, CREATED_AT, KIND)")
 	cmd.Flags().StringVar(&flagOrderDir, "order-direction", "DESC", "Sort direction (ASC, DESC)")
 	cmd.Flags().StringVar(&flagContractEnded, "contract-ended", "", "Filter by contract status (true or false)")
-	cmd.Flags().StringVar(&flagState, "state", "", "Filter by profile state (ACTIVE or INACTIVE)")
+	cmd.Flags().StringVar(&flagState, "state", "", "Filter by profile state (PENDING, ACTIVE, DEACTIVATED)")
 	cmd.Flags().StringVarP(&flagFilter, "filter", "q", "", "Filter users by name or email search query")
 	cmd.Flags().StringVar(&flagRole, "role", "", "Filter by membership role (OWNER, ADMIN, VIEWER, AUDITOR, EMPLOYEE)")
 	cmd.Flags().StringVar(&flagKind, "kind", "", "Filter by profile kind (EMPLOYEE, CONTRACTOR, SERVICE_ACCOUNT)")

--- a/pkg/cmd/user/list/list.go
+++ b/pkg/cmd/user/list/list.go
@@ -72,7 +72,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 		flagOrder         string
 		flagOrderDir      string
 		flagContractEnded string
-		flagState         string
+		flagState         []string
 		flagFilter        string
 		flagRole          string
 		flagKind          string
@@ -157,12 +157,14 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				filter["contractEnded"] = flagContractEnded == "true"
 			}
 
-			if flagState != "" {
-				if err := cmdutil.ValidateEnum("state", flagState, []string{"PENDING", "ACTIVE", "DEACTIVATED"}); err != nil {
-					return err
+			if len(flagState) > 0 {
+				for _, state := range flagState {
+					if err := cmdutil.ValidateEnum("state", state, []string{"PENDING", "ACTIVE", "DEACTIVATED"}); err != nil {
+						return err
+					}
 				}
 
-				filter["state"] = flagState
+				filter["states"] = flagState
 			}
 
 			if flagFilter != "" {
@@ -273,7 +275,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagOrder, "order-by", "", "Order by field (FULL_NAME, CREATED_AT, KIND)")
 	cmd.Flags().StringVar(&flagOrderDir, "order-direction", "DESC", "Sort direction (ASC, DESC)")
 	cmd.Flags().StringVar(&flagContractEnded, "contract-ended", "", "Filter by contract status (true or false)")
-	cmd.Flags().StringVar(&flagState, "state", "", "Filter by profile state (PENDING, ACTIVE, DEACTIVATED)")
+	cmd.Flags().StringSliceVar(&flagState, "state", nil, "Filter by profile state; repeat or comma-separate for multiple (PENDING, ACTIVE, DEACTIVATED)")
 	cmd.Flags().StringVarP(&flagFilter, "filter", "q", "", "Filter users by name or email search query")
 	cmd.Flags().StringVar(&flagRole, "role", "", "Filter by membership role (OWNER, ADMIN, VIEWER, AUDITOR, EMPLOYEE)")
 	cmd.Flags().StringVar(&flagKind, "kind", "", "Filter by profile kind (EMPLOYEE, CONTRACTOR, SERVICE_ACCOUNT)")

--- a/pkg/cmd/user/user.go
+++ b/pkg/cmd/user/user.go
@@ -23,7 +23,7 @@ package user
 import (
 	"github.com/spf13/cobra"
 	"go.probo.inc/probo/pkg/cmd/cmdutil"
-	"go.probo.inc/probo/pkg/cmd/user/archive"
+	"go.probo.inc/probo/pkg/cmd/user/deactivate"
 	"go.probo.inc/probo/pkg/cmd/user/list"
 	"go.probo.inc/probo/pkg/cmd/user/remove"
 	"go.probo.inc/probo/pkg/cmd/user/view"
@@ -37,7 +37,7 @@ func NewCmdUser(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.AddCommand(list.NewCmdList(f))
 	cmd.AddCommand(view.NewCmdView(f))
-	cmd.AddCommand(archive.NewCmdArchive(f))
+	cmd.AddCommand(deactivate.NewCmdDeactivate(f))
 	cmd.AddCommand(remove.NewCmdRemove(f))
 
 	return cmd

--- a/pkg/complianceportal/visitor/portal_access_service.go
+++ b/pkg/complianceportal/visitor/portal_access_service.go
@@ -396,9 +396,8 @@ func (s *Service) GrantPortalAccessByIDs(
 			}
 
 			if shouldSendEmail {
-				profile.State = coredata.ProfileStateActive
+				profile.MarkActive(now)
 
-				profile.UpdatedAt = now
 				if err := profile.Update(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot update profile: %w", err)
 				}

--- a/pkg/complianceportal/visitor/service.go
+++ b/pkg/complianceportal/visitor/service.go
@@ -394,6 +394,7 @@ func (s *Service) ProvisionPortalMember(
 					EmailAddress:   identity.EmailAddress,
 					Source:         coredata.ProfileSourceManual,
 					State:          coredata.ProfileStateActive,
+					ActivatedAt:    &now,
 					FullName:       identity.FullName,
 					CreatedAt:      now,
 					UpdatedAt:      now,

--- a/pkg/coredata/document_version_signature_filter.go
+++ b/pkg/coredata/document_version_signature_filter.go
@@ -28,15 +28,15 @@ type (
 	DocumentVersionSignatureFilter struct {
 		states         DocumentVersionSignatureStates
 		activeContract *bool
-		profileState   *ProfileState
+		profileStates  ProfileStateValues
 	}
 )
 
-func NewDocumentVersionSignatureFilter(states []DocumentVersionSignatureState, activeContract *bool, profileState *ProfileState) *DocumentVersionSignatureFilter {
+func NewDocumentVersionSignatureFilter(states []DocumentVersionSignatureState, activeContract *bool, profileStates []ProfileState) *DocumentVersionSignatureFilter {
 	return &DocumentVersionSignatureFilter{
 		states:         DocumentVersionSignatureStates(states),
 		activeContract: activeContract,
-		profileState:   profileState,
+		profileStates:  ProfileStateValues(profileStates),
 	}
 }
 
@@ -44,7 +44,7 @@ func (f *DocumentVersionSignatureFilter) SQLArguments() pgx.StrictNamedArgs {
 	return pgx.StrictNamedArgs{
 		"states":          f.states,
 		"active_contract": f.activeContract,
-		"profile_state":   f.profileState,
+		"profile_states":  f.profileStates,
 	}
 }
 
@@ -81,13 +81,13 @@ func (f *DocumentVersionSignatureFilter) SQLFragment() string {
     END
     AND
     CASE
-    WHEN @profile_state::text IS NULL
+    WHEN @profile_states::membership_state[] IS NULL
         THEN TRUE
     ELSE EXISTS (
         SELECT 1
         FROM iam_membership_profiles p
         WHERE p.id = signed_by_profile_id
-        AND p.state = @profile_state::membership_state
+        AND p.state = ANY(@profile_states::membership_state[])
     )
     END
 )`

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -70,6 +70,8 @@ type (
 		EnterpriseOrganization   *string       `db:"enterprise_organization"`
 		Division                 *string       `db:"division"`
 		ManagerValue             *string       `db:"manager_value"`
+		ActivatedAt              *time.Time    `db:"activated_at"`
+		DeactivatedAt            *time.Time    `db:"deactivated_at"`
 		CreatedAt                time.Time     `db:"created_at"`
 		UpdatedAt                time.Time     `db:"updated_at"`
 	}
@@ -94,6 +96,26 @@ func (p MembershipProfile) CursorKey(orderBy MembershipProfileOrderField) page.C
 	}
 
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
+}
+
+func (p *MembershipProfile) MarkPending(now time.Time) {
+	p.State = ProfileStatePending
+	p.ActivatedAt = nil
+	p.DeactivatedAt = nil
+	p.UpdatedAt = now
+}
+
+func (p *MembershipProfile) MarkActive(now time.Time) {
+	p.State = ProfileStateActive
+	p.ActivatedAt = &now
+	p.DeactivatedAt = nil
+	p.UpdatedAt = now
+}
+
+func (p *MembershipProfile) MarkDeactivated(now time.Time) {
+	p.State = ProfileStateDeactivated
+	p.DeactivatedAt = &now
+	p.UpdatedAt = now
 }
 
 func (p *MembershipProfile) AuthorizationAttributes(
@@ -192,6 +214,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM
@@ -269,6 +293,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM
@@ -350,6 +376,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM
@@ -430,6 +458,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM
@@ -507,6 +537,8 @@ WITH profiles AS (
         p.enterprise_organization,
         p.division,
         p.manager_value,
+        p.activated_at,
+        p.deactivated_at,
         p.created_at,
         p.updated_at
     FROM
@@ -550,6 +582,8 @@ SELECT
     enterprise_organization,
     division,
     manager_value,
+    activated_at,
+    deactivated_at,
     created_at,
     updated_at
 FROM profiles
@@ -620,6 +654,8 @@ WITH profiles AS (
         p.enterprise_organization,
         p.division,
         p.manager_value,
+        p.activated_at,
+        p.deactivated_at,
         p.created_at,
         p.updated_at
     FROM
@@ -662,6 +698,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM profiles p
@@ -743,6 +781,8 @@ profiles AS (
         mp.enterprise_organization,
         mp.division,
         mp.manager_value,
+        mp.activated_at,
+        mp.deactivated_at,
         mp.created_at,
         mp.updated_at
     FROM
@@ -785,6 +825,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM profiles p
@@ -1000,6 +1042,8 @@ INSERT INTO
         enterprise_organization,
         division,
         manager_value,
+        activated_at,
+        deactivated_at,
         created_at,
         updated_at
     )
@@ -1035,6 +1079,8 @@ VALUES (
     @enterprise_organization,
     @division,
     @manager_value,
+    @activated_at,
+    @deactivated_at,
     @created_at,
     @updated_at
 )
@@ -1072,6 +1118,8 @@ VALUES (
 		"enterprise_organization":    p.EnterpriseOrganization,
 		"division":                   p.Division,
 		"manager_value":              p.ManagerValue,
+		"activated_at":               p.ActivatedAt,
+		"deactivated_at":             p.DeactivatedAt,
 		"created_at":                 p.CreatedAt,
 		"updated_at":                 p.UpdatedAt,
 	}
@@ -1130,6 +1178,8 @@ SET
     enterprise_organization = @enterprise_organization,
     division = @division,
     manager_value = @manager_value,
+    activated_at = @activated_at,
+    deactivated_at = @deactivated_at,
     updated_at = @updated_at
 WHERE
     id = @id
@@ -1168,6 +1218,8 @@ WHERE
 		"enterprise_organization":    p.EnterpriseOrganization,
 		"division":                   p.Division,
 		"manager_value":              p.ManagerValue,
+		"activated_at":               p.ActivatedAt,
+		"deactivated_at":             p.DeactivatedAt,
 		"updated_at":                 p.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())

--- a/pkg/coredata/membership_profile_filter.go
+++ b/pkg/coredata/membership_profile_filter.go
@@ -37,7 +37,7 @@ type (
 		email                      *mail.Addr
 		userName                   *string
 		externalID                 *string
-		state                      *ProfileState
+		states                     ProfileStateValues
 		source                     *ProfileSource
 		query                      *string
 		role                       *MembershipRole
@@ -82,12 +82,17 @@ func (f *MembershipProfileFilter) WithExternalID(externalID string) *MembershipP
 }
 
 func (f *MembershipProfileFilter) WithState(state ProfileState) *MembershipProfileFilter {
-	f.state = &state
+	f.states = ProfileStateValues{state}
 	return f
 }
 
-func (f *MembershipProfileFilter) State() *ProfileState {
-	return f.state
+func (f *MembershipProfileFilter) WithStates(states ...ProfileState) *MembershipProfileFilter {
+	f.states = ProfileStateValues(states)
+	return f
+}
+
+func (f *MembershipProfileFilter) States() []ProfileState {
+	return f.states
 }
 
 func (f *MembershipProfileFilter) WithSource(source ProfileSource) *MembershipProfileFilter {
@@ -146,7 +151,7 @@ func (f *MembershipProfileFilter) SQLArguments() pgx.StrictNamedArgs {
 		"with_trust_center_access": f.withCompliancePortalAccess,
 		"contract_ended":           f.contractEnded,
 		"current_date":             f.currentDate,
-		"filter_state":             f.state,
+		"filter_states":            f.states,
 		"filter_source":            f.source,
 		"filter_query":             filterQuery,
 		"filter_role":              f.role,
@@ -192,8 +197,8 @@ AND (
 )
 AND (
 	CASE
-		WHEN @filter_state::text IS NOT NULL THEN
-			p.state = @filter_state::membership_state
+		WHEN @filter_states::membership_state[] IS NOT NULL THEN
+			p.state = ANY(@filter_states::membership_state[])
 		ELSE TRUE
 	END
 )

--- a/pkg/coredata/membership_profile_filter.go
+++ b/pkg/coredata/membership_profile_filter.go
@@ -81,11 +81,6 @@ func (f *MembershipProfileFilter) WithExternalID(externalID string) *MembershipP
 	return f
 }
 
-func (f *MembershipProfileFilter) WithState(state ProfileState) *MembershipProfileFilter {
-	f.states = ProfileStateValues{state}
-	return f
-}
-
 func (f *MembershipProfileFilter) WithStates(states ...ProfileState) *MembershipProfileFilter {
 	f.states = ProfileStateValues(states)
 	return f

--- a/pkg/coredata/migrations/20260728T143246Z.sql
+++ b/pkg/coredata/migrations/20260728T143246Z.sql
@@ -1,0 +1,55 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE iam_membership_profiles
+    ADD COLUMN activated_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN deactivated_at TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE iam_membership_profiles
+    ALTER COLUMN state DROP DEFAULT;
+
+ALTER TYPE membership_state RENAME TO membership_state_old;
+CREATE TYPE membership_state AS ENUM ('PENDING', 'ACTIVE', 'DEACTIVATED');
+
+ALTER TABLE iam_membership_profiles
+    ALTER COLUMN state TYPE membership_state
+    USING CASE
+        WHEN state::text = 'ACTIVE' THEN 'ACTIVE'::membership_state
+        ELSE 'DEACTIVATED'::membership_state
+    END;
+
+DROP TYPE membership_state_old;
+
+UPDATE iam_membership_profiles
+SET state = 'PENDING'
+WHERE state = 'DEACTIVATED'
+  AND source != 'SCIM'
+  AND EXISTS (
+      SELECT 1
+      FROM iam_invitations i
+      WHERE i.user_id = iam_membership_profiles.id
+        AND i.accepted_at IS NULL
+        AND (
+            i.expires_at >= NOW()
+            OR i.created_at >= NOW() - INTERVAL '7 days'
+        )
+  );
+
+UPDATE iam_membership_profiles
+SET activated_at = updated_at
+WHERE state = 'ACTIVE';
+
+UPDATE iam_membership_profiles
+SET deactivated_at = NOW()
+WHERE state = 'DEACTIVATED';

--- a/pkg/coredata/migrations/20260728T143246Z.sql
+++ b/pkg/coredata/migrations/20260728T143246Z.sql
@@ -46,10 +46,3 @@ WHERE state = 'DEACTIVATED'
         )
   );
 
-UPDATE iam_membership_profiles
-SET activated_at = updated_at
-WHERE state = 'ACTIVE';
-
-UPDATE iam_membership_profiles
-SET deactivated_at = NOW()
-WHERE state = 'DEACTIVATED';

--- a/pkg/coredata/profile_state.go
+++ b/pkg/coredata/profile_state.go
@@ -21,15 +21,21 @@
 package coredata
 
 import (
+	"database/sql/driver"
 	"encoding"
 	"fmt"
+	"strings"
 )
 
-type ProfileState string
+type (
+	ProfileState       string
+	ProfileStateValues []ProfileState
+)
 
 const (
-	ProfileStateActive   ProfileState = "ACTIVE"
-	ProfileStateInactive ProfileState = "INACTIVE"
+	ProfileStatePending     ProfileState = "PENDING"
+	ProfileStateActive      ProfileState = "ACTIVE"
+	ProfileStateDeactivated ProfileState = "DEACTIVATED"
 )
 
 var (
@@ -40,16 +46,18 @@ var (
 
 func ProfileStates() []ProfileState {
 	return []ProfileState{
+		ProfileStatePending,
 		ProfileStateActive,
-		ProfileStateInactive,
+		ProfileStateDeactivated,
 	}
 }
 
 func (v ProfileState) IsValid() bool {
 	switch v {
 	case
+		ProfileStatePending,
 		ProfileStateActive,
-		ProfileStateInactive:
+		ProfileStateDeactivated:
 		return true
 	}
 
@@ -73,4 +81,25 @@ func (v *ProfileState) UnmarshalText(text []byte) error {
 	*v = val
 
 	return nil
+}
+
+func (states ProfileStateValues) Value() (driver.Value, error) {
+	if len(states) == 0 {
+		return nil, nil
+	}
+
+	var result strings.Builder
+	result.WriteString("{")
+
+	for i, state := range states {
+		if i > 0 {
+			result.WriteString(",")
+		}
+
+		fmt.Fprintf(&result, "%q", state.String())
+	}
+
+	result.WriteString("}")
+
+	return result.String(), nil
 }

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -179,9 +179,8 @@ func (s *AuthService) ActivateAccount(
 				return NewUserManagedBySCIMError(profile.ID)
 			}
 
-			if profile.State == coredata.ProfileStateInactive {
-				profile.State = coredata.ProfileStateActive
-				profile.UpdatedAt = now
+			if profile.State == coredata.ProfileStatePending {
+				profile.MarkActive(now)
 
 				if err := profile.Update(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot update user: %w", err)

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -374,7 +374,7 @@ func (s *OrganizationService) RemoveUser(
 	)
 }
 
-func (s *OrganizationService) ArchiveUser(
+func (s *OrganizationService) DeactivateUser(
 	ctx context.Context,
 	scope coredata.Scoper,
 	organizationID gid.GID,
@@ -1171,55 +1171,6 @@ func (s *OrganizationService) UpdateUser(ctx context.Context, req *UpdateUserReq
 				previousUser,
 			); err != nil {
 				return fmt.Errorf("cannot insert webhook event: %w", err)
-			}
-
-			return nil
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return profile, nil
-}
-
-func (s *OrganizationService) UpdateUserState(
-	ctx context.Context,
-	userID gid.GID,
-	state coredata.ProfileState,
-) (*coredata.MembershipProfile, error) {
-	var (
-		scope   = coredata.NewScopeFromObjectID(userID)
-		profile = &coredata.MembershipProfile{}
-	)
-
-	err := s.pg.WithTx(
-		ctx,
-		func(ctx context.Context, tx pg.Tx) error {
-			if err := profile.LoadByID(ctx, tx, scope, userID); err != nil {
-				return fmt.Errorf("cannot load profile: %w", err)
-			}
-
-			now := time.Now()
-
-			switch state {
-			case coredata.ProfileStatePending:
-				profile.MarkPending(now)
-			case coredata.ProfileStateActive:
-				profile.MarkActive(now)
-			case coredata.ProfileStateDeactivated:
-				profile.MarkDeactivated(now)
-			}
-
-			if err := profile.Update(ctx, tx, scope); err != nil {
-				return fmt.Errorf("cannot update profile: %w", err)
-			}
-
-			if state == coredata.ProfileStateDeactivated {
-				signatures := &coredata.DocumentVersionSignatures{}
-				if err := signatures.DeleteRequestedBySignatory(ctx, tx, scope, profile.ID); err != nil {
-					return fmt.Errorf("cannot delete requested signatures: %w", err)
-				}
 			}
 
 			return nil

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -438,9 +438,8 @@ func (s *OrganizationService) ArchiveUser(
 
 			now := time.Now()
 
-			if profile.State != coredata.ProfileStateInactive {
-				profile.State = coredata.ProfileStateInactive
-				profile.UpdatedAt = now
+			if profile.State != coredata.ProfileStateDeactivated {
+				profile.MarkDeactivated(now)
 
 				if err := profile.Update(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot update profile state: %w", err)
@@ -503,6 +502,14 @@ func (s *OrganizationService) InviteUser(
 
 			if profile.Source == coredata.ProfileSourceSCIM {
 				return NewUserManagedBySCIMError(profile.ID)
+			}
+
+			if profile.State == coredata.ProfileStateDeactivated {
+				profile.MarkPending(now)
+
+				if err := profile.Update(ctx, tx, scope); err != nil {
+					return fmt.Errorf("cannot update profile state: %w", err)
+				}
 			}
 
 			err = invitation.Insert(ctx, tx, scope)
@@ -583,6 +590,7 @@ func (s *OrganizationService) CreateOrganization(
 			OrganizationID: organization.ID,
 			Source:         coredata.ProfileSourceManual,
 			State:          coredata.ProfileStateActive,
+			ActivatedAt:    &now,
 			CreatedAt:      now,
 			UpdatedAt:      now,
 		}
@@ -1038,8 +1046,8 @@ func (s *OrganizationService) CreateUser(ctx context.Context, scope coredata.Sco
 				Kind:                     req.Kind,
 				AdditionalEmailAddresses: req.AdditionalEmailAddresses,
 				Position:                 req.Position,
-				// User is created inactive
-				State:     coredata.ProfileStateInactive,
+				// User is pending until they accept an invitation.
+				State:     coredata.ProfileStatePending,
 				CreatedAt: now,
 				UpdatedAt: now,
 			}
@@ -1192,14 +1200,22 @@ func (s *OrganizationService) UpdateUserState(
 				return fmt.Errorf("cannot load profile: %w", err)
 			}
 
-			profile.State = state
-			profile.UpdatedAt = time.Now()
+			now := time.Now()
+
+			switch state {
+			case coredata.ProfileStatePending:
+				profile.MarkPending(now)
+			case coredata.ProfileStateActive:
+				profile.MarkActive(now)
+			case coredata.ProfileStateDeactivated:
+				profile.MarkDeactivated(now)
+			}
 
 			if err := profile.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update profile: %w", err)
 			}
 
-			if state == coredata.ProfileStateInactive {
+			if state == coredata.ProfileStateDeactivated {
 				signatures := &coredata.DocumentVersionSignatures{}
 				if err := signatures.DeleteRequestedBySignatory(ctx, tx, scope, profile.ID); err != nil {
 					return fmt.Errorf("cannot delete requested signatures: %w", err)

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -405,7 +405,7 @@ func (s *OrganizationService) DeactivateUser(
 			if membership.Role == coredata.MembershipRoleOwner && profile.State == coredata.ProfileStateActive {
 				profiles := coredata.MembershipProfiles{}
 
-				count, err := profiles.CountActiveOwnerByOrganizationID(ctx, tx, scope, organizationID)
+				count, err := profiles.CountActiveOwnerByOrganizationID(ctx, tx, scope, profile.OrganizationID)
 				if err != nil {
 					return fmt.Errorf("cannot count active owners: %w", err)
 				}

--- a/pkg/iam/saml/service.go
+++ b/pkg/iam/saml/service.go
@@ -322,6 +322,7 @@ func (s *Service) HandleAssertion(
 					OrganizationID: config.OrganizationID,
 					Source:         coredata.ProfileSourceSAML,
 					State:          coredata.ProfileStateActive,
+					ActivatedAt:    &now,
 					FullName:       fullname,
 					CreatedAt:      now,
 					UpdatedAt:      now,
@@ -332,7 +333,7 @@ func (s *Service) HandleAssertion(
 					return fmt.Errorf("cannot insert membership profile: %w", err)
 				}
 			} else {
-				if profile.State == coredata.ProfileStateInactive {
+				if profile.State == coredata.ProfileStateDeactivated {
 					return NewUserInactiveError(profile.ID)
 				}
 			}

--- a/pkg/iam/saml/service.go
+++ b/pkg/iam/saml/service.go
@@ -336,6 +336,10 @@ func (s *Service) HandleAssertion(
 				if profile.State == coredata.ProfileStateDeactivated {
 					return NewUserInactiveError(profile.ID)
 				}
+
+				if profile.State == coredata.ProfileStatePending {
+					profile.MarkActive(now)
+				}
 			}
 
 			if err := membership.LoadByIdentityIDAndOrganizationID(

--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -150,7 +150,7 @@ func (s *Service) CreateUser(
 
 	profileState := coredata.ProfileStateActive
 	if !attrs.Active {
-		profileState = coredata.ProfileStateInactive
+		profileState = coredata.ProfileStateDeactivated
 	}
 
 	var externalIdPtr *string
@@ -536,8 +536,8 @@ func (s *Service) updateUser(
 			previousMembership := *membership
 			previousUser := webhooktypes.NewUser(&previousProfile, &previousMembership)
 
-			shouldReactivate := attrs.Active != nil && *attrs.Active && profile.State == coredata.ProfileStateInactive
-			shouldDeactivate := attrs.Active != nil && !*attrs.Active && profile.State == coredata.ProfileStateActive
+			shouldReactivate := attrs.Active != nil && *attrs.Active && profile.State == coredata.ProfileStateDeactivated
+			shouldDeactivate := attrs.Active != nil && !*attrs.Active && profile.State != coredata.ProfileStateDeactivated
 
 			if attrs.FullName != "" {
 				profile.FullName = attrs.FullName
@@ -748,11 +748,9 @@ func (s *Service) updateUser(
 			}
 
 			if shouldReactivate {
-				profile.State = coredata.ProfileStateActive
-				profile.UpdatedAt = now
+				profile.MarkActive(now)
 			} else if shouldDeactivate {
-				profile.State = coredata.ProfileStateInactive
-				profile.UpdatedAt = now
+				profile.MarkDeactivated(now)
 			}
 
 			if profile.Source != coredata.ProfileSourceSCIM {
@@ -826,7 +824,15 @@ func applyUserAttributes(
 	now time.Time,
 ) {
 	profile.Source = coredata.ProfileSourceSCIM
-	profile.State = state
+	switch {
+	case state == coredata.ProfileStateActive && profile.State != coredata.ProfileStateActive:
+		profile.MarkActive(now)
+	case state == coredata.ProfileStateDeactivated && profile.State != coredata.ProfileStateDeactivated:
+		profile.MarkDeactivated(now)
+	default:
+		profile.State = state
+	}
+
 	profile.FullName = attrs.FullName
 	profile.Position = &attrs.Title
 	profile.UserName = &attrs.UserName
@@ -956,15 +962,14 @@ func (s *Service) deactivateProfileInTx(
 	profile *coredata.MembershipProfile,
 	membership *coredata.Membership,
 ) error {
-	if profile.State == coredata.ProfileStateInactive {
+	if profile.State == coredata.ProfileStateDeactivated {
 		return nil
 	}
 
 	previousUser := webhooktypes.NewUser(profile, membership)
 
 	now := time.Now()
-	profile.State = coredata.ProfileStateInactive
-	profile.UpdatedAt = now
+	profile.MarkDeactivated(now)
 
 	if err := profile.Update(ctx, tx, scope); err != nil {
 		return fmt.Errorf("cannot deactivate profile: %w", err)

--- a/pkg/iam/session_service.go
+++ b/pkg/iam/session_service.go
@@ -364,7 +364,7 @@ func (s SessionService) OpenPasswordChildSessionForOrganization(
 				return fmt.Errorf("cannot load profile: %w", err)
 			}
 
-			if profile.State == coredata.ProfileStateInactive {
+			if profile.State == coredata.ProfileStateDeactivated {
 				return NewUserInactiveError(profile.ID)
 			}
 
@@ -469,7 +469,7 @@ func (s SessionService) OpenSAMLChildSessionForOrganization(
 				return fmt.Errorf("cannot load profile: %w", err)
 			}
 
-			if profile.State == coredata.ProfileStateInactive {
+			if profile.State == coredata.ProfileStateDeactivated {
 				return NewUserInactiveError(profile.ID)
 			}
 
@@ -562,7 +562,7 @@ func (s SessionService) OpenOIDCChildSessionForOrganization(
 				return fmt.Errorf("cannot load profile: %w", err)
 			}
 
-			if profile.State == coredata.ProfileStateInactive {
+			if profile.State == coredata.ProfileStateDeactivated {
 				return NewUserInactiveError(profile.ID)
 			}
 
@@ -651,7 +651,7 @@ func (s SessionService) AssumeOrganizationSession(
 				return fmt.Errorf("cannot load profile: %w", err)
 			}
 
-			if profile.State == coredata.ProfileStateInactive {
+			if profile.State == coredata.ProfileStateDeactivated {
 				return NewUserInactiveError(profile.ID)
 			}
 

--- a/pkg/server/api/connect/v1/graphql/profile.graphql
+++ b/pkg/server/api/connect/v1/graphql/profile.graphql
@@ -71,7 +71,6 @@ enum ProfileOrderField
 
 input ProfileFilter {
   contractEnded: Boolean
-  state: ProfileState
   states: [ProfileState!]
   query: String
   role: MembershipRole

--- a/pkg/server/api/connect/v1/graphql/profile.graphql
+++ b/pkg/server/api/connect/v1/graphql/profile.graphql
@@ -104,9 +104,8 @@ extend type Mutation {
   createUser(input: CreateUserInput!): CreateUserPayload
     @authentication(required: PRESENT)
   deactivateUser(input: DeactivateUserInput!): DeactivateUserPayload
-  updateUser(input: UpdateUserInput!): UpdateUserPayload!
-  archiveUser(input: ArchiveUserInput!): ArchiveUserPayload
     @authentication(required: PRESENT)
+  updateUser(input: UpdateUserInput!): UpdateUserPayload!
   removeUser(input: RemoveUserInput!): RemoveUserPayload
     @authentication(required: PRESENT)
 }
@@ -148,11 +147,6 @@ input RemoveUserInput {
   profileId: ID!
 }
 
-input ArchiveUserInput {
-  organizationId: ID!
-  profileId: ID!
-}
-
 type CreateUserPayload {
   profileEdge: ProfileEdge!
 }
@@ -167,8 +161,4 @@ type UpdateUserPayload {
 
 type RemoveUserPayload {
   deletedProfileId: ID!
-}
-
-type ArchiveUserPayload {
-  archivedProfileId: ID!
 }

--- a/pkg/server/api/connect/v1/graphql/profile.graphql
+++ b/pkg/server/api/connect/v1/graphql/profile.graphql
@@ -30,9 +30,10 @@ type Profile implements Node {
 
 enum ProfileState
   @goModel(model: "go.probo.inc/probo/pkg/coredata.ProfileState") {
+  PENDING @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStatePending")
   ACTIVE @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStateActive")
-  INACTIVE
-    @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStateInactive")
+  DEACTIVATED
+    @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStateDeactivated")
 }
 
 enum ProfileSource
@@ -71,6 +72,7 @@ enum ProfileOrderField
 input ProfileFilter {
   contractEnded: Boolean
   state: ProfileState
+  states: [ProfileState!]
   query: String
   role: MembershipRole
   kind: String

--- a/pkg/server/api/connect/v1/identity_resolvers.go
+++ b/pkg/server/api/connect/v1/identity_resolvers.go
@@ -32,6 +32,10 @@ func (r *identityResolver) Profiles(ctx context.Context, obj *types.Identity, fi
 	if filter != nil {
 		filters = coredata.NewMembershipProfileFilter(filter.ContractEnded).WithMembership()
 
+		if len(filter.States) > 0 {
+			filters.WithStates(filter.States...)
+		}
+
 		if filter.State != nil {
 			filters.WithState(*filter.State)
 		}

--- a/pkg/server/api/connect/v1/identity_resolvers.go
+++ b/pkg/server/api/connect/v1/identity_resolvers.go
@@ -36,10 +36,6 @@ func (r *identityResolver) Profiles(ctx context.Context, obj *types.Identity, fi
 			filters.WithStates(filter.States...)
 		}
 
-		if filter.State != nil {
-			filters.WithState(*filter.State)
-		}
-
 		if filter.Query != nil {
 			filters.WithQuery(filter.Query)
 		}

--- a/pkg/server/api/connect/v1/organization_resolvers.go
+++ b/pkg/server/api/connect/v1/organization_resolvers.go
@@ -188,6 +188,10 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 	if filter != nil {
 		filters = coredata.NewMembershipProfileFilter(filter.ContractEnded).WithMembership()
 
+		if len(filter.States) > 0 {
+			filters.WithStates(filter.States...)
+		}
+
 		if filter.State != nil {
 			filters.WithState(*filter.State)
 		}

--- a/pkg/server/api/connect/v1/organization_resolvers.go
+++ b/pkg/server/api/connect/v1/organization_resolvers.go
@@ -192,10 +192,6 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 			filters.WithStates(filter.States...)
 		}
 
-		if filter.State != nil {
-			filters.WithState(*filter.State)
-		}
-
 		if filter.Query != nil {
 			filters.WithQuery(filter.Query)
 		}

--- a/pkg/server/api/connect/v1/profile_resolvers.go
+++ b/pkg/server/api/connect/v1/profile_resolvers.go
@@ -64,17 +64,23 @@ func (r *mutationResolver) CreateUser(ctx context.Context, input types.CreateUse
 
 // DeactivateUser is the resolver for the deactivateUser field.
 func (r *mutationResolver) DeactivateUser(ctx context.Context, input types.DeactivateUserInput) (*types.DeactivateUserPayload, error) {
-	if _, err := r.authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDeactivate); err != nil {
+	scope, err := r.authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDeactivate)
+	if err != nil {
 		return nil, err
 	}
 
-	_, err := r.iam.OrganizationService.UpdateUserState(
-		ctx,
-		input.ProfileID,
-		coredata.ProfileStateDeactivated,
-	)
+	err = r.iam.OrganizationService.DeactivateUser(ctx, scope, input.OrganizationID, input.ProfileID)
 	if err != nil {
-		r.logger.ErrorCtx(ctx, "cannot deactivate profile", log.Error(err))
+		if _, ok := errors.AsType[*iam.ErrUserManagedBySCIM](err); ok {
+			return nil, gqlutils.Conflictf(ctx, "user is managed by SCIM and cannot be deactivated")
+		}
+
+		if _, ok := errors.AsType[*iam.ErrLastActiveOwner](err); ok {
+			return nil, gqlutils.Conflictf(ctx, "cannot deactivate last active owner")
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot deactivate user", log.Error(err))
+
 		return nil, gqlutils.Internal(ctx)
 	}
 
@@ -109,31 +115,6 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input types.UpdateUse
 	return &types.UpdateUserPayload{
 		Profile: types.NewProfile(profile),
 	}, nil
-}
-
-// ArchiveUser is the resolver for the archiveUser field.
-func (r *mutationResolver) ArchiveUser(ctx context.Context, input types.ArchiveUserInput) (*types.ArchiveUserPayload, error) {
-	scope, err := r.authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDelete)
-	if err != nil {
-		return nil, err
-	}
-
-	err = r.iam.OrganizationService.ArchiveUser(ctx, scope, input.OrganizationID, input.ProfileID)
-	if err != nil {
-		if _, ok := errors.AsType[*iam.ErrUserManagedBySCIM](err); ok {
-			return nil, gqlutils.Conflictf(ctx, "user is managed by SCIM and cannot be archived")
-		}
-
-		if _, ok := errors.AsType[*iam.ErrLastActiveOwner](err); ok {
-			return nil, gqlutils.Conflictf(ctx, "cannot archive last active owner")
-		}
-
-		r.logger.ErrorCtx(ctx, "cannot archive user from organization", log.Error(err))
-
-		return nil, gqlutils.Internal(ctx)
-	}
-
-	return &types.ArchiveUserPayload{ArchivedProfileID: input.ProfileID}, nil
 }
 
 // RemoveUser is the resolver for the removeUser field.

--- a/pkg/server/api/connect/v1/profile_resolvers.go
+++ b/pkg/server/api/connect/v1/profile_resolvers.go
@@ -71,7 +71,7 @@ func (r *mutationResolver) DeactivateUser(ctx context.Context, input types.Deact
 	_, err := r.iam.OrganizationService.UpdateUserState(
 		ctx,
 		input.ProfileID,
-		coredata.ProfileStateInactive,
+		coredata.ProfileStateDeactivated,
 	)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot deactivate profile", log.Error(err))

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -282,7 +282,7 @@ func (r *documentVersionResolver) Signatures(ctx context.Context, obj *types.Doc
 	var (
 		signatureStates []coredata.DocumentVersionSignatureState
 		activeContract  *bool
-		profileState    *coredata.ProfileState
+		profileStates   []coredata.ProfileState
 	)
 
 	if filter != nil {
@@ -294,12 +294,12 @@ func (r *documentVersionResolver) Signatures(ctx context.Context, obj *types.Doc
 			activeContract = filter.ActiveContract
 		}
 
-		if filter.ProfileState != nil {
-			profileState = filter.ProfileState
+		if filter.ProfileStates != nil {
+			profileStates = filter.ProfileStates
 		}
 	}
 
-	signatureFilter := coredata.NewDocumentVersionSignatureFilter(signatureStates, activeContract, profileState)
+	signatureFilter := coredata.NewDocumentVersionSignatureFilter(signatureStates, activeContract, profileStates)
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 

--- a/pkg/server/api/console/v1/graphql/document.graphql
+++ b/pkg/server/api/console/v1/graphql/document.graphql
@@ -247,7 +247,7 @@ input DocumentVersionSignatureOrder {
 input DocumentVersionSignatureFilter {
     states: [DocumentVersionSignatureState!]
     activeContract: Boolean
-    profileState: ProfileState
+    profileStates: [ProfileState!]
 }
 
 input DocumentVersionApprovalQuorumOrder {

--- a/pkg/server/api/console/v1/graphql/organization.graphql
+++ b/pkg/server/api/console/v1/graphql/organization.graphql
@@ -9,9 +9,10 @@ type OrganizationContext {
 
 enum ProfileState
   @goModel(model: "go.probo.inc/probo/pkg/coredata.ProfileState") {
+  PENDING @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStatePending")
   ACTIVE @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStateActive")
-  INACTIVE
-    @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStateInactive")
+  DEACTIVATED
+    @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStateDeactivated")
 }
 
 enum MembershipRole
@@ -69,6 +70,7 @@ input ProfileOrder
 input ProfileFilter {
     contractEnded: Boolean
     state: ProfileState
+    states: [ProfileState!]
     query: String
     role: MembershipRole
     kind: String

--- a/pkg/server/api/console/v1/graphql/organization.graphql
+++ b/pkg/server/api/console/v1/graphql/organization.graphql
@@ -69,7 +69,6 @@ input ProfileOrder
 
 input ProfileFilter {
     contractEnded: Boolean
-    state: ProfileState
     states: [ProfileState!]
     query: String
     role: MembershipRole

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -119,6 +119,10 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 	if filter != nil {
 		filters = coredata.NewMembershipProfileFilter(filter.ContractEnded).WithMembership()
 
+		if len(filter.States) > 0 {
+			filters.WithStates(filter.States...)
+		}
+
 		if filter.State != nil {
 			filters.WithState(*filter.State)
 		}

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -123,10 +123,6 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 			filters.WithStates(filter.States...)
 		}
 
-		if filter.State != nil {
-			filters.WithState(*filter.State)
-		}
-
 		if filter.Query != nil {
 			filters.WithQuery(filter.Query)
 		}

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2776,6 +2776,10 @@ func (r *Resolver) ListUsersTool(ctx context.Context, req *mcp.CallToolRequest, 
 	if input.Filter != nil {
 		filter = coredata.NewMembershipProfileFilter(input.Filter.ContractEnded).WithMembership()
 
+		if len(input.Filter.States) > 0 {
+			filter.WithStates(input.Filter.States...)
+		}
+
 		if input.Filter.State != nil {
 			filter.WithState(*input.Filter.State)
 		}

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2994,26 +2994,26 @@ func (r *Resolver) RemoveUserTool(ctx context.Context, req *mcp.CallToolRequest,
 	return nil, types.RemoveUserOutput{DeletedUserID: input.ProfileID}, nil
 }
 
-func (r *Resolver) ArchiveUserTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ArchiveUserInput) (*mcp.CallToolResult, types.ArchiveUserOutput, error) {
-	scope, err := r.Authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDelete)
+func (r *Resolver) DeactivateUserTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeactivateUserInput) (*mcp.CallToolResult, types.DeactivateUserOutput, error) {
+	scope, err := r.Authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDeactivate)
 	if err != nil {
-		return nil, types.ArchiveUserOutput{}, err
+		return nil, types.DeactivateUserOutput{}, err
 	}
 
-	err = r.iamSvc.OrganizationService.ArchiveUser(ctx, scope, input.OrganizationID, input.ProfileID)
+	err = r.iamSvc.OrganizationService.DeactivateUser(ctx, scope, input.OrganizationID, input.ProfileID)
 	if err != nil {
 		if _, ok := errors.AsType[*iam.ErrUserManagedBySCIM](err); ok {
-			return nil, types.ArchiveUserOutput{}, fmt.Errorf("user is managed by SCIM and cannot be archived: %w", err)
+			return nil, types.DeactivateUserOutput{}, fmt.Errorf("user is managed by SCIM and cannot be deactivated: %w", err)
 		}
 
 		if _, ok := errors.AsType[*iam.ErrLastActiveOwner](err); ok {
-			return nil, types.ArchiveUserOutput{}, fmt.Errorf("cannot archive last active owner: %w", err)
+			return nil, types.DeactivateUserOutput{}, fmt.Errorf("cannot deactivate last active owner: %w", err)
 		}
 
-		return nil, types.ArchiveUserOutput{}, fmt.Errorf("archive user: %w", err)
+		return nil, types.DeactivateUserOutput{}, fmt.Errorf("deactivate user: %w", err)
 	}
 
-	return nil, types.ArchiveUserOutput{ArchivedUserID: input.ProfileID}, nil
+	return nil, types.DeactivateUserOutput{DeactivatedUserID: input.ProfileID}, nil
 }
 
 func (r *Resolver) DeleteDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.DeleteDataProtectionImpactAssessmentOutput, error) {

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2401,7 +2401,7 @@ func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *m
 	var (
 		signatureStates []coredata.DocumentVersionSignatureState
 		activeContract  *bool
-		profileState    *coredata.ProfileState
+		profileStates   []coredata.ProfileState
 	)
 
 	if input.Filter != nil {
@@ -2413,12 +2413,12 @@ func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *m
 			activeContract = input.Filter.ActiveContract
 		}
 
-		if input.Filter.ProfileState != nil {
-			profileState = input.Filter.ProfileState
+		if input.Filter.ProfileStates != nil {
+			profileStates = input.Filter.ProfileStates
 		}
 	}
 
-	signatureFilter := coredata.NewDocumentVersionSignatureFilter(signatureStates, activeContract, profileState)
+	signatureFilter := coredata.NewDocumentVersionSignatureFilter(signatureStates, activeContract, profileStates)
 
 	page, err := prb.Documents.ListSignatures(ctx, scope, input.DocumentVersionID, cursor, signatureFilter)
 	if err != nil {
@@ -2778,10 +2778,6 @@ func (r *Resolver) ListUsersTool(ctx context.Context, req *mcp.CallToolRequest, 
 
 		if len(input.Filter.States) > 0 {
 			filter.WithStates(input.Filter.States...)
-		}
-
-		if input.Filter.State != nil {
-			filter.WithState(*input.Filter.State)
 		}
 
 		if input.Filter.Query != nil {

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -1698,7 +1698,7 @@ components:
           $ref: "#/components/schemas/GID"
           description: Deleted user (profile) ID
 
-    ArchiveUserInput:
+    DeactivateUserInput:
       type: object
       required:
         - organization_id
@@ -1709,16 +1709,16 @@ components:
           description: Organization ID
         profile_id:
           $ref: "#/components/schemas/GID"
-          description: User (profile) ID to archive
+          description: User (profile) ID to deactivate
 
-    ArchiveUserOutput:
+    DeactivateUserOutput:
       type: object
       required:
-        - archived_user_id
+        - deactivated_user_id
       properties:
-        archived_user_id:
+        deactivated_user_id:
           $ref: "#/components/schemas/GID"
-          description: Archived user (profile) ID
+          description: Deactivated user (profile) ID
 
     GetProfileInput:
       type: object
@@ -12679,14 +12679,14 @@ tools:
       $ref: "#/components/schemas/RemoveUserInput"
     outputSchema:
       $ref: "#/components/schemas/RemoveUserOutput"
-  - name: archiveUser
-    description: Archive a user in the organization
+  - name: deactivateUser
+    description: Deactivate a user in the organization
     hints:
       readonly: false
     inputSchema:
-      $ref: "#/components/schemas/ArchiveUserInput"
+      $ref: "#/components/schemas/DeactivateUserInput"
     outputSchema:
-      $ref: "#/components/schemas/ArchiveUserOutput"
+      $ref: "#/components/schemas/DeactivateUserOutput"
   - name: addThirdParty
     description: Add a new thirdParty to the organization
     hints:

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -184,8 +184,9 @@ components:
     ProfileState:
       type: string
       enum:
+        - PENDING
         - ACTIVE
-        - INACTIVE
+        - DEACTIVATED
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.ProfileState
 
     ProfileKind:
@@ -526,7 +527,7 @@ components:
           description: Profile source (MANUAL, SCIM, or SAML)
         state:
           $ref: "#/components/schemas/ProfileState"
-          description: Profile state (ACTIVE or INACTIVE)
+          description: Profile state (PENDING, ACTIVE, or DEACTIVATED)
         position:
           type:
             - string
@@ -578,7 +579,12 @@ components:
               description: Filter by contract status. True returns only users with ended contracts, false returns only users with active or no contract.
             state:
               $ref: "#/components/schemas/ProfileState"
-              description: Filter by profile state (ACTIVE or INACTIVE)
+              description: Filter by profile state (PENDING, ACTIVE, or DEACTIVATED)
+            states:
+              type: array
+              items:
+                $ref: "#/components/schemas/ProfileState"
+              description: Filter by profile states (PENDING, ACTIVE, or DEACTIVATED)
             query:
               type: string
               description: Search by full name, email address, or position

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -577,9 +577,6 @@ components:
             contract_ended:
               type: boolean
               description: Filter by contract status. True returns only users with ended contracts, false returns only users with active or no contract.
-            state:
-              $ref: "#/components/schemas/ProfileState"
-              description: Filter by profile state (PENDING, ACTIVE, or DEACTIVATED)
             states:
               type: array
               items:
@@ -6421,9 +6418,11 @@ components:
             active_contract:
               type: boolean
               description: Signatory contract status
-            profile_state:
-              $ref: "#/components/schemas/ProfileState"
-              description: Signatory profile state
+            profile_states:
+              type: array
+              items:
+                $ref: "#/components/schemas/ProfileState"
+              description: Signatory profile states
 
     ListDocumentVersionSignaturesOutput:
       type: object


### PR DESCRIPTION
Closes ENG-450

Replace the binary profile ACTIVE/INACTIVE model with PENDING, ACTIVE, and DEACTIVATED so invited-but-not-yet-activated members remain assignable to assets, data, and risks instead of being treated like deactivated users.

Add activated_at/deactivated_at timestamps and Mark* lifecycle helpers, and update every transition (create, invite/re-invite, activation, archive, SCIM, SAML, sessions, compliance-portal grant) to the new states. Expose a multi-state states[] filter across coredata, GraphQL, MCP, and the console owner pickers, which now request ACTIVE and PENDING members.

A migration renames the membership_state enum, classifies existing inactive profiles as PENDING from recent invitation activity, and backfills the new timestamp columns.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split profile state into PENDING, ACTIVE, and DEACTIVATED so invited users stay assignable while only deactivated users are blocked (ENG-450). Switched filters to multi-select states[], renamed “archive” to “deactivate”, and limited owner pickers (including the assets table) to ACTIVE/PENDING.

### Coredata **`+148`** **`-19`**
Added activated_at/deactivated_at fields and MarkPending/MarkActive/MarkDeactivated helpers. Switched filters to states[] (SQL arrays) and changed signature filter to profileStates[]. Migration renames the enum, reclassifies recent invitees as PENDING, and leaves historical timestamps NULL.

### Service **`+45`** **`-69`**
Unified deactivate flow with SCIM and last-active-owner guards (owner count checks the profile’s organization). Invites can move DEACTIVATED → PENDING; SAML sign-in activates PENDING; sessions block only DEACTIVATED. Compliance-portal paths set activated_at/MarkActive.

### GraphQL API **`+33`** **`-60`**
Removed ProfileFilter.state in favor of states[] and updated resolvers to WithStates. Removed archiveUser; deactivateUser returns success. Document signatures filter switched from profileState to profileStates.

### MCP **`+37`** **`-32`**
Renamed archiveUser tool to deactivateUser with the unified guards. List users accepts states[]; list signatures accepts profileStates[].

### App: console **`+132`** **`-93`**
People filter is multi-select (Pending/Active/Deactivated) and queries pass states[]. Owner pickers (including the assets table) request ["ACTIVE","PENDING"]; labels/actions use Deactivate, and pending users are no longer styled as deactivated. Uses a checkbox dropdown and updates the row to PENDING on invite; cancels debounced search when status/role/kind/sort change. Document signature views filter by profileStates.

### prb (CLI) **`+22`** **`-20`**
Renamed command to user deactivate; list --state accepts multiple values (PENDING, ACTIVE, DEACTIVATED).

### Package: `n8n-node` **`+31`** **`-31`**
listUsers uses a multi-select state input; getAllSignatures accepts profileStates[]. Deactivate user operation calls deactivateUser and expects success.

### Package: `ui` **`+44`** **`-1`**
Added DropdownCheckboxItem for multi-select menus and exported it. Styled disabled checkbox items to be fully non-interactive.

### Tests **`+15`** **`-15`**
Updated e2e to use deactivateUser and expect DEACTIVATED.

<sup>Written for commit b27d22db2de4a8d4b6a1d5d89ab94a0aacb7ea30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

