### PR TITLE
Soft-fail Microsoft 365 MFA when registration fetch fails

### DIFF
--- a/apps/console/src/pages/organizations/access-reviews/sources/AccessReviewSourcesTab.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/sources/AccessReviewSourcesTab.tsx
@@ -47,6 +47,13 @@ import { AccessReviewSourceRow } from "../_components/AccessReviewSourceRow";
 import { createAccessReviewSourceMutation } from "../dialogs/accessReviewSourceMutations";
 import { AddAccessReviewSourceDialog, addAccessReviewSourceDialogConnectorProviderInfoFragment } from "../dialogs/AddAccessReviewSourceDialog";
 
+function clearOAuthCallbackParams(params: URLSearchParams) {
+  params.delete("connector_id");
+  params.delete("provider");
+  params.delete("error");
+  return params;
+}
+
 export const accessReviewSourcesTabQuery = graphql`
   query AccessReviewSourcesTabQuery($organizationId: ID!) {
     accessReviewDrivers {
@@ -145,9 +152,11 @@ export default function AccessReviewSourcesTab({ queryRef }: Props) {
     );
 
   // Handle OAuth callback: after the provider redirects back with connector_id,
-  // automatically create the access source for that connector.
+  // automatically create the access source for that connector. Missing scopes
+  // arrive as a backend error query param and are toasted like other errors.
   const callbackConnectorId = searchParams.get("connector_id");
   const callbackProvider = searchParams.get("provider");
+  const callbackError = searchParams.get("error");
   const hasSourceForCallback = !!callbackConnectorId
     && accessReviewSources?.edges.some(edge => edge.node.connectorId === callbackConnectorId);
 
@@ -155,11 +164,22 @@ export default function AccessReviewSourcesTab({ queryRef }: Props) {
     if (!callbackConnectorId) return;
 
     if (hasSourceForCallback) {
-      setSearchParams((params) => {
-        params.delete("connector_id");
-        params.delete("provider");
-        return params;
-      }, { replace: true });
+      // Create sets processedConnectorIdRef before the mutation; when Relay
+      // inserts the edge mid-callback, skip toasting here so onCompleted is
+      // the only toast. Reconnect never sets that ref, so it still toasts.
+      const createInFlight
+        = processedConnectorIdRef.current === callbackConnectorId;
+      if (callbackError && !createInFlight) {
+        toast({
+          title: t("accessReviewSourcesTab.messages.error"),
+          description: callbackError,
+          variant: "error",
+        });
+      }
+      if (!createInFlight) {
+        processedConnectorIdRef.current = null;
+        setSearchParams(clearOAuthCallbackParams, { replace: true });
+      }
       return;
     }
 
@@ -186,11 +206,7 @@ export default function AccessReviewSourcesTab({ queryRef }: Props) {
       onCompleted(_, errors) {
         if (errors?.length) {
           processedConnectorIdRef.current = null;
-          setSearchParams((params) => {
-            params.delete("connector_id");
-            params.delete("provider");
-            return params;
-          }, { replace: true });
+          setSearchParams(clearOAuthCallbackParams, { replace: true });
           toast({
             title: t("accessReviewSourcesTab.messages.error"),
             description: formatError(
@@ -201,24 +217,25 @@ export default function AccessReviewSourcesTab({ queryRef }: Props) {
           });
           return;
         }
-        toast({
-          title: t("accessReviewSourcesTab.messages.success"),
-          description: t("accessReviewSourcesTab.messages.created"),
-          variant: "success",
-        });
-        setSearchParams((params) => {
-          params.delete("connector_id");
-          params.delete("provider");
-          return params;
-        }, { replace: true });
+        if (callbackError) {
+          toast({
+            title: t("accessReviewSourcesTab.messages.error"),
+            description: callbackError,
+            variant: "error",
+          });
+        } else {
+          toast({
+            title: t("accessReviewSourcesTab.messages.success"),
+            description: t("accessReviewSourcesTab.messages.created"),
+            variant: "success",
+          });
+        }
+        processedConnectorIdRef.current = null;
+        setSearchParams(clearOAuthCallbackParams, { replace: true });
       },
       onError(error) {
         processedConnectorIdRef.current = null;
-        setSearchParams((params) => {
-          params.delete("connector_id");
-          params.delete("provider");
-          return params;
-        }, { replace: true });
+        setSearchParams(clearOAuthCallbackParams, { replace: true });
         toast({
           title: t("accessReviewSourcesTab.messages.error"),
           description: formatError(
@@ -232,6 +249,7 @@ export default function AccessReviewSourcesTab({ queryRef }: Props) {
   }, [
     callbackConnectorId,
     callbackProvider,
+    callbackError,
     connectorProviderInfos,
     createAccessReviewSource,
     hasSourceForCallback,

--- a/pkg/accessreview/drivers/microsoft_365.go
+++ b/pkg/accessreview/drivers/microsoft_365.go
@@ -23,6 +23,7 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,6 +32,7 @@ import (
 	"strings"
 	"time"
 
+	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/coredata"
 )
 
@@ -39,6 +41,7 @@ import (
 // HTTP client (Bearer token).
 type Microsoft365Driver struct {
 	httpClient *http.Client
+	logger     *log.Logger
 }
 
 var _ Driver = (*Microsoft365Driver)(nil)
@@ -68,7 +71,7 @@ var adminRoleDisplayNames = map[string]bool{
 	"Authentication Administrator":            true,
 }
 
-func NewMicrosoft365Driver(httpClient *http.Client) *Microsoft365Driver {
+func NewMicrosoft365Driver(httpClient *http.Client, logger *log.Logger) *Microsoft365Driver {
 	return &Microsoft365Driver{
 		httpClient: &http.Client{
 			Transport: &retryRoundTripper{
@@ -76,6 +79,7 @@ func NewMicrosoft365Driver(httpClient *http.Client) *Microsoft365Driver {
 				maxRetries: 3,
 			},
 		},
+		logger: logger,
 	}
 }
 
@@ -157,9 +161,19 @@ func (d *Microsoft365Driver) ListAccounts(ctx context.Context) ([]AccountRecord,
 		return nil, fmt.Errorf("cannot list users: %w", err)
 	}
 
+	// MFA registration details require AuditLog.Read.All. A failure here
+	// must not abort the account fetch — leave MFA unknown so the campaign
+	// can still proceed. Context cancel/deadline still fail the fetch so a
+	// timed-out source does not commit an incomplete result as success.
 	mfaStatuses, err := d.listMFAStatuses(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("cannot list MFA statuses: %w", err)
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("cannot list MFA statuses: %w", err)
+		}
+
+		d.logger.ErrorCtx(ctx, "cannot list microsoft 365 MFA statuses, reporting MFA unknown", log.Error(err))
+
+		mfaStatuses = map[string]coredata.MFAStatus{}
 	}
 
 	records := make([]AccountRecord, 0, len(users))

--- a/pkg/accessreview/drivers/microsoft_365_test.go
+++ b/pkg/accessreview/drivers/microsoft_365_test.go
@@ -22,11 +22,15 @@ package drivers
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/coredata"
 )
 
@@ -36,7 +40,7 @@ func TestMicrosoft365Driver(t *testing.T) {
 	rec := newRecorder(t, "testdata/microsoft_365", "MICROSOFT_365_TOKEN")
 	client := newVCRClient(rec, bearerAuth(os.Getenv("MICROSOFT_365_TOKEN")))
 
-	driver := NewMicrosoft365Driver(client)
+	driver := NewMicrosoft365Driver(client, log.NewLogger(log.WithName("test")))
 	records, err := driver.ListAccounts(context.Background())
 	require.NoError(t, err)
 	require.Len(t, records, 4)
@@ -82,4 +86,106 @@ func TestMicrosoft365Driver(t *testing.T) {
 	assert.Equal(t, coredata.MFAStatusUnknown, dana.MFAStatus)
 	require.NotNil(t, dana.Active)
 	assert.False(t, *dana.Active)
+}
+
+func TestMicrosoft365Driver_MFAFetchFailureLeavesUnknown(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			header := http.Header{"Content-Type": []string{"application/json"}}
+
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/directoryRoles"):
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     header,
+					Body:       io.NopCloser(strings.NewReader(`{"value":[]}`)),
+				}, nil
+			case strings.HasSuffix(r.URL.Path, "/users"):
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     header,
+					Body: io.NopCloser(strings.NewReader(`{
+						"value":[{
+							"id":"user-1",
+							"userPrincipalName":"alice@example.com",
+							"mail":"alice@example.com",
+							"displayName":"Alice",
+							"accountEnabled":true
+						}]
+					}`)),
+				}, nil
+			case strings.Contains(r.URL.Path, "userRegistrationDetails"):
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Header:     header,
+					Body: io.NopCloser(strings.NewReader(`{
+						"error":{
+							"code":"Authentication_RequestFromNonPremiumTenantOrB2CTenant",
+							"message":"Tenant is not a B2C tenant and doesn't have premium license"
+						}
+					}`)),
+				}, nil
+			default:
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Header:     header,
+					Body:       io.NopCloser(strings.NewReader(`{}`)),
+				}, nil
+			}
+		}),
+	}
+
+	driver := NewMicrosoft365Driver(client, log.NewLogger(log.WithName("test")))
+	records, err := driver.ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "alice@example.com", records[0].Email)
+	assert.Equal(t, coredata.MFAStatusUnknown, records[0].MFAStatus)
+}
+
+func TestMicrosoft365Driver_MFAFetchCanceledPropagates(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			header := http.Header{"Content-Type": []string{"application/json"}}
+
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/directoryRoles"):
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     header,
+					Body:       io.NopCloser(strings.NewReader(`{"value":[]}`)),
+				}, nil
+			case strings.HasSuffix(r.URL.Path, "/users"):
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     header,
+					Body: io.NopCloser(strings.NewReader(`{
+						"value":[{
+							"id":"user-1",
+							"userPrincipalName":"alice@example.com",
+							"mail":"alice@example.com",
+							"displayName":"Alice",
+							"accountEnabled":true
+						}]
+					}`)),
+				}, nil
+			case strings.Contains(r.URL.Path, "userRegistrationDetails"):
+				return nil, context.Canceled
+			default:
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Header:     header,
+					Body:       io.NopCloser(strings.NewReader(`{}`)),
+				}, nil
+			}
+		}),
+	}
+
+	driver := NewMicrosoft365Driver(client, log.NewLogger(log.WithName("test")))
+	_, err := driver.ListAccounts(context.Background())
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/pkg/accessreview/errors.go
+++ b/pkg/accessreview/errors.go
@@ -23,6 +23,7 @@ package accessreview
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"go.probo.inc/probo/pkg/gid"
 )
@@ -34,6 +35,7 @@ var (
 	ErrCampaignNotPendingActions = errors.New("access review campaign not pending actions")
 	ErrCampaignCompleted         = errors.New("access review campaign completed")
 	ErrCampaignCancelled         = errors.New("access review campaign cancelled")
+	ErrMissingOAuthScopes        = errors.New("missing required OAuth scopes")
 )
 
 type (
@@ -59,6 +61,10 @@ type (
 
 	CampaignCancelledError struct {
 		CampaignID gid.GID
+	}
+
+	MissingOAuthScopesError struct {
+		Scopes []string
 	}
 )
 
@@ -141,4 +147,21 @@ func (e *CampaignCancelledError) Error() string {
 
 func (e *CampaignCancelledError) Is(target error) bool {
 	return target == ErrCampaignCancelled
+}
+
+func NewMissingOAuthScopesError(scopes []string) error {
+	return &MissingOAuthScopesError{Scopes: append([]string(nil), scopes...)}
+}
+
+func (e *MissingOAuthScopesError) Error() string {
+	display := make([]string, len(e.Scopes))
+	for i, scope := range e.Scopes {
+		display[i] = strings.TrimPrefix(scope, "https://graph.microsoft.com/")
+	}
+
+	return "Missing required OAuth scopes: " + strings.Join(display, ", ")
+}
+
+func (e *MissingOAuthScopesError) Is(target error) bool {
+	return target == ErrMissingOAuthScopes
 }

--- a/pkg/accessreview/errors_test.go
+++ b/pkg/accessreview/errors_test.go
@@ -98,3 +98,19 @@ func TestCampaignClientErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestMissingOAuthScopesError(t *testing.T) {
+	t.Parallel()
+
+	err := accessreview.NewMissingOAuthScopesError([]string{
+		"https://graph.microsoft.com/AuditLog.Read.All",
+		"openid",
+	})
+
+	assert.Equal(
+		t,
+		"Missing required OAuth scopes: AuditLog.Read.All, openid",
+		err.Error(),
+	)
+	assert.ErrorIs(t, err, accessreview.ErrMissingOAuthScopes)
+}

--- a/pkg/accessreview/source_missing_scopes_test.go
+++ b/pkg/accessreview/source_missing_scopes_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package accessreview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.probo.inc/probo/pkg/connector"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestMissingOAuthScopesForConnector(t *testing.T) {
+	t.Parallel()
+
+	required := []string{
+		"openid",
+		"https://graph.microsoft.com/AuditLog.Read.All",
+		"https://graph.microsoft.com/User.Read.All",
+	}
+
+	t.Run("non oauth protocol returns empty", func(t *testing.T) {
+		t.Parallel()
+
+		dbConnector := coredata.Connector{
+			Protocol:   coredata.ConnectorProtocolAPIKey,
+			Connection: &connector.APIKeyConnection{APIKey: "k"},
+		}
+
+		assert.Empty(t, missingOAuthScopesForConnector(dbConnector, required))
+	})
+
+	t.Run("empty required returns empty", func(t *testing.T) {
+		t.Parallel()
+
+		dbConnector := coredata.Connector{
+			Protocol: coredata.ConnectorProtocolOAuth2,
+			Connection: &connector.OAuth2Connection{
+				Scope: "openid",
+			},
+		}
+
+		assert.Empty(t, missingOAuthScopesForConnector(dbConnector, nil))
+	})
+
+	t.Run("nil connection treats grant as empty", func(t *testing.T) {
+		t.Parallel()
+
+		dbConnector := coredata.Connector{
+			Protocol:   coredata.ConnectorProtocolOAuth2,
+			Connection: nil,
+		}
+
+		assert.Equal(
+			t,
+			[]string{
+				"https://graph.microsoft.com/AuditLog.Read.All",
+				"https://graph.microsoft.com/User.Read.All",
+				"openid",
+			},
+			missingOAuthScopesForConnector(dbConnector, required),
+		)
+	})
+
+	t.Run("partial grant returns missing scopes", func(t *testing.T) {
+		t.Parallel()
+
+		dbConnector := coredata.Connector{
+			Protocol: coredata.ConnectorProtocolOAuth2,
+			Connection: &connector.OAuth2Connection{
+				Scope: "openid User.Read.All",
+			},
+		}
+
+		assert.Equal(
+			t,
+			[]string{"https://graph.microsoft.com/AuditLog.Read.All"},
+			missingOAuthScopesForConnector(dbConnector, required),
+		)
+	})
+
+	t.Run("full grant returns empty", func(t *testing.T) {
+		t.Parallel()
+
+		dbConnector := coredata.Connector{
+			Protocol: coredata.ConnectorProtocolOAuth2,
+			Connection: &connector.OAuth2Connection{
+				Scope: "openid AuditLog.Read.All User.Read.All",
+			},
+		}
+
+		assert.Empty(t, missingOAuthScopesForConnector(dbConnector, required))
+	})
+}

--- a/pkg/accessreview/source_service.go
+++ b/pkg/accessreview/source_service.go
@@ -582,17 +582,17 @@ func (s *Service) SourceNeedsConfiguration(
 	return cfg.SelectedSlug(dbConnector) == "", nil
 }
 
-// SourceNeedsReconnect reports whether the connector is missing OAuth scopes
-// required by the current provider registration. Only OAuth2 connectors are
-// checked: API-key (and other non-OAuth) credentials have no grant scopes and
-// cannot be repaired by an OAuth reconnect, even when the provider also
-// advertises OAuth2Scopes for its dual-auth path. ErrResourceNotFound is
-// propagated for a missing connector.
-func (s *Service) SourceNeedsReconnect(
+// SourceMissingOAuthScopes returns the OAuth scopes required by the current
+// provider registration that are absent from the connector's stored grant.
+// Only OAuth2 connectors are checked: API-key (and other non-OAuth)
+// credentials have no grant scopes and return an empty slice, even when the
+// provider also advertises OAuth2Scopes for its dual-auth path.
+// ErrResourceNotFound is propagated for a missing connector.
+func (s *Service) SourceMissingOAuthScopes(
 	ctx context.Context,
 	scope coredata.Scoper,
 	connectorID gid.GID,
-) (bool, error) {
+) ([]string, error) {
 	var dbConnector coredata.Connector
 
 	err := s.pg.WithConn(
@@ -606,23 +606,52 @@ func (s *Service) SourceNeedsReconnect(
 		},
 	)
 	if err != nil {
-		return false, err
-	}
-
-	if dbConnector.Protocol != coredata.ConnectorProtocolOAuth2 {
-		return false, nil
+		return nil, err
 	}
 
 	required := s.providerRegistry.ProviderOAuth2Scopes(dbConnector.Provider)
+
+	return missingOAuthScopesForConnector(dbConnector, required), nil
+}
+
+// SourceNeedsReconnect reports whether the connector is missing OAuth scopes
+// required by the current provider registration. ErrResourceNotFound is
+// propagated for a missing connector.
+func (s *Service) SourceNeedsReconnect(
+	ctx context.Context,
+	scope coredata.Scoper,
+	connectorID gid.GID,
+) (bool, error) {
+	missing, err := s.SourceMissingOAuthScopes(ctx, scope, connectorID)
+	if err != nil {
+		return false, err
+	}
+
+	return len(missing) > 0, nil
+}
+
+// missingOAuthScopesForConnector returns scopes in required that are absent
+// from the connector's stored OAuth grant. Non-OAuth connectors and empty
+// required lists yield an empty result. A nil Connection is treated as
+// granting nothing.
+func missingOAuthScopesForConnector(
+	dbConnector coredata.Connector,
+	required []string,
+) []string {
+	if dbConnector.Protocol != coredata.ConnectorProtocolOAuth2 {
+		return []string{}
+	}
+
 	if len(required) == 0 {
-		return false, nil
+		return []string{}
 	}
 
-	if dbConnector.Connection == nil {
-		return true, nil
+	var granted []string
+	if dbConnector.Connection != nil {
+		granted = dbConnector.Connection.Scopes()
 	}
 
-	return len(connector.MissingScopes(required, dbConnector.Connection.Scopes())) > 0, nil
+	return connector.MissingScopes(required, granted)
 }
 
 // AutoSelectDefaultOrganization picks the first workspace/org a freshly linked

--- a/pkg/connector/provider/microsoft_365.go
+++ b/pkg/connector/provider/microsoft_365.go
@@ -48,8 +48,8 @@ func microsoft365Registration() *Registration {
 			"https://graph.microsoft.com/Directory.Read.All",
 			"https://graph.microsoft.com/RoleManagement.Read.Directory",
 		},
-		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger) (drivers.Driver, error) {
-			return drivers.NewMicrosoft365Driver(c), nil
+		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, logger *log.Logger) (drivers.Driver, error) {
+			return drivers.NewMicrosoft365Driver(c, logger.Named("microsoft365")), nil
 		},
 		NewNameResolver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger) drivers.NameResolver {
 			return drivers.NewMicrosoft365NameResolver(c)

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"go.gearno.de/kit/httpserver"
@@ -431,6 +432,19 @@ func handleConnectorComplete(
 		q := parsedURL.Query()
 		q.Set("connector_id", cnnctr.ID.String())
 		q.Set("provider", string(connectorProvider))
+
+		// Access-review sources toast missing scopes after redirect. Other
+		// continue URLs (Slack compliance page, SCIM settings, …) must not
+		// get a false missing-scope error from this access-review check.
+		if strings.Contains(state.ContinueURL, "/access-reviews/sources") {
+			missing, err := accessReviewSvc.SourceMissingOAuthScopes(r.Context(), scope, cnnctr.ID)
+			if err != nil {
+				logger.WarnCtx(r.Context(), "cannot determine missing OAuth scopes after connector callback", log.Error(err))
+			} else if len(missing) > 0 {
+				q.Set("error", accessreview.NewMissingOAuthScopesError(missing).Error())
+			}
+		}
+
 		parsedURL.RawQuery = q.Encode()
 
 		safeRedirect.Redirect(w, r, parsedURL.String(), "/", http.StatusSeeOther)


### PR DESCRIPTION
AuditLog.Read.All (and Entra Premium) are not available on every
tenant. Keep importing accounts with MFA unknown and log the error
instead of failing the whole source fetch.

Partial grants completed without feedback, leaving Reconnect
required unexplained. Surface a backend error string on the
access source row when required scopes are still absent.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Microsoft 365 imports running by soft-failing MFA registration fetches, and immediately surfaces missing OAuth scopes after OAuth reconnect. Missing scopes are computed on the backend, added to the access‑review sources callback as an error param, and toasted in the Console.

### Tests **`+235`** **`-1`**
Add coverage for missing-scope detection across cases (non‑OAuth, empty required, nil connection, partial/full grants) and Microsoft 365 tests confirming MFA fetch failures leave MFA unknown and that cancellation propagates.

### Service **`+84`** **`-18`**
Add SourceMissingOAuthScopes, extract missingOAuthScopesForConnector, and refactor SourceNeedsReconnect to use them; introduce MissingOAuthScopesError for concise user text. Inject a logger into the Microsoft 365 driver and, on MFA registration fetch failure, log and mark MFA as unknown; wire the logger via provider registration.

### GraphQL API **`+14`** **`-0`**
After connector callback, compute missing scopes and append a concise error query param only for access‑review sources; warn if the check fails.

### App: console **`+44`** **`-26`**
Toast backend “missing required OAuth scopes” errors after OAuth callback and centralize clearing of callback params; avoid duplicate toasts during in‑flight creation.

<sup>Written for commit d8c284399bf1f4cfb55cc7356d783897b7ece66f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



