### PR TITLE
Add organization onboarding wizard in console

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,4 +42,5 @@ Detailed guides for specific subsystems live in `contrib/claude/`:
 - [`contrib/claude/release/README.md`](contrib/claude/release/README.md) — Release process (per-track version bump, changelog, tag, push)
 - [`contrib/claude/sandbox.md`](contrib/claude/sandbox.md) — Lima sandbox environments (create, manage, access services)
 - [`contrib/claude/n8n.md`](contrib/claude/n8n.md) — n8n community node (resources, operations, GraphQL helpers)
+- [`contrib/claude/onboarding.md`](contrib/claude/onboarding.md) — Console organization onboarding wizard (unlisted route, steps, persistence)
 - [`contrib/claude/skills.md`](contrib/claude/skills.md) — Agent skills package (`@probo/skills`, compliance workflows, Probo MCP)

--- a/apps/console/src/pages/iam/organizations/NewOrganizationPage.tsx
+++ b/apps/console/src/pages/iam/organizations/NewOrganizationPage.tsx
@@ -83,7 +83,7 @@ function NewOrganizationPageInner() {
         }
 
         const org = r.createOrganization!.organization;
-        void navigate(`/organizations/${org!.id}`);
+        void navigate(`/organizations/${org!.id}/onboarding?welcome=1`);
         toast({
           title: t("common.success"), description: t("newOrganizationPage.messages.created"),
           variant: "success",

--- a/apps/console/src/pages/iam/organizations/onboarding/ScimOnboardingDoPanel.tsx
+++ b/apps/console/src/pages/iam/organizations/onboarding/ScimOnboardingDoPanel.tsx
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { Link } from "@probo/ui";
+import { Suspense, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { usePreloadedQuery, useQueryLoader } from "react-relay";
+
+import type { onboardingIamQueriesScimOnboardingDoPanelQuery } from "#/__generated__/iam/onboardingIamQueriesScimOnboardingDoPanelQuery.graphql";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { IAMRelayProvider } from "#/providers/IAMRelayProvider";
+import {
+  OnboardingStepActions,
+  OnboardingStepDoCard,
+} from "#/pages/organizations/onboarding/_components/OnboardingStepActions";
+
+import { ConnectorList } from "../settings/_components/ConnectorList";
+import { SCIMConfiguration } from "../settings/_components/SCIMConfiguration";
+import { scimOnboardingDoPanelQuery } from "./onboardingIamQueries";
+
+type ScimOnboardingDoPanelInnerProps = {
+  onContinue: () => void;
+  onDefer: () => void;
+  queryRef: NonNullable<
+    ReturnType<
+      typeof useQueryLoader<onboardingIamQueriesScimOnboardingDoPanelQuery>
+    >[0]
+  >;
+};
+
+function ScimOnboardingDoPanelInner(props: ScimOnboardingDoPanelInnerProps & {
+  onScimUpdated?: () => void;
+}) {
+  const { onContinue, onDefer, onScimUpdated, queryRef } = props;
+  const { t } = useTranslation("organizations/onboarding");
+  const organizationId = useOrganizationId();
+
+  const { organization } = usePreloadedQuery<onboardingIamQueriesScimOnboardingDoPanelQuery>(
+    scimOnboardingDoPanelQuery,
+    queryRef,
+  );
+  if (organization.__typename !== "Organization") {
+    throw new Error("invalid organization node");
+  }
+
+  const complete = !!organization.scimConfiguration?.id;
+
+  useEffect(() => {
+    if (complete) {
+      onScimUpdated?.();
+    }
+  }, [complete, onScimUpdated]);
+
+  const settingsHref = `/organizations/${organizationId}/settings/scim`;
+
+  return (
+    <OnboardingStepDoCard
+      title={t("steps.scim.doTitle")}
+      description={t("steps.scim.doDescription")}
+      complete={complete}
+      actions={(
+        <OnboardingStepActions
+          continueDisabled={!complete}
+          onContinue={onContinue}
+          onDefer={onDefer}
+          settingsLink={(
+            <Link to={settingsHref} variant="secondary" size="2">
+              {t("actions.openInSettings")}
+            </Link>
+          )}
+        />
+      )}
+    >
+      <div className="space-y-6 max-h-[min(28rem,50vh)] overflow-y-auto pr-1">
+        <ConnectorList fKey={organization} />
+        <div className="space-y-2 border-t border-border-mid pt-4">
+          <h4 className="text-2 font-medium">{t("steps.scim.manualScimHeading")}</h4>
+          <SCIMConfiguration fKey={organization} />
+        </div>
+      </div>
+    </OnboardingStepDoCard>
+  );
+}
+
+export function ScimOnboardingDoPanel(props: {
+  onContinue: () => void;
+  onDefer: () => void;
+  onScimUpdated?: () => void;
+}) {
+  const { onContinue, onDefer, onScimUpdated } = props;
+  const organizationId = useOrganizationId();
+  const [queryRef, loadQuery] = useQueryLoader<onboardingIamQueriesScimOnboardingDoPanelQuery>(
+    scimOnboardingDoPanelQuery,
+  );
+
+  useEffect(() => {
+    loadQuery({ organizationId }, { fetchPolicy: "store-and-network" });
+  }, [loadQuery, organizationId]);
+
+  if (!queryRef) {
+    return null;
+  }
+
+  return (
+    <IAMRelayProvider>
+      <Suspense fallback={null}>
+        <ScimOnboardingDoPanelInner
+          onContinue={onContinue}
+          onDefer={onDefer}
+          onScimUpdated={onScimUpdated}
+          queryRef={queryRef}
+        />
+      </Suspense>
+    </IAMRelayProvider>
+  );
+}

--- a/apps/console/src/pages/iam/organizations/onboarding/onboardingIamQueries.ts
+++ b/apps/console/src/pages/iam/organizations/onboarding/onboardingIamQueries.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { graphql } from "relay-runtime";
+
+export const onboardingIamStatusQuery = graphql`
+  query onboardingIamQueriesOnboardingIamStatusQuery($organizationId: ID!) {
+    organization: node(id: $organizationId) @required(action: THROW) {
+      __typename
+      ... on Organization {
+        scimConfiguration {
+          id
+        }
+      }
+    }
+  }
+`;
+
+export const scimOnboardingDoPanelQuery = graphql`
+  query onboardingIamQueriesScimOnboardingDoPanelQuery($organizationId: ID!) {
+    organization: node(id: $organizationId) @required(action: THROW) {
+      __typename
+      ... on Organization {
+        id
+        scimConfiguration {
+          id
+        }
+        ...ConnectorListFragment
+        ...SCIMConfigurationFragment
+      }
+    }
+  }
+`;

--- a/apps/console/src/pages/organizations/onboarding/OnboardingLayoutLoader.tsx
+++ b/apps/console/src/pages/organizations/onboarding/OnboardingLayoutLoader.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { Skeleton } from "@probo/ui";
+import { Suspense, useEffect } from "react";
+import { useQueryLoader } from "react-relay";
+
+import type { ViewerMembershipLayoutQuery } from "#/__generated__/iam/ViewerMembershipLayoutQuery.graphql";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { IAMRelayProvider } from "#/providers/IAMRelayProvider";
+
+import {
+  ViewerMembershipLayout,
+  viewerMembershipLayoutQuery,
+} from "../../iam/organizations/ViewerMembershipLayout";
+
+function OnboardingLayoutQueryLoader() {
+  const organizationId = useOrganizationId();
+  const [queryRef, loadQuery] = useQueryLoader<ViewerMembershipLayoutQuery>(
+    viewerMembershipLayoutQuery,
+  );
+
+  useEffect(() => {
+    loadQuery({ organizationId, hideSidebar: true });
+  }, [organizationId, loadQuery]);
+
+  if (!queryRef) {
+    return <Skeleton className="w-full h-screen" />;
+  }
+
+  return (
+    <Suspense fallback={<Skeleton className="w-full h-screen" />}>
+      <ViewerMembershipLayout queryRef={queryRef} hideSidebar />
+    </Suspense>
+  );
+}
+
+export default function OnboardingLayoutLoader() {
+  return (
+    <IAMRelayProvider>
+      <OnboardingLayoutQueryLoader />
+    </IAMRelayProvider>
+  );
+}

--- a/apps/console/src/pages/organizations/onboarding/OnboardingPage.tsx
+++ b/apps/console/src/pages/organizations/onboarding/OnboardingPage.tsx
@@ -1,0 +1,288 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { usePageTitle } from "@probo/hooks";
+import { Role } from "@probo/helpers";
+import { PageHeader } from "@probo/ui";
+import { useCallback, useEffect, useMemo, use } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  type PreloadedQuery,
+  graphql,
+  useFragment,
+  usePreloadedQuery,
+} from "react-relay";
+import { Navigate, useSearchParams } from "react-router";
+
+import type { onboardingIamQueriesOnboardingIamStatusQuery } from "#/__generated__/iam/onboardingIamQueriesOnboardingIamStatusQuery.graphql";
+import type { OnboardingPageQuery } from "#/__generated__/core/OnboardingPageQuery.graphql";
+import type { OnboardingPageStatusFragment$key } from "#/__generated__/core/OnboardingPageStatusFragment.graphql";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { CurrentUser } from "#/providers/CurrentUser";
+
+import { AccessReviewOnboardingDoPanel } from "./_components/AccessReviewOnboardingDoPanel";
+import { AgentOnboardingDoPanel } from "./_components/AgentOnboardingDoPanel";
+import { CongratsOnboardingStep } from "./_components/CongratsOnboardingStep";
+import {
+  AccessReviewOnboardingIllustration,
+  AgentOnboardingIllustration,
+  McpOnboardingIllustration,
+  ScimOnboardingIllustration,
+} from "./_components/illustrations/OnboardingIllustrations";
+import { McpOnboardingDoPanel } from "./_components/McpOnboardingDoPanel";
+import { OnboardingLearnPanel } from "./_components/OnboardingLearnPanel";
+import { OnboardingStepper } from "./_components/OnboardingStepper";
+import { ScimOnboardingDoPanel } from "#/pages/iam/organizations/onboarding/ScimOnboardingDoPanel";
+import { OnboardingSessionProvider, useOnboardingSession } from "./_lib/OnboardingSessionContext";
+import {
+  allIntegrationsComplete,
+  firstIncompleteStep,
+  isOnboardingStepId,
+  ONBOARDING_STEP_IDS,
+  type OnboardingCompletion,
+  type OnboardingStepId,
+} from "./_lib/onboardingSteps";
+import type { IntegrationStepId } from "./_lib/onboardingSteps";
+
+export const onboardingPageQuery = graphql`
+  query OnboardingPageQuery($organizationId: ID!) {
+    accessReviewDrivers {
+      ...AddAccessReviewSourceDialogConnectorProviderInfoFragment
+    }
+    organization: node(id: $organizationId) @required(action: THROW) {
+      __typename
+      ... on Organization {
+        ...OnboardingPageStatusFragment
+        ...AccessReviewOnboardingDoPanelFragment
+        ...AgentOnboardingDoPanelFragment
+      }
+    }
+  }
+`;
+
+const onboardingPageStatusFragment = graphql`
+  fragment OnboardingPageStatusFragment on Organization {
+    accessReviewSources(first: 50) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+    devices(first: 1) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+`;
+
+import { onboardingIamStatusQuery } from "#/pages/iam/organizations/onboarding/onboardingIamQueries";(current: OnboardingStepId): OnboardingStepId {
+  const index = ONBOARDING_STEP_IDS.indexOf(current);
+  return ONBOARDING_STEP_IDS[Math.min(index + 1, ONBOARDING_STEP_IDS.length - 1)]!;
+}
+
+function resolveInitialStep(
+  completion: OnboardingCompletion,
+  deferred: ReadonlySet<IntegrationStepId>,
+  welcome: boolean,
+): OnboardingStepId {
+  if (welcome) return "scim";
+  if (allIntegrationsComplete(completion)) return "congrats";
+  return firstIncompleteStep(completion, deferred);
+}
+
+function OnboardingPageInner(props: {
+  coreQueryRef: PreloadedQuery<OnboardingPageQuery>;
+  iamQueryRef: PreloadedQuery<onboardingIamQueriesOnboardingIamStatusQuery>;
+  refetchIamStatus: () => void;
+}) {
+  const { coreQueryRef, iamQueryRef, refetchIamStatus } = props;
+  const { t } = useTranslation("organizations/onboarding");
+  const role = use(CurrentUser).role;
+  const organizationId = useOrganizationId();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { clearDeferred, deferStep, deferredSteps } = useOnboardingSession();
+
+  const { accessReviewDrivers, organization } = usePreloadedQuery<OnboardingPageQuery>(
+    onboardingPageQuery,
+    coreQueryRef,
+  );
+  const iamData = usePreloadedQuery<onboardingIamQueriesOnboardingIamStatusQuery>(
+    onboardingIamStatusQuery,
+    iamQueryRef,
+  );
+
+  if (organization.__typename !== "Organization") {
+    throw new Error("invalid organization node");
+  }
+  if (iamData.organization.__typename !== "Organization") {
+    throw new Error("invalid organization node");
+  }
+
+  const orgStatus = useFragment<OnboardingPageStatusFragment$key>(
+    onboardingPageStatusFragment,
+    organization,
+  );
+
+  usePageTitle(t("pageTitle"));
+
+  const completion = useMemo<OnboardingCompletion>(
+    () => ({
+      scim: !!iamData.organization.scimConfiguration?.id,
+      accessReview: orgStatus.accessReviewSources.edges.length > 0,
+      agent: orgStatus.devices.edges.length > 0,
+    }),
+    [
+      iamData.organization.scimConfiguration?.id,
+      orgStatus.accessReviewSources.edges.length,
+      orgStatus.devices.edges.length,
+    ],
+  );
+
+  useEffect(() => {
+    for (const stepId of ["scim", "accessReview", "agent"] as const) {
+      if (completion[stepId]) {
+        clearDeferred(stepId);
+      }
+    }
+  }, [clearDeferred, completion]);
+
+  const welcome = searchParams.get("welcome") === "1";
+  const stepParam = searchParams.get("step");
+  const activeStep: OnboardingStepId = isOnboardingStepId(stepParam)
+    ? stepParam
+    : resolveInitialStep(completion, deferredSteps, welcome);
+
+  const refetchIamScim = useCallback(() => {
+    refetchIamStatus();
+  }, [refetchIamStatus]);
+
+  const goToStep = useCallback(
+    (stepId: OnboardingStepId) => {
+      const params = new URLSearchParams(searchParams);
+      params.set("step", stepId);
+      params.delete("welcome");
+      setSearchParams(params);
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const handleContinue = useCallback(() => {
+    goToStep(nextStep(activeStep));
+  }, [activeStep, goToStep]);
+
+  const handleDefer = useCallback(() => {
+    if (activeStep === "scim" || activeStep === "accessReview" || activeStep === "agent") {
+      deferStep(activeStep);
+    }
+    goToStep(nextStep(activeStep));
+  }, [activeStep, deferStep, goToStep]);
+
+  if (role === Role.EMPLOYEE) {
+    return <Navigate to={`/organizations/${organizationId}/employee`} replace />;
+  }
+  if (role === Role.AUDITOR) {
+    return <Navigate to={`/organizations/${organizationId}/measures`} replace />;
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8">
+      <PageHeader
+        title={t("title")}
+        description={t("description")}
+      />
+      <OnboardingStepper
+        activeStep={activeStep}
+        completion={completion}
+        deferredSteps={deferredSteps}
+        onStepClick={goToStep}
+      />
+
+      {activeStep === "congrats"
+        ? (
+            <CongratsOnboardingStep
+              completion={completion}
+              deferredSteps={deferredSteps}
+            />
+          )
+        : (
+            <div className="grid gap-8 lg:grid-cols-2 lg:gap-12">
+              <OnboardingLearnPanel
+                stepId={activeStep}
+                illustration={
+                  activeStep === "scim"
+                    ? <ScimOnboardingIllustration />
+                    : activeStep === "accessReview"
+                      ? <AccessReviewOnboardingIllustration />
+                      : activeStep === "agent"
+                        ? <AgentOnboardingIllustration />
+                        : <McpOnboardingIllustration />
+                }
+              />
+              <div>
+                {activeStep === "scim" && (
+                  <ScimOnboardingDoPanel
+                    onContinue={handleContinue}
+                    onDefer={handleDefer}
+                    onScimUpdated={refetchIamScim}
+                  />
+                )}
+                {activeStep === "accessReview" && (
+                  <AccessReviewOnboardingDoPanel
+                    accessReviewDrivers={accessReviewDrivers}
+                    organizationFKey={organization}
+                    onContinue={handleContinue}
+                    onDefer={handleDefer}
+                  />
+                )}
+                {activeStep === "agent" && (
+                  <AgentOnboardingDoPanel
+                    organizationFKey={organization}
+                    onContinue={handleContinue}
+                    onDefer={handleDefer}
+                  />
+                )}
+                {activeStep === "mcp" && (
+                  <McpOnboardingDoPanel
+                    onContinue={handleContinue}
+                    onDefer={handleDefer}
+                  />
+                )}
+              </div>
+            </div>
+          )}
+    </div>
+  );
+}
+
+export function OnboardingPage(props: {
+  coreQueryRef: PreloadedQuery<OnboardingPageQuery>;
+  iamQueryRef: PreloadedQuery<onboardingIamQueriesOnboardingIamStatusQuery>;
+  refetchIamStatus: () => void;
+}) {
+  return (
+    <OnboardingSessionProvider>
+      <OnboardingPageInner {...props} />
+    </OnboardingSessionProvider>
+  );
+}

--- a/apps/console/src/pages/organizations/onboarding/OnboardingPageLoader.tsx
+++ b/apps/console/src/pages/organizations/onboarding/OnboardingPageLoader.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { useCallback, useEffect } from "react";
+import { useQueryLoader } from "react-relay";
+
+import type { onboardingIamQueriesOnboardingIamStatusQuery } from "#/__generated__/iam/onboardingIamQueriesOnboardingIamStatusQuery.graphql";
+import type { OnboardingPageQuery } from "#/__generated__/core/OnboardingPageQuery.graphql";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { IAMRelayProvider } from "#/providers/IAMRelayProvider";
+
+import {
+  OnboardingPage,
+  onboardingPageQuery,
+} from "./OnboardingPage";
+import { onboardingIamStatusQuery } from "#/pages/iam/organizations/onboarding/onboardingIamQueries";
+
+export default function OnboardingPageLoader() {
+  const organizationId = useOrganizationId();
+  const [coreQueryRef, loadCoreQuery] = useQueryLoader<OnboardingPageQuery>(
+    onboardingPageQuery,
+  );
+  const [iamQueryRef, loadIamQuery] = useQueryLoader<onboardingIamQueriesOnboardingIamStatusQuery>(
+    onboardingIamStatusQuery,
+  );
+
+  useEffect(() => {
+    loadCoreQuery({ organizationId });
+  }, [loadCoreQuery, organizationId]);
+
+  useEffect(() => {
+    loadIamQuery({ organizationId });
+  }, [loadIamQuery, organizationId]);
+
+  const refetchIamStatus = useCallback(() => {
+    loadIamQuery({ organizationId }, { fetchPolicy: "network-only" });
+  }, [loadIamQuery, organizationId]);
+
+  if (!coreQueryRef || !iamQueryRef) {
+    return null;
+  }
+
+  return (
+    <IAMRelayProvider>
+      <OnboardingPage
+        coreQueryRef={coreQueryRef}
+        iamQueryRef={iamQueryRef}
+        refetchIamStatus={refetchIamStatus}
+      />
+    </IAMRelayProvider>
+  );
+}

--- a/apps/console/src/pages/organizations/onboarding/_components/AccessReviewOnboardingDoPanel.tsx
+++ b/apps/console/src/pages/organizations/onboarding/_components/AccessReviewOnboardingDoPanel.tsx
@@ -1,0 +1,254 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { formatError } from "@probo/helpers";
+import { Button, IconPlusLarge, Link, useToast } from "@probo/ui";
+import { useEffect, useMemo, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { graphql, useFragment, useMutation } from "react-relay";
+
+import type { AccessReviewOnboardingDoPanelFragment$key } from "#/__generated__/core/AccessReviewOnboardingDoPanelFragment.graphql";
+import type { accessReviewSourceMutationsCreateMutation } from "#/__generated__/core/accessReviewSourceMutationsCreateMutation.graphql";
+import type { AddAccessReviewSourceDialogConnectorProviderInfoFragment$key } from "#/__generated__/core/AddAccessReviewSourceDialogConnectorProviderInfoFragment.graphql";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { AddAccessReviewSourceDialog, addAccessReviewSourceDialogConnectorProviderInfoFragment } from "#/pages/organizations/access-reviews/dialogs/AddAccessReviewSourceDialog";
+import { createAccessReviewSourceMutation } from "#/pages/organizations/access-reviews/dialogs/accessReviewSourceMutations";
+import { useSearchParams } from "react-router";
+
+import {
+  OnboardingStepActions,
+  OnboardingStepDoCard,
+} from "./OnboardingStepActions";
+
+const accessReviewOnboardingDoPanelFragment = graphql`
+  fragment AccessReviewOnboardingDoPanelFragment on Organization {
+    canCreateSource: permission(action: "access-review:source:create")
+    accessReviewSources(first: 50) {
+      __id
+      edges {
+        node {
+          id
+          connectorId
+          connector {
+            provider
+          }
+        }
+      }
+    }
+  }
+`;
+
+function clearOAuthCallbackParams(params: URLSearchParams) {
+  params.delete("connector_id");
+  params.delete("provider");
+  params.delete("error");
+  return params;
+}
+
+type Props = {
+  accessReviewDrivers: AddAccessReviewSourceDialogConnectorProviderInfoFragment$key;
+  onContinue: () => void;
+  onDefer: () => void;
+  organizationFKey: AccessReviewOnboardingDoPanelFragment$key;
+};
+
+export function AccessReviewOnboardingDoPanel(props: Props) {
+  const { accessReviewDrivers, onContinue, onDefer, organizationFKey } = props;
+  const { t } = useTranslation("organizations/onboarding");
+  const { t: tSources } = useTranslation();
+  const { toast } = useToast();
+  const organizationId = useOrganizationId();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const processedConnectorIdRef = useRef<string | null>(null);
+
+  const organization = useFragment<AccessReviewOnboardingDoPanelFragment$key>(
+    accessReviewOnboardingDoPanelFragment,
+    organizationFKey,
+  );
+
+  const connectorProviderInfos = useFragment<AddAccessReviewSourceDialogConnectorProviderInfoFragment$key>(
+    addAccessReviewSourceDialogConnectorProviderInfoFragment,
+    accessReviewDrivers,
+  );
+
+  const accessReviewSources = organization.accessReviewSources;
+  const complete = accessReviewSources.edges.length > 0;
+
+  const existingSourceProviders = useMemo(
+    () =>
+      accessReviewSources.edges
+        .map(edge => edge.node.connector?.provider)
+        .filter((p): p is NonNullable<typeof p> => p != null),
+    [accessReviewSources.edges],
+  );
+
+  const [createAccessReviewSource, isCreatingSource]
+    = useMutation<accessReviewSourceMutationsCreateMutation>(
+      createAccessReviewSourceMutation,
+    );
+
+  const callbackConnectorId = searchParams.get("connector_id");
+  const callbackProvider = searchParams.get("provider");
+  const callbackError = searchParams.get("error");
+  const hasSourceForCallback = !!callbackConnectorId
+    && accessReviewSources.edges.some(
+      edge => edge.node.connectorId === callbackConnectorId,
+    );
+
+  useEffect(() => {
+    if (!callbackConnectorId) return;
+
+    if (hasSourceForCallback) {
+      const createInFlight
+        = processedConnectorIdRef.current === callbackConnectorId;
+      if (callbackError && !createInFlight) {
+        toast({
+          title: tSources("accessReviewSourcesTab.messages.error"),
+          description: callbackError,
+          variant: "error",
+        });
+      }
+      if (!createInFlight) {
+        processedConnectorIdRef.current = null;
+        setSearchParams(clearOAuthCallbackParams, { replace: true });
+      }
+      return;
+    }
+
+    if (processedConnectorIdRef.current === callbackConnectorId || isCreatingSource) {
+      return;
+    }
+    processedConnectorIdRef.current = callbackConnectorId;
+
+    const providerInfo = callbackProvider
+      ? connectorProviderInfos.find(p => p.provider === callbackProvider)
+      : null;
+    const sourceName = providerInfo?.displayName ?? callbackProvider ?? "Source";
+
+    createAccessReviewSource({
+      variables: {
+        input: {
+          organizationId,
+          connectorId: callbackConnectorId,
+          name: sourceName,
+          csvData: null,
+        },
+        connections: [accessReviewSources.__id],
+      },
+      onCompleted(_, errors) {
+        if (errors?.length) {
+          processedConnectorIdRef.current = null;
+          setSearchParams(clearOAuthCallbackParams, { replace: true });
+          toast({
+            title: tSources("accessReviewSourcesTab.messages.error"),
+            description: formatError(
+              tSources("accessReviewSourcesTab.errors.create"),
+              errors,
+            ),
+            variant: "error",
+          });
+          return;
+        }
+        if (callbackError) {
+          toast({
+            title: tSources("accessReviewSourcesTab.messages.error"),
+            description: callbackError,
+            variant: "error",
+          });
+        } else {
+          toast({
+            title: tSources("accessReviewSourcesTab.messages.success"),
+            description: tSources("accessReviewSourcesTab.messages.created"),
+            variant: "success",
+          });
+        }
+        processedConnectorIdRef.current = null;
+        setSearchParams(clearOAuthCallbackParams, { replace: true });
+      },
+      onError(error) {
+        processedConnectorIdRef.current = null;
+        setSearchParams(clearOAuthCallbackParams, { replace: true });
+        toast({
+          title: tSources("accessReviewSourcesTab.messages.error"),
+          description: formatError(
+            tSources("accessReviewSourcesTab.errors.create"),
+            error,
+          ),
+          variant: "error",
+        });
+      },
+    });
+  }, [
+    accessReviewSources.__id,
+    accessReviewSources.edges,
+    callbackConnectorId,
+    callbackError,
+    callbackProvider,
+    connectorProviderInfos,
+    createAccessReviewSource,
+    hasSourceForCallback,
+    isCreatingSource,
+    organizationId,
+    setSearchParams,
+    tSources,
+    toast,
+  ]);
+
+  const settingsHref = `/organizations/${organizationId}/access-reviews/sources`;
+
+  return (
+    <OnboardingStepDoCard
+      title={t("steps.accessReview.doTitle")}
+      description={t("steps.accessReview.doDescription")}
+      complete={complete}
+      actions={(
+        <OnboardingStepActions
+          continueDisabled={!complete}
+          onContinue={onContinue}
+          onDefer={onDefer}
+          settingsLink={(
+            <Link to={settingsHref} variant="secondary" size="2">
+              {t("actions.openInSettings")}
+            </Link>
+          )}
+        />
+      )}
+    >
+      {organization.canCreateSource
+        ? (
+            <AddAccessReviewSourceDialog
+              organizationId={organizationId}
+              connectionId={accessReviewSources.__id}
+              providerInfos={connectorProviderInfos}
+              existingSourceProviders={existingSourceProviders}
+            >
+              <Button icon={IconPlusLarge}>
+                {t("steps.accessReview.addConnector")}
+              </Button>
+            </AddAccessReviewSourceDialog>
+          )
+        : (
+            <p className="text-2 text-txt-secondary">
+              {t("steps.accessReview.noPermission")}
+            </p>
+          )}
+    </OnboardingStepDoCard>
+  );
+}

--- a/apps/console/src/pages/organizations/onboarding/_components/AgentOnboardingDoPanel.tsx
+++ b/apps/console/src/pages/organizations/onboarding/_components/AgentOnboardingDoPanel.tsx
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { Button, IconPlusLarge, Link } from "@probo/ui";
+import { useTranslation } from "react-i18next";
+import { graphql, useFragment } from "react-relay";
+
+import type { AgentOnboardingDoPanelFragment$key } from "#/__generated__/core/AgentOnboardingDoPanelFragment.graphql";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { CreateDeviceDialog } from "#/pages/organizations/devices/dialogs/CreateDeviceDialog";
+
+import {
+  OnboardingStepActions,
+  OnboardingStepDoCard,
+} from "./OnboardingStepActions";
+
+const agentOnboardingDoPanelFragment = graphql`
+  fragment AgentOnboardingDoPanelFragment on Organization {
+    canCreateDevice: permission(action: "itam:device:create")
+    devices(first: 1) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+`;
+
+type Props = {
+  onContinue: () => void;
+  onDefer: () => void;
+  organizationFKey: AgentOnboardingDoPanelFragment$key;
+};
+
+export function AgentOnboardingDoPanel(props: Props) {
+  const { onContinue, onDefer, organizationFKey } = props;
+  const { t } = useTranslation("organizations/onboarding");
+  const organizationId = useOrganizationId();
+
+  const organization = useFragment<AgentOnboardingDoPanelFragment$key>(
+    agentOnboardingDoPanelFragment,
+    organizationFKey,
+  );
+
+  const complete = organization.devices.edges.length > 0;
+  const settingsHref = `/organizations/${organizationId}/devices`;
+
+  return (
+    <OnboardingStepDoCard
+      title={t("steps.agent.doTitle")}
+      description={t("steps.agent.doDescription")}
+      complete={complete}
+      actions={(
+        <OnboardingStepActions
+          continueDisabled={!complete}
+          onContinue={onContinue}
+          onDefer={onDefer}
+          settingsLink={(
+            <Link to={settingsHref} variant="secondary" size="2">
+              {t("actions.openInSettings")}
+            </Link>
+          )}
+        />
+      )}
+    >
+      <p className="text-2 text-txt-secondary">{t("steps.agent.instructions")}</p>
+      {organization.canCreateDevice
+        ? (
+            <CreateDeviceDialog>
+              <Button icon={IconPlusLarge}>{t("steps.agent.registerDevice")}</Button>
+            </CreateDeviceDialog>
+          )
+        : (
+            <p className="text-2 text-txt-secondary">{t("steps.agent.noPermission")}</p>
+          )}
+    </OnboardingStepDoCard>
+  );
+}

--- a/apps/console/src/pages/organizations/onboarding/_components/CongratsOnboardingStep.tsx
+++ b/apps/console/src/pages/organizations/onboarding/_components/CongratsOnboardingStep.tsx
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { ButtonLink, Link } from "@probo/ui";
+import { useTranslation } from "react-i18next";
+
+import type { OnboardingCompletion } from "../_lib/onboardingSteps";
+import { INTEGRATION_STEP_IDS } from "../_lib/onboardingSteps";
+import type { IntegrationStepId } from "../_lib/onboardingSteps";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+
+import { CongratsOnboardingIllustration } from "./illustrations/OnboardingIllustrations";
+import { OnboardingStepDoCard } from "./OnboardingStepActions";
+
+type Props = {
+  completion: OnboardingCompletion;
+  deferredSteps: ReadonlySet<IntegrationStepId>;
+};
+
+export function CongratsOnboardingStep(props: Props) {
+  const { completion, deferredSteps } = props;
+  const { t } = useTranslation("organizations/onboarding");
+  const organizationId = useOrganizationId();
+
+  const pendingSteps = INTEGRATION_STEP_IDS.filter(
+    stepId => !completion[stepId],
+  );
+
+  const settingsPaths: Record<IntegrationStepId, string> = {
+    scim: `/organizations/${organizationId}/settings/scim`,
+    accessReview: `/organizations/${organizationId}/access-reviews/sources`,
+    agent: `/organizations/${organizationId}/devices`,
+  };
+
+  return (
+    <div className="mx-auto max-w-xl space-y-8 text-center">
+      <div
+        aria-hidden
+        className="mx-auto flex min-h-48 max-w-sm items-center justify-center"
+      >
+        <CongratsOnboardingIllustration />
+      </div>
+      <div className="space-y-2">
+        <h2 className="text-5 font-semibold text-txt-primary">
+          {t("steps.congrats.title")}
+        </h2>
+        <p className="text-2 text-txt-secondary">{t("steps.congrats.description")}</p>
+      </div>
+
+      {pendingSteps.length > 0 && (
+        <OnboardingStepDoCard
+          title={t("steps.congrats.pendingTitle")}
+          actions={<span />}
+        >
+          <ul className="space-y-2 text-left text-2">
+            {pendingSteps.map((stepId) => {
+              const deferred = deferredSteps.has(stepId);
+              return (
+                <li key={stepId} className="flex items-center justify-between gap-2">
+                  <span className="text-txt-secondary">
+                    {t(`stepper.${stepId}`)}
+                    {deferred && (
+                      <span className="text-txt-tertiary">
+                        {" "}
+                        —
+                        {" "}
+                        {t("status.later")}
+                      </span>
+                    )}
+                  </span>
+                  <Link to={settingsPaths[stepId]} size="2">
+                    {t("actions.finishLater")}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </OnboardingStepDoCard>
+      )}
+
+      <ButtonLink to={`/organizations/${organizationId}/tasks`} variant="secondary">
+        {t("steps.congrats.goToConsole")}
+      </ButtonLink>
+      <p className="text-2 text-txt-tertiary">{t("steps.congrats.closeHint")}</p>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/onboarding/_components/McpOnboardingDoPanel.tsx
+++ b/apps/console/src/pages/organizations/onboarding/_components/McpOnboardingDoPanel.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { Anchor, Card } from "@probo/ui";
+import { useTranslation } from "react-i18next";
+
+import {
+  OnboardingStepActions,
+  OnboardingStepDoCard,
+} from "./OnboardingStepActions";
+
+type Props = {
+  onContinue: () => void;
+  onDefer: () => void;
+};
+
+export function McpOnboardingDoPanel(props: Props) {
+  const { onContinue, onDefer } = props;
+  const { t } = useTranslation("organizations/onboarding");
+
+  const mcpUrl = `${window.location.origin}/mcp/v1`;
+
+  return (
+    <OnboardingStepDoCard
+      title={t("steps.mcp.doTitle")}
+      description={t("steps.mcp.doDescription")}
+      actions={(
+        <OnboardingStepActions
+          onContinue={onContinue}
+          onDefer={onDefer}
+        />
+      )}
+    >
+      <ol className="list-decimal space-y-3 pl-5 text-2 text-txt-secondary">
+        <li>{t("steps.mcp.steps.oauth")}</li>
+        <li>{t("steps.mcp.steps.url")}</li>
+        <li>{t("steps.mcp.steps.skills")}</li>
+      </ol>
+      <Card padded className="mt-4 bg-level-2">
+        <p className="text-1 text-txt-tertiary mb-1">{t("steps.mcp.endpointLabel")}</p>
+        <code className="text-2 break-all text-txt-primary">{mcpUrl}</code>
+      </Card>
+      <p className="text-2 text-txt-secondary">
+        <Anchor
+          href="https://github.com/getprobo/probo/tree/main/packages/skills"
+          target="_blank"
+          rel="noreferrer"
+        >
+          {t("steps.mcp.docsLink")}
+        </Anchor>
+      </p>
+    </OnboardingStepDoCard>
+  );
+}

--- a/apps/console/src/pages/organizations/onboarding/_components/OnboardingLearnPanel.tsx
+++ b/apps/console/src/pages/organizations/onboarding/_components/OnboardingLearnPanel.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { OnboardingStepId } from "../_lib/onboardingSteps";
+
+type OnboardingLearnPanelProps = {
+  stepId: Exclude<OnboardingStepId, "congrats">;
+  illustration: ReactNode;
+};
+
+export function OnboardingLearnPanel(props: OnboardingLearnPanelProps) {
+  const { stepId, illustration } = props;
+  const { t } = useTranslation("organizations/onboarding");
+
+  const bullets = t(`steps.${stepId}.bullets`, {
+    returnObjects: true,
+  }) as string[];
+
+  return (
+    <div className="flex flex-col gap-6 lg:sticky lg:top-8">
+      <div
+        aria-hidden
+        className="flex min-h-48 items-center justify-center rounded-4 bg-level-1 p-6 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2"
+      >
+        {illustration}
+      </div>
+      <div className="space-y-3">
+        <h2 className="text-4 font-semibold text-txt-primary">
+          {t(`steps.${stepId}.learnTitle`)}
+        </h2>
+        <p className="text-2 text-txt-secondary leading-relaxed">
+          {t(`steps.${stepId}.purpose`)}
+        </p>
+        <ul className="list-disc space-y-2 pl-5 text-2 text-txt-secondary">
+          {bullets.map(bullet => (
+            <li key={bullet}>{bullet}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/onboarding/_components/OnboardingStepActions.tsx
+++ b/apps/console/src/pages/organizations/onboarding/_components/OnboardingStepActions.tsx
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { Badge, Button } from "@probo/ui";
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+type OnboardingStepActionsProps = {
+  continueLabel?: string;
+  continueDisabled?: boolean;
+  onContinue: () => void;
+  onDefer?: () => void;
+  showDefer?: boolean;
+  settingsLink?: ReactNode;
+};
+
+export function OnboardingStepActions(props: OnboardingStepActionsProps) {
+  const {
+    continueDisabled = false,
+    continueLabel,
+    onContinue,
+    onDefer,
+    settingsLink,
+    showDefer = true,
+  } = props;
+  const { t } = useTranslation("organizations/onboarding");
+
+  return (
+    <div className="flex flex-col gap-4 border-t border-border-mid pt-6">
+      {settingsLink}
+      <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+        {showDefer && onDefer
+          ? (
+              <Button variant="ghost" type="button" onClick={onDefer}>
+                {t("actions.doLater")}
+              </Button>
+            )
+          : <span />}
+        <Button
+          type="button"
+          disabled={continueDisabled}
+          onClick={onContinue}
+          className="sm:min-w-40"
+        >
+          {continueLabel ?? t("actions.continue")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function OnboardingStepDoCard(props: {
+  title: string;
+  description?: string;
+  complete?: boolean;
+  children: ReactNode;
+  actions: ReactNode;
+}) {
+  const { actions, children, complete, description, title } = props;
+  const { t } = useTranslation("organizations/onboarding");
+
+  return (
+    <div className="space-y-6 rounded-4 border border-border-mid bg-level-1 p-6 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="space-y-1">
+          <h3 className="text-3 font-medium text-txt-primary">{title}</h3>
+          {description && (
+            <p className="text-2 text-txt-secondary">{description}</p>
+          )}
+        </div>
+        {complete && (
+          <Badge variant="success">{t("status.complete")}</Badge>
+        )}
+      </div>
+      {children}
+      {actions}
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/onboarding/_components/OnboardingStepper.tsx
+++ b/apps/console/src/pages/organizations/onboarding/_components/OnboardingStepper.tsx
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { IconCheckmark1 } from "@probo/ui";
+import { useTranslation } from "react-i18next";
+
+import {
+  INTEGRATION_STEP_IDS,
+  ONBOARDING_STEP_IDS,
+  type OnboardingCompletion,
+  type OnboardingStepId,
+} from "../_lib/onboardingSteps";
+import type { IntegrationStepId } from "../_lib/onboardingSteps";
+
+type OnboardingStepperProps = {
+  activeStep: OnboardingStepId;
+  completion: OnboardingCompletion;
+  deferredSteps: ReadonlySet<IntegrationStepId>;
+  onStepClick: (stepId: OnboardingStepId) => void;
+};
+
+function stepLabelKey(stepId: OnboardingStepId): string {
+  if (stepId === "congrats") return "stepper.congrats";
+  return `stepper.${stepId}`;
+}
+
+export function OnboardingStepper(props: OnboardingStepperProps) {
+  const { activeStep, completion, deferredSteps, onStepClick } = props;
+  const { t } = useTranslation("organizations/onboarding");
+
+  const steps = ONBOARDING_STEP_IDS;
+
+  return (
+    <nav aria-label={t("stepper.ariaLabel")} className="mb-8">
+      <ol className="flex flex-wrap gap-2">
+        {steps.map((stepId, index) => {
+          const isActive = stepId === activeStep;
+          const isIntegration = (INTEGRATION_STEP_IDS as readonly string[]).includes(
+            stepId,
+          );
+          const complete = isIntegration
+            && completion[stepId as IntegrationStepId];
+          const deferred = isIntegration
+            && deferredSteps.has(stepId as IntegrationStepId)
+            && !complete;
+
+          const clickable = stepId === "congrats"
+            ? activeStep !== "congrats"
+            : complete || deferred || steps.indexOf(activeStep) >= index;
+
+          return (
+            <li key={stepId}>
+              <button
+                type="button"
+                disabled={!clickable && !isActive}
+                onClick={() => clickable && onStepClick(stepId)}
+                className={[
+                  "flex items-center gap-2 rounded-3 px-3 py-2 text-2 transition-colors",
+                  isActive
+                    ? "bg-accent-3 text-accent-11 font-medium"
+                    : clickable
+                      ? "text-txt-secondary hover:bg-level-2"
+                      : "text-txt-tertiary cursor-default",
+                ].join(" ")}
+              >
+                <span
+                  className={[
+                    "flex size-6 shrink-0 items-center justify-center rounded-full text-1 font-medium",
+                    complete
+                      ? "bg-success-9 text-white"
+                      : isActive
+                        ? "bg-accent-9 text-white"
+                        : "bg-level-3 text-txt-secondary",
+                  ].join(" ")}
+                >
+                  {complete
+                    ? <IconCheckmark1 size={14} />
+                    : index + 1}
+                </span>
+                <span>{t(stepLabelKey(stepId))}</span>
+                {deferred && (
+                  <span className="text-1 text-txt-tertiary">
+                    ({t("status.later")})
+                  </span>
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/apps/console/src/pages/organizations/onboarding/_components/illustrations/OnboardingIllustrations.tsx
+++ b/apps/console/src/pages/organizations/onboarding/_components/illustrations/OnboardingIllustrations.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+export function ScimOnboardingIllustration() {
+  return (
+    <svg
+      viewBox="0 0 320 180"
+      className="h-full w-full max-w-sm text-accent-9"
+      role="img"
+      aria-hidden
+    >
+      <rect x="24" y="48" width="72" height="84" rx="8" className="fill-sand-4 stroke-sand-8" strokeWidth="2" />
+      <text x="60" y="98" textAnchor="middle" className="fill-sand-11 text-[11px] font-medium">IdP</text>
+      <path
+        d="M108 90 H148"
+        className="stroke-accent-9 motion-safe:animate-pulse"
+        strokeWidth="3"
+        strokeLinecap="round"
+        fill="none"
+      />
+      <polygon points="148,84 160,90 148,96" className="fill-accent-9" />
+      <rect x="168" y="40" width="128" height="100" rx="12" className="fill-accent-3 stroke-accent-8" strokeWidth="2" />
+      <text x="232" y="78" textAnchor="middle" className="fill-accent-11 text-[11px] font-medium">Probo</text>
+      <circle cx="200" cy="108" r="8" className="fill-green-9 motion-safe:animate-pulse" />
+      <circle cx="232" cy="118" r="8" className="fill-green-9 motion-safe:animate-pulse [animation-delay:200ms]" />
+      <circle cx="264" cy="108" r="8" className="fill-green-9 motion-safe:animate-pulse [animation-delay:400ms]" />
+    </svg>
+  );
+}
+
+export function AccessReviewOnboardingIllustration() {
+  return (
+    <svg viewBox="0 0 320 180" className="h-full w-full max-w-sm" aria-hidden>
+      <rect x="32" y="56" width="56" height="56" rx="8" className="fill-sand-4 stroke-sand-8" strokeWidth="2" />
+      <rect x="132" y="36" width="56" height="56" rx="8" className="fill-sand-4 stroke-sand-8" strokeWidth="2" />
+      <rect x="232" y="56" width="56" height="56" rx="8" className="fill-sand-4 stroke-sand-8" strokeWidth="2" />
+      <path d="M88 84 L132 64" className="stroke-accent-9 motion-safe:animate-pulse" strokeWidth="2" fill="none" />
+      <path d="M188 64 L232 84" className="stroke-accent-9 motion-safe:animate-pulse [animation-delay:150ms]" strokeWidth="2" fill="none" />
+      <rect x="112" y="112" width="96" height="48" rx="10" className="fill-accent-3 stroke-accent-9" strokeWidth="2" />
+      <text x="160" y="142" textAnchor="middle" className="fill-accent-11 text-[10px] font-medium">Review</text>
+    </svg>
+  );
+}
+
+export function AgentOnboardingIllustration() {
+  return (
+    <svg viewBox="0 0 320 180" className="h-full w-full max-w-sm" aria-hidden>
+      <rect x="100" y="40" width="120" height="80" rx="8" className="fill-sand-3 stroke-sand-8" strokeWidth="2" />
+      <rect x="108" y="48" width="104" height="56" rx="4" className="fill-sand-1" />
+      <rect x="140" y="128" width="40" height="8" rx="4" className="fill-sand-6" />
+      <circle cx="160" cy="100" r="16" className="fill-green-9 motion-safe:animate-pulse" />
+      <path d="M154 100 L158 104 L166 94" className="stroke-white" strokeWidth="2" fill="none" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function McpOnboardingIllustration() {
+  return (
+    <svg viewBox="0 0 320 180" className="h-full w-full max-w-sm" aria-hidden>
+      <rect x="40" y="50" width="80" height="80" rx="8" className="fill-sand-4 stroke-sand-8" strokeWidth="2" />
+      <text x="80" y="96" textAnchor="middle" className="fill-sand-11 text-[10px]">IDE</text>
+      <path d="M128 90 H192" className="stroke-accent-9 motion-safe:animate-pulse" strokeWidth="3" fill="none" />
+      <rect x="200" y="50" width="80" height="80" rx="8" className="fill-accent-3 stroke-accent-9" strokeWidth="2" />
+      <text x="240" y="96" textAnchor="middle" className="fill-accent-11 text-[10px]">MCP</text>
+    </svg>
+  );
+}
+
+export function CongratsOnboardingIllustration() {
+  return (
+    <svg viewBox="0 0 320 180" className="h-full w-full max-w-sm" aria-hidden>
+      <circle cx="160" cy="90" r="48" className="fill-green-3 stroke-green-9" strokeWidth="3" />
+      <path
+        d="M136 90 L152 106 L184 74"
+        className="stroke-green-11 motion-safe:animate-in motion-safe:zoom-in"
+        strokeWidth="4"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/apps/console/src/pages/organizations/onboarding/_lib/OnboardingSessionContext.tsx
+++ b/apps/console/src/pages/organizations/onboarding/_lib/OnboardingSessionContext.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import type { ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+import type { IntegrationStepId } from "./onboardingSteps";
+
+type OnboardingSessionContextValue = {
+  deferredSteps: ReadonlySet<IntegrationStepId>;
+  deferStep: (stepId: IntegrationStepId) => void;
+  clearDeferred: (stepId: IntegrationStepId) => void;
+};
+
+const OnboardingSessionContext = createContext<OnboardingSessionContextValue | null>(
+  null,
+);
+
+export function OnboardingSessionProvider(props: { children: ReactNode }) {
+  const { children } = props;
+  const [deferredSteps, setDeferredSteps] = useState<ReadonlySet<IntegrationStepId>>(
+    () => new Set(),
+  );
+
+  const deferStep = useCallback((stepId: IntegrationStepId) => {
+    setDeferredSteps(prev => new Set(prev).add(stepId));
+  }, []);
+
+  const clearDeferred = useCallback((stepId: IntegrationStepId) => {
+    setDeferredSteps((prev) => {
+      if (!prev.has(stepId)) return prev;
+      const next = new Set(prev);
+      next.delete(stepId);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({ deferredSteps, deferStep, clearDeferred }),
+    [clearDeferred, deferStep, deferredSteps],
+  );
+
+  return (
+    <OnboardingSessionContext.Provider value={value}>
+      {children}
+    </OnboardingSessionContext.Provider>
+  );
+}
+
+export function useOnboardingSession(): OnboardingSessionContextValue {
+  const ctx = useContext(OnboardingSessionContext);
+  if (!ctx) {
+    throw new Error("useOnboardingSession must be used within OnboardingSessionProvider");
+  }
+  return ctx;
+}

--- a/apps/console/src/pages/organizations/onboarding/_lib/onboardingSteps.ts
+++ b/apps/console/src/pages/organizations/onboarding/_lib/onboardingSteps.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+export const ONBOARDING_STEP_IDS = [
+  "scim",
+  "accessReview",
+  "agent",
+  "mcp",
+  "congrats",
+] as const;
+
+export type OnboardingStepId = (typeof ONBOARDING_STEP_IDS)[number];
+
+export const INTEGRATION_STEP_IDS = [
+  "scim",
+  "accessReview",
+  "agent",
+] as const satisfies readonly OnboardingStepId[];
+
+export type IntegrationStepId = (typeof INTEGRATION_STEP_IDS)[number];
+
+export function isOnboardingStepId(value: string | null): value is OnboardingStepId {
+  return value !== null && (ONBOARDING_STEP_IDS as readonly string[]).includes(value);
+}
+
+export type OnboardingCompletion = {
+  scim: boolean;
+  accessReview: boolean;
+  agent: boolean;
+};
+
+export function stepIsComplete(
+  stepId: IntegrationStepId,
+  completion: OnboardingCompletion,
+): boolean {
+  return completion[stepId];
+}
+
+export function firstIncompleteStep(
+  completion: OnboardingCompletion,
+  deferred: ReadonlySet<IntegrationStepId>,
+): OnboardingStepId {
+  for (const stepId of INTEGRATION_STEP_IDS) {
+    if (!stepIsComplete(stepId, completion) && !deferred.has(stepId)) {
+      return stepId;
+    }
+  }
+  if (!deferred.has("scim") && !completion.scim) return "scim";
+  if (!deferred.has("accessReview") && !completion.accessReview) return "accessReview";
+  if (!deferred.has("agent") && !completion.agent) return "agent";
+  return "mcp";
+}
+
+export function allIntegrationsComplete(completion: OnboardingCompletion): boolean {
+  return completion.scim && completion.accessReview && completion.agent;
+}

--- a/apps/console/src/pages/organizations/onboarding/_locales/en-US.json
+++ b/apps/console/src/pages/organizations/onboarding/_locales/en-US.json
@@ -1,0 +1,89 @@
+{
+  "pageTitle": "Organization onboarding",
+  "title": "Welcome to Probo",
+  "description": "Connect your stack in a few steps. You can finish anything later from Settings.",
+  "stepper": {
+    "ariaLabel": "Onboarding progress",
+    "scim": "SCIM",
+    "accessReview": "Access reviews",
+    "agent": "Probo agent",
+    "mcp": "MCP",
+    "congrats": "Done"
+  },
+  "status": {
+    "complete": "Connected",
+    "later": "Later"
+  },
+  "actions": {
+    "continue": "Continue",
+    "doLater": "Do this later",
+    "openInSettings": "Open in Settings",
+    "finishLater": "Finish in Settings"
+  },
+  "steps": {
+    "scim": {
+      "learnTitle": "Sync people from your identity provider",
+      "purpose": "SCIM keeps Probo aligned with joiners, movers, and leavers in your IdP. Accurate people data powers access reviews and ownership across the platform.",
+      "bullets": [
+        "Automatic user and group provisioning",
+        "Fewer manual invites and stale accounts",
+        "Consistent baseline for IAM and compliance workflows"
+      ],
+      "doTitle": "Connect SCIM",
+      "doDescription": "Connect Google Workspace, Microsoft 365, or enable manual SCIM credentials.",
+      "manualScimHeading": "Manual SCIM token"
+    },
+    "accessReview": {
+      "learnTitle": "Connect systems for access reviews",
+      "purpose": "Access review connectors pull account and permission data from your SaaS and identity tools so campaigns reflect real access.",
+      "bullets": [
+        "See who has access in each connected app",
+        "Run periodic access review campaigns",
+        "Evidence for auditors without spreadsheet hunts"
+      ],
+      "doTitle": "Add a connector",
+      "doDescription": "Choose a provider and authorize Probo to read access data.",
+      "addConnector": "Add connector",
+      "noPermission": "You do not have permission to add sources. Ask an organization admin, or open Settings later."
+    },
+    "agent": {
+      "learnTitle": "Enroll devices with the Probo agent",
+      "purpose": "The Probo agent reports endpoint posture (OS, encryption, and related signals) so you can manage fleet compliance alongside your cloud controls.",
+      "bullets": [
+        "Link employees to enrolled devices",
+        "Monitor posture from the Devices page",
+        "Support endpoint requirements in your frameworks"
+      ],
+      "doTitle": "Register a device",
+      "doDescription": "Create an enrollment and install the agent on a machine.",
+      "instructions": "Register a device to get an enrollment token, then install probo-agent on the endpoint using the instructions shown in the dialog.",
+      "registerDevice": "Register device",
+      "noPermission": "You do not have permission to register devices. Ask an organization admin, or open Devices in Settings later."
+    },
+    "mcp": {
+      "learnTitle": "Connect AI tools with Probo MCP",
+      "purpose": "The Probo MCP server lets Cursor, Claude Code, and other agents call your org data securely via OAuth—no static API keys in config files.",
+      "bullets": [
+        "OAuth to your Probo instance",
+        "Use compliance skills and workflows from your IDE",
+        "Same policies as the rest of the product"
+      ],
+      "doTitle": "Install MCP in your editor",
+      "doDescription": "Point your MCP client at this instance and complete OAuth when prompted.",
+      "steps": {
+        "oauth": "In Cursor or your agent, add an MCP server and choose OAuth when connecting.",
+        "url": "Use the endpoint below (HTTP transport).",
+        "skills": "Optional: install @probo/skills for ready-made compliance workflows."
+      },
+      "endpointLabel": "MCP endpoint",
+      "docsLink": "Probo skills and MCP setup guide"
+    },
+    "congrats": {
+      "title": "You are all set for now",
+      "description": "Thanks for walking through onboarding. You can close this tab or jump into the console anytime.",
+      "pendingTitle": "Still open",
+      "goToConsole": "Go to tasks",
+      "closeHint": "Safe to close this page—you can return to onboarding anytime with the same link."
+    }
+  }
+}

--- a/apps/console/src/pages/organizations/onboarding/_locales/fr-FR.json
+++ b/apps/console/src/pages/organizations/onboarding/_locales/fr-FR.json
@@ -1,0 +1,89 @@
+{
+  "pageTitle": "Intégration de l’organisation",
+  "title": "Bienvenue sur Probo",
+  "description": "Connectez votre stack en quelques étapes. Vous pourrez terminer plus tard depuis les paramètres.",
+  "stepper": {
+    "ariaLabel": "Progression de l’intégration",
+    "scim": "SCIM",
+    "accessReview": "Revues d’accès",
+    "agent": "Agent Probo",
+    "mcp": "MCP",
+    "congrats": "Terminé"
+  },
+  "status": {
+    "complete": "Connecté",
+    "later": "Plus tard"
+  },
+  "actions": {
+    "continue": "Continuer",
+    "doLater": "Plus tard",
+    "openInSettings": "Ouvrir dans les paramètres",
+    "finishLater": "Terminer dans les paramètres"
+  },
+  "steps": {
+    "scim": {
+      "learnTitle": "Synchroniser les personnes depuis votre IdP",
+      "purpose": "SCIM aligne Probo avec les arrivées, mouvements et départs dans votre fournisseur d’identité. Des données personnes fiables alimentent les revues d’accès et la gouvernance.",
+      "bullets": [
+        "Approvisionnement automatique des utilisateurs et groupes",
+        "Moins d’invitations manuelles et de comptes obsolètes",
+        "Base cohérente pour l’IAM et la conformité"
+      ],
+      "doTitle": "Connecter SCIM",
+      "doDescription": "Connectez Google Workspace, Microsoft 365 ou activez un jeton SCIM manuel.",
+      "manualScimHeading": "Jeton SCIM manuel"
+    },
+    "accessReview": {
+      "learnTitle": "Connecter les systèmes pour les revues d’accès",
+      "purpose": "Les connecteurs remontent comptes et droits depuis vos SaaS et outils d’identité pour des campagnes fidèles à la réalité.",
+      "bullets": [
+        "Voir qui a accès dans chaque application connectée",
+        "Lancer des campagnes de revue périodiques",
+        "Des preuves pour les auditeurs sans chasse aux tableurs"
+      ],
+      "doTitle": "Ajouter un connecteur",
+      "doDescription": "Choisissez un fournisseur et autorisez Probo à lire les données d’accès.",
+      "addConnector": "Ajouter un connecteur",
+      "noPermission": "Vous n’avez pas la permission d’ajouter des sources. Demandez à un admin ou ouvrez les paramètres plus tard."
+    },
+    "agent": {
+      "learnTitle": "Inscrire des postes avec l’agent Probo",
+      "purpose": "L’agent Probo remonte la posture des postes (OS, chiffrement, etc.) pour gérer la conformité endpoint avec vos contrôles cloud.",
+      "bullets": [
+        "Lier les employés aux postes inscrits",
+        "Suivre la posture depuis la page Appareils",
+        "Soutenir les exigences endpoint de vos référentiels"
+      ],
+      "doTitle": "Enregistrer un appareil",
+      "doDescription": "Créez une inscription et installez l’agent sur une machine.",
+      "instructions": "Enregistrez un appareil pour obtenir un jeton d’inscription, puis installez probo-agent en suivant les instructions du dialogue.",
+      "registerDevice": "Enregistrer un appareil",
+      "noPermission": "Vous n’avez pas la permission d’enregistrer des appareils. Demandez à un admin ou ouvrez Appareils plus tard."
+    },
+    "mcp": {
+      "learnTitle": "Connecter vos outils IA via MCP Probo",
+      "purpose": "Le serveur MCP Probo permet à Cursor, Claude Code et d’autres agents d’appeler vos données org via OAuth—sans clé API statique.",
+      "bullets": [
+        "OAuth vers votre instance Probo",
+        "Skills et workflows conformité depuis l’IDE",
+        "Les mêmes politiques que le reste du produit"
+      ],
+      "doTitle": "Installer MCP dans l’éditeur",
+      "doDescription": "Pointez votre client MCP vers cette instance et validez OAuth.",
+      "steps": {
+        "oauth": "Dans Cursor ou votre agent, ajoutez un serveur MCP et choisissez OAuth.",
+        "url": "Utilisez l’endpoint ci-dessous (transport HTTP).",
+        "skills": "Optionnel : installez @probo/skills pour des workflows prêts à l’emploi."
+      },
+      "endpointLabel": "Endpoint MCP",
+      "docsLink": "Guide skills et MCP Probo"
+    },
+    "congrats": {
+      "title": "C’est bon pour l’instant",
+      "description": "Merci d’avoir suivi l’intégration. Vous pouvez fermer cet onglet ou ouvrir la console.",
+      "pendingTitle": "Encore à faire",
+      "goToConsole": "Aller aux tâches",
+      "closeHint": "Vous pouvez fermer cette page—le même lien rouvre l’intégration."
+    }
+  }
+}

--- a/apps/console/src/pages/organizations/onboarding/routes.ts
+++ b/apps/console/src/pages/organizations/onboarding/routes.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { lazy } from "@probo/react-lazy";
+
+import { PageSkeleton } from "#/components/skeletons/PageSkeleton";
+
+export const onboardingRoutes = [
+  {
+    path: "onboarding",
+    Fallback: PageSkeleton,
+    Component: lazy(
+      () => import("#/pages/organizations/onboarding/OnboardingLayoutLoader"),
+    ),
+    children: [
+      {
+        index: true,
+        Fallback: PageSkeleton,
+        Component: lazy(
+          () => import("#/pages/organizations/onboarding/OnboardingPageLoader"),
+        ),
+      },
+    ],
+  },
+];

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -37,6 +37,7 @@ import { ViewerLayoutLoading } from "./pages/iam/memberships/ViewerLayoutLoading
 import { peopleRoutes } from "./pages/iam/organizations/people/routes";
 import { compliancePageRoutes } from "./pages/organizations/compliance-page/routes";
 import { cookieBannerRoutes } from "./pages/organizations/cookie-banners/routes";
+import { onboardingRoutes } from "./pages/organizations/onboarding/routes";
 import { deviceRoutes } from "./pages/organizations/devices/routes";
 import { riskRoutes } from "./pages/organizations/risks/routes";
 import { thirdPartyRoutes } from "./pages/organizations/third-parties/routes";
@@ -191,6 +192,7 @@ const routes = [
         path: "assume",
         Component: lazy(() => import("./pages/iam/organizations/AssumePageLoader")),
       },
+      ...onboardingRoutes,
       {
         path: "employee",
         ErrorBoundary: OrganizationErrorBoundary,

--- a/contrib/claude/onboarding.md
+++ b/contrib/claude/onboarding.md
@@ -1,0 +1,58 @@
+# Organization onboarding wizard (console)
+
+Unlisted wizard at `/organizations/:organizationId/onboarding` for peer / new
+organization setup. Not linked from sidebar or nav; shareable URL plus redirect
+after **Create organization**.
+
+## Steps
+
+| # | Step ID | Purpose | Done (GraphQL) |
+|---|---------|---------|----------------|
+| 1 | `scim` | IdP provisioning via SCIM | `organization.scimConfiguration` exists |
+| 2 | `accessReview` | Access review connectors | ≥1 `accessReviewSources` edge |
+| 3 | `agent` | Probo agent / device fleet | ≥1 `devices` edge |
+| 4 | `mcp` | MCP setup instructions | Never auto; **Continue** always |
+| 5 | `congrats` | Completion | Reach step 5 in flow |
+
+## UX
+
+- **Learn** panel: title, purpose, bullets, SVG/CSS illustration (`prefers-reduced-motion`).
+- **Do** panel: embedded existing flows (SCIM connectors, add access review source, create device).
+- **Do this later** on steps 1–4: session-only deferral; advances to next step.
+- **Continue** on MCP without checkbox.
+- **Congrats**: done vs still-to-do from integration state; optional link to console tasks.
+
+## Persistence
+
+- No backend onboarding model.
+- **Done** = live integration data (refetch after mutations).
+- **Deferred** = in-memory React context only (no `localStorage`); lost on tab close or refresh.
+
+## Navigation
+
+- Post-create: navigate to `/organizations/:id/onboarding`.
+- Step in URL: `?step=scim|accessReview|agent|mcp|congrats` (browser back).
+- Initial step: first incomplete integration step, or **congrats** if all complete.
+- `?welcome=1` after create: start at step 1 even if empty (optional; default first gap).
+
+## Access
+
+- Authenticated org member required.
+- **Employee** → redirect to `employee` portal.
+- **Auditor** → redirect to `measures`.
+- Missing permissions: show learn panel + deep link to settings; still allow **Do this later**.
+
+## Layout
+
+- `hideSidebar` org layout (focused wizard), same pattern as employee layout.
+
+## Deep links (finish later)
+
+- SCIM → `/organizations/:id/settings/scim`
+- Access review → `/organizations/:id/access-reviews/sources`
+- Devices → `/organizations/:id/devices`
+- MCP → instance `${origin}` + `/mcp/v1`, skills / IDE docs
+
+## i18n
+
+- Namespace `organizations/onboarding` → `pages/organizations/onboarding/_locales/*.json`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an unlisted organization onboarding wizard at `/organizations/:organizationId/onboarding` for peer / new org setup.

- **Steps:** SCIM → access review connectors → Probo agent → MCP instructions → congrats
- **UX:** Learn panel (copy + animated SVG illustrations), Do panel (embedded existing flows), **Do this later** on each integration step
- **Persistence:** Integration “done” comes from GraphQL; deferrals are **session-only** (in-memory context, no backend / no localStorage)
- **Entry:** Redirect after **Create organization** to `?welcome=1`; same URL is shareable (not linked from nav)
- **Layout:** `hideSidebar` focused layout; employees and auditors are redirected away
- **Spec:** [`contrib/claude/onboarding.md`](contrib/claude/onboarding.md)

## Test plan

- [ ] Create a new organization → lands on onboarding step 1 (SCIM)
- [ ] Connect SCIM (IdP or manual) → Continue enables; stepper shows complete
- [ ] **Do this later** advances without marking complete; congrats lists pending items
- [ ] Add access review source; register a device; MCP step Continue → congrats
- [ ] Open `/organizations/:id/onboarding` directly when integrations already done → congrats
- [ ] Employee role cannot access wizard (redirect to employee portal)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb425-d584-761a-9268-490ee71bbd82?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb425-d584-761a-9268-490ee71bbd82&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an unlisted organization onboarding wizard at `/organizations/:organizationId/onboarding` with a focused layout and stepper. New orgs redirect here to guide setup through SCIM, access review connectors, device agent, and MCP instructions.

### App: console **`+1863`** **`-1`**
- New onboarding route and focused layout (`hideSidebar`), plus loaders and Relay queries.
- Step flow: SCIM → access review → agent → MCP → congrats; session-only “Do this later”.
- Embedded flows: SCIM connectors/credentials, add access review source, register device; links to Settings.
- Access control: employees → employee portal; auditors → measures.
- Creation redirect: after creating an org, navigate to `/onboarding?welcome=1`. Added i18n (`en-US`, `fr-FR`) and illustrations.

### Agents **`+58`** **`-0`**
- Added `contrib/claude/onboarding.md` documenting the wizard steps, UX, deferrals, access, and deep links.

### Other **`+1`** **`-0`**
- Linked the onboarding doc from `AGENTS.md`.

<sup>Written for commit 0c1e9760a6e23bf7f3a8649f2e1f5af137d83eba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

