### PR TITLE
Sync console document lang with i18next locale

### DIFF
--- a/apps/console/src/lib/i18n/i18n.ts
+++ b/apps/console/src/lib/i18n/i18n.ts
@@ -29,6 +29,12 @@ import { resolveLanguage, SUPPORTED_LANGUAGES } from "./resolveLanguage";
 // react-i18next's hooks read from, so no I18nextProvider is required.
 const i18n = createInstance();
 
+function syncDocumentLanguage(language: string) {
+  document.documentElement.lang = language;
+}
+
+i18n.on("languageChanged", syncDocumentLanguage);
+
 void i18n
   .use(globBackend)
   .use(initReactI18next)
@@ -42,6 +48,9 @@ void i18n
     ns: [DEFAULT_NAMESPACE],
     interpolation: { escapeValue: false },
     react: { useSuspense: true },
+  })
+  .then(() => {
+    syncDocumentLanguage(i18n.language);
   });
 
 export { i18n };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes ENG-666: the console shipped French (and other) locales but left `<html lang="en">` static in `index.html`, so screen readers treated localized UI as English (WCAG 3.1.1).

## Change

Update `document.documentElement.lang` when i18next initializes and on the `languageChanged` event, matching the approach used in the compliance portal's `LocaleLayout`.

## Testing

- TypeScript change only; `npm run check` in `apps/console` was not run (dependencies not installed in agent environment).

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-666](https://linear.app/probo/issue/ENG-666/console-hardcodes-html-langen-despite-shipping-a-french-locale)

<div><a href="https://cursor.com/agents/bc-f863ec08-d4e6-4f37-856c-de64264ff202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f863ec08-d4e6-4f37-856c-de64264ff202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the document language with the active `i18next` locale so screen readers announce the UI in the correct language. Addresses ENG-666 (WCAG 3.1.1) by updating the HTML lang attribute on init and whenever the language changes.

### App: console **`+9`** **`-0`**
- Add a helper to set document.documentElement.lang from the current `i18next` language.
- Run it after `react-i18next` init and on `languageChanged` to keep `<html lang>` in sync.

<sup>Written for commit 6cbfe7e7553e62ff6f55f2693bec5638db3d53ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

