### PR TITLE
Enable tagged (accessible) PDF generation

### DIFF
--- a/pkg/docgen/generator.go
+++ b/pkg/docgen/generator.go
@@ -214,6 +214,7 @@ type (
 	}
 
 	SignaturePageData struct {
+		Title      string
 		Signatures []SignatureData
 		Landscape  bool
 	}

--- a/pkg/docgen/signature_page_template.html
+++ b/pkg/docgen/signature_page_template.html
@@ -4,10 +4,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{if .Title}}{{.Title}} — {{end}}Document Signatures</title>
     <style>
         @page {
             size: {{- if .Landscape}} A4 landscape {{- else}} A4 {{- end}};
             margin: 1in;
+        }
+
+        thead {
+            display: table-header-group;
         }
 
         body {

--- a/pkg/docgen/template.html
+++ b/pkg/docgen/template.html
@@ -19,6 +19,10 @@
             }
         }
 
+        thead {
+            display: table-header-group;
+        }
+
         body {
             font-family: Arial, sans-serif;
             font-size: 11pt;

--- a/pkg/esign/certificate.html.tmpl
+++ b/pkg/esign/certificate.html.tmpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <style>

--- a/pkg/esign/certificate.html.tmpl
+++ b/pkg/esign/certificate.html.tmpl
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <title>Certificate Of Completion{{if .DocumentTypeName}} — {{.DocumentTypeName}}{{end}}</title>
     <style>
       @page {
         @bottom-right {
@@ -10,6 +11,10 @@
           font-size: 8px;
           color: #777;
         }
+      }
+
+      thead {
+        display: table-header-group;
       }
 
       * {

--- a/pkg/html2pdf/converter.go
+++ b/pkg/html2pdf/converter.go
@@ -58,6 +58,12 @@ type (
 		Scale                    float64       // Print scale (0.1 to 2.0)
 		WaitForExpression        string        // Optional JS expression polled until true before printing
 		WaitForExpressionTimeout time.Duration // Max time to wait (default 15s)
+		// GenerateTaggedPDF enables accessible PDF tagging (structure tree, reading
+		// order). Nil defaults to true.
+		GenerateTaggedPDF *bool
+		// GenerateDocumentOutline embeds a document outline (bookmarks). Nil defaults
+		// to true.
+		GenerateDocumentOutline *bool
 	}
 
 	Option func(*Converter)
@@ -122,6 +128,22 @@ func getPageDimensions(format PageFormat, orientation Orientation) (width, heigh
 	return w, h
 }
 
+func generateTaggedPDFEnabled(cfg RenderConfig) bool {
+	if cfg.GenerateTaggedPDF != nil {
+		return *cfg.GenerateTaggedPDF
+	}
+
+	return true
+}
+
+func generateDocumentOutlineEnabled(cfg RenderConfig) bool {
+	if cfg.GenerateDocumentOutline != nil {
+		return *cfg.GenerateDocumentOutline
+	}
+
+	return true
+}
+
 func (c *Converter) GeneratePDF(ctx context.Context, htmlDocument []byte, cfg RenderConfig) (io.Reader, error) {
 	var (
 		rootSpan = trace.SpanFromContext(ctx)
@@ -155,6 +177,9 @@ func (c *Converter) GeneratePDF(ctx context.Context, htmlDocument []byte, cfg Re
 		scale = 1.0
 	}
 
+	generateTaggedPDF := generateTaggedPDFEnabled(cfg)
+	generateDocumentOutline := generateDocumentOutlineEnabled(cfg)
+
 	var pdfBytes []byte
 
 	c.l.InfoCtx(
@@ -168,6 +193,8 @@ func (c *Converter) GeneratePDF(ctx context.Context, htmlDocument []byte, cfg Re
 		log.Float64("marginRight", marginRight),
 		log.Float64("scale", scale),
 		log.Bool("printBackground", cfg.PrintBackground),
+		log.Bool("generateTaggedPDF", generateTaggedPDF),
+		log.Bool("generateDocumentOutline", generateDocumentOutline),
 	)
 
 	htmlContent := string(htmlDocument)
@@ -231,6 +258,8 @@ func (c *Converter) GeneratePDF(ctx context.Context, htmlDocument []byte, cfg Re
 					WithMarginRight(marginRight).
 					WithScale(scale).
 					WithPreferCSSPageSize(false).
+					WithGenerateTaggedPDF(generateTaggedPDF).
+					WithGenerateDocumentOutline(generateDocumentOutline).
 					Do(ctx)
 
 				return err

--- a/pkg/html2pdf/converter_test.go
+++ b/pkg/html2pdf/converter_test.go
@@ -72,6 +72,26 @@ func TestWithLogger(t *testing.T) {
 	assert.NotNil(t, converter.l)
 }
 
+func TestGenerateTaggedPDFEnabled(t *testing.T) {
+	assert.True(t, generateTaggedPDFEnabled(RenderConfig{}))
+
+	disabled := false
+	assert.False(t, generateTaggedPDFEnabled(RenderConfig{GenerateTaggedPDF: &disabled}))
+
+	enabled := true
+	assert.True(t, generateTaggedPDFEnabled(RenderConfig{GenerateTaggedPDF: &enabled}))
+}
+
+func TestGenerateDocumentOutlineEnabled(t *testing.T) {
+	assert.True(t, generateDocumentOutlineEnabled(RenderConfig{}))
+
+	disabled := false
+	assert.False(t, generateDocumentOutlineEnabled(RenderConfig{GenerateDocumentOutline: &disabled}))
+
+	enabled := true
+	assert.True(t, generateDocumentOutlineEnabled(RenderConfig{GenerateDocumentOutline: &enabled}))
+}
+
 func TestGetPageDimensions(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -212,6 +232,7 @@ func TestGeneratePDF_WithValidChrome(t *testing.T) {
 
 	// Verify it looks like a PDF file (starts with PDF magic bytes)
 	assert.True(t, bytes.HasPrefix(pdfContent, []byte("%PDF-")))
+	assert.Contains(t, string(pdfContent), "/StructTreeRoot")
 }
 
 func TestGeneratePDF_ScaleHandling(t *testing.T) {

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -2908,6 +2908,11 @@ func generateSignaturePagePDF(
 		return nil, nil
 	}
 
+	document := &coredata.Document{}
+	if err := document.LoadByID(ctx, conn, scope, version.DocumentID); err != nil {
+		return nil, fmt.Errorf("cannot load document: %w", err)
+	}
+
 	signatureData := make([]docgen.SignatureData, len(*signaturesWithPeople))
 	for i, sig := range *signaturesWithPeople {
 		signatureData[i] = docgen.SignatureData{
@@ -2921,6 +2926,7 @@ func generateSignaturePagePDF(
 	isLandscape := version.Orientation == coredata.DocumentVersionOrientationLandscape
 
 	htmlContent, err := docgen.RenderSignaturePageHTML(docgen.SignaturePageData{
+		Title:      document.Title,
 		Signatures: signatureData,
 		Landscape:  isLandscape,
 	})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PDFs rendered through `pkg/html2pdf` now request Chrome’s tagged-PDF and document-outline options by default, so exports include a structure tree and bookmarks where the source HTML supports it. HTML templates were updated so table headers repeat on page breaks and PDF viewers receive a proper document title.

Fixes getprobo/probo#1572 / ENG-664.

## Changes

### Converter (`pkg/html2pdf`)

- **`RenderConfig`**: optional `GenerateTaggedPDF` and `GenerateDocumentOutline` pointer fields; unset (`nil`) defaults to **enabled**.
- **`GeneratePDF`**: passes `WithGenerateTaggedPDF` and `WithGenerateDocumentOutline` to CDP `Page.printToPDF`.

### Templates

- **`lang="en"`** on `pkg/esign/certificate.html.tmpl` (aligned with docgen templates) so Chrome can emit `/Lang`.
- **`thead { display: table-header-group; }`** in `docgen/template.html`, `docgen/signature_page_template.html`, and `esign/certificate.html.tmpl` so header rows repeat across page breaks.
- **`<title>`** on signature page and certificate templates:
  - Signature page: `{{.Title}} — Document Signatures` (`Title` loaded from the parent document in `generateSignaturePagePDF`).
  - Certificate: `Certificate Of Completion — {{.DocumentTypeName}}`.

## Verification

- `go test ./pkg/html2pdf/...` (unit tests for tagged-PDF defaults)
- With `CHROME_WS_URL` set, `TestGeneratePDF_WithValidChrome` asserts `/StructTreeRoot` in the output.

Manual check (from the issue):

```bash
qpdf --qdf --object-streams=disable out.pdf - | grep -c "/StructTreeRoot"
```

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-664](https://linear.app/probo/issue/ENG-664/pdf-generation-does-not-produce-tagged-accessible-pdfs)

<div><a href="https://cursor.com/agents/bc-4d650834-5f22-425d-bb7f-51cc17f60f31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d650834-5f22-425d-bb7f-51cc17f60f31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable tagged, accessible PDFs by default in `pkg/html2pdf`, adding structure trees and bookmarks where supported. Also set PDF titles, repeat table headers in templates, and emit `/Lang`; addresses ENG-664.

### Service **`+51`** **`-1`**
- Added `RenderConfig.GenerateTaggedPDF` and `RenderConfig.GenerateDocumentOutline` (default on); passed to Chrome via `WithGenerateTaggedPDF` and `WithGenerateDocumentOutline`.
- `pkg/esign/certificate.html.tmpl`: `<html lang="en">` and `<title>` so PDFs include `/Lang` and a document title.
- `pkg/docgen` templates: `thead { display: table-header-group; }` to repeat table headers across page breaks.
- Signature page: added `<title>` and `SignaturePageData.Title`; load parent document title and pass it in `generateSignaturePagePDF`.

### Tests **`+21`** **`-0`**
- Unit tests for default-on behavior and explicit enable/disable of tagging and outline, and assertion that PDFs contain `/StructTreeRoot`.

<sup>Written for commit 250ce927d8c1049826dd7376ce7e2c827546a1ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

