### PR TITLE
Allow audits to nest under a parent audit

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1670,8 +1670,9 @@
     "messages": { "success": "Success", "error": "Error", "updated": "Audit updated successfully" },
     "deleteReportConfirmation": "This will permanently delete the audit report \"{{name}}\". This action cannot be undone.",
     "states": { "not_started": "Not Started", "in_progress": "In Progress", "completed": "Completed", "rejected": "Rejected", "outdated": "Outdated" },
-    "fields": { "name": "Name", "namePlaceholder": "Audit name", "state": "State", "validFrom": "Valid From", "validUntil": "Valid Until", "auditStartDate": "Audit Start Date", "auditEndDate": "Audit End Date" },
+    "fields": { "name": "Name", "namePlaceholder": "Audit name", "state": "State", "parentAudit": "Parent audit", "validFrom": "Valid From", "validUntil": "Valid Until", "auditStartDate": "Audit Start Date", "auditEndDate": "Audit End Date" },
     "actions": { "delete": "Delete", "update": "Update", "updating": "Updating...", "download": "Download" },
+    "childAudits": { "title": "Child audits" },
     "report": { "title": "Audit Report", "uploaded": "Uploaded {{date}}", "uploadDescription": "Upload the final audit report document (PDF recommended)", "dropzoneDescription": "Only PDF up to 25MB are allowed" }
   },
   "auditsPage": {
@@ -1691,7 +1692,7 @@
     "errors": { "create": "Failed to create audit" },
     "fileSize": "{{value}} MB",
     "loading": "Loading...",
-    "fields": { "framework": "Framework", "frameworkPlaceholder": "Select a framework", "name": "Name", "namePlaceholder": "Audit name", "state": "State", "validFrom": "Valid From", "validUntil": "Valid Until", "auditStartDate": "Audit Start Date", "auditEndDate": "Audit End Date" },
+    "fields": { "framework": "Framework", "frameworkPlaceholder": "Select a framework", "name": "Name", "namePlaceholder": "Audit name", "parentAudit": "Parent audit", "state": "State", "validFrom": "Valid From", "validUntil": "Valid Until", "auditStartDate": "Audit Start Date", "auditEndDate": "Audit End Date" },
     "states": { "not_started": "Not Started", "in_progress": "In Progress", "completed": "Completed", "rejected": "Rejected", "outdated": "Outdated" },
     "actions": { "create": "Create" }
   },

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -3440,6 +3440,7 @@
       "name": "Nom",
       "namePlaceholder": "Nom de l’audit",
       "state": "État",
+      "parentAudit": "Audit parent",
       "validFrom": "Valide à partir de",
       "validUntil": "Valide jusqu’au",
       "auditStartDate": "Date de début de l’audit",
@@ -3450,6 +3451,9 @@
       "update": "Mettre à jour",
       "updating": "Mise à jour...",
       "download": "Télécharger"
+    },
+    "childAudits": {
+      "title": "Audits enfants"
     },
     "report": {
       "title": "Rapport d’audit",
@@ -3519,6 +3523,7 @@
       "frameworkPlaceholder": "Sélectionner un référentiel",
       "name": "Nom",
       "namePlaceholder": "Nom de l’audit",
+      "parentAudit": "Audit parent",
       "state": "État",
       "validFrom": "Valide à partir de",
       "validUntil": "Valide jusqu’au",

--- a/apps/console/src/components/form/AuditSelectField.tsx
+++ b/apps/console/src/components/form/AuditSelectField.tsx
@@ -60,11 +60,13 @@ type Props<T extends FieldValues = FieldValues> = {
   name: Path<T>;
   label?: string;
   error?: string;
+  excludeAuditId?: string;
 } & ComponentProps<typeof Field>;
 
 export function AuditSelectField<T extends FieldValues = FieldValues>({
   organizationId,
   control,
+  excludeAuditId,
   ...props
 }: Props<T>) {
   return (
@@ -77,6 +79,7 @@ export function AuditSelectField<T extends FieldValues = FieldValues>({
           control={control}
           name={props.name}
           disabled={props.disabled}
+          excludeAuditId={excludeAuditId}
         />
       </Suspense>
     </Field>
@@ -84,10 +87,13 @@ export function AuditSelectField<T extends FieldValues = FieldValues>({
 }
 
 function AuditSelectWithQuery<T extends FieldValues = FieldValues>(
-  props: Pick<Props<T>, "organizationId" | "control" | "name" | "disabled">,
+  props: Pick<
+    Props<T>,
+    "organizationId" | "control" | "name" | "disabled" | "excludeAuditId"
+  >,
 ) {
   const { t } = useTranslation();
-  const { name, organizationId, control } = props;
+  const { name, organizationId, control, excludeAuditId } = props;
   const data = useLazyLoadQuery<AuditSelectFieldQuery>(
     auditsQuery,
     { organizationId },
@@ -96,7 +102,8 @@ function AuditSelectWithQuery<T extends FieldValues = FieldValues>(
   const audits
     = data?.organization?.audits?.edges
       ?.map(edge => edge.node)
-      .filter(node => node !== null) ?? [];
+      .filter(node => node !== null)
+      .filter(node => node.id !== excludeAuditId) ?? [];
 
   const NONE_VALUE = "__NONE__";
 

--- a/apps/console/src/hooks/graph/AuditGraph.ts
+++ b/apps/console/src/hooks/graph/AuditGraph.ts
@@ -49,6 +49,25 @@ export const auditNodeQuery = graphql`
         validUntil
         auditStartDate
         auditEndDate
+        parentAudit {
+          id
+          name
+          framework {
+            name
+          }
+        }
+        childAudits(first: 50) {
+          edges {
+            node {
+              id
+              name
+              state
+              framework {
+                name
+              }
+            }
+          }
+        }
         reportFile {
           id
           fileName
@@ -95,6 +114,10 @@ export const createAuditMutation = graphql`
           validUntil
           auditStartDate
           auditEndDate
+          parentAudit {
+            id
+            name
+          }
           reportFile {
             id
             fileName
@@ -123,6 +146,13 @@ export const updateAuditMutation = graphql`
         validUntil
         auditStartDate
         auditEndDate
+        parentAudit {
+          id
+          name
+          framework {
+            name
+          }
+        }
         reportFile {
           id
           fileName
@@ -189,6 +219,7 @@ export const useCreateAudit = (connectionId: string) => {
   return (input: {
     organizationId: string;
     frameworkId: string;
+    parentAuditId?: string | null;
     name?: string | null;
     validFrom?: string;
     validUntil?: string;
@@ -210,6 +241,7 @@ export const useCreateAudit = (connectionId: string) => {
         input: {
           organizationId: input.organizationId,
           frameworkId: input.frameworkId,
+          parentAuditId: input.parentAuditId || null,
           name: input.name,
           validFrom: input.validFrom,
           validUntil: input.validUntil,
@@ -234,6 +266,7 @@ export const useUpdateAudit = () => {
   return (input: {
     id: string;
     name?: string | null;
+    parentAuditId?: string | null;
     validFrom?: string | null;
     validUntil?: string | null;
     auditStartDate?: string | null;

--- a/apps/console/src/pages/organizations/audits/AuditDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/audits/AuditDetailsPage.tsx
@@ -22,6 +22,7 @@ import {
   auditStates,
   formatDatetime,
   formatError,
+  getAuditStateLabel,
   getAuditStateVariant,
   type GraphQLError,
 } from "@probo/helpers";
@@ -49,10 +50,11 @@ import {
   type PreloadedQuery,
   usePreloadedQuery,
 } from "react-relay";
-import { useNavigate } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { z } from "zod";
 
 import type { AuditGraphNodeQuery } from "#/__generated__/core/AuditGraphNodeQuery.graphql";
+import { AuditSelectField } from "#/components/form/AuditSelectField";
 import { ControlledField } from "#/components/form/ControlledField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
@@ -67,6 +69,7 @@ import {
 
 const updateAuditSchema = z.object({
   name: z.string().nullable().optional(),
+  parentAuditId: z.string().optional(),
   validFrom: z.string().optional(),
   validUntil: z.string().optional(),
   auditStartDate: z.string().optional(),
@@ -104,6 +107,7 @@ export default function AuditDetailsPage(props: Props) {
     = useFormWithSchema(updateAuditSchema, {
       defaultValues: {
         name: auditEntry.name || null,
+        parentAuditId: auditEntry.parentAudit?.id || "",
         validFrom: auditEntry.validFrom?.split("T")[0] || "",
         validUntil: auditEntry.validUntil?.split("T")[0] || "",
         auditStartDate: auditEntry.auditStartDate?.split("T")[0] || "",
@@ -118,6 +122,11 @@ export default function AuditDetailsPage(props: Props) {
   const confirm = useConfirm();
   const { toast } = useToast();
 
+  const childAudits
+    = auditEntry.childAudits?.edges
+      ?.map(edge => edge.node)
+      .filter(node => node !== null) ?? [];
+
   const onSubmit = handleSubmit(async (formData) => {
     if (!auditEntry.id) return;
 
@@ -125,6 +134,7 @@ export default function AuditDetailsPage(props: Props) {
       await updateAudit({
         id: auditEntry.id,
         name: formData.name || null,
+        parentAuditId: formData.parentAuditId || null,
         validFrom: formatDatetime(formData.validFrom) ?? null,
         validUntil: formatDatetime(formData.validUntil) ?? null,
         auditStartDate: formatDatetime(formData.auditStartDate) ?? null,
@@ -228,6 +238,15 @@ export default function AuditDetailsPage(props: Props) {
             />
           </Field>
 
+          <AuditSelectField
+            organizationId={organizationId}
+            control={control}
+            name="parentAuditId"
+            label={t("auditDetailsPage.fields.parentAudit")}
+            excludeAuditId={auditEntry.id ?? undefined}
+            disabled={!auditEntry.canUpdate}
+          />
+
           <ControlledField
             control={control}
             name="state"
@@ -268,75 +287,106 @@ export default function AuditDetailsPage(props: Props) {
           </div>
         </form>
 
-        <Card padded className="mt-6">
-          <div className="space-y-4">
-            <h3 className="text-lg font-medium">
-              {t("auditDetailsPage.report.title")}
-            </h3>
+        <div className="space-y-6">
+          {childAudits.length > 0 && (
+            <Card padded>
+              <div className="space-y-4">
+                <h3 className="text-lg font-medium">
+                  {t("auditDetailsPage.childAudits.title")}
+                </h3>
+                <ul className="space-y-2">
+                  {childAudits.map(child => (
+                    <li key={child.id}>
+                      <Link
+                        to={`/organizations/${organizationId}/audits/${child.id}`}
+                        className="flex items-center justify-between rounded-lg border border-border-low px-3 py-2 hover:bg-level-1"
+                      >
+                        <span className="text-sm">
+                          {child.name
+                            ? `${child.framework?.name} — ${child.name}`
+                            : child.framework?.name}
+                        </span>
+                        <Badge variant={getAuditStateVariant(child.state)}>
+                          {getAuditStateLabel(t, child.state)}
+                        </Badge>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </Card>
+          )}
 
-            {auditEntry.reportFile
-              ? (
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between p-4 bg-success-50 border border-success-200 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <IconArrowInbox className="text-success-600" size={20} />
-                        <div className="flex-1">
-                          <p className="font-medium text-success-900">
-                            {auditEntry.reportFile.fileName}
-                          </p>
-                          <div className="flex items-center gap-4 text-sm text-success-700">
-                            <span>
-                              {fileSize(auditEntry.reportFile.size, t)}
-                            </span>
-                            <span>
-                              {t("auditDetailsPage.report.uploaded", {
-                                date: dateFormat(
-                                  i18n.language,
-                                  auditEntry.reportFile.createdAt,
-                                ),
-                              })}
-                            </span>
+          <Card padded className="mt-6">
+            <div className="space-y-4">
+              <h3 className="text-lg font-medium">
+                {t("auditDetailsPage.report.title")}
+              </h3>
+
+              {auditEntry.reportFile
+                ? (
+                    <div className="space-y-4">
+                      <div className="flex items-center justify-between p-4 bg-success-50 border border-success-200 rounded-lg">
+                        <div className="flex items-center gap-3">
+                          <IconArrowInbox className="text-success-600" size={20} />
+                          <div className="flex-1">
+                            <p className="font-medium text-success-900">
+                              {auditEntry.reportFile.fileName}
+                            </p>
+                            <div className="flex items-center gap-4 text-sm text-success-700">
+                              <span>
+                                {fileSize(auditEntry.reportFile.size, t)}
+                              </span>
+                              <span>
+                                {t("auditDetailsPage.report.uploaded", {
+                                  date: dateFormat(
+                                    i18n.language,
+                                    auditEntry.reportFile.createdAt,
+                                  ),
+                                })}
+                              </span>
+                            </div>
                           </div>
                         </div>
+                        <ActionDropdown>
+                          <DropdownItem
+                            onClick={() => {
+                              if (auditEntry.reportFile?.downloadUrl) {
+                                window.open(auditEntry.reportFile.downloadUrl, "_blank", "noopener,noreferrer");
+                              }
+                            }}
+                            icon={IconArrowInbox}
+                          >
+                            {t("auditDetailsPage.actions.download")}
+                          </DropdownItem>
+                          <DropdownItem
+                            variant="danger"
+                            icon={IconTrashCan}
+                            onClick={handleDeleteReport}
+                          >
+                            {t("auditDetailsPage.actions.delete")}
+                          </DropdownItem>
+                        </ActionDropdown>
                       </div>
-                      <ActionDropdown>
-                        <DropdownItem
-                          onClick={() => {
-                            if (auditEntry.reportFile?.downloadUrl) {
-                              window.open(auditEntry.reportFile.downloadUrl, "_blank", "noopener,noreferrer");
-                            }
-                          }}
-                          icon={IconArrowInbox}
-                        >
-                          {t("auditDetailsPage.actions.download")}
-                        </DropdownItem>
-                        <DropdownItem
-                          variant="danger"
-                          icon={IconTrashCan}
-                          onClick={handleDeleteReport}
-                        >
-                          {t("auditDetailsPage.actions.delete")}
-                        </DropdownItem>
-                      </ActionDropdown>
                     </div>
-                  </div>
-                )
-              : (
-                  <div className="space-y-4">
-                    <p className="text-neutral-600">
-                      {t("auditDetailsPage.report.uploadDescription")}
-                    </p>
-                    <Dropzone
-                      description={t("auditDetailsPage.report.dropzoneDescription")}
-                      isUploading={isUploading}
-                      onDrop={files => void handleUploadFile(files)}
-                      accept={{ "application/pdf": [".pdf"] }}
-                      maxSize={25}
-                    />
-                  </div>
-                )}
-          </div>
-        </Card>
+                  )
+                : (
+                    <div className="space-y-4">
+                      <p className="text-neutral-600">
+                        {t("auditDetailsPage.report.uploadDescription")}
+                      </p>
+                      <Dropzone
+                        description={t("auditDetailsPage.report.dropzoneDescription")}
+                        isUploading={isUploading}
+                        onDrop={files => void handleUploadFile(files)}
+                        accept={{ "application/pdf": [".pdf"] }}
+                        maxSize={25}
+                      />
+                    </div>
+                  )}
+            </div>
+          </Card>
+        </div>
       </div>
     </div>
   );

--- a/apps/console/src/pages/organizations/audits/dialogs/CreateAuditDialog.tsx
+++ b/apps/console/src/pages/organizations/audits/dialogs/CreateAuditDialog.tsx
@@ -47,6 +47,7 @@ import { graphql } from "relay-runtime";
 import { z } from "zod";
 
 import type { CreateAuditDialogFrameworksQuery } from "#/__generated__/core/CreateAuditDialogFrameworksQuery.graphql";
+import { AuditSelectField } from "#/components/form/AuditSelectField";
 import { ControlledField } from "#/components/form/ControlledField";
 import { useCreateAudit } from "#/hooks/graph/AuditGraph";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
@@ -89,6 +90,7 @@ export function CreateAuditDialog({
   const { toast } = useToast();
   const schema = z.object({
     frameworkId: z.string().min(1, t("createAuditDialog.validation.frameworkRequired")),
+    parentAuditId: z.string().optional(),
     name: z.string().optional(),
     validFrom: z.string().optional(),
     validUntil: z.string().optional(),
@@ -106,6 +108,7 @@ export function CreateAuditDialog({
     = useFormWithSchema(schema, {
       defaultValues: {
         frameworkId: "",
+        parentAuditId: "",
         name: "",
         validFrom: "",
         validUntil: "",
@@ -123,6 +126,7 @@ export function CreateAuditDialog({
       await createAudit({
         organizationId,
         frameworkId: data.frameworkId,
+        parentAuditId: data.parentAuditId || null,
         name: data.name || null,
         validFrom: formatDatetime(data.validFrom),
         validUntil: formatDatetime(data.validUntil),
@@ -215,6 +219,13 @@ export function CreateAuditDialog({
               placeholder={t("createAuditDialog.fields.namePlaceholder")}
             />
           </Field>
+
+          <AuditSelectField
+            organizationId={organizationId}
+            control={control}
+            name="parentAuditId"
+            label={t("createAuditDialog.fields.parentAudit")}
+          />
 
           <ControlledField
             control={control}

--- a/e2e/console/audit_test.go
+++ b/e2e/console/audit_test.go
@@ -1982,3 +1982,169 @@ func TestAudit_DeleteReport_RBAC(t *testing.T) {
 		testutil.RequireForbiddenError(t, err, "viewer should not be able to delete report")
 	})
 }
+
+func TestAudit_ParentAudit(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	frameworkID := factory.NewFramework(owner).WithName("ISO 27001 for Parent Audit").Create()
+
+	parentID := factory.NewAudit(owner, frameworkID).
+		WithName("ISO 27001 2024-2027 cycle").
+		Create()
+
+	childID := factory.NewAudit(owner, frameworkID).
+		WithName("Year 1 internal audit").
+		WithParentAuditID(parentID).
+		Create()
+
+	const query = `
+		query($id: ID!) {
+			node(id: $id) {
+				... on Audit {
+					id
+					name
+					parentAudit {
+						id
+						name
+					}
+					childAudits(first: 10) {
+						totalCount
+						edges {
+							node {
+								id
+								name
+							}
+						}
+					}
+				}
+			}
+		}
+	`
+
+	t.Run("child references parent", func(t *testing.T) {
+		var result struct {
+			Node struct {
+				ID          string `json:"id"`
+				Name        string `json:"name"`
+				ParentAudit *struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"parentAudit"`
+			} `json:"node"`
+		}
+
+		err := owner.Execute(query, map[string]any{"id": childID}, &result)
+		require.NoError(t, err)
+		require.NotNil(t, result.Node.ParentAudit)
+		assert.Equal(t, parentID, result.Node.ParentAudit.ID)
+		assert.Equal(t, "ISO 27001 2024-2027 cycle", result.Node.ParentAudit.Name)
+	})
+
+	t.Run("parent lists children", func(t *testing.T) {
+		var result struct {
+			Node struct {
+				ID          string `json:"id"`
+				ChildAudits struct {
+					TotalCount int `json:"totalCount"`
+					Edges      []struct {
+						Node struct {
+							ID   string `json:"id"`
+							Name string `json:"name"`
+						} `json:"node"`
+					} `json:"edges"`
+				} `json:"childAudits"`
+			} `json:"node"`
+		}
+
+		err := owner.Execute(query, map[string]any{"id": parentID}, &result)
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Node.ChildAudits.TotalCount)
+		require.Len(t, result.Node.ChildAudits.Edges, 1)
+		assert.Equal(t, childID, result.Node.ChildAudits.Edges[0].Node.ID)
+		assert.Equal(t, "Year 1 internal audit", result.Node.ChildAudits.Edges[0].Node.Name)
+	})
+
+	t.Run("update parent and clear", func(t *testing.T) {
+		siblingID := factory.NewAudit(owner, frameworkID).
+			WithName("Surveillance audit 1").
+			Create()
+
+		const updateQuery = `
+			mutation($input: UpdateAuditInput!) {
+				updateAudit(input: $input) {
+					audit {
+						id
+						parentAudit { id }
+					}
+				}
+			}
+		`
+
+		var updateResult struct {
+			UpdateAudit struct {
+				Audit struct {
+					ID          string `json:"id"`
+					ParentAudit *struct {
+						ID string `json:"id"`
+					} `json:"parentAudit"`
+				} `json:"audit"`
+			} `json:"updateAudit"`
+		}
+
+		err := owner.Execute(updateQuery, map[string]any{
+			"input": map[string]any{
+				"id":            siblingID,
+				"parentAuditId": parentID,
+			},
+		}, &updateResult)
+		require.NoError(t, err)
+		require.NotNil(t, updateResult.UpdateAudit.Audit.ParentAudit)
+		assert.Equal(t, parentID, updateResult.UpdateAudit.Audit.ParentAudit.ID)
+
+		err = owner.Execute(updateQuery, map[string]any{
+			"input": map[string]any{
+				"id":            siblingID,
+				"parentAuditId": nil,
+			},
+		}, &updateResult)
+		require.NoError(t, err)
+		assert.Nil(t, updateResult.UpdateAudit.Audit.ParentAudit)
+	})
+
+	t.Run("rejects self as parent", func(t *testing.T) {
+		const updateQuery = `
+			mutation($input: UpdateAuditInput!) {
+				updateAudit(input: $input) {
+					audit { id }
+				}
+			}
+		`
+
+		err := owner.Execute(updateQuery, map[string]any{
+			"input": map[string]any{
+				"id":            parentID,
+				"parentAuditId": parentID,
+			},
+		}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects cycle", func(t *testing.T) {
+		const updateQuery = `
+			mutation($input: UpdateAuditInput!) {
+				updateAudit(input: $input) {
+					audit { id }
+				}
+			}
+		`
+
+		err := owner.Execute(updateQuery, map[string]any{
+			"input": map[string]any{
+				"id":            parentID,
+				"parentAuditId": childID,
+			},
+		}, nil)
+		require.Error(t, err)
+	})
+}

--- a/e2e/internal/factory/factory.go
+++ b/e2e/internal/factory/factory.go
@@ -696,6 +696,9 @@ func CreateAudit(c *testutil.Client, frameworkID string, attrs ...Attrs) string 
 	if state := a.getStringPtr("state"); state != nil {
 		input["state"] = *state
 	}
+	if parentAuditID := a.getString("parentAuditId", ""); parentAuditID != "" {
+		input["parentAuditId"] = parentAuditID
+	}
 
 	var result struct {
 		CreateAudit struct {
@@ -730,6 +733,11 @@ func (b *AuditBuilder) WithName(name string) *AuditBuilder {
 
 func (b *AuditBuilder) WithState(state string) *AuditBuilder {
 	b.attrs["state"] = state
+	return b
+}
+
+func (b *AuditBuilder) WithParentAuditID(parentAuditID string) *AuditBuilder {
+	b.attrs["parentAuditId"] = parentAuditID
 	return b
 }
 

--- a/e2e/mcp/audit_test.go
+++ b/e2e/mcp/audit_test.go
@@ -94,6 +94,50 @@ func TestMCP_Audit_CRUD(t *testing.T) {
 	assert.Equal(t, addResult.Audit.ID, deleteResult.DeletedAuditID)
 }
 
+func TestMCP_Audit_ParentAudit(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	mc := testutil.NewMCPClient(t, owner)
+	frameworkID := factory.CreateFramework(owner)
+
+	var parentResult struct {
+		Audit struct {
+			ID string `json:"id"`
+		} `json:"audit"`
+	}
+	mc.CallToolInto("addAudit", map[string]any{
+		"frameworkId": frameworkID,
+		"name":        factory.SafeName("ParentAudit"),
+	}, &parentResult)
+	require.NotEmpty(t, parentResult.Audit.ID)
+
+	var childResult struct {
+		Audit struct {
+			ID            string  `json:"id"`
+			ParentAuditID *string `json:"parentAuditId"`
+		} `json:"audit"`
+	}
+	mc.CallToolInto("addAudit", map[string]any{
+		"frameworkId":   frameworkID,
+		"name":          factory.SafeName("ChildAudit"),
+		"parentAuditId": parentResult.Audit.ID,
+	}, &childResult)
+	require.NotEmpty(t, childResult.Audit.ID)
+	require.NotNil(t, childResult.Audit.ParentAuditID)
+	assert.Equal(t, parentResult.Audit.ID, *childResult.Audit.ParentAuditID)
+
+	var listResult struct {
+		Audits []struct {
+			ID string `json:"id"`
+		} `json:"audits"`
+	}
+	mc.CallToolInto("listChildAudits", map[string]any{
+		"parentAuditId": parentResult.Audit.ID,
+	}, &listResult)
+	require.Len(t, listResult.Audits, 1)
+	assert.Equal(t, childResult.Audit.ID, listResult.Audits[0].ID)
+}
+
 func TestMCP_AuditLog(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)

--- a/packages/n8n-node/nodes/Probo/actions/audit/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/audit/create.operation.ts
@@ -85,6 +85,13 @@ export const description: INodeProperties[] = [
 				description: 'The name of the audit',
 			},
 			{
+				displayName: 'Parent Audit ID',
+				name: 'parentAuditId',
+				type: 'string',
+				default: '',
+				description: 'Parent audit ID for multi-year cycles (e.g. ISO 27001)',
+			},
+			{
 				displayName: 'State',
 				name: 'state',
 				type: 'options',
@@ -139,6 +146,7 @@ export async function execute(
 	const frameworkId = this.getNodeParameter('frameworkId', itemIndex) as string;
 	const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as {
 		name?: string;
+		parentAuditId?: string;
 		state?: string;
 		validFrom?: string;
 		validUntil?: string;
@@ -158,7 +166,10 @@ export async function execute(
 						validUntil
 						auditStartDate
 						auditEndDate
-						reportUrl
+						parentAudit {
+							id
+							name
+						}
 						compliancePortalVisibility
 						createdAt
 						updatedAt
@@ -173,6 +184,7 @@ export async function execute(
 		frameworkId,
 	};
 	if (additionalFields.name) input.name = additionalFields.name;
+	if (additionalFields.parentAuditId) input.parentAuditId = additionalFields.parentAuditId;
 	if (additionalFields.state) input.state = additionalFields.state;
 	if (additionalFields.validFrom) input.validFrom = additionalFields.validFrom;
 	if (additionalFields.validUntil) input.validUntil = additionalFields.validUntil;

--- a/packages/n8n-node/nodes/Probo/actions/audit/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/audit/update.operation.ts
@@ -71,6 +71,13 @@ export const description: INodeProperties[] = [
 				description: 'The name of the audit',
 			},
 			{
+				displayName: 'Parent Audit ID',
+				name: 'parentAuditId',
+				type: 'string',
+				default: '',
+				description: 'Parent audit ID for multi-year cycles (e.g. ISO 27001)',
+			},
+			{
 				displayName: 'State',
 				name: 'state',
 				type: 'options',
@@ -124,6 +131,7 @@ export async function execute(
 	const id = this.getNodeParameter('id', itemIndex) as string;
 	const updateFields = this.getNodeParameter('updateFields', itemIndex, {}) as {
 		name?: string;
+		parentAuditId?: string;
 		state?: string;
 		validFrom?: string;
 		validUntil?: string;
@@ -142,7 +150,10 @@ export async function execute(
 					validUntil
 					auditStartDate
 					auditEndDate
-					reportUrl
+					parentAudit {
+						id
+						name
+					}
 					compliancePortalVisibility
 					createdAt
 					updatedAt
@@ -153,6 +164,7 @@ export async function execute(
 
 	const input: Record<string, unknown> = { id };
 	if (updateFields.name) input.name = updateFields.name;
+	if (updateFields.parentAuditId) input.parentAuditId = updateFields.parentAuditId;
 	if (updateFields.state) input.state = updateFields.state;
 	if (updateFields.validFrom) input.validFrom = updateFields.validFrom;
 	if (updateFields.validUntil) input.validUntil = updateFields.validUntil;

--- a/pkg/cmd/audit/create/create.go
+++ b/pkg/cmd/audit/create/create.go
@@ -42,6 +42,10 @@ mutation($input: CreateAuditInput!) {
         validUntil
         auditStartDate
         auditEndDate
+        parentAudit {
+          id
+          name
+        }
       }
     }
   }
@@ -68,6 +72,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	var (
 		flagOrg                        string
 		flagFramework                  string
+		flagParent                     string
 		flagName                       string
 		flagState                      string
 		flagValidFrom                  string
@@ -154,6 +159,10 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				input["frameworkId"] = flagFramework
 			}
 
+			if flagParent != "" {
+				input["parentAuditId"] = flagParent
+			}
+
 			if flagState != "" {
 				input["state"] = flagState
 			}
@@ -205,6 +214,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
 	cmd.Flags().StringVar(&flagFramework, "framework", "", "Framework ID")
+	cmd.Flags().StringVar(&flagParent, "parent", "", "Parent audit ID (for multi-year cycles)")
 	cmd.Flags().StringVar(&flagName, "name", "", "Audit name (required)")
 	cmd.Flags().StringVar(&flagState, "state", "", "Audit state: NOT_STARTED, IN_PROGRESS, COMPLETED, REJECTED, OUTDATED")
 	cmd.Flags().StringVar(&flagValidFrom, "valid-from", "", "Valid from date (e.g. 2026-01-01)")

--- a/pkg/cmd/audit/update/update.go
+++ b/pkg/cmd/audit/update/update.go
@@ -40,6 +40,10 @@ mutation($input: UpdateAuditInput!) {
       validUntil
       auditStartDate
       auditEndDate
+      parentAudit {
+        id
+        name
+      }
     }
   }
 }
@@ -62,6 +66,8 @@ type updateResponse struct {
 func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	var (
 		flagName                       string
+		flagParent                     string
+		flagClearParent                bool
 		flagState                      string
 		flagValidFrom                  string
 		flagValidUntil                 string
@@ -99,6 +105,12 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 
 			if cmd.Flags().Changed("name") {
 				input["name"] = flagName
+			}
+
+			if flagClearParent {
+				input["parentAuditId"] = nil
+			} else if cmd.Flags().Changed("parent") {
+				input["parentAuditId"] = flagParent
 			}
 
 			if cmd.Flags().Changed("state") {
@@ -155,6 +167,8 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flagName, "name", "", "Audit name")
+	cmd.Flags().StringVar(&flagParent, "parent", "", "Parent audit ID (for multi-year cycles)")
+	cmd.Flags().BoolVar(&flagClearParent, "clear-parent", false, "Clear the parent audit")
 	cmd.Flags().StringVar(&flagState, "state", "", "Audit state: NOT_STARTED, IN_PROGRESS, COMPLETED, REJECTED, OUTDATED")
 	cmd.Flags().StringVar(&flagValidFrom, "valid-from", "", "Valid from date (e.g. 2026-01-01)")
 	cmd.Flags().StringVar(&flagValidUntil, "valid-until", "", "Valid until date (e.g. 2026-12-31)")

--- a/pkg/cmd/audit/view/view.go
+++ b/pkg/cmd/audit/view/view.go
@@ -42,6 +42,10 @@ query($id: ID!) {
       validUntil
       auditStartDate
       auditEndDate
+      parentAudit {
+        id
+        name
+      }
       createdAt
       updatedAt
     }

--- a/pkg/coredata/audit.go
+++ b/pkg/coredata/audit.go
@@ -40,6 +40,7 @@ type (
 		Name                       *string                    `db:"name"`
 		OrganizationID             gid.GID                    `db:"organization_id"`
 		FrameworkID                gid.GID                    `db:"framework_id"`
+		ParentAuditID              *gid.GID                   `db:"parent_audit_id"`
 		ReportFileID               *gid.GID                   `db:"report_file_id"`
 		ValidFrom                  *time.Time                 `db:"valid_from"`
 		ValidUntil                 *time.Time                 `db:"valid_until"`
@@ -265,6 +266,7 @@ INSERT INTO audits (
 	tenant_id,
 	organization_id,
 	framework_id,
+	parent_audit_id,
 	report_file_id,
 	valid_from,
 	valid_until,
@@ -280,6 +282,7 @@ INSERT INTO audits (
 	@tenant_id,
 	@organization_id,
 	@framework_id,
+	@parent_audit_id,
 	@report_file_id,
 	@valid_from,
 	@valid_until,
@@ -298,6 +301,7 @@ INSERT INTO audits (
 		"tenant_id":               scope.GetTenantID(),
 		"organization_id":         a.OrganizationID,
 		"framework_id":            a.FrameworkID,
+		"parent_audit_id":         a.ParentAuditID,
 		"report_file_id":          a.ReportFileID,
 		"valid_from":              a.ValidFrom,
 		"valid_until":             a.ValidUntil,
@@ -326,6 +330,7 @@ func (a *Audit) Update(
 UPDATE audits
 SET
 	name = @name,
+	parent_audit_id = @parent_audit_id,
 	report_file_id = @report_file_id,
 	valid_from = @valid_from,
 	valid_until = @valid_until,
@@ -344,6 +349,7 @@ WHERE
 	args := pgx.StrictNamedArgs{
 		"id":                      a.ID,
 		"name":                    a.Name,
+		"parent_audit_id":         a.ParentAuditID,
 		"report_file_id":          a.ReportFileID,
 		"valid_from":              a.ValidFrom,
 		"valid_until":             a.ValidUntil,
@@ -663,6 +669,91 @@ LIMIT 1;
 	}
 
 	*a = audit
+
+	return nil
+}
+
+func (a *Audits) CountByParentAuditID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	parentAuditID gid.GID,
+) (int, error) {
+	q := `
+SELECT
+	COUNT(id)
+FROM
+	audits
+WHERE
+	%s
+	AND parent_audit_id = @parent_audit_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"parent_audit_id": parentAuditID}
+	maps.Copy(args, scope.SQLArguments())
+
+	row := conn.QueryRow(ctx, q, args)
+
+	var count int
+
+	err := row.Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("cannot count child audits: %w", err)
+	}
+
+	return count, nil
+}
+
+func (a *Audits) LoadByParentAuditID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	parentAuditID gid.GID,
+	cursor *page.Cursor[AuditOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	name,
+	organization_id,
+	framework_id,
+	parent_audit_id,
+	report_file_id,
+	valid_from,
+	valid_until,
+	audit_start_date,
+	audit_end_date,
+	state,
+	trust_center_visibility,
+	created_at,
+	updated_at
+FROM
+	audits
+WHERE
+	%s
+	AND parent_audit_id = @parent_audit_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"parent_audit_id": parentAuditID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query child audits: %w", err)
+	}
+
+	audits, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[Audit])
+	if err != nil {
+		return fmt.Errorf("cannot collect child audits: %w", err)
+	}
+
+	*a = audits
 
 	return nil
 }

--- a/pkg/coredata/migrations/20260728T164810Z.sql
+++ b/pkg/coredata/migrations/20260728T164810Z.sql
@@ -1,0 +1,26 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TABLE audits
+ADD COLUMN parent_audit_id TEXT REFERENCES audits(id) ON DELETE SET NULL;
+
+ALTER TABLE audits
+ADD CONSTRAINT audits_parent_audit_id_not_self
+CHECK (parent_audit_id IS NULL OR parent_audit_id <> id);

--- a/pkg/probo/audit_service.go
+++ b/pkg/probo/audit_service.go
@@ -41,6 +41,7 @@ type (
 	CreateAuditRequest struct {
 		OrganizationID             gid.GID
 		FrameworkID                gid.GID
+		ParentAuditID              *gid.GID
 		Name                       *string
 		ValidFrom                  *time.Time
 		ValidUntil                 *time.Time
@@ -53,6 +54,7 @@ type (
 	UpdateAuditRequest struct {
 		ID                         gid.GID
 		Name                       **string
+		ParentAuditID              **gid.GID
 		ValidFrom                  *time.Time
 		ValidUntil                 *time.Time
 		AuditStartDate             *time.Time
@@ -72,6 +74,7 @@ func (car *CreateAuditRequest) Validate() error {
 
 	v.Check(car.OrganizationID, "organization_id", validator.Required(), validator.GID(coredata.OrganizationEntityType))
 	v.Check(car.FrameworkID, "framework_id", validator.Required(), validator.GID(coredata.FrameworkEntityType))
+	v.Check(car.ParentAuditID, "parent_audit_id", validator.GID(coredata.AuditEntityType))
 	v.Check(car.Name, "name", validator.SafeTextNoNewLine(TitleMaxLength))
 	v.Check(car.ValidUntil, "valid_until", validator.After(car.ValidFrom))
 	v.Check(car.AuditEndDate, "audit_end_date", validator.After(car.AuditStartDate))
@@ -86,6 +89,7 @@ func (uar *UpdateAuditRequest) Validate() error {
 
 	v.Check(uar.ID, "id", validator.Required(), validator.GID(coredata.AuditEntityType))
 	v.Check(uar.Name, "name", validator.SafeTextNoNewLine(TitleMaxLength))
+	v.Check(uar.ParentAuditID, "parent_audit_id", validator.GID(coredata.AuditEntityType))
 	v.Check(uar.ValidUntil, "valid_until", validator.After(uar.ValidFrom))
 	v.Check(uar.AuditEndDate, "audit_end_date", validator.After(uar.AuditStartDate))
 	v.Check(uar.State, "state", validator.OneOfSlice(coredata.AuditStates()))
@@ -205,6 +209,22 @@ func (s *AuditService) Create(
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
+			if req.ParentAuditID != nil {
+				parent, err := s.loadParentAudit(
+					ctx,
+					conn,
+					scope,
+					*req.ParentAuditID,
+					req.OrganizationID,
+					"parent_audit_id",
+				)
+				if err != nil {
+					return err
+				}
+
+				audit.ParentAuditID = &parent.ID
+			}
+
 			if err := audit.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert audit: %w", err)
 			}
@@ -238,6 +258,38 @@ func (s *AuditService) Update(
 
 			if req.Name != nil {
 				audit.Name = *req.Name
+			}
+
+			if req.ParentAuditID != nil {
+				if *req.ParentAuditID == nil {
+					audit.ParentAuditID = nil
+				} else {
+					if **req.ParentAuditID == audit.ID {
+						return validator.ValidationErrors{{
+							Field:   "parent_audit_id",
+							Code:    validator.ErrorCodeCustom,
+							Message: "audit cannot be its own parent",
+						}}
+					}
+
+					parent, err := s.loadParentAudit(
+						ctx,
+						conn,
+						scope,
+						**req.ParentAuditID,
+						audit.OrganizationID,
+						"parent_audit_id",
+					)
+					if err != nil {
+						return err
+					}
+
+					if err := s.assertNoAuditCycle(ctx, conn, scope, audit.ID, parent.ID, "parent_audit_id"); err != nil {
+						return err
+					}
+
+					audit.ParentAuditID = &parent.ID
+				}
 			}
 
 			if req.ValidFrom != nil {
@@ -584,4 +636,130 @@ func (s AuditService) ListForFindingID(
 	}
 
 	return page.NewPage(audits, cursor), nil
+}
+
+func (s AuditService) CountForParentAuditID(
+	ctx context.Context, scope coredata.Scoper,
+	parentAuditID gid.GID,
+) (int, error) {
+	var count int
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) (err error) {
+			audits := coredata.Audits{}
+
+			count, err = audits.CountByParentAuditID(ctx, conn, scope, parentAuditID)
+			if err != nil {
+				return fmt.Errorf("cannot count child audits: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (s AuditService) ListForParentAuditID(
+	ctx context.Context, scope coredata.Scoper,
+	parentAuditID gid.GID,
+	cursor *page.Cursor[coredata.AuditOrderField],
+) (*page.Page[*coredata.Audit, coredata.AuditOrderField], error) {
+	var audits coredata.Audits
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			parent := &coredata.Audit{}
+			if err := parent.LoadByID(ctx, conn, scope, parentAuditID); err != nil {
+				return fmt.Errorf("cannot load parent audit: %w", err)
+			}
+
+			err := audits.LoadByParentAuditID(ctx, conn, scope, parent.ID, cursor)
+			if err != nil {
+				return fmt.Errorf("cannot load child audits: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(audits, cursor), nil
+}
+
+func (s AuditService) loadParentAudit(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	parentAuditID gid.GID,
+	organizationID gid.GID,
+	field string,
+) (*coredata.Audit, error) {
+	parent := &coredata.Audit{}
+	if err := parent.LoadByID(ctx, conn, scope, parentAuditID); err != nil {
+		return nil, validator.ValidationErrors{{
+			Field:   field,
+			Code:    validator.ErrorCodeCustom,
+			Message: "parent audit not found",
+		}}
+	}
+
+	if parent.OrganizationID != organizationID {
+		return nil, validator.ValidationErrors{{
+			Field:   field,
+			Code:    validator.ErrorCodeCustom,
+			Message: "parent audit belongs to a different organization",
+		}}
+	}
+
+	return parent, nil
+}
+
+// assertNoAuditCycle walks the ancestor chain starting from the proposed
+// parent. If it reaches the audit being updated, the new parent would make
+// the audit an ancestor of itself (a cycle), which is rejected.
+func (s AuditService) assertNoAuditCycle(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	auditID gid.GID,
+	proposedParentID gid.GID,
+	field string,
+) error {
+	visited := make(map[gid.GID]bool)
+	currentID := proposedParentID
+
+	for {
+		if currentID == auditID {
+			return validator.ValidationErrors{{
+				Field:   field,
+				Code:    validator.ErrorCodeCustom,
+				Message: "audit cannot be nested under itself or one of its descendants",
+			}}
+		}
+
+		if visited[currentID] {
+			return nil
+		}
+
+		visited[currentID] = true
+
+		current := &coredata.Audit{}
+		if err := current.LoadByID(ctx, conn, scope, currentID); err != nil {
+			return fmt.Errorf("cannot load parent audit: %w", err)
+		}
+
+		if current.ParentAuditID == nil {
+			return nil
+		}
+
+		currentID = *current.ParentAuditID
+	}
 }

--- a/pkg/server/api/console/v1/audit_resolvers.go
+++ b/pkg/server/api/console/v1/audit_resolvers.go
@@ -67,6 +67,61 @@ func (r *auditResolver) Framework(ctx context.Context, obj *types.Audit) (*types
 	return types.NewFramework(framework), nil
 }
 
+// ParentAudit is the resolver for the parentAudit field.
+func (r *auditResolver) ParentAudit(ctx context.Context, obj *types.Audit) (*types.Audit, error) {
+	if obj.ParentAudit == nil {
+		return nil, nil
+	}
+
+	scope, err := r.authorize(ctx, obj.ParentAudit.ID, probo.ActionAuditGet)
+	if err != nil {
+		return nil, err
+	}
+
+	parent, err := r.probo.Audits.Get(ctx, scope, obj.ParentAudit.ID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return nil, gqlutils.NotFound(ctx, err)
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot load parent audit", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewAudit(parent), nil
+}
+
+// ChildAudits is the resolver for the childAudits field.
+func (r *auditResolver) ChildAudits(ctx context.Context, obj *types.Audit, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) (*types.AuditConnection, error) {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAuditList)
+	if err != nil {
+		return nil, err
+	}
+
+	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
+		Field:     coredata.AuditOrderFieldCreatedAt,
+		Direction: page.OrderDirectionDesc,
+	}
+
+	if orderBy != nil {
+		pageOrderBy = page.OrderBy[coredata.AuditOrderField]{
+			Field:     orderBy.Field,
+			Direction: orderBy.Direction,
+		}
+	}
+
+	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
+
+	page, err := r.probo.Audits.ListForParentAuditID(ctx, scope, obj.ID, cursor)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot list child audits", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewAuditConnection(page, r, obj.ID), nil
+}
+
 // ReportFile is the resolver for the reportFile field.
 func (r *auditResolver) ReportFile(ctx context.Context, obj *types.Audit) (*types.File, error) {
 	if obj.ReportFile == nil {
@@ -206,6 +261,14 @@ func (r *auditConnectionResolver) TotalCount(ctx context.Context, obj *types.Aud
 		count, err := r.probo.Audits.CountForControlID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count audits", log.Error(err))
+			return 0, gqlutils.Internal(ctx)
+		}
+
+		return count, nil
+	case *auditResolver:
+		count, err := r.probo.Audits.CountForParentAuditID(ctx, scope, obj.ParentID)
+		if err != nil {
+			r.logger.ErrorCtx(ctx, "cannot count child audits", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
 		}
 
@@ -381,6 +444,7 @@ func (r *mutationResolver) CreateAudit(ctx context.Context, input types.CreateAu
 	req := probo.CreateAuditRequest{
 		OrganizationID:             input.OrganizationID,
 		FrameworkID:                input.FrameworkID,
+		ParentAuditID:              input.ParentAuditID,
 		Name:                       input.Name,
 		ValidFrom:                  input.ValidFrom,
 		ValidUntil:                 input.ValidUntil,
@@ -439,6 +503,7 @@ func (r *mutationResolver) UpdateAudit(ctx context.Context, input types.UpdateAu
 	req := probo.UpdateAuditRequest{
 		ID:                         input.ID,
 		Name:                       gqlutils.UnwrapOmittable(input.Name),
+		ParentAuditID:              gqlutils.UnwrapOmittable(input.ParentAuditID),
 		ValidFrom:                  input.ValidFrom,
 		ValidUntil:                 input.ValidUntil,
 		AuditStartDate:             input.AuditStartDate,

--- a/pkg/server/api/console/v1/graphql/audit.graphql
+++ b/pkg/server/api/console/v1/graphql/audit.graphql
@@ -157,6 +157,14 @@ type Audit implements Node {
     name: String
     organization: Organization @goField(forceResolver: true)
     framework: Framework @goField(forceResolver: true)
+    parentAudit: Audit @goField(forceResolver: true)
+    childAudits(
+        first: Int
+        after: CursorKey
+        last: Int
+        before: CursorKey
+        orderBy: AuditOrder
+    ): AuditConnection @goField(forceResolver: true)
     validFrom: Datetime
     validUntil: Datetime
     auditStartDate: Datetime
@@ -282,6 +290,7 @@ type PublishFindingListPayload {
 input CreateAuditInput {
     organizationId: ID!
     frameworkId: ID!
+    parentAuditId: ID
     name: String
     validFrom: Datetime
     validUntil: Datetime
@@ -295,6 +304,7 @@ input CreateAuditInput {
 input UpdateAuditInput {
     id: ID!
     name: String @goField(omittable: true)
+    parentAuditId: ID @goField(omittable: true)
     validFrom: Datetime
     validUntil: Datetime
     auditStartDate: Datetime

--- a/pkg/server/api/console/v1/types/audit.go
+++ b/pkg/server/api/console/v1/types/audit.go
@@ -85,6 +85,12 @@ func NewAudit(a *coredata.Audit) *Audit {
 		UpdatedAt:                  a.UpdatedAt,
 	}
 
+	if a.ParentAuditID != nil {
+		node.ParentAudit = &Audit{
+			ID: *a.ParentAuditID,
+		}
+	}
+
 	if a.ReportFileID != nil {
 		node.ReportFile = &File{
 			ID: *a.ReportFileID,

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -1503,6 +1503,7 @@ func (r *Resolver) AddAuditTool(ctx context.Context, req *mcp.CallToolRequest, i
 			AuditEndDate:   input.AuditEndDate,
 			State:          input.State,
 			FrameworkID:    input.FrameworkID,
+			ParentAuditID:  input.ParentAuditID,
 		},
 	)
 	if err != nil {
@@ -1527,6 +1528,7 @@ func (r *Resolver) UpdateAuditTool(ctx context.Context, req *mcp.CallToolRequest
 		&probo.UpdateAuditRequest{
 			ID:                         input.ID,
 			Name:                       UnwrapOmittable(input.Name),
+			ParentAuditID:              UnwrapOmittable(input.ParentAuditID),
 			ValidFrom:                  input.ValidFrom,
 			ValidUntil:                 input.ValidUntil,
 			AuditStartDate:             input.AuditStartDate,
@@ -7350,4 +7352,32 @@ func (r *Resolver) DeleteCommitmentTool(ctx context.Context, req *mcp.CallToolRe
 	}
 
 	return nil, types.DeleteCommitmentOutput{DeletedCommitmentID: input.ID}, nil
+}
+
+func (r *Resolver) ListChildAuditsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListChildAuditsInput) (*mcp.CallToolResult, types.ListChildAuditsOutput, error) {
+	scope, err := r.Authorize(ctx, input.ParentAuditID, probo.ActionAuditList)
+	if err != nil {
+		return nil, types.ListChildAuditsOutput{}, err
+	}
+
+	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
+		Field:     coredata.AuditOrderFieldCreatedAt,
+		Direction: page.OrderDirectionDesc,
+	}
+
+	if input.OrderBy != nil {
+		pageOrderBy = page.OrderBy[coredata.AuditOrderField]{
+			Field:     input.OrderBy.Field,
+			Direction: input.OrderBy.Direction,
+		}
+	}
+
+	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
+
+	page, err := r.proboSvc.Audits.ListForParentAuditID(ctx, scope, input.ParentAuditID, cursor)
+	if err != nil {
+		return nil, types.ListChildAuditsOutput{}, fmt.Errorf("cannot list child audits: %w", err)
+	}
+
+	return nil, types.NewListChildAuditsOutput(page), nil
 }

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -4659,6 +4659,9 @@ components:
         framework_id:
           $ref: "#/components/schemas/GID"
           description: Framework ID
+        parent_audit_id:
+          $ref: "#/components/schemas/GID"
+          description: Parent audit ID, when this audit belongs to a multi-year cycle
         name:
           type:
             - string
@@ -4765,6 +4768,37 @@ components:
           items:
             $ref: "#/components/schemas/Audit"
 
+    ListChildAuditsInput:
+      type: object
+      required:
+        - parent_audit_id
+      properties:
+        parent_audit_id:
+          $ref: "#/components/schemas/GID"
+          description: Parent audit ID
+        order_by:
+          $ref: "#/components/schemas/AuditOrderBy"
+          description: Audit order by
+        size:
+          type: integer
+          description: Page size
+        cursor:
+          $ref: "#/components/schemas/CursorKey"
+          description: Page cursor
+
+    ListChildAuditsOutput:
+      type: object
+      required:
+        - audits
+      properties:
+        next_cursor:
+          $ref: "#/components/schemas/CursorKey"
+          description: Next cursor
+        audits:
+          type: array
+          items:
+            $ref: "#/components/schemas/Audit"
+
     GetAuditInput:
       type: object
       required:
@@ -4794,6 +4828,9 @@ components:
         framework_id:
           $ref: "#/components/schemas/GID"
           description: Framework ID
+        parent_audit_id:
+          $ref: "#/components/schemas/GID"
+          description: Parent audit ID for multi-year cycles (e.g. ISO 27001)
         name:
           type: string
           description: Audit name
@@ -4836,6 +4873,13 @@ components:
         name:
           type: ["string", "null"]
           description: Audit name
+          go.probo.inc/mcpgen/omittable: true
+        parent_audit_id:
+          anyOf:
+            - type: string
+              $ref: "#/components/schemas/GID"
+            - type: "null"
+          description: Parent audit ID. Pass null to clear.
           go.probo.inc/mcpgen/omittable: true
         valid_from:
           type:
@@ -13253,6 +13297,15 @@ tools:
       $ref: "#/components/schemas/ListAuditsInput"
     outputSchema:
       $ref: "#/components/schemas/ListAuditsOutput"
+  - name: listChildAudits
+    description: List child audits belonging to a parent audit (e.g. annual and surveillance audits under an ISO 27001 cycle)
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/ListChildAuditsInput"
+    outputSchema:
+      $ref: "#/components/schemas/ListChildAuditsOutput"
   - name: getAudit
     description: Get an audit by ID
     hints:

--- a/pkg/server/api/mcp/v1/types/audit.go
+++ b/pkg/server/api/mcp/v1/types/audit.go
@@ -31,6 +31,7 @@ func NewAudit(a *coredata.Audit, file *coredata.File) *Audit {
 		Name:                       a.Name,
 		OrganizationID:             a.OrganizationID,
 		FrameworkID:                a.FrameworkID,
+		ParentAuditID:              a.ParentAuditID,
 		State:                      a.State,
 		CompliancePortalVisibility: a.CompliancePortalVisibility,
 		HasReport:                  a.ReportFileID != nil,
@@ -102,6 +103,25 @@ func NewListFindingAuditsOutput(auditPage *page.Page[*coredata.Audit, coredata.A
 	}
 
 	return ListFindingAuditsOutput{
+		NextCursor: nextCursor,
+		Audits:     audits,
+	}
+}
+
+func NewListChildAuditsOutput(auditPage *page.Page[*coredata.Audit, coredata.AuditOrderField]) ListChildAuditsOutput {
+	audits := make([]*Audit, 0, len(auditPage.Data))
+	for _, v := range auditPage.Data {
+		audits = append(audits, NewAudit(v, nil))
+	}
+
+	var nextCursor *page.CursorKey
+
+	if len(auditPage.Data) > 0 {
+		cursorKey := auditPage.Data[len(auditPage.Data)-1].CursorKey(auditPage.Cursor.OrderBy.Field)
+		nextCursor = &cursorKey
+	}
+
+	return ListChildAuditsOutput{
 		NextCursor: nextCursor,
 		Audits:     audits,
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audits can optionally reference a parent audit so multi-year cycles (e.g. ISO 27001) can group annual internal audits, certification, and surveillance audits under one cycle. Standalone audits like SOC 2 remain unchanged.

### Changes

- Add nullable `parent_audit_id` on `audits` (FK to self, `ON DELETE SET NULL`, no self-parent)
- Expose `parentAudit` / `childAudits` on GraphQL, plus `parentAuditId` on create/update
- Service validation: same organization, no self-parent, no cycles
- Sync MCP (`parent_audit_id`, `listChildAudits`), CLI (`--parent` / `--clear-parent`), and n8n
- Console UI: parent select on create/details, child list on details
- E2E coverage for GraphQL and MCP parent/child behavior

## Test plan

- [ ] Create a parent cycle audit and child audits with `parentAuditId`
- [ ] Confirm `childAudits` lists children and clearing parent works
- [ ] Confirm self-parent and cycle updates are rejected
- [ ] Confirm SOC 2-style audits without a parent still work as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddb50d1d-b9d6-471e-a437-7cfc7989ef75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddb50d1d-b9d6-471e-a437-7cfc7989ef75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Audits can now link to an optional parent audit. This enables grouping multi‑year cycles (e.g., ISO 27001) while leaving standalone audits unchanged.

### Coredata **`+117`** **`-0`**
- Add nullable `parent_audit_id` with FK (`ON DELETE SET NULL`) and not‑self constraint.
- Include parent in insert/update; add count/list by parent ID.

### Service **`+178`** **`-0`**
- Support `parentAuditId` on create/update; clearable on update.
- Validate same org, no self‑parent, and prevent ancestor cycles.
- Add list/count helpers for child audits.

### GraphQL API **`+81`** **`-0`**
- Add `parentAudit` and paginated `childAudits` fields; expose `parentAuditId` on create/update.
- Implement resolvers for parent/children and total counts.

### MCP **`+103`** **`-0`**
- Extend `addAudit`/`updateAudit` to accept `parentAuditId`.
- Add `listChildAudits` tool; update spec and types.

### prb (CLI) **`+28`** **`-0`**
- Add `--parent` to create/update and `--clear-parent` to remove the link.
- Show parent audit in `view`.

### App: console **`+177`** **`-70`**
- Add parent audit select (create/details) with self‑exclusion.
- Show child audits list with state badges and links.
- Update queries/fragments and i18n strings.

### Package: n8n-node **`+26`** **`-2`**
- Add “Parent Audit ID” to create/update operations.
- Return parent info in responses.

### Tests **`+218`** **`-0`**
- E2E coverage for parent/child GraphQL and MCP flows.
- Verify clearing parent works and reject self‑parent or cycles.
- Factory supports `parentAuditId`.

<sup>Written for commit 515a78ae7286276dc815cdafc522cdc36a025815. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

