### PR TITLE
Allow deleting access review campaigns except in progress

### DIFF
--- a/apps/console/src/pages/organizations/access-reviews/campaigns/AccessReviewCampaignsTab.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/AccessReviewCampaignsTab.tsx
@@ -132,9 +132,9 @@ export default function AccessReviewCampaignsTab({ queryRef }: Props) {
     deleteCampaignMutation,
   );
 
-  // Only DRAFT and CANCELLED campaigns can be deleted (enforced by the backend).
+  // Only DRAFT, CANCELLED, and COMPLETED campaigns can be deleted (enforced by the backend).
   const isDeletableStatus = (status: string) =>
-    status === "DRAFT" || status === "CANCELLED";
+    status === "DRAFT" || status === "CANCELLED" || status === "COMPLETED";
 
   const handleDelete = (campaignId: string, campaignName: string) => {
     confirm(

--- a/apps/console/src/pages/organizations/access-reviews/campaigns/AccessReviewCampaignsTab.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/AccessReviewCampaignsTab.tsx
@@ -132,10 +132,6 @@ export default function AccessReviewCampaignsTab({ queryRef }: Props) {
     deleteCampaignMutation,
   );
 
-  // Only DRAFT, CANCELLED, and COMPLETED campaigns can be deleted (enforced by the backend).
-  const isDeletableStatus = (status: string) =>
-    status === "DRAFT" || status === "CANCELLED" || status === "COMPLETED";
-
   const handleDelete = (campaignId: string, campaignName: string) => {
     confirm(
       () => {
@@ -182,9 +178,7 @@ export default function AccessReviewCampaignsTab({ queryRef }: Props) {
     );
   };
 
-  const hasActions = accessReviewCampaigns.edges.some(
-    edge => edge.node.canDelete && isDeletableStatus(edge.node.status),
-  );
+  const hasActions = accessReviewCampaigns.edges.some(edge => edge.node.canDelete);
 
   return (
     <div className="space-y-4">
@@ -215,8 +209,7 @@ export default function AccessReviewCampaignsTab({ queryRef }: Props) {
                 </Thead>
                 <Tbody>
                   {accessReviewCampaigns.edges.map((edge) => {
-                    const canDeleteRow
-                      = edge.node.canDelete && isDeletableStatus(edge.node.status);
+                    const canDeleteRow = edge.node.canDelete;
                     return (
                       <Tr
                         key={edge.node.id}

--- a/apps/console/src/pages/organizations/access-reviews/campaigns/AccessReviewCampaignsTab.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/AccessReviewCampaignsTab.tsx
@@ -132,6 +132,8 @@ export default function AccessReviewCampaignsTab({ queryRef }: Props) {
     deleteCampaignMutation,
   );
 
+  const isDeletableStatus = (status: string) => status !== "IN_PROGRESS";
+
   const handleDelete = (campaignId: string, campaignName: string) => {
     confirm(
       () => {
@@ -178,7 +180,9 @@ export default function AccessReviewCampaignsTab({ queryRef }: Props) {
     );
   };
 
-  const hasActions = accessReviewCampaigns.edges.some(edge => edge.node.canDelete);
+  const hasActions = accessReviewCampaigns.edges.some(
+    edge => edge.node.canDelete && isDeletableStatus(edge.node.status),
+  );
 
   return (
     <div className="space-y-4">
@@ -209,7 +213,8 @@ export default function AccessReviewCampaignsTab({ queryRef }: Props) {
                 </Thead>
                 <Tbody>
                   {accessReviewCampaigns.edges.map((edge) => {
-                    const canDeleteRow = edge.node.canDelete;
+                    const canDeleteRow
+                      = edge.node.canDelete && isDeletableStatus(edge.node.status);
                     return (
                       <Tr
                         key={edge.node.id}

--- a/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
@@ -216,7 +216,7 @@ export default function CampaignDetailPage({ queryRef }: Props) {
   const isInProgress = campaign.status === "IN_PROGRESS";
   const isDraft = campaign.status === "DRAFT";
   const isPendingActions = campaign.status === "PENDING_ACTIONS";
-  const canDelete = campaign.canDelete;
+  const canDelete = campaign.canDelete && !isInProgress;
 
   const campaignIdRef = useRef(campaign.id);
 

--- a/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
@@ -216,9 +216,7 @@ export default function CampaignDetailPage({ queryRef }: Props) {
   const isInProgress = campaign.status === "IN_PROGRESS";
   const isDraft = campaign.status === "DRAFT";
   const isPendingActions = campaign.status === "PENDING_ACTIONS";
-  const isCancelled = campaign.status === "CANCELLED";
-  const isCompleted = campaign.status === "COMPLETED";
-  const canDelete = campaign.canDelete && (isDraft || isCancelled || isCompleted);
+  const canDelete = campaign.canDelete;
 
   const campaignIdRef = useRef(campaign.id);
 

--- a/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
@@ -217,7 +217,8 @@ export default function CampaignDetailPage({ queryRef }: Props) {
   const isDraft = campaign.status === "DRAFT";
   const isPendingActions = campaign.status === "PENDING_ACTIONS";
   const isCancelled = campaign.status === "CANCELLED";
-  const canDelete = campaign.canDelete && (isDraft || isCancelled);
+  const isCompleted = campaign.status === "COMPLETED";
+  const canDelete = campaign.canDelete && (isDraft || isCancelled || isCompleted);
 
   const campaignIdRef = useRef(campaign.id);
 

--- a/pkg/accessreview/campaign_service.go
+++ b/pkg/accessreview/campaign_service.go
@@ -205,12 +205,6 @@ func (s *Service) DeleteCampaign(
 				return fmt.Errorf("cannot load campaign: %w", err)
 			}
 
-			if campaign.Status != coredata.AccessReviewCampaignStatusDraft &&
-				campaign.Status != coredata.AccessReviewCampaignStatusCancelled &&
-				campaign.Status != coredata.AccessReviewCampaignStatusCompleted {
-				return NewCampaignNotDeletableError(campaign.ID)
-			}
-
 			if err := campaign.Delete(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot delete campaign: %w", err)
 			}

--- a/pkg/accessreview/campaign_service.go
+++ b/pkg/accessreview/campaign_service.go
@@ -206,7 +206,8 @@ func (s *Service) DeleteCampaign(
 			}
 
 			if campaign.Status != coredata.AccessReviewCampaignStatusDraft &&
-				campaign.Status != coredata.AccessReviewCampaignStatusCancelled {
+				campaign.Status != coredata.AccessReviewCampaignStatusCancelled &&
+				campaign.Status != coredata.AccessReviewCampaignStatusCompleted {
 				return NewCampaignNotDeletableError(campaign.ID)
 			}
 

--- a/pkg/accessreview/campaign_service.go
+++ b/pkg/accessreview/campaign_service.go
@@ -205,6 +205,10 @@ func (s *Service) DeleteCampaign(
 				return fmt.Errorf("cannot load campaign: %w", err)
 			}
 
+			if campaign.Status == coredata.AccessReviewCampaignStatusInProgress {
+				return NewCampaignNotDeletableError(campaign.ID)
+			}
+
 			if err := campaign.Delete(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot delete campaign: %w", err)
 			}

--- a/pkg/accessreview/errors.go
+++ b/pkg/accessreview/errors.go
@@ -30,7 +30,6 @@ import (
 var (
 	ErrCampaignMissingSources    = errors.New("access review campaign missing scope sources")
 	ErrCampaignNotDraft          = errors.New("access review campaign not draft")
-	ErrCampaignNotDeletable      = errors.New("access review campaign not deletable")
 	ErrCampaignNotPendingActions = errors.New("access review campaign not pending actions")
 	ErrCampaignCompleted         = errors.New("access review campaign completed")
 	ErrCampaignCancelled         = errors.New("access review campaign cancelled")
@@ -42,10 +41,6 @@ type (
 	}
 
 	CampaignNotDraftError struct {
-		CampaignID gid.GID
-	}
-
-	CampaignNotDeletableError struct {
 		CampaignID gid.GID
 	}
 
@@ -87,21 +82,6 @@ func (e *CampaignNotDraftError) Error() string {
 
 func (e *CampaignNotDraftError) Is(target error) bool {
 	return target == ErrCampaignNotDraft
-}
-
-func NewCampaignNotDeletableError(campaignID gid.GID) error {
-	return &CampaignNotDeletableError{CampaignID: campaignID}
-}
-
-func (e *CampaignNotDeletableError) Error() string {
-	return fmt.Sprintf(
-		"access review campaign %q cannot be deleted unless it is draft, cancelled, or completed",
-		e.CampaignID,
-	)
-}
-
-func (e *CampaignNotDeletableError) Is(target error) bool {
-	return target == ErrCampaignNotDeletable
 }
 
 func NewCampaignNotPendingActionsError(campaignID gid.GID) error {

--- a/pkg/accessreview/errors.go
+++ b/pkg/accessreview/errors.go
@@ -95,7 +95,7 @@ func NewCampaignNotDeletableError(campaignID gid.GID) error {
 
 func (e *CampaignNotDeletableError) Error() string {
 	return fmt.Sprintf(
-		"access review campaign %q cannot be deleted unless it is draft or cancelled",
+		"access review campaign %q cannot be deleted unless it is draft, cancelled, or completed",
 		e.CampaignID,
 	)
 }

--- a/pkg/accessreview/errors.go
+++ b/pkg/accessreview/errors.go
@@ -30,6 +30,7 @@ import (
 var (
 	ErrCampaignMissingSources    = errors.New("access review campaign missing scope sources")
 	ErrCampaignNotDraft          = errors.New("access review campaign not draft")
+	ErrCampaignNotDeletable      = errors.New("access review campaign not deletable")
 	ErrCampaignNotPendingActions = errors.New("access review campaign not pending actions")
 	ErrCampaignCompleted         = errors.New("access review campaign completed")
 	ErrCampaignCancelled         = errors.New("access review campaign cancelled")
@@ -41,6 +42,10 @@ type (
 	}
 
 	CampaignNotDraftError struct {
+		CampaignID gid.GID
+	}
+
+	CampaignNotDeletableError struct {
 		CampaignID gid.GID
 	}
 
@@ -82,6 +87,21 @@ func (e *CampaignNotDraftError) Error() string {
 
 func (e *CampaignNotDraftError) Is(target error) bool {
 	return target == ErrCampaignNotDraft
+}
+
+func NewCampaignNotDeletableError(campaignID gid.GID) error {
+	return &CampaignNotDeletableError{CampaignID: campaignID}
+}
+
+func (e *CampaignNotDeletableError) Error() string {
+	return fmt.Sprintf(
+		"access review campaign %q cannot be deleted while it is in progress",
+		e.CampaignID,
+	)
+}
+
+func (e *CampaignNotDeletableError) Is(target error) bool {
+	return target == ErrCampaignNotDeletable
 }
 
 func NewCampaignNotPendingActionsError(campaignID gid.GID) error {

--- a/pkg/accessreview/errors_test.go
+++ b/pkg/accessreview/errors_test.go
@@ -58,6 +58,15 @@ func TestCampaignClientErrors(t *testing.T) {
 			sentinel: accessreview.ErrCampaignNotDraft,
 		},
 		{
+			name: "not deletable",
+			err:  accessreview.NewCampaignNotDeletableError(campaignID),
+			wantText: fmt.Sprintf(
+				"access review campaign %q cannot be deleted while it is in progress",
+				campaignID,
+			),
+			sentinel: accessreview.ErrCampaignNotDeletable,
+		},
+		{
 			name: "not pending actions",
 			err:  accessreview.NewCampaignNotPendingActionsError(campaignID),
 			wantText: fmt.Sprintf(

--- a/pkg/accessreview/errors_test.go
+++ b/pkg/accessreview/errors_test.go
@@ -58,15 +58,6 @@ func TestCampaignClientErrors(t *testing.T) {
 			sentinel: accessreview.ErrCampaignNotDraft,
 		},
 		{
-			name: "not deletable",
-			err:  accessreview.NewCampaignNotDeletableError(campaignID),
-			wantText: fmt.Sprintf(
-				"access review campaign %q cannot be deleted unless it is draft, cancelled, or completed",
-				campaignID,
-			),
-			sentinel: accessreview.ErrCampaignNotDeletable,
-		},
-		{
 			name: "not pending actions",
 			err:  accessreview.NewCampaignNotPendingActionsError(campaignID),
 			wantText: fmt.Sprintf(

--- a/pkg/accessreview/errors_test.go
+++ b/pkg/accessreview/errors_test.go
@@ -61,7 +61,7 @@ func TestCampaignClientErrors(t *testing.T) {
 			name: "not deletable",
 			err:  accessreview.NewCampaignNotDeletableError(campaignID),
 			wantText: fmt.Sprintf(
-				"access review campaign %q cannot be deleted unless it is draft or cancelled",
+				"access review campaign %q cannot be deleted unless it is draft, cancelled, or completed",
 				campaignID,
 			),
 			sentinel: accessreview.ErrCampaignNotDeletable,

--- a/pkg/server/api/console/v1/access_review_campaign_resolvers.go
+++ b/pkg/server/api/console/v1/access_review_campaign_resolvers.go
@@ -787,6 +787,10 @@ func (r *mutationResolver) DeleteAccessReviewCampaign(ctx context.Context, input
 			return nil, gqlutils.NotFound(ctx, err)
 		}
 
+		if errors.Is(err, accessreview.ErrCampaignNotDeletable) {
+			return nil, gqlutils.Invalid(ctx, err)
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot delete access review campaign", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/access_review_campaign_resolvers.go
+++ b/pkg/server/api/console/v1/access_review_campaign_resolvers.go
@@ -787,10 +787,6 @@ func (r *mutationResolver) DeleteAccessReviewCampaign(ctx context.Context, input
 			return nil, gqlutils.NotFound(ctx, err)
 		}
 
-		if errors.Is(err, accessreview.ErrCampaignNotDeletable) {
-			return nil, gqlutils.Invalid(ctx, err)
-		}
-
 		r.logger.ErrorCtx(ctx, "cannot delete access review campaign", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [ENG-663](https://linear.app/probo/issue/ENG-663/allow-deleting-completed-access-review-campaigns).

Access review campaigns could not be removed once they left draft/cancelled: delete was rejected by status, and completed campaigns could not be cancelled first.

## Changes

- **API** (`DeleteCampaign`): allow delete in every status except `IN_PROGRESS` (while sources are still being fetched).
- **Console**: show delete when the user has `access-review:campaign:delete`, except for in-progress campaigns.
- Restore `CampaignNotDeletableError` with a clear in-progress message for GraphQL clients.

## Test plan

- [ ] Delete campaigns in DRAFT, PENDING_ACTIONS, COMPLETED, and CANCELLED via GraphQL/MCP.
- [ ] Confirm delete is rejected for `IN_PROGRESS` campaigns.
- [ ] Confirm delete is still denied without the delete permission.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-663](https://linear.app/probo/issue/ENG-663/allow-deleting-completed-access-review-campaigns)

<div><a href="https://cursor.com/agents/bc-d12d1d1c-ea67-49f6-bc08-75d5f9fa4fa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d12d1d1c-ea67-49f6-bc08-75d5f9fa4fa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow deleting access review campaigns in any status except IN_PROGRESS. The console shows delete when the user has `access-review:campaign:delete` and the campaign is not in progress (ENG-663).

### Tests **`+1`** **`-1`**
- Updated expected text for `CampaignNotDeletableError` to reflect the in-progress restriction.

### Service **`+2`** **`-3`**
- In `DeleteCampaign`, block delete only for `IN_PROGRESS`; all other statuses allowed.
- Updated `CampaignNotDeletableError` message to match the new rule.

### App: console **`+2`** **`-5`**
- Show Delete when `canDelete` and status !== `IN_PROGRESS` on list and detail pages.

<sup>Written for commit b229da0115cb629d5047910fb896c7320f5324dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

