### PR TITLE
Make auth cookie SameSite configurable (ENG-665)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,7 @@
 # ── Cookie ────────────────────────────────────────────────────────────
 # PROBOD_AUTH_COOKIE_DOMAIN=localhost
 # PROBOD_AUTH_COOKIE_SECURE=false
+# PROBOD_AUTH_COOKIE_SAMESITE=lax
 # PROBOD_AUTH_COOKIE_DURATION=24
 
 # ── Postgres ──────────────────────────────────────────────────────────

--- a/contrib/helm/charts/probo/templates/deployment.yaml
+++ b/contrib/helm/charts/probo/templates/deployment.yaml
@@ -135,6 +135,8 @@ spec:
                   key: cookie-secret
             - name: PROBOD_AUTH_COOKIE_DURATION
               value: {{ .Values.probo.auth.cookieDuration | quote }}
+            - name: PROBOD_AUTH_COOKIE_SAMESITE
+              value: {{ .Values.probo.auth.cookieSameSite | quote }}
             - name: PROBOD_AUTH_PASSWORD_PEPPER
               valueFrom:
                 secretKeyRef:

--- a/contrib/helm/charts/probo/values.yaml
+++ b/contrib/helm/charts/probo/values.yaml
@@ -229,6 +229,8 @@ probo:
     emailConfirmationTokenValidity: 3600
     cookieName: "SSID"
     cookieDomain: "probo.example.com"
+    # lax, strict, or none (none requires HTTPS / secure cookies)
+    cookieSameSite: "lax"
     # REQUIRED: Generate with openssl rand -base64 32
     cookieSecret: ""
     cookieDuration: 24

--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -59,6 +59,13 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 
 	pgCACertBundle := b.getPgCACertBundle()
 
+	authCookieSameSite, err := probodconfig.ParseCookieSameSite(
+		b.resolver.getEnvOrDefault("PROBOD_AUTH_COOKIE_SAMESITE", "lax"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse PROBOD_AUTH_COOKIE_SAMESITE: %w", err)
+	}
+
 	cfg := &probodconfig.FullConfig{
 		Unit: probodconfig.UnitConfig{
 			Metrics: probodconfig.MetricsConfig{
@@ -118,6 +125,7 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 					Secret:   b.resolver.getEnv("PROBOD_AUTH_COOKIE_SECRET"),
 					Duration: b.resolver.getEnvIntOrDefault("PROBOD_AUTH_COOKIE_DURATION", 24),
 					Secure:   b.resolver.getEnvBoolOrDefault("PROBOD_AUTH_COOKIE_SECURE", true),
+					SameSite: authCookieSameSite,
 				},
 				Password: probodconfig.PasswordConfig{
 					Pepper:     b.resolver.getEnv("PROBOD_AUTH_PASSWORD_PEPPER"),
@@ -557,6 +565,10 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 
 	if b.resolver.Err() != nil {
 		return nil, b.resolver.Err()
+	}
+
+	if err := cfg.Probod.Auth.Cookie.Validate(); err != nil {
+		return nil, fmt.Errorf("cannot validate auth cookie config: %w", err)
 	}
 
 	return cfg, nil

--- a/pkg/bootstrap/builder_test.go
+++ b/pkg/bootstrap/builder_test.go
@@ -335,6 +335,7 @@ func TestBuilder_Build_CustomValues(t *testing.T) {
 	env["PROBOD_AUTH_EMAIL_CONFIRMATION_TOKEN_VALIDITY"] = "43200"
 	env["PROBOD_AUTH_COOKIE_DOMAIN"] = ".example.com"
 	env["PROBOD_AUTH_COOKIE_DURATION"] = "48"
+	env["PROBOD_AUTH_COOKIE_SAMESITE"] = "strict"
 	// SAML
 	env["PROBOD_SAML_DOMAIN_VERIFICATION_INTERVAL_SECONDS"] = "120"
 	env["PROBOD_SAML_DOMAIN_VERIFICATION_RESOLVER_ADDR"] = "1.1.1.1:53"
@@ -471,6 +472,7 @@ func TestBuilder_Build_CustomValues(t *testing.T) {
 	assert.Equal(t, 43200, cfg.Probod.Auth.EmailConfirmationTokenValidity)
 	assert.Equal(t, ".example.com", cfg.Probod.Auth.Cookie.Domain)
 	assert.Equal(t, 48, cfg.Probod.Auth.Cookie.Duration)
+	assert.Equal(t, probodconfig.CookieSameSiteStrict, cfg.Probod.Auth.Cookie.SameSite)
 	// SAML
 	assert.Equal(t, 120, cfg.Probod.Auth.SAML.DomainVerificationIntervalSeconds)
 	assert.Equal(t, "1.1.1.1:53", cfg.Probod.Auth.SAML.DomainVerificationResolverAddr)
@@ -894,6 +896,33 @@ func TestBuilder_Build_PgCABundleFromFile(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "ca-bundle-from-file", cfg.Probod.Pg.CACertBundle)
+}
+
+func TestBuilder_Build_AuthCookieSameSiteInvalid(t *testing.T) {
+	env := requiredEnv()
+	env["PROBOD_AUTH_COOKIE_SAMESITE"] = "invalid"
+
+	b := NewBuilder(NewResolver(mockEnv(env)))
+	b.samlCertificate = "test-cert"
+	b.samlPrivateKey = "test-key"
+
+	_, err := b.Build()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PROBOD_AUTH_COOKIE_SAMESITE")
+}
+
+func TestBuilder_Build_AuthCookieSameSiteNoneRequiresSecure(t *testing.T) {
+	env := requiredEnv()
+	env["PROBOD_AUTH_COOKIE_SAMESITE"] = "none"
+	env["PROBOD_AUTH_COOKIE_SECURE"] = "false"
+
+	b := NewBuilder(NewResolver(mockEnv(env)))
+	b.samlCertificate = "test-cert"
+	b.samlPrivateKey = "test-key"
+
+	_, err := b.Build()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secure")
 }
 
 func TestBuilder_parseOriginsList(t *testing.T) {

--- a/pkg/probod/aliases.go
+++ b/pkg/probod/aliases.go
@@ -38,6 +38,7 @@ type (
 	OAuth2ServerConfig            = probodconfig.OAuth2ServerConfig
 	OAuth2SigningKeyConfig        = probodconfig.OAuth2SigningKeyConfig
 	CookieConfig                  = probodconfig.CookieConfig
+	CookieSameSite                = probodconfig.CookieSameSite
 	PasswordConfig                = probodconfig.PasswordConfig
 	AWSConfig                     = probodconfig.AWSConfig
 	ConnectorConfig               = probodconfig.ConnectorConfig
@@ -66,4 +67,10 @@ type (
 	SCIMBridgeConfig           = probodconfig.SCIMBridgeConfig
 	ITAMConfig                 = probodconfig.ITAMConfig
 	SlackConfig                = probodconfig.SlackConfig
+)
+
+const (
+	CookieSameSiteLax    = probodconfig.CookieSameSiteLax
+	CookieSameSiteStrict = probodconfig.CookieSameSiteStrict
+	CookieSameSiteNone   = probodconfig.CookieSameSiteNone
 )

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -134,6 +134,7 @@ func New() *Implm {
 					Duration: 24,
 					Domain:   "localhost",
 					Secure:   true,
+					SameSite: CookieSameSiteLax,
 				},
 				DisableSignup:                       false,
 				InvitationConfirmationTokenValidity: 3600,
@@ -278,6 +279,18 @@ func (impl *Implm) Run(
 	if err != nil {
 		rootSpan.RecordError(err)
 		return fmt.Errorf("cannot get cookie secret bytes: %w", err)
+	}
+
+	if err := impl.cfg.Auth.Cookie.Validate(); err != nil {
+		rootSpan.RecordError(err)
+		return fmt.Errorf("cannot validate auth cookie config: %w", err)
+	}
+
+	authCookieMaxAge := int(time.Duration(impl.cfg.Auth.Cookie.Duration) * time.Hour)
+	authCookie, err := authSecureCookieConfig(impl.cfg.Auth.Cookie, authCookieMaxAge)
+	if err != nil {
+		rootSpan.RecordError(err)
+		return fmt.Errorf("cannot configure auth cookie: %w", err)
 	}
 
 	awsConfig, err := awsconfig.NewConfig(
@@ -768,16 +781,7 @@ func (impl *Implm) Run(
 			CustomDomainCname: impl.cfg.CustomDomains.CnameTarget,
 			TokenSecret:       impl.cfg.Auth.Cookie.Secret,
 			Logger:            l.Named("http.server"),
-			Cookie: securecookie.Config{
-				Name:     impl.cfg.Auth.Cookie.Name,
-				Domain:   impl.cfg.Auth.Cookie.Domain,
-				Path:     "/",
-				MaxAge:   int(time.Duration(impl.cfg.Auth.Cookie.Duration) * time.Hour),
-				Secret:   impl.cfg.Auth.Cookie.Secret,
-				Secure:   impl.cfg.Auth.Cookie.Secure,
-				HTTPOnly: true,
-				SameSite: http.SameSiteLaxMode,
-			},
+			Cookie:            authCookie,
 		},
 	)
 	if err != nil {
@@ -796,17 +800,8 @@ func (impl *Implm) Run(
 			File:              fileManagerService,
 			ESign:             esignService,
 			Mailman:           mailmanService,
-			Cookie: securecookie.Config{
-				Name:     impl.cfg.Auth.Cookie.Name,
-				Domain:   impl.cfg.Auth.Cookie.Domain,
-				Path:     "/",
-				MaxAge:   int(time.Duration(impl.cfg.Auth.Cookie.Duration) * time.Hour),
-				Secret:   impl.cfg.Auth.Cookie.Secret,
-				Secure:   impl.cfg.Auth.Cookie.Secure,
-				HTTPOnly: true,
-				SameSite: http.SameSiteLaxMode,
-			},
-			TokenSecret: impl.cfg.Auth.Cookie.Secret,
+			Cookie:            authCookie,
+			TokenSecret:       impl.cfg.Auth.Cookie.Secret,
 			GraphQLLimits: gqlutils.Limits{
 				ParserTokenLimit:  impl.cfg.Api.GraphQL.ParserTokenLimit,
 				ComplexityLimit:   impl.cfg.Api.GraphQL.ComplexityLimit,
@@ -1603,4 +1598,22 @@ func oauth2ServerOptions(cfg OAuth2ServerConfig) []oauth2.Option {
 	}
 
 	return opts
+}
+
+func authSecureCookieConfig(c CookieConfig, maxAgeSeconds int) (securecookie.Config, error) {
+	sameSite, err := c.HTTPSameSite()
+	if err != nil {
+		return securecookie.Config{}, err
+	}
+
+	return securecookie.Config{
+		Name:     c.Name,
+		Domain:   c.Domain,
+		Path:     "/",
+		MaxAge:   maxAgeSeconds,
+		Secret:   c.Secret,
+		Secure:   c.Secure,
+		HTTPOnly: true,
+		SameSite: sameSite,
+	}, nil
 }

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -287,6 +287,7 @@ func (impl *Implm) Run(
 	}
 
 	authCookieMaxAge := int(time.Duration(impl.cfg.Auth.Cookie.Duration) * time.Hour)
+
 	authCookie, err := authSecureCookieConfig(impl.cfg.Auth.Cookie, authCookieMaxAge)
 	if err != nil {
 		rootSpan.RecordError(err)

--- a/pkg/probodconfig/auth_config.go
+++ b/pkg/probodconfig/auth_config.go
@@ -23,7 +23,33 @@ package probodconfig
 import (
 	"encoding/base64"
 	"fmt"
+	"net/http"
+	"strings"
 )
+
+type CookieSameSite string
+
+const (
+	CookieSameSiteLax    CookieSameSite = "lax"
+	CookieSameSiteStrict CookieSameSite = "strict"
+	CookieSameSiteNone   CookieSameSite = "none"
+)
+
+func ParseCookieSameSite(raw string) (CookieSameSite, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", string(CookieSameSiteLax):
+		return CookieSameSiteLax, nil
+	case string(CookieSameSiteStrict):
+		return CookieSameSiteStrict, nil
+	case string(CookieSameSiteNone):
+		return CookieSameSiteNone, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid same-site value %q: must be lax, strict, or none",
+			raw,
+		)
+	}
+}
 
 type AuthConfig struct {
 	Cookie                              CookieConfig       `json:"cookie"`
@@ -55,11 +81,38 @@ type OAuth2SigningKeyConfig struct {
 }
 
 type CookieConfig struct {
-	Domain   string `json:"domain,omitempty"`
-	Secret   string `json:"secret"`
-	Duration int    `json:"duration"`
-	Name     string `json:"name,omitempty"`
-	Secure   bool   `json:"secure"`
+	Domain   string         `json:"domain,omitempty"`
+	Secret   string         `json:"secret"`
+	Duration int            `json:"duration"`
+	Name     string         `json:"name,omitempty"`
+	Secure   bool           `json:"secure"`
+	SameSite CookieSameSite `json:"same-site,omitempty"`
+}
+
+func (c CookieConfig) HTTPSameSite() (http.SameSite, error) {
+	switch c.SameSite {
+	case "", CookieSameSiteLax:
+		return http.SameSiteLaxMode, nil
+	case CookieSameSiteStrict:
+		return http.SameSiteStrictMode, nil
+	case CookieSameSiteNone:
+		return http.SameSiteNoneMode, nil
+	default:
+		return 0, fmt.Errorf("invalid cookie same-site value %q", c.SameSite)
+	}
+}
+
+func (c CookieConfig) Validate() error {
+	sameSite, err := c.HTTPSameSite()
+	if err != nil {
+		return err
+	}
+
+	if sameSite == http.SameSiteNoneMode && !c.Secure {
+		return fmt.Errorf("cookie same-site none requires secure cookies")
+	}
+
+	return nil
 }
 
 type PasswordConfig struct {

--- a/pkg/probodconfig/auth_config_test.go
+++ b/pkg/probodconfig/auth_config_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package probodconfig_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.probo.inc/probo/pkg/probodconfig"
+)
+
+func TestParseCookieSameSite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    probodconfig.CookieSameSite
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: probodconfig.CookieSameSiteLax},
+		{name: "lax", input: "lax", want: probodconfig.CookieSameSiteLax},
+		{name: "Lax", input: "Lax", want: probodconfig.CookieSameSiteLax},
+		{name: "strict", input: "strict", want: probodconfig.CookieSameSiteStrict},
+		{name: "none", input: "none", want: probodconfig.CookieSameSiteNone},
+		{name: "invalid", input: "cross-site", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := probodconfig.ParseCookieSameSite(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCookieConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cookie  probodconfig.CookieConfig
+		wantErr bool
+	}{
+		{
+			name: "lax without secure",
+			cookie: probodconfig.CookieConfig{
+				SameSite: probodconfig.CookieSameSiteLax,
+				Secure:   false,
+			},
+		},
+		{
+			name: "none requires secure",
+			cookie: probodconfig.CookieConfig{
+				SameSite: probodconfig.CookieSameSiteNone,
+				Secure:   false,
+			},
+			wantErr: true,
+		},
+		{
+			name: "none with secure",
+			cookie: probodconfig.CookieConfig{
+				SameSite: probodconfig.CookieSameSiteNone,
+				Secure:   true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cookie.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCookieConfig_HTTPSameSite(t *testing.T) {
+	t.Parallel()
+
+	cookie := probodconfig.CookieConfig{SameSite: probodconfig.CookieSameSiteStrict}
+
+	got, err := cookie.HTTPSameSite()
+	require.NoError(t, err)
+	assert.Equal(t, http.SameSiteStrictMode, got)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `same-site` to `CookieConfig` (YAML/JSON) with `lax`, `strict`, or `none`, defaulting to `lax`.
- Maps `PROBOD_AUTH_COOKIE_SAMESITE` in probod-bootstrap and exposes `probo.auth.cookieSameSite` in the Helm chart.
- Wires configured SameSite into both API and compliance portal session cookies; rejects `none` when `Secure` is false.

Fixes ENG-665.

## Test plan

- [x] `go test ./pkg/probodconfig/... ./pkg/bootstrap/...`
- [ ] Cross-site setup: set `PROBOD_AUTH_COOKIE_SAMESITE=none` and `PROBOD_AUTH_COOKIE_SECURE=true`, confirm `Set-Cookie` includes `SameSite=None; Secure`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-665](https://linear.app/probo/issue/ENG-665/auth-cookie-samesite-is-hardcoded-and-not-configurable)

<div><a href="https://cursor.com/agents/bc-65471a5d-ab29-41cb-a41e-106a09e9ae47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65471a5d-ab29-41cb-a41e-106a09e9ae47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the auth session cookie SameSite setting configurable for both API and compliance portal. Adds `same-site` to `CookieConfig`, maps `PROBOD_AUTH_COOKIE_SAMESITE`, exposes `probo.auth.cookieSameSite` in Helm, and enforces that `none` requires secure cookies (ENG-665).

### Service **`+112`** **`-26`**
- Added `CookieSameSite` enum, `ParseCookieSameSite`, `HTTPSameSite()`, and `Validate()` to `CookieConfig`.
- Builder reads `PROBOD_AUTH_COOKIE_SAMESITE`, sets it on config, and validates cookie config.
- `probod` now centralizes cookie setup via `authSecureCookieConfig`, using configured SameSite for both services; removed hardcoded `Lax`.
- Exported aliases and constants in `pkg/probod/aliases.go` for external use.
- Fixed lint in cookie wiring (added required spacing for `wsl_v5`).

### Tests **`+150`** **`-0`**
- New tests for SameSite parsing, HTTP mapping, and validation (including “none requires secure”).
- Builder tests cover invalid values and secure requirement; updated custom values test to assert `strict`.

### Other **`+5`** **`-0`**
- Added `PROBOD_AUTH_COOKIE_SAMESITE` to `.env.example`.
- Helm: exposed `probo.auth.cookieSameSite` in `values.yaml` and wired to `PROBOD_AUTH_COOKIE_SAMESITE` in the deployment template.

<sup>Written for commit 555b121108636ffa90ad87d5cce7c693cf4b2ec1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

