### PR TITLE
Reuse existing membership profiles when creating users

### DIFF
--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -21,14 +21,207 @@
 package console_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/e2e/internal/factory"
 	"go.probo.inc/probo/e2e/internal/testutil"
+	"go.probo.inc/probo/internal/test"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
 )
+
+// TestUser_CreateUserReusesOrphanProfile covers promoting a profile that exists
+// without a membership (compliance-portal visitors / historical SCIM orphans)
+// into a console member. createUser must reuse the existing profile instead of
+// failing on the identity+organization uniqueness constraint.
+func TestUser_CreateUserReusesOrphanProfile(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	email := factory.SafeEmail()
+	orgID := owner.GetOrganizationID()
+	tenantID := orgID.TenantID()
+	now := time.Now().UTC()
+
+	identityID := gid.New(gid.NilTenant, coredata.IdentityEntityType)
+	orphanProfileID := gid.New(tenantID, coredata.MembershipProfileEntityType)
+
+	err := test.PGClient(t).WithConn(
+		context.Background(),
+		func(ctx context.Context, conn pg.Querier) error {
+			_, err := conn.Exec(
+				ctx,
+				`
+				INSERT INTO identities (
+					id,
+					email_address,
+					full_name,
+					email_address_verified,
+					created_at,
+					updated_at
+				)
+				VALUES ($1, $2, $3, true, $4, $4)
+				`,
+				identityID.String(),
+				email,
+				"Portal Visitor",
+				now,
+			)
+			if err != nil {
+				return err
+			}
+
+			_, err = conn.Exec(
+				ctx,
+				`
+				INSERT INTO iam_membership_profiles (
+					tenant_id,
+					id,
+					identity_id,
+					organization_id,
+					source,
+					state,
+					full_name,
+					additional_email_addresses,
+					created_at,
+					updated_at
+				)
+				VALUES ($1, $2, $3, $4, 'MANUAL', 'ACTIVE', $5, '{}'::citext[], $6, $6)
+				`,
+				tenantID.String(),
+				orphanProfileID.String(),
+				identityID.String(),
+				orgID.String(),
+				"Portal Visitor",
+				now,
+			)
+
+			return err
+		},
+	)
+	require.NoError(t, err, "test setup: cannot seed orphan membership profile")
+
+	const profilesQuery = `
+		query($id: ID!, $query: String!) {
+			node(id: $id) {
+				... on Organization {
+					profiles(first: 10, filter: { query: $query }) {
+						edges {
+							node {
+								id
+								fullName
+								state
+								membership { role }
+							}
+						}
+					}
+				}
+			}
+		}
+	`
+
+	type profilesResult struct {
+		Node struct {
+			Profiles struct {
+				Edges []struct {
+					Node struct {
+						ID         string `json:"id"`
+						FullName   string `json:"fullName"`
+						State      string `json:"state"`
+						Membership struct {
+							Role string `json:"role"`
+						} `json:"membership"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"profiles"`
+		} `json:"node"`
+	}
+
+	var before profilesResult
+
+	err = owner.ExecuteConnect(profilesQuery, map[string]any{
+		"id":    orgID.String(),
+		"query": email,
+	}, &before)
+	require.NoError(t, err)
+	assert.Empty(t, before.Node.Profiles.Edges, "orphan profile must not appear in people list")
+
+	const createUserMutation = `
+		mutation($input: CreateUserInput!) {
+			createUser(input: $input) {
+				profileEdge {
+					node {
+						id
+						fullName
+						state
+						membership { role }
+					}
+				}
+			}
+		}
+	`
+
+	var createResult struct {
+		CreateUser struct {
+			ProfileEdge struct {
+				Node struct {
+					ID         string `json:"id"`
+					FullName   string `json:"fullName"`
+					State      string `json:"state"`
+					Membership struct {
+						Role string `json:"role"`
+					} `json:"membership"`
+				} `json:"node"`
+			} `json:"profileEdge"`
+		} `json:"createUser"`
+	}
+
+	err = owner.ExecuteConnect(createUserMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId":           orgID.String(),
+			"emailAddress":             email,
+			"fullName":                 "Promoted Console User",
+			"role":                     "EMPLOYEE",
+			"kind":                     "EMPLOYEE",
+			"additionalEmailAddresses": []string{},
+		},
+	}, &createResult)
+	require.NoError(t, err)
+
+	created := createResult.CreateUser.ProfileEdge.Node
+	assert.Equal(t, orphanProfileID.String(), created.ID, "createUser must reuse the existing profile")
+	assert.Equal(t, "Promoted Console User", created.FullName)
+	assert.Equal(t, "ACTIVE", created.State, "existing portal profile state must be preserved")
+	assert.Equal(t, "EMPLOYEE", created.Membership.Role)
+
+	var after profilesResult
+
+	err = owner.ExecuteConnect(profilesQuery, map[string]any{
+		"id":    orgID.String(),
+		"query": email,
+	}, &after)
+	require.NoError(t, err)
+	require.Len(t, after.Node.Profiles.Edges, 1)
+	assert.Equal(t, orphanProfileID.String(), after.Node.Profiles.Edges[0].Node.ID)
+	assert.Equal(t, "EMPLOYEE", after.Node.Profiles.Edges[0].Node.Membership.Role)
+
+	_, err = owner.DoConnect(createUserMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId":           orgID.String(),
+			"emailAddress":             email,
+			"fullName":                 "Duplicate Create",
+			"role":                     "VIEWER",
+			"kind":                     "EMPLOYEE",
+			"additionalEmailAddresses": []string{},
+		},
+	})
+	testutil.RequireErrorCode(t, err, "CONFLICT")
+}
 
 // TestUser_AdminCannotCreateOwner is a non-regression test for the vertical
 // privilege escalation where an ADMIN could mint an OWNER membership via

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1036,36 +1036,102 @@ func (s *OrganizationService) CreateUser(ctx context.Context, scope coredata.Sco
 				}
 			}
 
-			profile = &coredata.MembershipProfile{
-				ID:                       gid.New(req.OrganizationID.TenantID(), coredata.MembershipProfileEntityType),
-				IdentityID:               identity.ID,
-				OrganizationID:           req.OrganizationID,
-				EmailAddress:             req.EmailAddress,
-				Source:                   coredata.ProfileSourceManual,
-				FullName:                 req.FullName,
-				Kind:                     req.Kind,
-				AdditionalEmailAddresses: req.AdditionalEmailAddresses,
-				Position:                 req.Position,
-				// User is pending until they accept an invitation.
-				State:     coredata.ProfileStatePending,
-				CreatedAt: now,
-				UpdatedAt: now,
+			existingProfile := &coredata.MembershipProfile{}
+
+			err := existingProfile.LoadByIdentityIDAndOrganizationID(
+				ctx,
+				conn,
+				scope,
+				identity.ID,
+				req.OrganizationID,
+			)
+			if err != nil && !errors.Is(err, coredata.ErrResourceNotFound) {
+				return fmt.Errorf("cannot load profile: %w", err)
 			}
 
-			if req.ContractStartDate != nil {
-				profile.ContractStartDate = *req.ContractStartDate
-			}
+			if err == nil {
+				if existingProfile.Source == coredata.ProfileSourceSCIM {
+					return NewUserManagedBySCIMError(existingProfile.ID)
+				}
 
-			if req.ContractEndDate != nil {
-				profile.ContractEndDate = *req.ContractEndDate
-			}
+				existingMembership := &coredata.Membership{}
 
-			if err := profile.Insert(ctx, conn); err != nil {
-				if errors.Is(err, coredata.ErrResourceAlreadyExists) {
+				err := existingMembership.LoadByIdentityIDAndOrganizationID(
+					ctx,
+					conn,
+					scope,
+					identity.ID,
+					req.OrganizationID,
+				)
+				if err == nil {
 					return NewUserAlreadyExistsError(identity.ID, req.OrganizationID)
 				}
 
-				return fmt.Errorf("cannot insert profile: %w", err)
+				if !errors.Is(err, coredata.ErrResourceNotFound) {
+					return fmt.Errorf("cannot load membership: %w", err)
+				}
+
+				// Reuse orphan / compliance-portal profiles so the same person
+				// record can later receive a console membership. Keep state as-is:
+				// portal access requires ACTIVE, and CreateUser is already
+				// authorized to grant the requested role.
+				profile = existingProfile
+				profile.FullName = req.FullName
+				profile.Kind = req.Kind
+				profile.AdditionalEmailAddresses = req.AdditionalEmailAddresses
+				profile.Position = req.Position
+				profile.UpdatedAt = now
+
+				if req.ContractStartDate != nil {
+					profile.ContractStartDate = *req.ContractStartDate
+				}
+
+				if req.ContractEndDate != nil {
+					profile.ContractEndDate = *req.ContractEndDate
+				}
+
+				if err := profile.Update(ctx, conn, scope); err != nil {
+					return fmt.Errorf("cannot update profile: %w", err)
+				}
+
+				if profile.ContractEndDate != nil && profile.ContractEndDate.Before(now) {
+					signatures := &coredata.DocumentVersionSignatures{}
+					if err := signatures.DeleteRequestedBySignatory(ctx, conn, scope, profile.ID); err != nil {
+						return fmt.Errorf("cannot delete requested signatures: %w", err)
+					}
+				}
+			} else {
+				profile = &coredata.MembershipProfile{
+					ID:                       gid.New(req.OrganizationID.TenantID(), coredata.MembershipProfileEntityType),
+					IdentityID:               identity.ID,
+					OrganizationID:           req.OrganizationID,
+					EmailAddress:             req.EmailAddress,
+					Source:                   coredata.ProfileSourceManual,
+					FullName:                 req.FullName,
+					Kind:                     req.Kind,
+					AdditionalEmailAddresses: req.AdditionalEmailAddresses,
+					Position:                 req.Position,
+					// User is pending until they accept an invitation.
+					State:     coredata.ProfileStatePending,
+					CreatedAt: now,
+					UpdatedAt: now,
+				}
+
+				if req.ContractStartDate != nil {
+					profile.ContractStartDate = *req.ContractStartDate
+				}
+
+				if req.ContractEndDate != nil {
+					profile.ContractEndDate = *req.ContractEndDate
+				}
+
+				if err := profile.Insert(ctx, conn); err != nil {
+					if errors.Is(err, coredata.ErrResourceAlreadyExists) {
+						return NewUserAlreadyExistsError(identity.ID, req.OrganizationID)
+					}
+
+					return fmt.Errorf("cannot insert profile: %w", err)
+				}
 			}
 
 			membership := &coredata.Membership{
@@ -1077,6 +1143,10 @@ func (s *OrganizationService) CreateUser(ctx context.Context, scope coredata.Sco
 				UpdatedAt:      now,
 			}
 			if err := membership.Insert(ctx, conn, scope); err != nil {
+				if errors.Is(err, coredata.ErrResourceAlreadyExists) {
+					return NewUserAlreadyExistsError(identity.ID, req.OrganizationID)
+				}
+
 				return fmt.Errorf("cannot insert membership: %w", err)
 			}
 

--- a/pkg/server/api/connect/v1/profile_resolvers.go
+++ b/pkg/server/api/connect/v1/profile_resolvers.go
@@ -52,6 +52,10 @@ func (r *mutationResolver) CreateUser(ctx context.Context, input types.CreateUse
 			return nil, gqlutils.Conflict(ctx, err)
 		}
 
+		if _, ok := errors.AsType[*iam.ErrUserManagedBySCIM](err); ok {
+			return nil, gqlutils.Conflictf(ctx, "user is managed by SCIM and cannot be created manually")
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot create user", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2875,6 +2875,10 @@ func (r *Resolver) CreateUserTool(ctx context.Context, req *mcp.CallToolRequest,
 			return nil, types.CreateUserOutput{}, fmt.Errorf("user with email already exists: %w", err)
 		}
 
+		if _, ok := errors.AsType[*iam.ErrUserManagedBySCIM](err); ok {
+			return nil, types.CreateUserOutput{}, fmt.Errorf("user managed by SCIM: %w", err)
+		}
+
 		return nil, types.CreateUserOutput{}, fmt.Errorf("create user: %w", err)
 	}
 


### PR DESCRIPTION
Allows promoting compliance-portal or orphan profiles into console members instead of failing on the unique identity/org constraint. Adds e2e coverage for the reuse path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses existing compliance-portal or orphan membership profiles when creating users to avoid identity/org conflicts and promote them into console members. Adds e2e coverage and returns clear conflicts for SCIM-managed or duplicate users.

### Tests **`+193`** **`-0`**
- Seeds an orphan profile, runs createUser, and verifies the profile ID is reused.
- Confirms the orphan is hidden until membership exists, preserves state, sets role, and a second create returns CONFLICT.

### Service **`+93`** **`-23`**
- Loads a profile by identity+organization; if found without a membership, reuses it and updates fields (name, kind, emails, dates) while keeping state. Returns a specific error for SCIM-managed profiles.
- Maps duplicate profile/membership inserts to “user already exists”.
- When contractEndDate is in the past, deletes requested document signatures for the profile.

### GraphQL API **`+4`** **`-0`**
- Maps SCIM-managed user errors to a Conflict with a clear “user is managed by SCIM and cannot be created manually” message.

### MCP **`+4`** **`-0`**
- Returns a clear “user managed by SCIM” message on create instead of a generic error.

<sup>Written for commit e4a35a503c26da2eeb2dd0cefb4225660e63e331. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

