### PR TITLE
Drop leftover trust center page_title columns

### DIFF
--- a/pkg/coredata/migrations/20260710T152544Z.sql
+++ b/pkg/coredata/migrations/20260710T152544Z.sql
@@ -12,5 +12,23 @@
 -- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 -- PERFORMANCE OF THIS SOFTWARE.
 
-ALTER TABLE trust_centers
-    RENAME COLUMN page_title TO title;
+-- Idempotent: no-op when page_title was already renamed or never added.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'trust_centers'
+          AND column_name = 'page_title'
+    ) AND NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'trust_centers'
+          AND column_name = 'title'
+    ) THEN
+        ALTER TABLE trust_centers
+            RENAME COLUMN page_title TO title;
+    END IF;
+END $$;

--- a/pkg/coredata/migrations/20260721T133736Z.sql
+++ b/pkg/coredata/migrations/20260721T133736Z.sql
@@ -12,12 +12,37 @@
 -- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 -- PERFORMANCE OF THIS SOFTWARE.
 
--- title is the full home page heading. Rows that still store the org name as a
--- fragment (the pre-migration default) are backfilled to the English hero copy
--- the UI previously rendered via i18n ("Compliance at {{name}}.").
-UPDATE trust_centers tc
-SET title = 'Compliance at ' || o.name || '.',
-    updated_at = NOW()
-FROM organizations o
-WHERE tc.organization_id = o.id
-  AND tc.title = o.name;
+-- title (or page_title, if the rename was skipped) is the full home page
+-- heading. Rows that still store the org name as a fragment (the
+-- pre-migration default) are backfilled to the English hero copy the UI
+-- previously rendered via i18n ("Compliance at {{name}}.").
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'trust_centers'
+          AND column_name = 'title'
+    ) THEN
+        UPDATE trust_centers tc
+        SET title = 'Compliance at ' || o.name || '.',
+            updated_at = NOW()
+        FROM organizations o
+        WHERE tc.organization_id = o.id
+          AND tc.title = o.name;
+    ELSIF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'trust_centers'
+          AND column_name = 'page_title'
+    ) THEN
+        UPDATE trust_centers tc
+        SET page_title = 'Compliance at ' || o.name || '.',
+            updated_at = NOW()
+        FROM organizations o
+        WHERE tc.organization_id = o.id
+          AND tc.page_title = o.name;
+    END IF;
+END $$;

--- a/pkg/coredata/migrations/20260721T165706Z.sql
+++ b/pkg/coredata/migrations/20260721T165706Z.sql
@@ -32,5 +32,10 @@ WHERE tc.organization_id = o.id;
 ALTER TABLE trust_centers
     ALTER COLUMN entity_name DROP DEFAULT;
 
+-- Drop both names: installs that applied page_title but skipped the
+-- rename still have page_title; fully renamed installs have title.
 ALTER TABLE trust_centers
-    DROP COLUMN title;
+    DROP COLUMN IF EXISTS title;
+
+ALTER TABLE trust_centers
+    DROP COLUMN IF EXISTS page_title;

--- a/pkg/coredata/migrations/20260730T132804Z.sql
+++ b/pkg/coredata/migrations/20260730T132804Z.sql
@@ -1,0 +1,82 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+-- trust_centers branding briefly lived as page_title, then title, then
+-- entity_name. Inserts only populate entity_name; leftover NOT NULL
+-- page_title/title columns make organization create fail with
+-- SQLSTATE 23502. Ensure entity_name is present and drop the obsolete
+-- columns for installs that got stuck between those renames.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'trust_centers'
+          AND column_name = 'entity_name'
+    ) THEN
+        ALTER TABLE trust_centers
+            ADD COLUMN entity_name TEXT NOT NULL DEFAULT '';
+
+        UPDATE trust_centers tc
+        SET entity_name = o.name
+        FROM organizations o
+        WHERE tc.organization_id = o.id
+          AND tc.entity_name = '';
+
+        IF EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'trust_centers'
+              AND column_name = 'page_title'
+        ) THEN
+            UPDATE trust_centers
+            SET entity_name = page_title
+            WHERE entity_name = ''
+              AND page_title IS NOT NULL
+              AND page_title <> '';
+        END IF;
+
+        IF EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'trust_centers'
+              AND column_name = 'title'
+        ) THEN
+            UPDATE trust_centers
+            SET entity_name = title
+            WHERE entity_name = ''
+              AND title IS NOT NULL
+              AND title <> '';
+        END IF;
+
+        ALTER TABLE trust_centers
+            ALTER COLUMN entity_name DROP DEFAULT;
+    END IF;
+END $$;
+
+ALTER TABLE trust_centers
+    DROP COLUMN IF EXISTS page_title;
+
+ALTER TABLE trust_centers
+    DROP COLUMN IF EXISTS title;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Organization create fails when `trust_centers` still has the obsolete NOT NULL `page_title` (or `title`) column:

```
cannot insert organization: cannot insert compliance portal: …
ERROR: null value in column "page_title" … (SQLSTATE 23502)
```

Inserts only populate `entity_name`. Branding briefly lived as `page_title` → `title` → `entity_name`; installs that skipped the rename can keep the old NOT NULL column beside `entity_name`, so new portal rows violate the constraint.

## Changes

- Make the `page_title` → `title` rename idempotent
- Make the title backfill accept either `title` or `page_title`
- Drop both obsolete columns when introducing `entity_name`
- Add a repair migration that ensures `entity_name` exists and drops leftover `page_title`/`title`

## Test plan

- [x] Applied full migration chain on a fresh DB → only `entity_name` remains
- [x] Simulated stuck schema (`page_title` + `entity_name`) → repair drops `page_title`; insert with `entity_name` succeeds
- [x] Simulated `page_title`-only schema → repair adds `entity_name` from `page_title` and drops the old column
- [x] Simulated skipped rename, then continued migrations → hardened chain reaches `entity_name`-only schema

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b31e7f3-6d40-4535-adcf-67eab4deb2d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b31e7f3-6d40-4535-adcf-67eab4deb2d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes org creation failures by removing leftover NOT NULL `page_title`/`title` columns in `trust_centers` and making migrations idempotent. Ensures only `entity_name` is used going forward.

### Coredata **`+142`** **`-12`**
- Make `page_title` → `title` rename idempotent.
- Backfill uses `title` or `page_title` if present.
- When adding `entity_name`, drop `title` and `page_title` with IF EXISTS.
- Add repair migration to create/backfill `entity_name` from `organizations.name`, `page_title`, or `title`, then drop obsolete columns.

<sup>Written for commit c94de82093eb6ba0ab9e9ad4a02925b562527bcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

