### PR TITLE
Include activated_at in SCIM export profile load

### DIFF
--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -535,6 +535,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SCIM_EVENT CSV exports failed with:

```text
cannot collect profiles by ids: cannot find field activated_at in returned row
```

`MembershipProfiles.LoadExistingByIDs` scans into `MembershipProfile`, but its SELECT omitted `activated_at` / `deactivated_at` after the profile-state split added those columns. `pgx.RowToAddrOfStructByName` then rejected every row.

## Change

Select `p.activated_at` and `p.deactivated_at` in `LoadExistingByIDs`, matching the other membership-profile loaders.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b1a3399-bdf6-47cc-b770-88b251292bf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b1a3399-bdf6-47cc-b770-88b251292bf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SCIM_EVENT CSV export failures by selecting `activated_at` and `deactivated_at` when loading membership profiles by ID. This lets the query scan into `MembershipProfile` and unblocks SCIM exports.

### Coredata **`+2`** **`-0`**
- Add `p.activated_at` and `p.deactivated_at` to `MembershipProfiles.LoadExistingByIDs` SELECT.
- Fixes pgx scan error: "cannot find field activated_at in returned row."

<sup>Written for commit d598715b46a27d08296c6bbe0cf82a643f7542f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

