### PR TITLE
Join identities in MembershipProfiles.LoadExistingByIDs

### DIFF
--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -506,7 +506,7 @@ SELECT
     p.id,
     p.identity_id,
     p.organization_id,
-    ''::citext AS email_address,
+    i.email_address,
     p.source,
     p.state,
     p.full_name,
@@ -541,6 +541,8 @@ SELECT
     p.updated_at
 FROM
     iam_membership_profiles p
+INNER JOIN identities i
+    ON i.id = p.identity_id
 WHERE
     p.%s
     AND p.id = ANY(@profile_ids)

--- a/pkg/iam/log_export_csv.go
+++ b/pkg/iam/log_export_csv.go
@@ -307,28 +307,13 @@ func loadSCIMProfileExportInfo(
 		return scimProfileExportLookup{}, fmt.Errorf("cannot load SCIM export profiles: %w", err)
 	}
 
-	identityIDs := make([]gid.GID, 0, len(profiles))
-	for _, profile := range profiles {
-		identityIDs = append(identityIDs, profile.IdentityID)
-	}
-
-	var identities coredata.Identities
-	if err := identities.LoadByIDs(ctx, conn, identityIDs); err != nil {
-		return scimProfileExportLookup{}, fmt.Errorf("cannot load SCIM profile identity emails: %w", err)
-	}
-
-	emailByIdentityID := make(map[gid.GID]string, len(identities))
-	for _, identity := range identities {
-		emailByIdentityID[identity.ID] = identity.EmailAddress.String()
-	}
-
 	lookup := scimProfileExportLookup{
 		byProfileID: make(map[gid.GID]scimProfileExportInfo, len(profiles)),
 		byUserName:  make(map[string]scimProfileExportInfo, len(profiles)),
 	}
 	for _, profile := range profiles {
 		info := scimProfileExportInfo{
-			email:    emailByIdentityID[profile.IdentityID],
+			email:    profile.EmailAddress.String(),
 			fullName: profileFullName(profile),
 		}
 


### PR DESCRIPTION
## Summary
- SCIM_EVENT CSV export was failing with `cannot write CSV: cannot load SCIM export profiles: cannot collect profiles by ids: can't scan into dest[3] (col: email_address): cannot parse address : mail: no address`
- Root cause: `MembershipProfiles.LoadExistingByIDs` selected a placeholder `''::citext AS email_address` instead of the real address (unlike every other `MembershipProfile` query, which joins `identities`), and scanning that empty string into `mail.Addr` fails since `net/mail.ParseAddress("")` rejects it.
- Fix: join `identities` in `LoadExistingByIDs` the same way `LoadByID`, `LoadByIdentityIDAndOrganizationID`, etc. already do, so the query returns the real email address. Also drop the now-redundant separate identity lookup in `loadSCIMProfileExportInfo` (pkg/iam/log_export_csv.go) since profiles carry their real email directly.

## Test plan
- [x] `go build ./pkg/coredata/... ./pkg/iam/...`
- [x] `go vet ./pkg/coredata/... ./pkg/mail/...`
- [ ] Re-run a SCIM_EVENT export for an organization with SCIM events referencing membership profiles and confirm it completes with correct emails in the CSV