### PR TITLE
transfermanager: honour the S3 client's RequestChecksumCalculation

### DIFF
--- a/pkg/filemanager/s3.go
+++ b/pkg/filemanager/s3.go
@@ -234,7 +234,19 @@ func (s *Service) PutFile(
 	// Transfer manager accepts unseekable readers (e.g. io.Pipe) by buffering
 	// parts in memory, which works against plain-HTTP S3-compatible endpoints
 	// where PutObject checksums require a seekable body.
-	uploader := transfermanager.New(s.s3Client)
+	//
+	// The transfer manager keeps its OWN RequestChecksumCalculation, which takes
+	// precedence over the one configured on the S3 client and defaults to
+	// WhenSupported. Left alone it therefore discards the client's setting —
+	// including AWS_REQUEST_CHECKSUM_CALCULATION and the shared-config value —
+	// and adds a CRC32 checksum to every upload regardless. S3-compatible
+	// endpoints that do not implement AWS's checksum scheme reject those writes,
+	// and the failure surfaces as an opaque `SignatureDoesNotMatch: Access
+	// denied`, which reads as a credential problem rather than a checksum one.
+	// Propagate the client's setting so configuring it actually takes effect.
+	uploader := transfermanager.New(s.s3Client, func(o *transfermanager.Options) {
+		o.RequestChecksumCalculation = s.s3Client.Options().RequestChecksumCalculation
+	})
 
 	input := &transfermanager.UploadObjectInput{
 		Bucket:       new(file.BucketName),

--- a/pkg/filemanager/s3.go
+++ b/pkg/filemanager/s3.go
@@ -244,9 +244,12 @@ func (s *Service) PutFile(
 	// and the failure surfaces as an opaque `SignatureDoesNotMatch: Access
 	// denied`, which reads as a credential problem rather than a checksum one.
 	// Propagate the client's setting so configuring it actually takes effect.
-	uploader := transfermanager.New(s.s3Client, func(o *transfermanager.Options) {
-		o.RequestChecksumCalculation = s.s3Client.Options().RequestChecksumCalculation
-	})
+	uploader := transfermanager.New(
+		s.s3Client,
+		func(o *transfermanager.Options) {
+			o.RequestChecksumCalculation = s.s3Client.Options().RequestChecksumCalculation
+		},
+	)
 
 	input := &transfermanager.UploadObjectInput{
 		Bucket:       new(file.BucketName),

--- a/pkg/filemanager/s3_test.go
+++ b/pkg/filemanager/s3_test.go
@@ -40,17 +40,34 @@ import (
 	"go.probo.inc/probo/pkg/filemanager"
 )
 
-func newTestS3Service(t *testing.T, handler http.HandlerFunc) *filemanager.Service {
+// withRequestChecksumCalculation sets the S3 client's RequestChecksumCalculation
+// for a test built with newTestS3Service.
+func withRequestChecksumCalculation(v aws.RequestChecksumCalculation) func(*aws.Config) {
+	return func(cfg *aws.Config) {
+		cfg.RequestChecksumCalculation = v
+	}
+}
+
+func newTestS3Service(
+	t *testing.T,
+	handler http.HandlerFunc,
+	opts ...func(*aws.Config),
+) *filemanager.Service {
 	t.Helper()
 
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
+	cfg := aws.Config{
+		Region:      "us-east-1",
+		Credentials: credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	s3Client := awss3.NewFromConfig(
-		aws.Config{
-			Region:      "us-east-1",
-			Credentials: credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
-		},
+		cfg,
 		func(o *awss3.Options) {
 			o.BaseEndpoint = aws.String(srv.URL)
 			o.UsePathStyle = true
@@ -356,31 +373,6 @@ type unseekableReader struct{ r io.Reader }
 
 func (u unseekableReader) Read(p []byte) (int, error) { return u.r.Read(p) }
 
-func newTestS3ServiceWithChecksum(
-	t *testing.T,
-	checksum aws.RequestChecksumCalculation,
-	handler http.HandlerFunc,
-) *filemanager.Service {
-	t.Helper()
-
-	srv := httptest.NewServer(handler)
-	t.Cleanup(srv.Close)
-
-	s3Client := awss3.NewFromConfig(
-		aws.Config{
-			Region:                     "us-east-1",
-			Credentials:                credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
-			RequestChecksumCalculation: checksum,
-		},
-		func(o *awss3.Options) {
-			o.BaseEndpoint = aws.String(srv.URL)
-			o.UsePathStyle = true
-		},
-	)
-
-	return filemanager.NewService(nil, nil, s3Client, log.NewLogger(log.WithOutput(io.Discard)))
-}
-
 // requestCarriesChecksum reports whether an upload request asks the server to
 // verify an AWS checksum, in any of the forms the SDK can use: a declared
 // algorithm, a precomputed header, or a chunked body with a trailing checksum.
@@ -435,9 +427,8 @@ func TestPutFile_HonoursRequestChecksumCalculation(t *testing.T) {
 				putHeader http.Header
 			)
 
-			svc := newTestS3ServiceWithChecksum(
+			svc := newTestS3Service(
 				t,
-				tc.checksum,
 				func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == http.MethodPut {
 						mu.Lock()
@@ -452,6 +443,7 @@ func TestPutFile_HonoursRequestChecksumCalculation(t *testing.T) {
 					w.Header().Set("Content-Length", "16")
 					w.WriteHeader(http.StatusOK)
 				},
+				withRequestChecksumCalculation(tc.checksum),
 			)
 
 			file := &coredata.File{

--- a/pkg/filemanager/s3_test.go
+++ b/pkg/filemanager/s3_test.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -346,4 +348,131 @@ func TestOpenFile_NotModifiedByModifiedSince(t *testing.T) {
 	require.NotNil(t, obj)
 	assert.True(t, obj.NotModified)
 	assert.Nil(t, obj.Body)
+}
+
+// unseekableReader hides io.Seeker so the SDK takes the streaming path, which is
+// what a real multipart form upload looks like.
+type unseekableReader struct{ r io.Reader }
+
+func (u unseekableReader) Read(p []byte) (int, error) { return u.r.Read(p) }
+
+func newTestS3ServiceWithChecksum(
+	t *testing.T,
+	checksum aws.RequestChecksumCalculation,
+	handler http.HandlerFunc,
+) *filemanager.Service {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	s3Client := awss3.NewFromConfig(
+		aws.Config{
+			Region:                     "us-east-1",
+			Credentials:                credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
+			RequestChecksumCalculation: checksum,
+		},
+		func(o *awss3.Options) {
+			o.BaseEndpoint = aws.String(srv.URL)
+			o.UsePathStyle = true
+		},
+	)
+
+	return filemanager.NewService(nil, nil, s3Client, log.NewLogger(log.WithOutput(io.Discard)))
+}
+
+// requestCarriesChecksum reports whether an upload request asks the server to
+// verify an AWS checksum, in any of the forms the SDK can use: a declared
+// algorithm, a precomputed header, or a chunked body with a trailing checksum.
+func requestCarriesChecksum(h http.Header) bool {
+	if h.Get("X-Amz-Sdk-Checksum-Algorithm") != "" || h.Get("X-Amz-Trailer") != "" {
+		return true
+	}
+	if strings.Contains(h.Get("Content-Encoding"), "aws-chunked") {
+		return true
+	}
+	for name := range h {
+		if strings.HasPrefix(strings.ToLower(name), "x-amz-checksum-") {
+			return true
+		}
+	}
+	return false
+}
+
+// The transfer manager keeps its own RequestChecksumCalculation, which takes
+// precedence over the S3 client's. Before the accompanying fix it ignored the
+// client entirely and always applied CRC32, so S3-compatible endpoints that do
+// not implement AWS's checksum scheme (Google Cloud Storage's S3-interop
+// endpoint among them) rejected every upload with an opaque
+// `SignatureDoesNotMatch`. This asserts the client's setting is honoured in
+// both directions, so the regression cannot come back silently.
+func TestPutFile_HonoursRequestChecksumCalculation(t *testing.T) {
+	t.Parallel()
+
+	const content = "evidence payload"
+
+	for _, tc := range []struct {
+		name         string
+		checksum     aws.RequestChecksumCalculation
+		wantChecksum bool
+	}{
+		{
+			name:         "when required omits checksum",
+			checksum:     aws.RequestChecksumCalculationWhenRequired,
+			wantChecksum: false,
+		},
+		{
+			name:         "when supported adds checksum",
+			checksum:     aws.RequestChecksumCalculationWhenSupported,
+			wantChecksum: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				mu        sync.Mutex
+				putHeader http.Header
+			)
+
+			svc := newTestS3ServiceWithChecksum(
+				t,
+				tc.checksum,
+				func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodPut {
+						mu.Lock()
+						putHeader = r.Header.Clone()
+						mu.Unlock()
+						_, _ = io.Copy(io.Discard, r.Body)
+						w.Header().Set("ETag", `"abc123"`)
+						w.WriteHeader(http.StatusOK)
+						return
+					}
+					// HeadObject, which PutFile issues to learn the stored size.
+					w.Header().Set("Content-Length", "16")
+					w.WriteHeader(http.StatusOK)
+				},
+			)
+
+			file := &coredata.File{
+				BucketName: "uploads",
+				FileKey:    "tenant/evidence",
+				MimeType:   "text/plain",
+				FileSize:   int64(len(content)),
+			}
+
+			_, err := svc.PutFile(
+				context.Background(),
+				file,
+				unseekableReader{r: strings.NewReader(content)},
+				map[string]string{},
+			)
+			require.NoError(t, err)
+
+			mu.Lock()
+			defer mu.Unlock()
+			require.NotNil(t, putHeader, "expected an upload request to reach the server")
+			assert.Equal(t, tc.wantChecksum, requestCarriesChecksum(putHeader))
+		})
+	}
 }


### PR DESCRIPTION
## Problem

`PutFile` builds the S3 transfer manager with no options:

```go
uploader := transfermanager.New(s.s3Client)
```

The transfer manager keeps its **own** `RequestChecksumCalculation`, and its documentation is explicit that it *"takes precedence over the `RequestChecksumCalculation` configured on the underlying S3 client"*. It defaults to `WhenSupported`.

So the client's setting is silently discarded. A deployment that configures `when_required` — via `AWS_REQUEST_CHECKSUM_CALCULATION`, shared config, or `aws.Config` directly — still gets a CRC32 checksum on every transfer-manager upload.

## Evidence

Captured the actual request headers the transfer manager emits against an `httptest` server, with `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` set:

**Before (current `main`)**
```
Content-Length:                 13
X-Amz-Checksum-Crc32:           Ww2ACA==
X-Amz-Content-Sha256:           1b5bfa2f…
X-Amz-Sdk-Checksum-Algorithm:   CRC32
```

**After**
```
Content-Length:                 13
X-Amz-Content-Sha256:           1b5bfa2f…
```

The configuration is requested but not applied; after the change it is.

## Why it matters

Some S3-compatible endpoints do not implement AWS's checksum scheme and reject writes that carry it. `when_required` is the documented escape hatch for exactly that, and today it has no effect on this code path — leaving no way to turn the behaviour off short of patching.

## Fix

Propagate the client's setting to the transfer manager, so configuring it takes effect:

```go
uploader := transfermanager.New(s.s3Client, func(o *transfermanager.Options) {
    o.RequestChecksumCalculation = s.s3Client.Options().RequestChecksumCalculation
})
```

## Compatibility

No behaviour change for anyone who has not set it — the client and the transfer manager both default to `WhenSupported`, so the propagated value is identical. Only deployments that explicitly configured `when_required` see a difference, and that difference is what they asked for.

## Scope — deliberately narrow

This fixes `filemanager.PutFile` only. Note that several other upload paths (`pkg/probo/file_service.go`, `document_service.go`, `framework_service.go`, the `third_party_*_agreement` services, and `pkg/complianceportal/management/*`) call `s3.PutObject` directly rather than going through `filemanager`, so they are unaffected by this change — they already honour the client's setting, since they use the client directly. I have not touched them; consolidating those onto `filemanager` looks worthwhile but is a separate concern and a much larger diff.

## Tests

Adds `TestPutFile_HonoursRequestChecksumCalculation`, a table test asserting the setting is honoured in **both** directions — `when_required` produces no checksum, `when_supported` still produces one. It uses the existing `httptest` harness, so no external dependency, and inspects the request for any of the forms the SDK can use (declared algorithm, precomputed header, or chunked body with trailing checksum).

Verified as a real regression guard, not merely a passing test:

- with the fix: both cases pass
- with the fix reverted: `when_required` fails (`expected: false, actual: true`), `when_supported` still passes

`gofmt` and `go vet` are clean, and the full `pkg/filemanager` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)