### PR TITLE
Clear document mappings on soft delete

### DIFF
--- a/e2e/console/mapping_test.go
+++ b/e2e/console/mapping_test.go
@@ -728,6 +728,106 @@ func TestRiskDocumentMapping_CreateDelete(t *testing.T) {
 	})
 }
 
+func TestRiskDocumentMapping_DeleteDocumentClearsMappingAndAllowsRiskDelete(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	riskID := factory.NewRisk(owner).
+		WithName("Risk linked to deleted document").
+		Create()
+	documentID := factory.NewDocument(owner).
+		WithTitle("Document linked to risk").
+		Create()
+
+	_, err := owner.Do(`
+		mutation($input: CreateRiskDocumentMappingInput!) {
+			createRiskDocumentMapping(input: $input) {
+				riskEdge { node { id } }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"riskId":     riskID,
+			"documentId": documentID,
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = owner.Do(`
+		mutation DeleteDocument($input: DeleteDocumentInput!) {
+			deleteDocument(input: $input) {
+				deletedDocumentId
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{"documentId": documentID},
+	})
+	require.NoError(t, err)
+
+	_, err = owner.Do(`
+		mutation($input: DeleteRiskDocumentMappingInput!) {
+			deleteRiskDocumentMapping(input: $input) {
+				deletedRiskId
+				deletedDocumentId
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"riskId":     riskID,
+			"documentId": documentID,
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = owner.Do(`
+		mutation DeleteRisk($input: DeleteRiskInput!) {
+			deleteRisk(input: $input) {
+				deletedRiskId
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{"riskId": riskID},
+	})
+	require.NoError(t, err)
+}
+
+func TestRiskDocumentMapping_DeleteRiskWithActiveDocumentMapping(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	riskID := factory.NewRisk(owner).
+		WithName("Risk with active document link").
+		Create()
+	documentID := factory.NewDocument(owner).
+		WithTitle("Document still linked to risk").
+		Create()
+
+	_, err := owner.Do(`
+		mutation($input: CreateRiskDocumentMappingInput!) {
+			createRiskDocumentMapping(input: $input) {
+				riskEdge { node { id } }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"riskId":     riskID,
+			"documentId": documentID,
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = owner.Do(`
+		mutation DeleteRisk($input: DeleteRiskInput!) {
+			deleteRisk(input: $input) {
+				deletedRiskId
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{"riskId": riskID},
+	})
+	require.NoError(t, err)
+}
+
 func TestRiskObligationMapping_CreateDelete(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)

--- a/e2e/console/mapping_test.go
+++ b/e2e/console/mapping_test.go
@@ -728,7 +728,51 @@ func TestRiskDocumentMapping_CreateDelete(t *testing.T) {
 	})
 }
 
-func TestRiskDocumentMapping_DeleteDocumentClearsMappingAndAllowsRiskDelete(t *testing.T) {
+func loadRiskLinkedDocumentIDs(
+	t *testing.T,
+	owner *testutil.Client,
+	riskID string,
+) []string {
+	t.Helper()
+
+	var result struct {
+		Node struct {
+			Documents struct {
+				Edges []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"documents"`
+		} `json:"node"`
+	}
+
+	err := owner.Execute(`
+		query($id: ID!) {
+			node(id: $id) {
+				... on Risk {
+					documents(first: 10) {
+						edges {
+							node {
+								id
+							}
+						}
+					}
+				}
+			}
+		}
+	`, map[string]any{"id": riskID}, &result)
+	require.NoError(t, err)
+
+	ids := make([]string, 0, len(result.Node.Documents.Edges))
+	for _, edge := range result.Node.Documents.Edges {
+		ids = append(ids, edge.Node.ID)
+	}
+
+	return ids
+}
+
+func TestRiskDocumentMapping_DeleteDocumentClearsRiskDocumentLink(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 
@@ -753,6 +797,9 @@ func TestRiskDocumentMapping_DeleteDocumentClearsMappingAndAllowsRiskDelete(t *t
 	})
 	require.NoError(t, err)
 
+	linkedDocumentIDs := loadRiskLinkedDocumentIDs(t, owner, riskID)
+	require.Contains(t, linkedDocumentIDs, documentID)
+
 	_, err = owner.Do(`
 		mutation DeleteDocument($input: DeleteDocumentInput!) {
 			deleteDocument(input: $input) {
@@ -764,31 +811,9 @@ func TestRiskDocumentMapping_DeleteDocumentClearsMappingAndAllowsRiskDelete(t *t
 	})
 	require.NoError(t, err)
 
-	_, err = owner.Do(`
-		mutation($input: DeleteRiskDocumentMappingInput!) {
-			deleteRiskDocumentMapping(input: $input) {
-				deletedRiskId
-				deletedDocumentId
-			}
-		}
-	`, map[string]any{
-		"input": map[string]any{
-			"riskId":     riskID,
-			"documentId": documentID,
-		},
-	})
-	require.NoError(t, err)
-
-	_, err = owner.Do(`
-		mutation DeleteRisk($input: DeleteRiskInput!) {
-			deleteRisk(input: $input) {
-				deletedRiskId
-			}
-		}
-	`, map[string]any{
-		"input": map[string]any{"riskId": riskID},
-	})
-	require.NoError(t, err)
+	linkedDocumentIDs = loadRiskLinkedDocumentIDs(t, owner, riskID)
+	assert.NotContains(t, linkedDocumentIDs, documentID)
+	assert.Empty(t, linkedDocumentIDs)
 }
 
 func TestRiskDocumentMapping_DeleteRiskWithActiveDocumentMapping(t *testing.T) {

--- a/e2e/console/mapping_test.go
+++ b/e2e/console/mapping_test.go
@@ -814,9 +814,20 @@ func TestRiskDocumentMapping_DeleteDocumentClearsRiskDocumentLink(t *testing.T) 
 	linkedDocumentIDs = loadRiskLinkedDocumentIDs(t, owner, riskID)
 	assert.NotContains(t, linkedDocumentIDs, documentID)
 	assert.Empty(t, linkedDocumentIDs)
+
+	_, err = owner.Do(`
+		mutation DeleteRisk($input: DeleteRiskInput!) {
+			deleteRisk(input: $input) {
+				deletedRiskId
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{"riskId": riskID},
+	})
+	require.NoError(t, err)
 }
 
-func TestRiskDocumentMapping_DeleteRiskWithActiveDocumentMapping(t *testing.T) {
+func TestRiskDocumentMapping_DeleteRiskRequiresUnlinkedDocuments(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 
@@ -831,6 +842,32 @@ func TestRiskDocumentMapping_DeleteRiskWithActiveDocumentMapping(t *testing.T) {
 		mutation($input: CreateRiskDocumentMappingInput!) {
 			createRiskDocumentMapping(input: $input) {
 				riskEdge { node { id } }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"riskId":     riskID,
+			"documentId": documentID,
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = owner.Do(`
+		mutation DeleteRisk($input: DeleteRiskInput!) {
+			deleteRisk(input: $input) {
+				deletedRiskId
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{"riskId": riskID},
+	})
+	require.Error(t, err)
+
+	_, err = owner.Do(`
+		mutation($input: DeleteRiskDocumentMappingInput!) {
+			deleteRiskDocumentMapping(input: $input) {
+				deletedRiskId
+				deletedDocumentId
 			}
 		}
 	`, map[string]any{

--- a/pkg/coredata/migrations/20260729T150130Z.sql
+++ b/pkg/coredata/migrations/20260729T150130Z.sql
@@ -1,0 +1,43 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+DELETE FROM risks_documents rd
+WHERE EXISTS (
+    SELECT 1
+    FROM documents d
+    WHERE d.id = rd.document_id
+        AND d.deleted_at IS NOT NULL
+);
+
+DELETE FROM controls_documents cd
+WHERE EXISTS (
+    SELECT 1
+    FROM documents d
+    WHERE d.id = cd.document_id
+        AND d.deleted_at IS NOT NULL
+);
+
+DELETE FROM measures_documents md
+WHERE EXISTS (
+    SELECT 1
+    FROM documents d
+    WHERE d.id = md.document_id
+        AND d.deleted_at IS NOT NULL
+);

--- a/pkg/coredata/risk_document.go
+++ b/pkg/coredata/risk_document.go
@@ -108,33 +108,6 @@ WHERE
 	return err
 }
 
-func (rp RiskDocument) DeleteByRiskID(
-	ctx context.Context,
-	conn pg.Tx,
-	scope Scoper,
-	riskID gid.GID,
-) error {
-	q := `
-DELETE
-FROM
-    risks_documents
-WHERE
-    %s
-    AND risk_id = @risk_id;
-`
-
-	q = fmt.Sprintf(q, scope.SQLFragment())
-
-	args := pgx.StrictNamedArgs{
-		"risk_id": riskID,
-	}
-	maps.Copy(args, scope.SQLArguments())
-
-	_, err := conn.Exec(ctx, q, args)
-
-	return err
-}
-
 func (rp RiskDocument) DeleteByDocumentIDs(
 	ctx context.Context,
 	conn pg.Tx,

--- a/pkg/coredata/risk_document.go
+++ b/pkg/coredata/risk_document.go
@@ -108,6 +108,33 @@ WHERE
 	return err
 }
 
+func (rp RiskDocument) DeleteByRiskID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	riskID gid.GID,
+) error {
+	q := `
+DELETE
+FROM
+    risks_documents
+WHERE
+    %s
+    AND risk_id = @risk_id;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"risk_id": riskID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+
+	return err
+}
+
 func (rp RiskDocument) DeleteByDocumentIDs(
 	ctx context.Context,
 	conn pg.Tx,

--- a/pkg/probo/control_service.go
+++ b/pkg/probo/control_service.go
@@ -501,7 +501,7 @@ func (s ControlService) DeleteDocumentMapping(
 	documentID gid.GID,
 ) (*coredata.Control, *coredata.Document, error) {
 	control := &coredata.Control{}
-	document := &coredata.Document{}
+	document := &coredata.Document{ID: documentID}
 
 	err := s.svc.pg.WithTx(
 		ctx,
@@ -511,11 +511,13 @@ func (s ControlService) DeleteDocumentMapping(
 			}
 
 			if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
-				return fmt.Errorf("cannot load document: %w", err)
+				if !errors.Is(err, coredata.ErrResourceNotFound) {
+					return fmt.Errorf("cannot load document: %w", err)
+				}
 			}
 
 			controlDocument := &coredata.ControlDocument{}
-			if err := controlDocument.Delete(ctx, tx, scope, control.ID, document.ID); err != nil {
+			if err := controlDocument.Delete(ctx, tx, scope, control.ID, documentID); err != nil {
 				return fmt.Errorf("cannot delete control document mapping: %w", err)
 			}
 

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -1598,6 +1598,10 @@ func (s *DocumentService) SoftDelete(
 				return fmt.Errorf("cannot emit document deleted webhook: %w", err)
 			}
 
+			if err := s.deleteDocumentEntityMappings(ctx, scope, tx, []gid.GID{documentID}); err != nil {
+				return err
+			}
+
 			if err := s.clearDocumentReferences(ctx, scope, tx, []gid.GID{documentID}); err != nil {
 				return err
 			}
@@ -1622,6 +1626,10 @@ func (s *DocumentService) BulkSoftDelete(
 		func(ctx context.Context, tx pg.Tx) error {
 			if err := s.emitDocumentLifecycleEventsInTx(ctx, scope, tx, documentIDs, coredata.WebhookEventTypeDocumentDeleted); err != nil {
 				return fmt.Errorf("cannot emit document deleted webhooks: %w", err)
+			}
+
+			if err := s.deleteDocumentEntityMappings(ctx, scope, tx, documentIDs); err != nil {
+				return err
 			}
 
 			if err := s.clearDocumentReferences(ctx, scope, tx, documentIDs); err != nil {
@@ -1652,19 +1660,8 @@ func (s *DocumentService) BulkArchive(
 				}
 			}
 
-			controlDocument := coredata.ControlDocument{}
-			if err := controlDocument.DeleteByDocumentIDs(ctx, tx, scope, documentIDs); err != nil {
-				return fmt.Errorf("cannot delete control mappings: %w", err)
-			}
-
-			riskDocument := coredata.RiskDocument{}
-			if err := riskDocument.DeleteByDocumentIDs(ctx, tx, scope, documentIDs); err != nil {
-				return fmt.Errorf("cannot delete risk mappings: %w", err)
-			}
-
-			measureDocument := coredata.MeasureDocument{}
-			if err := measureDocument.DeleteByDocumentIDs(ctx, tx, scope, documentIDs); err != nil {
-				return fmt.Errorf("cannot delete measure mappings: %w", err)
+			if err := s.deleteDocumentEntityMappings(ctx, scope, tx, documentIDs); err != nil {
+				return err
 			}
 
 			if err := s.clearDocumentReferences(ctx, scope, tx, documentIDs); err != nil {
@@ -1714,6 +1711,33 @@ func (s *DocumentService) BulkUnarchive(
 			return nil
 		},
 	)
+}
+
+func (s *DocumentService) deleteDocumentEntityMappings(
+	ctx context.Context, scope coredata.Scoper,
+	tx pg.Tx,
+	documentIDs []gid.GID,
+) error {
+	if len(documentIDs) == 0 {
+		return nil
+	}
+
+	controlDocument := coredata.ControlDocument{}
+	if err := controlDocument.DeleteByDocumentIDs(ctx, tx, scope, documentIDs); err != nil {
+		return fmt.Errorf("cannot delete control mappings: %w", err)
+	}
+
+	riskDocument := coredata.RiskDocument{}
+	if err := riskDocument.DeleteByDocumentIDs(ctx, tx, scope, documentIDs); err != nil {
+		return fmt.Errorf("cannot delete risk mappings: %w", err)
+	}
+
+	measureDocument := coredata.MeasureDocument{}
+	if err := measureDocument.DeleteByDocumentIDs(ctx, tx, scope, documentIDs); err != nil {
+		return fmt.Errorf("cannot delete measure mappings: %w", err)
+	}
+
+	return nil
 }
 
 // clearDocumentReferences nullifies references to the given document IDs in
@@ -2476,19 +2500,8 @@ func (s *DocumentService) Archive(
 				return err
 			}
 
-			controlDocument := coredata.ControlDocument{}
-			if err := controlDocument.DeleteByDocumentIDs(ctx, tx, scope, []gid.GID{documentID}); err != nil {
-				return fmt.Errorf("cannot delete control mappings: %w", err)
-			}
-
-			riskDocument := coredata.RiskDocument{}
-			if err := riskDocument.DeleteByDocumentIDs(ctx, tx, scope, []gid.GID{documentID}); err != nil {
-				return fmt.Errorf("cannot delete risk mappings: %w", err)
-			}
-
-			measureDocument := coredata.MeasureDocument{}
-			if err := measureDocument.DeleteByDocumentIDs(ctx, tx, scope, []gid.GID{documentID}); err != nil {
-				return fmt.Errorf("cannot delete measure mappings: %w", err)
+			if err := s.deleteDocumentEntityMappings(ctx, scope, tx, []gid.GID{documentID}); err != nil {
+				return err
 			}
 
 			if err := s.clearDocumentReferences(ctx, scope, tx, []gid.GID{documentID}); err != nil {

--- a/pkg/probo/measure_service.go
+++ b/pkg/probo/measure_service.go
@@ -789,7 +789,7 @@ func (s MeasureService) DeleteDocumentMapping(
 	documentID gid.GID,
 ) (*coredata.Measure, *coredata.Document, error) {
 	measure := &coredata.Measure{}
-	document := &coredata.Document{}
+	document := &coredata.Document{ID: documentID}
 
 	err := s.svc.pg.WithTx(
 		ctx,
@@ -799,11 +799,13 @@ func (s MeasureService) DeleteDocumentMapping(
 			}
 
 			if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
-				return fmt.Errorf("cannot load document: %w", err)
+				if !errors.Is(err, coredata.ErrResourceNotFound) {
+					return fmt.Errorf("cannot load document: %w", err)
+				}
 			}
 
 			measureDocument := &coredata.MeasureDocument{}
-			if err := measureDocument.Delete(ctx, tx, scope, measure.ID, document.ID); err != nil {
+			if err := measureDocument.Delete(ctx, tx, scope, measure.ID, documentID); err != nil {
 				return fmt.Errorf("cannot delete measure document mapping: %w", err)
 			}
 

--- a/pkg/probo/risk_service.go
+++ b/pkg/probo/risk_service.go
@@ -612,15 +612,10 @@ func (s RiskService) Delete(
 	riskID gid.GID,
 ) error {
 	risk := &coredata.Risk{}
-	riskDocument := &coredata.RiskDocument{}
 
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := riskDocument.DeleteByRiskID(ctx, tx, scope, riskID); err != nil {
-				return fmt.Errorf("cannot delete risk document mappings: %w", err)
-			}
-
 			return risk.Delete(ctx, tx, scope, riskID)
 		},
 	)

--- a/pkg/probo/risk_service.go
+++ b/pkg/probo/risk_service.go
@@ -249,7 +249,7 @@ func (s RiskService) DeleteDocumentMapping(
 ) (*coredata.Risk, *coredata.Document, error) {
 	riskDocument := &coredata.RiskDocument{}
 	risk := &coredata.Risk{}
-	document := &coredata.Document{}
+	document := &coredata.Document{ID: documentID}
 
 	err := s.svc.pg.WithTx(
 		ctx,
@@ -259,10 +259,12 @@ func (s RiskService) DeleteDocumentMapping(
 			}
 
 			if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
-				return fmt.Errorf("cannot load document: %w", err)
+				if !errors.Is(err, coredata.ErrResourceNotFound) {
+					return fmt.Errorf("cannot load document: %w", err)
+				}
 			}
 
-			return riskDocument.Delete(ctx, tx, scope, risk.ID, document.ID)
+			return riskDocument.Delete(ctx, tx, scope, risk.ID, documentID)
 		},
 	)
 	if err != nil {
@@ -610,10 +612,15 @@ func (s RiskService) Delete(
 	riskID gid.GID,
 ) error {
 	risk := &coredata.Risk{}
+	riskDocument := &coredata.RiskDocument{}
 
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
+			if err := riskDocument.DeleteByRiskID(ctx, tx, scope, riskID); err != nil {
+				return fmt.Errorf("cannot delete risk document mappings: %w", err)
+			}
+
 			return risk.Delete(ctx, tx, scope, riskID)
 		},
 	)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [ENG-662](https://linear.app/probo/issue/ENG-662): deleting documents left rows in `risks_documents` (and related junction tables), which blocked `deleteRisk` and caused `unlinkRisk` to fail with `cannot load document: resource not found` for already-deleted documents.

## Changes

- **`SoftDelete` / `BulkSoftDelete`**: remove control, risk, and measure document mappings (same behavior archive already had), via shared `deleteDocumentEntityMappings`.
- **`deleteRisk`**: delete `risks_documents` rows for the risk before removing the risk, so leftover mappings no longer cause FK errors.
- **`unlinkRisk` / document mapping delete** (risk, control, measure): delete the junction row even when the document is soft-deleted or missing.
- **Migration**: delete orphaned junction rows that still reference soft-deleted documents.
- **E2E**: cover document delete clearing mappings and risk delete with an active document link.

## Verification

- `go test ./pkg/coredata/... -short` passes locally.
- Full e2e (`TestRiskDocumentMapping_*`) not run in this environment (probo package build requires email assets).

After deploy, affected risks should be deletable via MCP/console without manual DB cleanup; the migration cleans existing orphan links on migrate.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-662](https://linear.app/probo/issue/ENG-662/deleted-documents-leave-orphaned-risk-links-blocking-deletion)

<div><a href="https://cursor.com/agents/bc-299ee5c2-6c61-4982-b0fa-94e75d1e761c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-299ee5c2-6c61-4982-b0fa-94e75d1e761c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears control/risk/measure document mappings when documents are soft-deleted or archived, and requires risks to be unlinked from documents before deletion. Fixes ENG-662 and migrates existing orphan mapping rows.

### Tests **`+162`** **`-0`**
- Verify deleteDocument clears risk links and risk.documents is empty.
- Ensure deleteRisk fails with active document links and succeeds after unlink.

### Coredata **`+43`** **`-0`**
- Migration removes junction rows referencing soft-deleted documents in `risks_documents`, `controls_documents`, and `measures_documents`.

### Service **`+54`** **`-35`**
- SoftDelete/BulkSoftDelete remove entity mappings via shared deleteDocumentEntityMappings; Archive/BulkArchive use the same helper.
- Risk/Control/Measure delete-mapping endpoints tolerate missing or soft-deleted documents and delete by the provided documentID.

<sup>Written for commit 255bea47386c15b52539003e02e2a46beefac719. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

