### PR TITLE
Default MCP third-party list to level 1

### DIFF
--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -76,7 +76,12 @@ func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRe
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	thirdPartyFilter := coredata.NewThirdPartyFilter(nil, input.Level, nil, nil, nil)
+	level := input.Level
+	if level == nil {
+		level = new(1)
+	}
+
+	thirdPartyFilter := coredata.NewThirdPartyFilter(nil, level, nil, nil, nil)
 
 	page, err := prb.ThirdParties.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor, thirdPartyFilter)
 	if err != nil {

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -663,7 +663,7 @@ components:
           description: Organization ID
         level:
           type: integer
-          description: Filter by level
+          description: Filter by hierarchy depth (1 = direct third party, 2+ = third party of a third party / indirect). Defaults to 1 when omitted.
         order_by:
           $ref: "#/components/schemas/ThirdPartyOrderBy"
           description: ThirdParty order by
@@ -12606,7 +12606,7 @@ tools:
       $ref: "#/components/schemas/ListOrganizationsOutput"
   - name: listThirdParties
     title: List Third Parties
-    description: List all thirdParties for the organization
+    description: List thirdParties for the organization. By default only direct third parties (level 1) are returned; pass level to filter by hierarchy depth.
     hints:
       readonly: true
       destructive: false


### PR DESCRIPTION
Agents usually need direct vendors, not the full hierarchy. Mirror listDocuments: omit level to get level 1, pass level to override. Document the default in the tool and field descriptions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default `listThirdParties` to return only level 1 (direct third parties) when `level` is omitted. This mirrors `listDocuments` and avoids fetching the full hierarchy by default.

### MCP **`+8`** **`-3`**
- In `schema.resolvers.go`, set `level` to 1 when `input.Level` is nil before calling `coredata.NewThirdPartyFilter`.
- In `specification.yaml`, define `level` as hierarchy depth with a default of 1 and clarify the `listThirdParties` tool description.

<sup>Written for commit 41da4bbad12b283780161cc4ef71aaebf91e7e7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

