### PR TITLE
Mark archived HubSpot users as inactive

### DIFF
--- a/cmd/probod/CHANGELOG.md
+++ b/cmd/probod/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `probod` (the server, including the bundled `@probo/conso
 
 ## Unreleased
 
+### Fixed
+
+- HubSpot access-review connector now marks deactivated/archived users as inactive by consulting the Owners API (`archived=true`) instead of treating every Settings Users row as active. Existing HubSpot connectors must reconnect (or private apps must grant `crm.objects.owners.read`) before inactive detection works.
+
 ## [0.249.1] - 2026-08-06
 
 ### Fixed

--- a/pkg/accessreview/drivers/hubspot.go
+++ b/pkg/accessreview/drivers/hubspot.go
@@ -94,6 +94,11 @@ type (
 			} `json:"next"`
 		} `json:"paging"`
 	}
+
+	hubspotSeenKeys struct {
+		userIDs map[string]struct{}
+		emails  map[string]struct{}
+	}
 )
 
 const (
@@ -118,47 +123,29 @@ func (d *HubSpotDriver) ListAccounts(ctx context.Context) ([]AccountRecord, erro
 		return nil, err
 	}
 
+	// Owners archived=true is HubSpot's authoritative deactivated-user list.
+	// Settings Users has no status field; without this call every account
+	// would be stored as active via COALESCE(@active, TRUE) on upsert.
 	archivedOwners, err := d.fetchAllOwners(ctx, true)
 	if err != nil {
 		return nil, err
 	}
 
-	archivedByUserID := make(map[string]hubspotOwner, len(archivedOwners))
-	archivedByEmail := make(map[string]hubspotOwner, len(archivedOwners))
-	for _, owner := range archivedOwners {
-		if owner.Type != "" && !strings.EqualFold(owner.Type, "PERSON") {
-			continue
-		}
-
-		if id := hubspotOwnerUserID(owner); id != "" {
-			archivedByUserID[id] = owner
-		}
-
-		if email := strings.ToLower(strings.TrimSpace(owner.Email)); email != "" {
-			archivedByEmail[email] = owner
-		}
-	}
+	archivedByUserID, archivedByEmail := hubspotIndexArchivedOwners(archivedOwners)
 
 	records := make([]AccountRecord, 0, len(users)+len(archivedOwners))
-	seenUserIDs := make(map[string]struct{}, len(users)+len(archivedOwners))
+	seen := newHubspotSeenKeys(len(users) + len(archivedOwners))
 
 	for _, u := range users {
-		fullName := strings.TrimSpace(u.FirstName + " " + u.LastName)
+		owner, inactive := hubspotLookupArchived(u.ID, u.Email, archivedByUserID, archivedByEmail)
 
-		active := true
-		if _, ok := archivedByUserID[u.ID]; ok {
-			active = false
-		} else if email := strings.ToLower(strings.TrimSpace(u.Email)); email != "" {
-			if _, ok := archivedByEmail[email]; ok {
-				active = false
-			}
-		}
+		fullName := hubspotDisplayName(u.FirstName, u.LastName, u.Email)
 
 		record := AccountRecord{
 			Email:       u.Email,
 			FullName:    fullName,
 			Roles:       hubspotRoles(u, roleMap),
-			Active:      new(active),
+			Active:      new(!inactive),
 			IsAdmin:     u.SuperAdmin,
 			ExternalID:  u.ID,
 			MFAStatus:   coredata.MFAStatusUnknown,
@@ -166,31 +153,32 @@ func (d *HubSpotDriver) ListAccounts(ctx context.Context) ([]AccountRecord, erro
 			AccountType: coredata.AccessReviewEntryAccountTypeUser,
 		}
 
-		if record.Email != "" || record.ExternalID != "" {
-			records = append(records, record)
-			if u.ID != "" {
-				seenUserIDs[u.ID] = struct{}{}
-			}
+		if record.Email == "" && record.ExternalID == "" {
+			continue
+		}
+
+		records = append(records, record)
+		seen.mark(u.ID, u.Email)
+		// If we matched an archived owner by email only, also mark its
+		// settings user ID so the archived-only pass cannot emit a duplicate.
+		if inactive {
+			seen.mark(hubspotOwnerUserID(owner), owner.Email)
 		}
 	}
 
 	// Settings Users does not always list deactivated accounts. Surface
 	// archived owners that never appeared above so reviews still see them.
 	for _, owner := range archivedOwners {
-		if owner.Type != "" && !strings.EqualFold(owner.Type, "PERSON") {
+		if !hubspotOwnerIsPerson(owner) {
 			continue
 		}
 
 		userID := hubspotOwnerUserID(owner)
-		if userID != "" {
-			if _, seen := seenUserIDs[userID]; seen {
-				continue
-			}
-
-			seenUserIDs[userID] = struct{}{}
+		if seen.has(userID, owner.Email) {
+			continue
 		}
 
-		fullName := strings.TrimSpace(owner.FirstName + " " + owner.LastName)
+		fullName := hubspotDisplayName(owner.FirstName, owner.LastName, owner.Email)
 		externalID := userID
 		if externalID == "" {
 			externalID = owner.ID
@@ -208,9 +196,12 @@ func (d *HubSpotDriver) ListAccounts(ctx context.Context) ([]AccountRecord, erro
 			AccountType: coredata.AccessReviewEntryAccountTypeUser,
 		}
 
-		if record.Email != "" || record.ExternalID != "" {
-			records = append(records, record)
+		if record.Email == "" && record.ExternalID == "" {
+			continue
 		}
+
+		records = append(records, record)
+		seen.mark(userID, owner.Email)
 	}
 
 	return records, nil
@@ -455,18 +446,112 @@ func hubspotRoleIDs(user hubspotUser) []string {
 	return ids
 }
 
+func hubspotIndexArchivedOwners(
+	owners []hubspotOwner,
+) (byUserID map[string]hubspotOwner, byEmail map[string]hubspotOwner) {
+	byUserID = make(map[string]hubspotOwner, len(owners))
+	byEmail = make(map[string]hubspotOwner, len(owners))
+
+	for _, owner := range owners {
+		if !hubspotOwnerIsPerson(owner) {
+			continue
+		}
+
+		if id := hubspotOwnerUserID(owner); id != "" {
+			byUserID[id] = owner
+		}
+
+		if email := hubspotNormalizeEmail(owner.Email); email != "" {
+			byEmail[email] = owner
+		}
+	}
+
+	return byUserID, byEmail
+}
+
+func hubspotLookupArchived(
+	userID string,
+	email string,
+	byUserID map[string]hubspotOwner,
+	byEmail map[string]hubspotOwner,
+) (hubspotOwner, bool) {
+	if userID != "" {
+		if owner, ok := byUserID[userID]; ok {
+			return owner, true
+		}
+	}
+
+	if normalized := hubspotNormalizeEmail(email); normalized != "" {
+		if owner, ok := byEmail[normalized]; ok {
+			return owner, true
+		}
+	}
+
+	return hubspotOwner{}, false
+}
+
+func hubspotOwnerIsPerson(owner hubspotOwner) bool {
+	return owner.Type == "" || strings.EqualFold(owner.Type, "PERSON")
+}
+
 // hubspotOwnerUserID returns the Settings Users ID for an owner. Archived
 // owners leave userId null and expose the ID only on userIdIncludingInactive.
 func hubspotOwnerUserID(owner hubspotOwner) string {
-	if owner.UserIDIncludingInactive != nil {
+	if owner.UserIDIncludingInactive != nil && *owner.UserIDIncludingInactive != 0 {
 		return strconv.FormatInt(*owner.UserIDIncludingInactive, 10)
 	}
 
-	if owner.UserID != nil {
+	if owner.UserID != nil && *owner.UserID != 0 {
 		return strconv.FormatInt(*owner.UserID, 10)
 	}
 
 	return ""
+}
+
+func hubspotDisplayName(firstName, lastName, email string) string {
+	fullName := strings.TrimSpace(firstName + " " + lastName)
+	if fullName != "" {
+		return fullName
+	}
+
+	return strings.TrimSpace(email)
+}
+
+func hubspotNormalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+func newHubspotSeenKeys(capacity int) *hubspotSeenKeys {
+	return &hubspotSeenKeys{
+		userIDs: make(map[string]struct{}, capacity),
+		emails:  make(map[string]struct{}, capacity),
+	}
+}
+
+func (s *hubspotSeenKeys) mark(userID, email string) {
+	if userID != "" {
+		s.userIDs[userID] = struct{}{}
+	}
+
+	if normalized := hubspotNormalizeEmail(email); normalized != "" {
+		s.emails[normalized] = struct{}{}
+	}
+}
+
+func (s *hubspotSeenKeys) has(userID, email string) bool {
+	if userID != "" {
+		if _, ok := s.userIDs[userID]; ok {
+			return true
+		}
+	}
+
+	if normalized := hubspotNormalizeEmail(email); normalized != "" {
+		if _, ok := s.emails[normalized]; ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 // hubspotNameResolver resolves the HubSpot account name.

--- a/pkg/accessreview/drivers/hubspot.go
+++ b/pkg/accessreview/drivers/hubspot.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"go.probo.inc/probo/pkg/coredata"
@@ -33,6 +34,12 @@ import (
 
 // HubSpotDriver fetches account users from HubSpot via OAuth2-authenticated
 // REST requests.
+//
+// The Settings Users API (`/settings/v3/users`) exposes roles and super-admin
+// flags but has no active/archived signal. Deactivated HubSpot users are
+// owners with `archived=true` on `/crm/v3/owners`; this driver merges both
+// APIs so inactive accounts are returned with Active=false instead of being
+// misclassified as active.
 type HubSpotDriver struct {
 	httpClient *http.Client
 	baseURL    string
@@ -57,15 +64,30 @@ type (
 		RoleIDs       []string `json:"roleIds"`
 		PrimaryTeamID string   `json:"primaryTeamId"`
 		SuperAdmin    bool     `json:"superAdmin"`
-		Archived      *bool    `json:"archived"`
-		Deactivated   *bool    `json:"deactivated"`
-		IsActive      *bool    `json:"isActive"`
-		Active        *bool    `json:"active"`
-		HSDeactivated *bool    `json:"hs_deactivated"`
 	}
 
 	hubspotUsersResponse struct {
 		Results []hubspotUser `json:"results"`
+		Paging  *struct {
+			Next *struct {
+				After string `json:"after"`
+			} `json:"next"`
+		} `json:"paging"`
+	}
+
+	hubspotOwner struct {
+		ID                      string `json:"id"`
+		Email                   string `json:"email"`
+		FirstName               string `json:"firstName"`
+		LastName                string `json:"lastName"`
+		Type                    string `json:"type"`
+		Archived                bool   `json:"archived"`
+		UserID                  *int64 `json:"userId"`
+		UserIDIncludingInactive *int64 `json:"userIdIncludingInactive"`
+	}
+
+	hubspotOwnersResponse struct {
+		Results []hubspotOwner `json:"results"`
 		Paging  *struct {
 			Next *struct {
 				After string `json:"after"`
@@ -78,6 +100,7 @@ const (
 	hubspotUsersPath       = "/settings/v3/users"
 	hubspotRolesPath       = "/settings/v3/users/roles"
 	hubspotAccountInfoPath = "/account-info/v3/details"
+	hubspotOwnersPath      = "/crm/v3/owners"
 )
 
 func NewHubSpotDriver(httpClient *http.Client, baseURL string) *HubSpotDriver {
@@ -90,9 +113,113 @@ func NewHubSpotDriver(httpClient *http.Client, baseURL string) *HubSpotDriver {
 func (d *HubSpotDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
 	roleMap, _ := d.fetchRoles(ctx)
 
+	users, err := d.fetchAllUsers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	archivedOwners, err := d.fetchAllOwners(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	archivedByUserID := make(map[string]hubspotOwner, len(archivedOwners))
+	archivedByEmail := make(map[string]hubspotOwner, len(archivedOwners))
+	for _, owner := range archivedOwners {
+		if owner.Type != "" && !strings.EqualFold(owner.Type, "PERSON") {
+			continue
+		}
+
+		if id := hubspotOwnerUserID(owner); id != "" {
+			archivedByUserID[id] = owner
+		}
+
+		if email := strings.ToLower(strings.TrimSpace(owner.Email)); email != "" {
+			archivedByEmail[email] = owner
+		}
+	}
+
+	records := make([]AccountRecord, 0, len(users)+len(archivedOwners))
+	seenUserIDs := make(map[string]struct{}, len(users)+len(archivedOwners))
+
+	for _, u := range users {
+		fullName := strings.TrimSpace(u.FirstName + " " + u.LastName)
+
+		active := true
+		if _, ok := archivedByUserID[u.ID]; ok {
+			active = false
+		} else if email := strings.ToLower(strings.TrimSpace(u.Email)); email != "" {
+			if _, ok := archivedByEmail[email]; ok {
+				active = false
+			}
+		}
+
+		record := AccountRecord{
+			Email:       u.Email,
+			FullName:    fullName,
+			Roles:       hubspotRoles(u, roleMap),
+			Active:      new(active),
+			IsAdmin:     u.SuperAdmin,
+			ExternalID:  u.ID,
+			MFAStatus:   coredata.MFAStatusUnknown,
+			AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
+			AccountType: coredata.AccessReviewEntryAccountTypeUser,
+		}
+
+		if record.Email != "" || record.ExternalID != "" {
+			records = append(records, record)
+			if u.ID != "" {
+				seenUserIDs[u.ID] = struct{}{}
+			}
+		}
+	}
+
+	// Settings Users does not always list deactivated accounts. Surface
+	// archived owners that never appeared above so reviews still see them.
+	for _, owner := range archivedOwners {
+		if owner.Type != "" && !strings.EqualFold(owner.Type, "PERSON") {
+			continue
+		}
+
+		userID := hubspotOwnerUserID(owner)
+		if userID != "" {
+			if _, seen := seenUserIDs[userID]; seen {
+				continue
+			}
+
+			seenUserIDs[userID] = struct{}{}
+		}
+
+		fullName := strings.TrimSpace(owner.FirstName + " " + owner.LastName)
+		externalID := userID
+		if externalID == "" {
+			externalID = owner.ID
+		}
+
+		record := AccountRecord{
+			Email:       owner.Email,
+			FullName:    fullName,
+			Roles:       []string{"User"},
+			Active:      new(false),
+			IsAdmin:     false,
+			ExternalID:  externalID,
+			MFAStatus:   coredata.MFAStatusUnknown,
+			AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
+			AccountType: coredata.AccessReviewEntryAccountTypeUser,
+		}
+
+		if record.Email != "" || record.ExternalID != "" {
+			records = append(records, record)
+		}
+	}
+
+	return records, nil
+}
+
+func (d *HubSpotDriver) fetchAllUsers(ctx context.Context) ([]hubspotUser, error) {
 	var (
-		records []AccountRecord
-		after   string
+		users []hubspotUser
+		after string
 	)
 
 	for range maxPaginationPages {
@@ -101,34 +228,40 @@ func (d *HubSpotDriver) ListAccounts(ctx context.Context) ([]AccountRecord, erro
 			return nil, err
 		}
 
-		for _, u := range resp.Results {
-			fullName := strings.TrimSpace(u.FirstName + " " + u.LastName)
-
-			record := AccountRecord{
-				Email:       u.Email,
-				FullName:    fullName,
-				Roles:       hubspotRoles(u, roleMap),
-				Active:      hubspotUserActive(u),
-				IsAdmin:     u.SuperAdmin,
-				ExternalID:  u.ID,
-				MFAStatus:   coredata.MFAStatusUnknown,
-				AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
-				AccountType: coredata.AccessReviewEntryAccountTypeUser,
-			}
-
-			if record.Email != "" || record.ExternalID != "" {
-				records = append(records, record)
-			}
-		}
+		users = append(users, resp.Results...)
 
 		if resp.Paging == nil || resp.Paging.Next == nil || resp.Paging.Next.After == "" {
-			return records, nil
+			return users, nil
 		}
 
 		after = resp.Paging.Next.After
 	}
 
-	return nil, fmt.Errorf("cannot list all hubspot accounts: %w", ErrPaginationLimitReached)
+	return nil, fmt.Errorf("cannot list all hubspot users: %w", ErrPaginationLimitReached)
+}
+
+func (d *HubSpotDriver) fetchAllOwners(ctx context.Context, archived bool) ([]hubspotOwner, error) {
+	var (
+		owners []hubspotOwner
+		after  string
+	)
+
+	for range maxPaginationPages {
+		resp, err := d.fetchOwners(ctx, archived, after)
+		if err != nil {
+			return nil, err
+		}
+
+		owners = append(owners, resp.Results...)
+
+		if resp.Paging == nil || resp.Paging.Next == nil || resp.Paging.Next.After == "" {
+			return owners, nil
+		}
+
+		after = resp.Paging.Next.After
+	}
+
+	return nil, fmt.Errorf("cannot list all hubspot owners: %w", ErrPaginationLimitReached)
 }
 
 func (d *HubSpotDriver) fetchUsers(ctx context.Context, after string) (*hubspotUsersResponse, error) {
@@ -169,6 +302,54 @@ func (d *HubSpotDriver) fetchUsers(ctx context.Context, after string) (*hubspotU
 	var resp hubspotUsersResponse
 	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
 		return nil, fmt.Errorf("cannot decode hubspot users response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+func (d *HubSpotDriver) fetchOwners(
+	ctx context.Context,
+	archived bool,
+	after string,
+) (*hubspotOwnersResponse, error) {
+	endpoint, err := url.JoinPath(d.baseURL, hubspotOwnersPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build hubspot owners URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create hubspot owners request: %w", err)
+	}
+
+	q := req.URL.Query()
+	q.Set("limit", "100")
+	q.Set("archived", strconv.FormatBool(archived))
+
+	if after != "" {
+		q.Set("after", after)
+	}
+
+	req.URL.RawQuery = q.Encode()
+
+	req.Header.Set("Accept", "application/json")
+
+	httpResp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot execute hubspot owners request: %w", err)
+	}
+
+	defer func() {
+		_ = httpResp.Body.Close()
+	}()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, fmt.Errorf("cannot fetch hubspot owners: unexpected status %d", httpResp.StatusCode)
+	}
+
+	var resp hubspotOwnersResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("cannot decode hubspot owners response: %w", err)
 	}
 
 	return &resp, nil
@@ -274,28 +455,18 @@ func hubspotRoleIDs(user hubspotUser) []string {
 	return ids
 }
 
-func hubspotUserActive(user hubspotUser) *bool {
-	if user.IsActive != nil {
-		return new(*user.IsActive)
+// hubspotOwnerUserID returns the Settings Users ID for an owner. Archived
+// owners leave userId null and expose the ID only on userIdIncludingInactive.
+func hubspotOwnerUserID(owner hubspotOwner) string {
+	if owner.UserIDIncludingInactive != nil {
+		return strconv.FormatInt(*owner.UserIDIncludingInactive, 10)
 	}
 
-	if user.Active != nil {
-		return new(*user.Active)
+	if owner.UserID != nil {
+		return strconv.FormatInt(*owner.UserID, 10)
 	}
 
-	if user.Deactivated != nil {
-		return new(!*user.Deactivated)
-	}
-
-	if user.HSDeactivated != nil {
-		return new(!*user.HSDeactivated)
-	}
-
-	if user.Archived != nil {
-		return new(!*user.Archived)
-	}
-
-	return nil
+	return ""
 }
 
 // hubspotNameResolver resolves the HubSpot account name.

--- a/pkg/accessreview/drivers/hubspot_test.go
+++ b/pkg/accessreview/drivers/hubspot_test.go
@@ -22,10 +22,7 @@ package drivers
 
 import (
 	"context"
-	"io"
-	"net/http"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,134 +38,41 @@ func TestHubSpotDriver(t *testing.T) {
 
 	records, err := driver.ListAccounts(context.Background())
 	require.NoError(t, err)
-	require.NotEmpty(t, records)
-
-	r := records[0]
-	assert.NotEmpty(t, r.Email)
-	assert.NotEmpty(t, r.FullName)
-	assert.NotEmpty(t, r.ExternalID)
-	require.NotNil(t, r.Active)
-	assert.True(t, *r.Active)
-}
-
-func TestHubSpotDriverArchivedUsers(t *testing.T) {
-	t.Parallel()
-
-	client := &http.Client{
-		Transport: roundTripFunc(
-			func(req *http.Request) (*http.Response, error) {
-				switch {
-				case req.URL.Path == "/settings/v3/users/roles":
-					return hubspotResponse(
-						http.StatusOK,
-						`{"results":[{"id":"role-1","name":"Sales Admin"}]}`,
-					), nil
-				case req.URL.Path == "/settings/v3/users":
-					return hubspotResponse(
-						http.StatusOK,
-						`{"results":[{"id":"10000001","email":"active@example.com","firstName":"Active","lastName":"User","roleIds":["role-1"],"superAdmin":false},{"id":"10000002","email":"still-listed@example.com","firstName":"Listed","lastName":"Inactive","roleIds":[],"superAdmin":false}]}`,
-					), nil
-				case req.URL.Path == "/crm/v3/owners" && req.URL.Query().Get("archived") == "true":
-					return hubspotResponse(
-						http.StatusOK,
-						`{"results":[{"id":"owner-2","email":"still-listed@example.com","firstName":"Listed","lastName":"Inactive","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":10000002},{"id":"owner-3","email":"gone@example.com","firstName":"","lastName":"","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":10000003}]}`,
-					), nil
-				default:
-					return hubspotResponse(http.StatusNotFound, `{"message":"not found"}`), nil
-				}
-			},
-		),
-	}
-
-	driver := NewHubSpotDriver(client, "https://api.hubapi.com")
-
-	records, err := driver.ListAccounts(context.Background())
-	require.NoError(t, err)
 	require.Len(t, records, 3)
 
-	assert.Equal(t, "active@example.com", records[0].Email)
-	assert.Equal(t, []string{"Sales Admin"}, records[0].Roles)
-	require.NotNil(t, records[0].Active)
-	assert.True(t, *records[0].Active)
+	// Active super-admin with a resolved role.
+	active := records[0]
+	assert.Equal(t, "10000001", active.ExternalID)
+	assert.Equal(t, "john.smith@example.com", active.Email)
+	assert.Equal(t, "John Smith", active.FullName)
+	assert.Equal(t, []string{"Sales Admin", "Super Admin"}, active.Roles)
+	assert.True(t, active.IsAdmin)
+	require.NotNil(t, active.Active)
+	assert.True(t, *active.Active)
 
-	assert.Equal(t, "10000002", records[1].ExternalID)
-	assert.Equal(t, "still-listed@example.com", records[1].Email)
-	require.NotNil(t, records[1].Active)
-	assert.False(t, *records[1].Active)
+	// Still listed in Settings Users, but archived as an owner → inactive.
+	listedInactive := records[1]
+	assert.Equal(t, "10000002", listedInactive.ExternalID)
+	assert.Equal(t, "jane.doe@example.com", listedInactive.Email)
+	assert.Equal(t, "Jane Doe", listedInactive.FullName)
+	assert.False(t, listedInactive.IsAdmin)
+	require.NotNil(t, listedInactive.Active)
+	assert.False(t, *listedInactive.Active)
 
-	// Archived-only owner: empty HubSpot name falls back to email, Active=false.
-	assert.Equal(t, "10000003", records[2].ExternalID)
-	assert.Equal(t, "gone@example.com", records[2].Email)
-	assert.Equal(t, "gone@example.com", records[2].FullName)
-	require.NotNil(t, records[2].Active)
-	assert.False(t, *records[2].Active)
-}
-
-func TestHubSpotDriverEmailMatchDoesNotDuplicate(t *testing.T) {
-	t.Parallel()
-
-	// Settings user ID differs from owner userIdIncludingInactive, but the
-	// email matches. The driver must mark the settings row inactive and must
-	// not emit a second archived-only row for the same person.
-	client := &http.Client{
-		Transport: roundTripFunc(
-			func(req *http.Request) (*http.Response, error) {
-				switch {
-				case req.URL.Path == "/settings/v3/users/roles":
-					return hubspotResponse(http.StatusOK, `{"results":[]}`), nil
-				case req.URL.Path == "/settings/v3/users":
-					return hubspotResponse(
-						http.StatusOK,
-						`{"results":[{"id":"settings-1","email":"Jane.Doe@Example.com","firstName":"Jane","lastName":"Doe","roleIds":[],"superAdmin":true}]}`,
-					), nil
-				case req.URL.Path == "/crm/v3/owners" && req.URL.Query().Get("archived") == "true":
-					return hubspotResponse(
-						http.StatusOK,
-						`{"results":[{"id":"owner-9","email":"jane.doe@example.com","firstName":"","lastName":"","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":999}]}`,
-					), nil
-				default:
-					return hubspotResponse(http.StatusNotFound, `{"message":"not found"}`), nil
-				}
-			},
-		),
-	}
-
-	driver := NewHubSpotDriver(client, "https://api.hubapi.com")
-
-	records, err := driver.ListAccounts(context.Background())
-	require.NoError(t, err)
-	require.Len(t, records, 1)
-
-	assert.Equal(t, "settings-1", records[0].ExternalID)
-	assert.Equal(t, "Jane.Doe@Example.com", records[0].Email)
-	assert.Equal(t, []string{"Super Admin"}, records[0].Roles)
-	require.NotNil(t, records[0].Active)
-	assert.False(t, *records[0].Active)
+	// Archived-only owner (missing from Settings Users); empty name → email.
+	archivedOnly := records[2]
+	assert.Equal(t, "10000003", archivedOnly.ExternalID)
+	assert.Equal(t, "gone@example.com", archivedOnly.Email)
+	assert.Equal(t, "gone@example.com", archivedOnly.FullName)
+	require.NotNil(t, archivedOnly.Active)
+	assert.False(t, *archivedOnly.Active)
 }
 
 func TestHubSpotDriverOwnersRequired(t *testing.T) {
 	t.Parallel()
 
-	client := &http.Client{
-		Transport: roundTripFunc(
-			func(req *http.Request) (*http.Response, error) {
-				switch req.URL.Path {
-				case "/settings/v3/users/roles":
-					return hubspotResponse(http.StatusOK, `{"results":[]}`), nil
-				case "/settings/v3/users":
-					return hubspotResponse(
-						http.StatusOK,
-						`{"results":[{"id":"1","email":"a@example.com","firstName":"A","lastName":"B","roleIds":[],"superAdmin":false}]}`,
-					), nil
-				case "/crm/v3/owners":
-					return hubspotResponse(http.StatusForbidden, `{"message":"missing scope"}`), nil
-				default:
-					return hubspotResponse(http.StatusNotFound, `{"message":"not found"}`), nil
-				}
-			},
-		),
-	}
-
+	rec := newRecorder(t, "testdata/hubspot_owners_forbidden", "HUBSPOT_TOKEN")
+	client := newVCRClient(rec, bearerAuth(os.Getenv("HUBSPOT_TOKEN")))
 	driver := NewHubSpotDriver(client, "https://api.hubapi.com")
 
 	_, err := driver.ListAccounts(context.Background())
@@ -176,35 +80,20 @@ func TestHubSpotDriverOwnersRequired(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot fetch hubspot owners")
 }
 
-func TestHubSpotDriverSkipsNonPersonOwners(t *testing.T) {
+func TestHubSpotDriverEmailMatchDoesNotDuplicate(t *testing.T) {
 	t.Parallel()
 
-	client := &http.Client{
-		Transport: roundTripFunc(
-			func(req *http.Request) (*http.Response, error) {
-				switch {
-				case req.URL.Path == "/settings/v3/users/roles":
-					return hubspotResponse(http.StatusOK, `{"results":[]}`), nil
-				case req.URL.Path == "/settings/v3/users":
-					return hubspotResponse(http.StatusOK, `{"results":[]}`), nil
-				case req.URL.Path == "/crm/v3/owners" && req.URL.Query().Get("archived") == "true":
-					return hubspotResponse(
-						http.StatusOK,
-						`{"results":[{"id":"queue-1","email":"queue@example.com","type":"QUEUE","archived":true,"userId":null,"userIdIncludingInactive":null},{"id":"owner-1","email":"person@example.com","firstName":"P","lastName":"erson","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":42}]}`,
-					), nil
-				default:
-					return hubspotResponse(http.StatusNotFound, `{"message":"not found"}`), nil
-				}
-			},
-		),
-	}
-
+	rec := newRecorder(t, "testdata/hubspot_email_match", "HUBSPOT_TOKEN")
+	client := newVCRClient(rec, bearerAuth(os.Getenv("HUBSPOT_TOKEN")))
 	driver := NewHubSpotDriver(client, "https://api.hubapi.com")
 
 	records, err := driver.ListAccounts(context.Background())
 	require.NoError(t, err)
 	require.Len(t, records, 1)
-	assert.Equal(t, "42", records[0].ExternalID)
+
+	assert.Equal(t, "settings-1", records[0].ExternalID)
+	assert.Equal(t, "Jane.Doe@example.com", records[0].Email)
+	assert.Equal(t, []string{"Super Admin"}, records[0].Roles)
 	require.NotNil(t, records[0].Active)
 	assert.False(t, *records[0].Active)
 }
@@ -284,19 +173,5 @@ func TestHubSpotRoles(t *testing.T) {
 
 			assert.Equal(t, tt.want, hubspotRoles(tt.user, roleMap))
 		})
-	}
-}
-
-type roundTripFunc func(req *http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
-func hubspotResponse(statusCode int, body string) *http.Response {
-	return &http.Response{
-		StatusCode: statusCode,
-		Body:       io.NopCloser(strings.NewReader(body)),
-		Header:     make(http.Header),
 	}
 }

--- a/pkg/accessreview/drivers/hubspot_test.go
+++ b/pkg/accessreview/drivers/hubspot_test.go
@@ -71,7 +71,7 @@ func TestHubSpotDriverArchivedUsers(t *testing.T) {
 				case req.URL.Path == "/crm/v3/owners" && req.URL.Query().Get("archived") == "true":
 					return hubspotResponse(
 						http.StatusOK,
-						`{"results":[{"id":"owner-2","email":"still-listed@example.com","firstName":"Listed","lastName":"Inactive","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":10000002},{"id":"owner-3","email":"gone@example.com","firstName":"Fully","lastName":"Archived","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":10000003}]}`,
+						`{"results":[{"id":"owner-2","email":"still-listed@example.com","firstName":"Listed","lastName":"Inactive","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":10000002},{"id":"owner-3","email":"gone@example.com","firstName":"","lastName":"","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":10000003}]}`,
 					), nil
 				default:
 					return hubspotResponse(http.StatusNotFound, `{"message":"not found"}`), nil
@@ -96,10 +96,54 @@ func TestHubSpotDriverArchivedUsers(t *testing.T) {
 	require.NotNil(t, records[1].Active)
 	assert.False(t, *records[1].Active)
 
+	// Archived-only owner: empty HubSpot name falls back to email, Active=false.
 	assert.Equal(t, "10000003", records[2].ExternalID)
 	assert.Equal(t, "gone@example.com", records[2].Email)
+	assert.Equal(t, "gone@example.com", records[2].FullName)
 	require.NotNil(t, records[2].Active)
 	assert.False(t, *records[2].Active)
+}
+
+func TestHubSpotDriverEmailMatchDoesNotDuplicate(t *testing.T) {
+	t.Parallel()
+
+	// Settings user ID differs from owner userIdIncludingInactive, but the
+	// email matches. The driver must mark the settings row inactive and must
+	// not emit a second archived-only row for the same person.
+	client := &http.Client{
+		Transport: roundTripFunc(
+			func(req *http.Request) (*http.Response, error) {
+				switch {
+				case req.URL.Path == "/settings/v3/users/roles":
+					return hubspotResponse(http.StatusOK, `{"results":[]}`), nil
+				case req.URL.Path == "/settings/v3/users":
+					return hubspotResponse(
+						http.StatusOK,
+						`{"results":[{"id":"settings-1","email":"Jane.Doe@Example.com","firstName":"Jane","lastName":"Doe","roleIds":[],"superAdmin":true}]}`,
+					), nil
+				case req.URL.Path == "/crm/v3/owners" && req.URL.Query().Get("archived") == "true":
+					return hubspotResponse(
+						http.StatusOK,
+						`{"results":[{"id":"owner-9","email":"jane.doe@example.com","firstName":"","lastName":"","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":999}]}`,
+					), nil
+				default:
+					return hubspotResponse(http.StatusNotFound, `{"message":"not found"}`), nil
+				}
+			},
+		),
+	}
+
+	driver := NewHubSpotDriver(client, "https://api.hubapi.com")
+
+	records, err := driver.ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	assert.Equal(t, "settings-1", records[0].ExternalID)
+	assert.Equal(t, "Jane.Doe@Example.com", records[0].Email)
+	assert.Equal(t, []string{"Super Admin"}, records[0].Roles)
+	require.NotNil(t, records[0].Active)
+	assert.False(t, *records[0].Active)
 }
 
 func TestHubSpotDriverOwnersRequired(t *testing.T) {
@@ -130,6 +174,58 @@ func TestHubSpotDriverOwnersRequired(t *testing.T) {
 	_, err := driver.ListAccounts(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot fetch hubspot owners")
+}
+
+func TestHubSpotDriverSkipsNonPersonOwners(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripFunc(
+			func(req *http.Request) (*http.Response, error) {
+				switch {
+				case req.URL.Path == "/settings/v3/users/roles":
+					return hubspotResponse(http.StatusOK, `{"results":[]}`), nil
+				case req.URL.Path == "/settings/v3/users":
+					return hubspotResponse(http.StatusOK, `{"results":[]}`), nil
+				case req.URL.Path == "/crm/v3/owners" && req.URL.Query().Get("archived") == "true":
+					return hubspotResponse(
+						http.StatusOK,
+						`{"results":[{"id":"queue-1","email":"queue@example.com","type":"QUEUE","archived":true,"userId":null,"userIdIncludingInactive":null},{"id":"owner-1","email":"person@example.com","firstName":"P","lastName":"erson","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":42}]}`,
+					), nil
+				default:
+					return hubspotResponse(http.StatusNotFound, `{"message":"not found"}`), nil
+				}
+			},
+		),
+	}
+
+	driver := NewHubSpotDriver(client, "https://api.hubapi.com")
+
+	records, err := driver.ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "42", records[0].ExternalID)
+	require.NotNil(t, records[0].Active)
+	assert.False(t, *records[0].Active)
+}
+
+func TestHubSpotOwnerUserID(t *testing.T) {
+	t.Parallel()
+
+	inactiveID := int64(9685555)
+	activeID := int64(123)
+
+	assert.Equal(t, "9685555", hubspotOwnerUserID(hubspotOwner{
+		UserIDIncludingInactive: &inactiveID,
+	}))
+	assert.Equal(t, "123", hubspotOwnerUserID(hubspotOwner{
+		UserID: &activeID,
+	}))
+	assert.Equal(t, "", hubspotOwnerUserID(hubspotOwner{}))
+	zero := int64(0)
+	assert.Equal(t, "", hubspotOwnerUserID(hubspotOwner{
+		UserIDIncludingInactive: &zero,
+	}))
 }
 
 func TestHubSpotRoles(t *testing.T) {

--- a/pkg/accessreview/drivers/hubspot_test.go
+++ b/pkg/accessreview/drivers/hubspot_test.go
@@ -47,6 +47,8 @@ func TestHubSpotDriver(t *testing.T) {
 	assert.NotEmpty(t, r.Email)
 	assert.NotEmpty(t, r.FullName)
 	assert.NotEmpty(t, r.ExternalID)
+	require.NotNil(t, r.Active)
+	assert.True(t, *r.Active)
 }
 
 func TestHubSpotDriverArchivedUsers(t *testing.T) {
@@ -55,16 +57,21 @@ func TestHubSpotDriverArchivedUsers(t *testing.T) {
 	client := &http.Client{
 		Transport: roundTripFunc(
 			func(req *http.Request) (*http.Response, error) {
-				switch req.URL.Path {
-				case "/settings/v3/users/roles":
+				switch {
+				case req.URL.Path == "/settings/v3/users/roles":
 					return hubspotResponse(
 						http.StatusOK,
 						`{"results":[{"id":"role-1","name":"Sales Admin"}]}`,
 					), nil
-				case "/settings/v3/users":
+				case req.URL.Path == "/settings/v3/users":
 					return hubspotResponse(
 						http.StatusOK,
-						`{"results":[{"id":"user-1","email":"active@example.com","firstName":"Active","lastName":"User","roleIds":["role-1"],"superAdmin":false,"isActive":true},{"id":"user-2","email":"","firstName":"Archived","lastName":"User","superAdmin":false,"archived":true}]}`,
+						`{"results":[{"id":"10000001","email":"active@example.com","firstName":"Active","lastName":"User","roleIds":["role-1"],"superAdmin":false},{"id":"10000002","email":"still-listed@example.com","firstName":"Listed","lastName":"Inactive","roleIds":[],"superAdmin":false}]}`,
+					), nil
+				case req.URL.Path == "/crm/v3/owners" && req.URL.Query().Get("archived") == "true":
+					return hubspotResponse(
+						http.StatusOK,
+						`{"results":[{"id":"owner-2","email":"still-listed@example.com","firstName":"Listed","lastName":"Inactive","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":10000002},{"id":"owner-3","email":"gone@example.com","firstName":"Fully","lastName":"Archived","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":10000003}]}`,
 					), nil
 				default:
 					return hubspotResponse(http.StatusNotFound, `{"message":"not found"}`), nil
@@ -77,16 +84,52 @@ func TestHubSpotDriverArchivedUsers(t *testing.T) {
 
 	records, err := driver.ListAccounts(context.Background())
 	require.NoError(t, err)
-	require.Len(t, records, 2)
+	require.Len(t, records, 3)
 
+	assert.Equal(t, "active@example.com", records[0].Email)
 	assert.Equal(t, []string{"Sales Admin"}, records[0].Roles)
 	require.NotNil(t, records[0].Active)
 	assert.True(t, *records[0].Active)
 
-	assert.Equal(t, "user-2", records[1].ExternalID)
-	assert.Empty(t, records[1].Email)
+	assert.Equal(t, "10000002", records[1].ExternalID)
+	assert.Equal(t, "still-listed@example.com", records[1].Email)
 	require.NotNil(t, records[1].Active)
 	assert.False(t, *records[1].Active)
+
+	assert.Equal(t, "10000003", records[2].ExternalID)
+	assert.Equal(t, "gone@example.com", records[2].Email)
+	require.NotNil(t, records[2].Active)
+	assert.False(t, *records[2].Active)
+}
+
+func TestHubSpotDriverOwnersRequired(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripFunc(
+			func(req *http.Request) (*http.Response, error) {
+				switch req.URL.Path {
+				case "/settings/v3/users/roles":
+					return hubspotResponse(http.StatusOK, `{"results":[]}`), nil
+				case "/settings/v3/users":
+					return hubspotResponse(
+						http.StatusOK,
+						`{"results":[{"id":"1","email":"a@example.com","firstName":"A","lastName":"B","roleIds":[],"superAdmin":false}]}`,
+					), nil
+				case "/crm/v3/owners":
+					return hubspotResponse(http.StatusForbidden, `{"message":"missing scope"}`), nil
+				default:
+					return hubspotResponse(http.StatusNotFound, `{"message":"not found"}`), nil
+				}
+			},
+		),
+	}
+
+	driver := NewHubSpotDriver(client, "https://api.hubapi.com")
+
+	_, err := driver.ListAccounts(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot fetch hubspot owners")
 }
 
 func TestHubSpotRoles(t *testing.T) {

--- a/pkg/accessreview/drivers/testdata/hubspot.yaml
+++ b/pkg/accessreview/drivers/testdata/hubspot.yaml
@@ -135,3 +135,43 @@ interactions:
         status: 200 OK
         code: 200
         duration: 212.332792ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.hubapi.com
+        form:
+            archived:
+                - "true"
+            limit:
+                - "100"
+        headers:
+            Accept:
+                - application/json
+        url: https://api.hubapi.com/crm/v3/owners?archived=true&limit=100
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"results":[]}'
+        headers:
+            Access-Control-Allow-Credentials:
+                - "false"
+            Cf-Cache-Status:
+                - DYNAMIC
+            Content-Type:
+                - application/json;charset=utf-8
+            Date:
+                - Thu, 26 Mar 2026 12:54:02 GMT
+            Server:
+                - cloudflare
+            X-Content-Type-Options:
+                - nosniff
+        status: 200 OK
+        code: 200
+        duration: 100ms

--- a/pkg/accessreview/drivers/testdata/hubspot_email_match.yaml
+++ b/pkg/accessreview/drivers/testdata/hubspot_email_match.yaml
@@ -1,11 +1,7 @@
-# Hand-authored cassette for HubSpot access-review fetch (Bearer token
-# stripped by the recorder). Three interactions mirror ListAccounts:
-#   1. GET /settings/v3/users/roles — role name map
-#   2. GET /settings/v3/users — provisioned users (no status field)
-#   3. GET /crm/v3/owners?archived=true — deactivated owners
-# Coverage: active super-admin with a role, still-listed deactivated user
-# matched by userIdIncludingInactive, archived-only owner with empty name
-# (display falls back to email), and a non-PERSON queue owner that is skipped.
+# Hand-authored cassette: Settings user ID differs from the archived owner's
+# userIdIncludingInactive, but emails match (case-insensitive). The driver
+# must mark the settings row inactive and must not emit a second archived-only
+# row for the same person.
 version: 2
 interactions:
     - id: 0
@@ -26,7 +22,7 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"results":[{"id":"role-sales","name":"Sales Admin"}]}'
+        body: '{"results":[]}'
         headers:
             Content-Type:
                 - application/json;charset=utf-8
@@ -54,7 +50,7 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"results":[{"id":"10000001","email":"john.smith@example.com","firstName":"John","lastName":"Smith","roleIds":["role-sales"],"superAdmin":true},{"id":"10000002","email":"jane.doe@example.com","firstName":"Jane","lastName":"Doe","roleIds":[],"superAdmin":false}]}'
+        body: '{"results":[{"id":"settings-1","email":"Jane.Doe@example.com","firstName":"Jane","lastName":"Doe","roleIds":[],"superAdmin":true}]}'
         headers:
             Content-Type:
                 - application/json;charset=utf-8
@@ -84,7 +80,7 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"results":[{"id":"owner-2","email":"jane.doe@example.com","firstName":"Jane","lastName":"Doe","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":10000002},{"id":"owner-3","email":"gone@example.com","firstName":"","lastName":"","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":10000003},{"id":"queue-1","email":"queue@example.com","type":"QUEUE","archived":true,"userId":null,"userIdIncludingInactive":null}]}'
+        body: '{"results":[{"id":"owner-9","email":"jane.doe@example.com","firstName":"","lastName":"","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":999}]}'
         headers:
             Content-Type:
                 - application/json;charset=utf-8

--- a/pkg/accessreview/drivers/testdata/hubspot_owners_forbidden.yaml
+++ b/pkg/accessreview/drivers/testdata/hubspot_owners_forbidden.yaml
@@ -1,11 +1,6 @@
-# Hand-authored cassette for HubSpot access-review fetch (Bearer token
-# stripped by the recorder). Three interactions mirror ListAccounts:
-#   1. GET /settings/v3/users/roles — role name map
-#   2. GET /settings/v3/users — provisioned users (no status field)
-#   3. GET /crm/v3/owners?archived=true — deactivated owners
-# Coverage: active super-admin with a role, still-listed deactivated user
-# matched by userIdIncludingInactive, archived-only owner with empty name
-# (display falls back to email), and a non-PERSON queue owner that is skipped.
+# Hand-authored cassette: Owners API rejects the token for missing
+# crm.objects.owners.read. Settings Users succeeds first; the driver must
+# fail the fetch rather than classify every user as active.
 version: 2
 interactions:
     - id: 0
@@ -26,7 +21,7 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"results":[{"id":"role-sales","name":"Sales Admin"}]}'
+        body: '{"results":[]}'
         headers:
             Content-Type:
                 - application/json;charset=utf-8
@@ -54,7 +49,7 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"results":[{"id":"10000001","email":"john.smith@example.com","firstName":"John","lastName":"Smith","roleIds":["role-sales"],"superAdmin":true},{"id":"10000002","email":"jane.doe@example.com","firstName":"Jane","lastName":"Doe","roleIds":[],"superAdmin":false}]}'
+        body: '{"results":[{"id":"10000001","email":"john.smith@example.com","firstName":"John","lastName":"Smith","roleIds":[],"superAdmin":false}]}'
         headers:
             Content-Type:
                 - application/json;charset=utf-8
@@ -84,10 +79,10 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"results":[{"id":"owner-2","email":"jane.doe@example.com","firstName":"Jane","lastName":"Doe","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":10000002},{"id":"owner-3","email":"gone@example.com","firstName":"","lastName":"","type":"PERSON","archived":true,"userId":null,"userIdIncludingInactive":10000003},{"id":"queue-1","email":"queue@example.com","type":"QUEUE","archived":true,"userId":null,"userIdIncludingInactive":null}]}'
+        body: '{"status":"error","message":"This app hasn''t been granted all required scopes to make this call.","category":"MISSING_SCOPES"}'
         headers:
             Content-Type:
                 - application/json;charset=utf-8
-        status: 200 OK
-        code: 200
+        status: 403 Forbidden
+        code: 403
         duration: 100ms

--- a/pkg/accessreview/drivers/vcr_test.go
+++ b/pkg/accessreview/drivers/vcr_test.go
@@ -189,3 +189,11 @@ func newVCRClientWithHeader(rec *recorder.Recorder, header, value string) *http.
 
 	return &http.Client{Transport: transport}
 }
+
+// roundTripFunc is a test helper that adapts a function to http.RoundTripper
+// for stubbing HTTP responses outside VCR cassettes.
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/pkg/connector/provider/hubspot.go
+++ b/pkg/connector/provider/hubspot.go
@@ -42,7 +42,7 @@ func hubspotRegistration() *Registration {
 			// the host.
 			APIBase: "https://api.hubapi.com",
 		},
-		OAuth2Scopes:   []string{"settings.users.read"},
+		OAuth2Scopes:   []string{"settings.users.read", "crm.objects.owners.read"},
 		SupportsAPIKey: true,
 		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
 			return drivers.NewHubSpotDriver(c, ep.APIBase), nil


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

HubSpot's Settings Users API (`/settings/v3/users`) has no active/archived/deactivated fields. The driver left `Active` nil, and entry upsert used `COALESCE(@active, TRUE)`, so every HubSpot account showed as active — including deactivated ones.

## Fix

- Merge Settings Users (roles / super-admin) with the Owners API (`/crm/v3/owners?archived=true`), HubSpot's authoritative deactivated-user list
- Mark matches as `Active=false` by settings user ID (`userIdIncludingInactive`) or case-insensitive email
- Include archived owners missing from Settings Users
- Deduplicate by both user ID and email so email-only matches cannot emit a second row
- Fall back empty archived owner names to email (HubSpot clears names on deactivate)
- Request `crm.objects.owners.read` in addition to `settings.users.read` on HubSpot connect
- Fail the fetch if Owners API is unauthorized (missing scope) instead of silently classifying everyone as active

## Required for this to work in production

1. HubSpot OAuth app (developer portal) must include `crm.objects.owners.read`
2. Existing OAuth connectors must reconnect so the new scope is granted
3. Private app / API-key connectors must grant `crm.objects.owners.read` on the HubSpot private app

Until then, access-review fetches for HubSpot will error with `cannot fetch hubspot owners` rather than return wrong active status.

## Testing

Cassette-driven (hand-authored VCR fixtures, same pattern as Square/Render):

- `testdata/hubspot.yaml` — active, listed-but-archived, archived-only, non-person owner skipped
- `testdata/hubspot_email_match.yaml` — email-only match without duplicate row
- `testdata/hubspot_owners_forbidden.yaml` — missing owners scope fails the fetch

```
go test ./pkg/accessreview/drivers/ -run HubSpot
go test ./pkg/connector/provider/
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-773a1c8b-aaae-490a-8a0f-4f546120e449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-773a1c8b-aaae-490a-8a0f-4f546120e449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks archived HubSpot users as inactive by merging Settings Users with archived Owners. Adds `crm.objects.owners.read`; existing HubSpot connectors must reconnect or grant the scope.

### Service **`+517`** **`-128`**
- Merge Settings Users with archived Owners to flag deactivated accounts.
- Match by `userIdIncludingInactive` or case-insensitive email; dedupe by ID/email.
- Include archived owners not in Users; skip non-person owners; fall back blank names to email.
- Add Owners fetch + pagination; fail fetch when Owners call is unauthorized.
- Request `crm.objects.owners.read` in the provider; drop unused user-active fields.

### Tests **`+73`** **`-51`**
- Switch to VCR cassettes for HubSpot driver tests.
- Add cases for email-dedup and missing Owners scope; cover active, listed-but-archived, archived-only, and non-person owners.

### Other **`+4`** **`-0`**
- Update `probod` changelog noting reconnect/grant requirement for `crm.objects.owners.read`.

<sup>Written for commit 9bc3a2927c900d605731c3ec12aa9d755a027576. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

