### PR TITLE
Allow closing access reviews when a connector fetch fails

### DIFF
--- a/apps/console/src/pages/organizations/access-reviews/_components/accessReviewHelpers.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/_components/accessReviewHelpers.tsx
@@ -52,6 +52,49 @@ export function fetchStatusBadgeVariant(status: string): BadgeVariant {
   }
 }
 
+type CampaignSourcePendingCloseCount = {
+  id: string;
+  fetchAttempts: {
+    edges: ReadonlyArray<{
+      node: { status: string };
+    }>;
+  };
+  entries?: {
+    edges: ReadonlyArray<{
+      node: { decision: string };
+    }>;
+  } | null;
+};
+
+/** Pending decisions that still block closing the campaign (mirrors backend). */
+export function countPendingEntriesBlockingClose(
+  totalPendingCount: number,
+  sources: ReadonlyArray<CampaignSourcePendingCloseCount>,
+): number {
+  const failedSourceIds = new Set(
+    sources
+      .filter(source => source.fetchAttempts.edges[0]?.node.status === "FAILED")
+      .map(source => source.id),
+  );
+
+  if (failedSourceIds.size === 0) {
+    return totalPendingCount;
+  }
+
+  let pendingOnFailedSources = 0;
+  for (const source of sources) {
+    if (!failedSourceIds.has(source.id)) {
+      continue;
+    }
+
+    pendingOnFailedSources += (source.entries?.edges ?? []).filter(
+      edge => edge.node.decision === "PENDING",
+    ).length;
+  }
+
+  return Math.max(0, totalPendingCount - pendingOnFailedSources);
+}
+
 export function statusLabel(
   t: (key: string) => string,
   status: string,

--- a/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
@@ -65,6 +65,7 @@ import { useOrganizationId } from "#/hooks/useOrganizationId";
 
 import { AccessEntryRolesCell } from "../_components/AccessEntryRolesCell";
 import {
+  countPendingEntriesBlockingClose,
   decisionBadgeVariant,
   fetchStatusBadgeVariant,
   flagBadgeVariant,
@@ -226,7 +227,7 @@ export default function CampaignDetailPage({ queryRef }: Props) {
   }, [campaign.id]);
 
   useEffect(() => {
-    if (!isInProgress) return;
+    if (!isInProgress && !isPendingActions) return;
     const interval = setInterval(() => {
       if (document.hidden) return;
       fetchQuery<CampaignDetailPageQuery>(
@@ -237,7 +238,7 @@ export default function CampaignDetailPage({ queryRef }: Props) {
       ).subscribe({});
     }, 3000);
     return () => clearInterval(interval);
-  }, [isInProgress, environment]);
+  }, [isInProgress, isPendingActions, environment]);
   const existingCampaignSourceIds = useMemo(
     () => campaign.sources.flatMap(s => s.source?.id ? [s.source.id] : []),
     [campaign.sources],
@@ -254,7 +255,11 @@ export default function CampaignDetailPage({ queryRef }: Props) {
   const [deleteCampaign, isDeleting]
     = useMutation<CampaignDetailPageDeleteMutation>(deleteCampaignMutation);
 
-  const canComplete = campaign.pendingEntries.totalCount === 0;
+  const pendingBlockingClose = countPendingEntriesBlockingClose(
+    campaign.pendingEntries.totalCount,
+    campaign.sources,
+  );
+  const canComplete = pendingBlockingClose === 0;
 
   const handleStart = () => {
     startCampaign({

--- a/pkg/accessreview/campaign_close_test.go
+++ b/pkg/accessreview/campaign_close_test.go
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package accessreview_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/internal/test"
+	"go.probo.inc/probo/pkg/accessreview"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+func TestCloseCampaign_IgnoresPendingOnFailedSourceFetch(t *testing.T) {
+	t.Parallel()
+
+	client := test.PGClient(t)
+	ctx := context.Background()
+	fx := seedCampaignCloseFixture(t, ctx, client)
+
+	tenantID := fx.scope.GetTenantID()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	failureMsg := "We couldn't fetch accounts from this source."
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		failedAttempt := &coredata.AccessReviewCampaignSourceFetchAttempt{
+			ID:                           gid.New(tenantID, coredata.AccessReviewCampaignSourceFetchAttemptEntityType),
+			OrganizationID:               fx.organizationID,
+			AccessReviewCampaignSourceID: fx.failedCampaignSourceID,
+			Status:                       coredata.AccessReviewCampaignSourceFetchStatusFailed,
+			Error:                        &failureMsg,
+			CompletedAt:                  &now,
+			CreatedAt:                    now,
+			UpdatedAt:                    now,
+		}
+		if err := failedAttempt.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		successAttempt := &coredata.AccessReviewCampaignSourceFetchAttempt{
+			ID:                           gid.New(tenantID, coredata.AccessReviewCampaignSourceFetchAttemptEntityType),
+			OrganizationID:               fx.organizationID,
+			AccessReviewCampaignSourceID: fx.successCampaignSourceID,
+			Status:                       coredata.AccessReviewCampaignSourceFetchStatusSuccess,
+			FetchedAccountsCount:         1,
+			CompletedAt:                  &now,
+			CreatedAt:                    now,
+			UpdatedAt:                    now,
+		}
+		if err := successAttempt.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		pendingOnFailed := &coredata.AccessReviewEntry{
+			ID:                           gid.New(tenantID, coredata.AccessReviewEntryEntityType),
+			OrganizationID:               fx.organizationID,
+			AccessReviewCampaignID:       fx.campaignID,
+			AccessReviewCampaignSourceID: fx.failedCampaignSourceID,
+			Email:                        "orphan@example.com",
+			FullName:                     "Orphan",
+			Roles:                        []string{"member"},
+			MFAStatus:                    coredata.MFAStatusUnknown,
+			AuthMethod:                   coredata.AccessReviewEntryAuthMethodUnknown,
+			AccountType:                  coredata.AccessReviewEntryAccountTypeUser,
+			ExternalID:                   "orphan",
+			AccountKey:                   "orphan@example.com",
+			IncrementalTag:               coredata.AccessReviewEntryIncrementalTagNew,
+			Flags:                        []coredata.AccessReviewEntryFlag{},
+			FlagReasons:                  []string{},
+			Decision:                     coredata.AccessReviewEntryDecisionPending,
+			CreatedAt:                    now,
+			UpdatedAt:                    now,
+		}
+		if err := pendingOnFailed.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		decidedOnSuccess := &coredata.AccessReviewEntry{
+			ID:                           gid.New(tenantID, coredata.AccessReviewEntryEntityType),
+			OrganizationID:               fx.organizationID,
+			AccessReviewCampaignID:       fx.campaignID,
+			AccessReviewCampaignSourceID: fx.successCampaignSourceID,
+			Email:                        "reviewed@example.com",
+			FullName:                     "Reviewed",
+			Roles:                        []string{"member"},
+			MFAStatus:                    coredata.MFAStatusUnknown,
+			AuthMethod:                   coredata.AccessReviewEntryAuthMethodUnknown,
+			AccountType:                  coredata.AccessReviewEntryAccountTypeUser,
+			ExternalID:                   "reviewed",
+			AccountKey:                   "reviewed@example.com",
+			IncrementalTag:               coredata.AccessReviewEntryIncrementalTagNew,
+			Flags:                        []coredata.AccessReviewEntryFlag{},
+			FlagReasons:                  []string{},
+			Decision:                     coredata.AccessReviewEntryDecisionApproved,
+			CreatedAt:                    now,
+			UpdatedAt:                    now,
+		}
+
+		return decidedOnSuccess.Upsert(ctx, tx, fx.scope)
+	}))
+
+	svc := accessreview.NewService(client, nil, nil, nil, nil)
+
+	campaign, err := svc.CloseCampaign(ctx, fx.scope, fx.campaignID)
+	require.NoError(t, err)
+	assert.Equal(t, coredata.AccessReviewCampaignStatusCompleted, campaign.Status)
+}
+
+type campaignCloseFixture struct {
+	scope                   coredata.Scoper
+	organizationID          gid.GID
+	sourceID                gid.GID
+	campaignID              gid.GID
+	successCampaignSourceID gid.GID
+	failedCampaignSourceID  gid.GID
+}
+
+func seedCampaignCloseFixture(
+	t *testing.T,
+	ctx context.Context,
+	client *pg.Client,
+) campaignCloseFixture {
+	t.Helper()
+
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+	campaignID := gid.New(tenantID, coredata.AccessReviewCampaignEntityType)
+	sourceID := gid.New(tenantID, coredata.AccessReviewSourceEntityType)
+	successCampaignSourceID := gid.New(tenantID, coredata.AccessReviewCampaignSourceEntityType)
+	failedCampaignSourceID := gid.New(tenantID, coredata.AccessReviewCampaignSourceEntityType)
+	now := time.Now().UTC()
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		org := &coredata.Organization{
+			ID:        organizationID,
+			TenantID:  tenantID,
+			Name:      "Close Campaign Test Org",
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		if err := org.Insert(ctx, tx); err != nil {
+			return err
+		}
+
+		source := &coredata.AccessReviewSource{
+			ID:             sourceID,
+			OrganizationID: organizationID,
+			Name:           "Close Campaign Test Source",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		if err := source.Insert(ctx, tx, scope); err != nil {
+			return err
+		}
+
+		campaign := &coredata.AccessReviewCampaign{
+			ID:             campaignID,
+			OrganizationID: organizationID,
+			Name:           "Close Campaign Test",
+			Status:         coredata.AccessReviewCampaignStatusPendingActions,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		if err := campaign.Insert(ctx, tx, scope); err != nil {
+			return err
+		}
+
+		successSource := &coredata.AccessReviewCampaignSource{
+			ID:                     successCampaignSourceID,
+			OrganizationID:         organizationID,
+			AccessReviewCampaignID: campaignID,
+			AccessReviewSourceID:   &sourceID,
+			Name:                   "Success Snapshot",
+			CreatedAt:              now,
+			UpdatedAt:              now,
+		}
+		if err := successSource.Upsert(ctx, tx, scope); err != nil {
+			return err
+		}
+
+		failedSource := &coredata.AccessReviewCampaignSource{
+			ID:                     failedCampaignSourceID,
+			OrganizationID:         organizationID,
+			AccessReviewCampaignID: campaignID,
+			AccessReviewSourceID:   &sourceID,
+			Name:                   "Failed Snapshot",
+			CreatedAt:              now,
+			UpdatedAt:              now,
+		}
+
+		return failedSource.Upsert(ctx, tx, scope)
+	}))
+
+	t.Cleanup(func() {
+		_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
+			_, err := tx.Exec(ctx, `DELETE FROM access_review_campaign_source_fetch_attempts WHERE access_review_campaign_source_id = ANY($1)`, []gid.GID{successCampaignSourceID, failedCampaignSourceID})
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.Exec(ctx, `DELETE FROM access_review_entries WHERE access_review_campaign_id = $1`, campaignID)
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.Exec(ctx, `DELETE FROM access_review_campaign_sources WHERE access_review_campaign_id = $1`, campaignID)
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.Exec(ctx, `DELETE FROM access_review_campaigns WHERE id = $1`, campaignID)
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.Exec(ctx, `DELETE FROM access_review_sources WHERE id = $1`, sourceID)
+			if err != nil {
+				return err
+			}
+
+			_, err = tx.Exec(ctx, `DELETE FROM organizations WHERE id = $1`, organizationID)
+
+			return err
+		})
+	})
+
+	return campaignCloseFixture{
+		scope:                   scope,
+		organizationID:          organizationID,
+		sourceID:                sourceID,
+		campaignID:              campaignID,
+		successCampaignSourceID: successCampaignSourceID,
+		failedCampaignSourceID:  failedCampaignSourceID,
+	}
+}

--- a/pkg/accessreview/campaign_service.go
+++ b/pkg/accessreview/campaign_service.go
@@ -401,17 +401,11 @@ func (s *Service) CloseCampaign(
 				return NewCampaignNotPendingActionsError(campaign.ID)
 			}
 
-			entries := coredata.AccessReviewEntries{}
-			filter := &coredata.AccessReviewEntryFilter{
-				Decision: new(coredata.AccessReviewEntryDecisionPending),
-			}
-
-			pendingCount, err := entries.CountByCampaignID(
+			pendingCount, err := countPendingEntriesBlockingClose(
 				ctx,
 				conn,
 				scope,
 				campaignID,
-				filter,
 			)
 			if err != nil {
 				return fmt.Errorf("cannot count pending entries: %w", err)
@@ -438,6 +432,63 @@ func (s *Service) CloseCampaign(
 	}
 
 	return campaign, nil
+}
+
+// countPendingEntriesBlockingClose returns pending entry decisions that still
+// block closing the campaign. Entries on sources whose latest fetch failed are
+// excluded: the connector could not be reached and reviewers proceed on the
+// sources that succeeded.
+func countPendingEntriesBlockingClose(
+	ctx context.Context,
+	conn pg.Tx,
+	scope coredata.Scoper,
+	campaignID gid.GID,
+) (int, error) {
+	latest := coredata.AccessReviewCampaignSourceFetchAttempts{}
+	if err := latest.LoadLatestByCampaignID(ctx, conn, scope, campaignID); err != nil {
+		return 0, fmt.Errorf("cannot load latest fetch attempts: %w", err)
+	}
+
+	failedSourceIDs := make([]gid.GID, 0, len(latest))
+	for _, attempt := range latest {
+		if attempt.Status == coredata.AccessReviewCampaignSourceFetchStatusFailed {
+			failedSourceIDs = append(failedSourceIDs, attempt.AccessReviewCampaignSourceID)
+		}
+	}
+
+	entries := coredata.AccessReviewEntries{}
+	filter := &coredata.AccessReviewEntryFilter{
+		Decision: new(coredata.AccessReviewEntryDecisionPending),
+	}
+
+	pendingCount, err := entries.CountByCampaignID(
+		ctx,
+		conn,
+		scope,
+		campaignID,
+		filter,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("cannot count pending entries: %w", err)
+	}
+
+	for _, sourceID := range failedSourceIDs {
+		failedSourcePending, err := entries.CountByCampaignIDAndSourceID(
+			ctx,
+			conn,
+			scope,
+			campaignID,
+			sourceID,
+			filter,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("cannot count pending entries for source: %w", err)
+		}
+
+		pendingCount -= failedSourcePending
+	}
+
+	return pendingCount, nil
 }
 
 func lockCampaignForUpdate(ctx context.Context, tx pg.Tx, scope coredata.Scoper, campaignID gid.GID) error {

--- a/pkg/accessreview/worker.go
+++ b/pkg/accessreview/worker.go
@@ -24,8 +24,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
 	"go.gearno.de/kit/worker"
@@ -140,32 +142,52 @@ func (h *sourceFetchHandler) handle(
 
 	campaignSource := &coredata.AccessReviewCampaignSource{}
 	if err := h.loadCampaignSource(ctx, scope, attempt.AccessReviewCampaignSourceID, campaignSource); err != nil {
-		commitErr := h.commitFailedSourceFetch(ctx, attempt, fmt.Errorf("cannot load campaign source: %w", err))
-		if commitErr != nil {
-			return fmt.Errorf("cannot load campaign source: %w, and cannot commit failed fetch attempt: %w", err, commitErr)
+		failureErr := fmt.Errorf("cannot load campaign source: %w", err)
+		campaignID, idErr := h.loadCampaignIDForCampaignSource(
+			ctx,
+			scope,
+			attempt.AccessReviewCampaignSourceID,
+		)
+		if idErr != nil {
+			campaignID = gid.Nil
 		}
 
-		return fmt.Errorf("cannot load campaign source: %w", err)
+		if finalizeErr := h.failAttemptAndFinalizeCampaign(
+			ctx,
+			attempt,
+			campaignID,
+			failureErr,
+		); finalizeErr != nil {
+			return fmt.Errorf("cannot load campaign source: %w, and cannot commit failed fetch attempt: %w", err, finalizeErr)
+		}
+
+		return nil
 	}
 
 	campaign, err := h.svc.GetCampaign(ctx, scope, campaignSource.AccessReviewCampaignID)
 	if err != nil {
-		commitErr := h.commitFailedSourceFetch(ctx, attempt, fmt.Errorf("cannot load campaign: %w", err))
-		if commitErr != nil {
-			return fmt.Errorf("cannot load campaign: %w, and cannot commit failed fetch attempt: %w", err, commitErr)
+		failureErr := fmt.Errorf("cannot load campaign: %w", err)
+		if finalizeErr := h.failAttemptAndFinalizeCampaign(
+			ctx,
+			attempt,
+			campaignSource.AccessReviewCampaignID,
+			failureErr,
+		); finalizeErr != nil {
+			return fmt.Errorf("cannot load campaign: %w, and cannot commit failed fetch attempt: %w", err, finalizeErr)
 		}
 
-		return fmt.Errorf("cannot load campaign: %w", err)
+		return nil
 	}
 
 	count, err := h.svc.FetchSource(ctx, scope, campaign, campaignSource)
 	if err != nil {
-		if commitErr := h.commitFailedSourceFetch(ctx, attempt, err); commitErr != nil {
-			return fmt.Errorf("cannot fetch source: %w, and cannot commit failed fetch attempt: %w", err, commitErr)
-		}
-
-		if finalizeErr := h.finalizeCampaignFetchLifecycle(ctx, attempt.TenantID, campaignSource.AccessReviewCampaignID); finalizeErr != nil {
-			return fmt.Errorf("cannot finalize campaign after failed fetch attempt: %w", finalizeErr)
+		if finalizeErr := h.failAttemptAndFinalizeCampaign(
+			ctx,
+			attempt,
+			campaignSource.AccessReviewCampaignID,
+			err,
+		); finalizeErr != nil {
+			return fmt.Errorf("cannot fetch source: %w, and cannot commit failed fetch attempt: %w", err, finalizeErr)
 		}
 
 		return nil
@@ -196,9 +218,66 @@ func (h *sourceFetchHandler) loadCampaignSource(
 	)
 }
 
+func (h *sourceFetchHandler) loadCampaignIDForCampaignSource(
+	ctx context.Context,
+	scope coredata.Scoper,
+	campaignSourceID gid.GID,
+) (gid.GID, error) {
+	var campaignID gid.GID
+
+	err := h.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			q := `
+SELECT access_review_campaign_id
+FROM access_review_campaign_sources
+WHERE
+	%s
+	AND id = @campaign_source_id
+`
+			q = fmt.Sprintf(q, scope.SQLFragment())
+
+			args := pgx.StrictNamedArgs{"campaign_source_id": campaignSourceID}
+			maps.Copy(args, scope.SQLArguments())
+
+			if err := conn.QueryRow(ctx, q, args).Scan(&campaignID); err != nil {
+				return fmt.Errorf("cannot load campaign id for source: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return gid.Nil, err
+	}
+
+	return campaignID, nil
+}
+
 // commitFailedSourceFetch marks the in-flight attempt as failed with a generic,
 // user-facing message and logs the raw error so the internal detail stays in the
 // logs only.
+func (h *sourceFetchHandler) failAttemptAndFinalizeCampaign(
+	ctx context.Context,
+	attempt *coredata.AccessReviewCampaignSourceFetchAttempt,
+	campaignID gid.GID,
+	failureErr error,
+) error {
+	if err := h.commitFailedSourceFetch(ctx, attempt, failureErr); err != nil {
+		return err
+	}
+
+	if campaignID == gid.Nil {
+		return nil
+	}
+
+	if err := h.finalizeCampaignFetchLifecycle(ctx, attempt.TenantID, campaignID); err != nil {
+		return fmt.Errorf("cannot finalize campaign after failed fetch attempt: %w", err)
+	}
+
+	return nil
+}
+
 func (h *sourceFetchHandler) commitFailedSourceFetch(
 	ctx context.Context,
 	attempt *coredata.AccessReviewCampaignSourceFetchAttempt,
@@ -278,12 +357,21 @@ func (h *sourceFetchHandler) finalizeCampaignFetchLifecycle(
 				return nil
 			}
 
+			var campaignSources coredata.AccessReviewCampaignSources
+			if err := campaignSources.LoadByCampaignID(ctx, tx, scope, campaignID); err != nil {
+				return fmt.Errorf("cannot load campaign sources: %w", err)
+			}
+
+			if len(campaignSources) == 0 {
+				return nil
+			}
+
 			latest := coredata.AccessReviewCampaignSourceFetchAttempts{}
 			if err := latest.LoadLatestByCampaignID(ctx, tx, scope, campaignID); err != nil {
 				return fmt.Errorf("cannot load latest fetch attempts: %w", err)
 			}
 
-			if len(latest) == 0 {
+			if len(latest) != len(campaignSources) {
 				return nil
 			}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [ENG-661](https://linear.app/probo/issue/ENG-661/cant-close-access-review-when-one-connection-failed): reviewers could finish every reachable account decision but still could not complete a campaign when one connector/source fetch failed.

- **Backend:** `CloseCampaign` ignores pending decisions on campaign sources whose **latest fetch attempt is `FAILED`**, so a broken connector no longer blocks closure after successful sources are reviewed.
- **Worker:** Every failed fetch attempt now runs campaign lifecycle finalization (not only `FetchSource` errors), and a campaign moves to `PENDING_ACTIONS` only when **each** campaign source has a latest fetch attempt and all of those are terminal.
- **Console:** The Complete campaign button uses the same pending-count rule as the API, and the detail page refreshes while `PENDING_ACTIONS` so pending counts stay in sync after decisions.

## Test plan

- [ ] Start a campaign with multiple sources; force one connector fetch to fail and complete decisions on the others → **Complete campaign** succeeds.
- [ ] Regression: campaign with all sources succeeding still requires every pending entry to be decided before close.
- [ ] `go test ./pkg/accessreview/...` (integration test `TestCloseCampaign_IgnoresPendingOnFailedSourceFetch` when Postgres is available)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-661](https://linear.app/probo/issue/ENG-661/cant-close-access-review-when-one-connection-failed)

<div><a href="https://cursor.com/agents/bc-cbd0c13b-0590-4329-9924-237bc3d3ddea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbd0c13b-0590-4329-9924-237bc3d3ddea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows closing access review campaigns even if a connector fetch failed, by ignoring pending decisions on those failed sources. Addresses ENG-661 so API, worker, and console use the same rule.

### Service **`+161`** **`-22`**
- `CloseCampaign` subtracts pending entries from sources whose latest fetch is `FAILED` (via `countPendingEntriesBlockingClose`).
- Worker finalizes the campaign after any failed fetch attempt and moves to `PENDING_ACTIONS` only when every source has a latest attempt.
- Adds `failAttemptAndFinalizeCampaign` and `loadCampaignIDForCampaignSource` to handle failures more reliably.

### App: console **`+51`** **`-3`**
- Adds `countPendingEntriesBlockingClose` to mirror backend logic for pending counts.
- `CampaignDetailPage` enables Complete only when blocking pending count is zero and auto-refreshes while `PENDING_ACTIONS`.

### Tests **`+259`** **`-0`**
- Adds `TestCloseCampaign_IgnoresPendingOnFailedSourceFetch` to verify pending entries on failed sources do not block close.

<sup>Written for commit e4b877b51ca07a87bdc0e855239ff13d50541e40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

