### PR TITLE
Link findings to third parties

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -353,7 +353,7 @@
     "messages": { "successTitle": "Success", "deleted": "Finding deleted successfully", "updated": "Finding updated successfully" },
     "errors": { "title": "Error", "delete": "Failed to delete finding", "update": "Failed to update finding" },
     "deleteConfirmation": "This will permanently delete the finding {{referenceId}}. This action cannot be undone.",
-    "fields": { "description": "Description", "source": "Source", "owner": "Owner", "status": "Status", "priority": "Priority", "acceptedRisk": "Accepted risk", "dateIdentified": "Date identified", "dueDate": "Due date", "rootCause": "Root cause", "correctiveAction": "Corrective action", "effectivenessCheck": "Effectiveness check" },
+    "fields": { "description": "Description", "source": "Source", "owner": "Owner", "status": "Status", "priority": "Priority", "acceptedRisk": "Accepted risk", "thirdParties": "Third parties", "dateIdentified": "Date identified", "dueDate": "Due date", "rootCause": "Root cause", "correctiveAction": "Corrective action", "effectivenessCheck": "Effectiveness check" },
     "placeholders": { "description": "Enter description", "source": "Enter source", "rootCause": "Enter root cause", "correctiveAction": "Enter corrective action", "effectivenessCheck": "Enter effectiveness check details" },
     "actions": { "delete": "Delete", "updating": "Updating...", "update": "Update" }
   },
@@ -2305,7 +2305,16 @@
     "level": "Level {{level}}",
     "from": "From:",
     "actions": { "startVetting": "Start Vetting", "delete": "Delete" },
-    "tabs": { "overview": "Overview", "certifications": "Certifications", "complianceReports": "Compliance reports", "riskAssessment": "Risk Assessment", "contacts": "Contacts", "services": "Services", "thirdParties": "Third Parties", "measures": "Measures" }
+    "tabs": { "overview": "Overview", "certifications": "Certifications", "complianceReports": "Compliance reports", "riskAssessment": "Risk Assessment", "contacts": "Contacts", "services": "Services", "thirdParties": "Third Parties", "measures": "Measures", "findings": "Findings" }
+  },
+  "thirdPartyFindingsPage": {
+    "title": "Findings",
+    "description": "Findings linked to this third party.",
+    "columns": { "referenceId": "Reference ID", "description": "Description", "status": "Status", "priority": "Priority" },
+    "empty": "No findings are linked to this third party.",
+    "noDescription": "No description",
+    "loading": "Loading...",
+    "loadMore": "Load more"
   },
   "addChildThirdPartyDialog": {
     "title": "Add a third party",

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -753,6 +753,7 @@
       "owner": "Propriétaire",
       "status": "Statut",
       "priority": "Priorité",
+      "thirdParties": "Tiers",
       "dateIdentified": "Date d’identification",
       "dueDate": "Date d’échéance",
       "rootCause": "Cause racine",
@@ -5345,8 +5346,23 @@
       "contacts": "Contacts",
       "services": "Services",
       "thirdParties": "Tiers",
-      "measures": "Mesures"
+      "measures": "Mesures",
+      "findings": "Constats"
     }
+  },
+  "thirdPartyFindingsPage": {
+    "title": "Constats",
+    "description": "Constats liés à ce tiers.",
+    "columns": {
+      "referenceId": "ID de référence",
+      "description": "Description",
+      "status": "Statut",
+      "priority": "Priorité"
+    },
+    "empty": "Aucun constat n’est lié à ce tiers.",
+    "noDescription": "Aucune description",
+    "loading": "Chargement...",
+    "loadMore": "Afficher plus"
   },
   "addChildThirdPartyDialog": {
     "title": "Ajouter un tiers",

--- a/apps/console/src/pages/organizations/findings/FindingDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/findings/FindingDetailsPage.tsx
@@ -58,6 +58,7 @@ import type { FindingDetailsPageUpdateMutation } from "#/__generated__/core/Find
 import { ControlledField } from "#/components/form/ControlledField";
 import { PeopleSelectField } from "#/components/form/PeopleSelectField";
 import { RiskSelectField } from "#/components/form/RiskSelectField";
+import { ThirdPartiesMultiSelectField } from "#/components/form/ThirdPartiesMultiSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 
@@ -85,6 +86,15 @@ export const findingDetailsPageQuery = graphql`
         risk {
           id
           name
+        }
+        thirdParties(first: 100, orderBy: { direction: ASC, field: NAME }) {
+          edges {
+            node {
+              id
+              name
+              websiteUrl
+            }
+          }
         }
         canUpdate: permission(action: "core:finding:update")
         canDelete: permission(action: "core:finding:delete")
@@ -154,6 +164,7 @@ const updateFindingSchema = z
     priority: z.enum(["LOW", "MEDIUM", "HIGH"]),
     ownerId: z.string().nullable().optional(),
     riskId: z.string().nullable().optional(),
+    thirdPartyIds: z.array(z.string()),
   })
   .refine(
     data => data.status !== "RISK_ACCEPTED" || Boolean(data.riskId),
@@ -270,6 +281,7 @@ export default function FindingDetailsPage(props: Props) {
         priority: finding.priority || "MEDIUM",
         ownerId: finding.owner?.id ?? null,
         riskId: finding.risk?.id ?? null,
+        thirdPartyIds: finding.thirdParties?.edges.map(edge => edge.node.id) ?? [],
       },
     });
 
@@ -301,6 +313,7 @@ export default function FindingDetailsPage(props: Props) {
           riskId: formData.status === "RISK_ACCEPTED"
             ? formData.riskId || null
             : null,
+          thirdPartyIds: formData.thirdPartyIds,
         },
       },
       onCompleted() {
@@ -475,6 +488,14 @@ export default function FindingDetailsPage(props: Props) {
                 required
               />
             )}
+
+            <ThirdPartiesMultiSelectField
+              organizationId={organizationId}
+              control={control}
+              name="thirdPartyIds"
+              label={t("findingDetails.fields.thirdParties")}
+              selectedThirdParties={finding.thirdParties?.edges.map(edge => edge.node) ?? []}
+            />
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <Field label={t("findingDetails.fields.dateIdentified")}>

--- a/apps/console/src/pages/organizations/third-parties/ThirdPartyDetailLayout.tsx
+++ b/apps/console/src/pages/organizations/third-parties/ThirdPartyDetailLayout.tsx
@@ -79,6 +79,9 @@ export const thirdPartyDetailLayoutQuery = graphql`
         measuresInfo: measures(first: 0) {
           totalCount
         }
+        findingsInfo: findings(first: 0) {
+          totalCount
+        }
       }
     }
   }
@@ -196,6 +199,7 @@ export default function ThirdPartyDetailLayout(props: ThirdPartyDetailLayoutProp
   const logo = faviconUrl(thirdParty.websiteUrl);
   const reportsCount = thirdParty.complianceReportsInfo?.edges.length ?? 0;
   const measuresCount = thirdParty.measuresInfo?.totalCount ?? 0;
+  const findingsCount = thirdParty.findingsInfo.totalCount;
   const isVettingFailed = thirdParty.vettingStatus === "FAILED";
   const ancestors = thirdParty.ancestors ?? [];
 
@@ -305,6 +309,10 @@ export default function ThirdPartyDetailLayout(props: ThirdPartyDetailLayoutProp
         <TabLink to={`${baseThirdPartyUrl}/measures`}>
           {t("thirdPartyDetailLayout.tabs.measures")}
           {measuresCount > 0 && <TabBadge>{measuresCount}</TabBadge>}
+        </TabLink>
+        <TabLink to={`${baseThirdPartyUrl}/findings`}>
+          {t("thirdPartyDetailLayout.tabs.findings")}
+          {findingsCount > 0 && <TabBadge>{findingsCount}</TabBadge>}
         </TabLink>
       </Tabs>
 

--- a/apps/console/src/pages/organizations/third-parties/findings/ThirdPartyFindingsPage.tsx
+++ b/apps/console/src/pages/organizations/third-parties/findings/ThirdPartyFindingsPage.tsx
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { Button, Card, PageHeader, Table, Tbody, Th, Thead, Tr } from "@probo/ui";
+import { useTranslation } from "react-i18next";
+import {
+  graphql,
+  type PreloadedQuery,
+  usePaginationFragment,
+  usePreloadedQuery,
+} from "react-relay";
+
+import type { ThirdPartyFindingsPage_thirdParty$key } from "#/__generated__/core/ThirdPartyFindingsPage_thirdParty.graphql";
+import type { ThirdPartyFindingsPageQuery } from "#/__generated__/core/ThirdPartyFindingsPageQuery.graphql";
+import type { ThirdPartyFindingsPageRefetchQuery } from "#/__generated__/core/ThirdPartyFindingsPageRefetchQuery.graphql";
+
+import { ThirdPartyFindingListItem } from "./_components/ThirdPartyFindingListItem";
+
+const thirdPartyFindingsFragment = graphql`
+  fragment ThirdPartyFindingsPage_thirdParty on ThirdParty
+  @refetchable(queryName: "ThirdPartyFindingsPageRefetchQuery")
+  @argumentDefinitions(
+    first: { type: "Int", defaultValue: 50 }
+    after: { type: "CursorKey" }
+  ) {
+    findings(
+      first: $first
+      after: $after
+      orderBy: { direction: DESC, field: CREATED_AT }
+    ) @connection(key: "ThirdPartyFindingsPage_findings", filters: []) {
+      edges {
+        node {
+          id
+          ...ThirdPartyFindingListItem_finding
+        }
+      }
+    }
+  }
+`;
+
+export const thirdPartyFindingsPageQuery = graphql`
+  query ThirdPartyFindingsPageQuery($thirdPartyId: ID!) {
+    node(id: $thirdPartyId) {
+      __typename
+      ... on ThirdParty {
+        ...ThirdPartyFindingsPage_thirdParty
+      }
+    }
+  }
+`;
+
+interface ThirdPartyFindingsPageProps {
+  queryRef: PreloadedQuery<ThirdPartyFindingsPageQuery>;
+}
+
+export function ThirdPartyFindingsPage({ queryRef }: ThirdPartyFindingsPageProps) {
+  const { t } = useTranslation();
+  const data = usePreloadedQuery<ThirdPartyFindingsPageQuery>(
+    thirdPartyFindingsPageQuery,
+    queryRef,
+  );
+  if (data.node?.__typename !== "ThirdParty") {
+    throw new Error("Third party not found");
+  }
+
+  const { data: thirdParty, ...pagination } = usePaginationFragment<
+    ThirdPartyFindingsPageRefetchQuery,
+    ThirdPartyFindingsPage_thirdParty$key
+  >(thirdPartyFindingsFragment, data.node);
+  const findings = thirdParty.findings.edges.map(edge => edge.node);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t("thirdPartyFindingsPage.title")}
+        description={t("thirdPartyFindingsPage.description")}
+      />
+      {findings.length > 0
+        ? (
+            <Card>
+              <Table>
+                <Thead>
+                  <Tr>
+                    <Th>{t("thirdPartyFindingsPage.columns.referenceId")}</Th>
+                    <Th>{t("thirdPartyFindingsPage.columns.description")}</Th>
+                    <Th>{t("thirdPartyFindingsPage.columns.status")}</Th>
+                    <Th>{t("thirdPartyFindingsPage.columns.priority")}</Th>
+                  </Tr>
+                </Thead>
+                <Tbody>
+                  {findings.map(finding => (
+                    <ThirdPartyFindingListItem
+                      key={finding.id}
+                      findingKey={finding}
+                    />
+                  ))}
+                </Tbody>
+              </Table>
+              {pagination.hasNext && (
+                <div className="border-t p-4">
+                  <Button
+                    variant="secondary"
+                    disabled={pagination.isLoadingNext}
+                    onClick={() => pagination.loadNext(50)}
+                  >
+                    {pagination.isLoadingNext
+                      ? t("thirdPartyFindingsPage.loading")
+                      : t("thirdPartyFindingsPage.loadMore")}
+                  </Button>
+                </div>
+              )}
+            </Card>
+          )
+        : (
+            <Card padded>
+              <p className="py-8 text-center text-txt-secondary">
+                {t("thirdPartyFindingsPage.empty")}
+              </p>
+            </Card>
+          )}
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/third-parties/findings/ThirdPartyFindingsPageLoader.tsx
+++ b/apps/console/src/pages/organizations/third-parties/findings/ThirdPartyFindingsPageLoader.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { Suspense, useEffect } from "react";
+import { useQueryLoader } from "react-relay";
+import { useParams } from "react-router";
+
+import type { ThirdPartyFindingsPageQuery } from "#/__generated__/core/ThirdPartyFindingsPageQuery.graphql";
+import { PageSkeleton } from "#/components/skeletons/PageSkeleton";
+
+import { ThirdPartyFindingsPage, thirdPartyFindingsPageQuery } from "./ThirdPartyFindingsPage";
+
+export default function ThirdPartyFindingsPageLoader() {
+  const { thirdPartyId } = useParams<{ thirdPartyId: string }>();
+  const [queryRef, loadQuery]
+    = useQueryLoader<ThirdPartyFindingsPageQuery>(thirdPartyFindingsPageQuery);
+
+  useEffect(() => {
+    if (thirdPartyId) {
+      loadQuery({ thirdPartyId });
+    }
+  }, [loadQuery, thirdPartyId]);
+
+  if (!queryRef) {
+    return <PageSkeleton />;
+  }
+
+  return (
+    <Suspense fallback={<PageSkeleton />}>
+      <ThirdPartyFindingsPage queryRef={queryRef} />
+    </Suspense>
+  );
+}

--- a/apps/console/src/pages/organizations/third-parties/findings/_components/ThirdPartyFindingListItem.tsx
+++ b/apps/console/src/pages/organizations/third-parties/findings/_components/ThirdPartyFindingListItem.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { getStatusVariant } from "@probo/helpers";
+import { Badge, Td, Tr } from "@probo/ui";
+import { useTranslation } from "react-i18next";
+import { graphql, useFragment } from "react-relay";
+import { Link } from "react-router";
+
+import type { ThirdPartyFindingListItem_finding$key } from "#/__generated__/core/ThirdPartyFindingListItem_finding.graphql";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+
+const findingListItemFragment = graphql`
+  fragment ThirdPartyFindingListItem_finding on Finding {
+    id
+    referenceId
+    description
+    status
+    priority
+  }
+`;
+
+export function ThirdPartyFindingListItem({
+  findingKey,
+}: {
+  findingKey: ThirdPartyFindingListItem_finding$key;
+}) {
+  const { t } = useTranslation();
+  const organizationId = useOrganizationId();
+  const finding = useFragment(findingListItemFragment, findingKey);
+
+  return (
+    <Tr>
+      <Td>
+        <Link
+          to={`/organizations/${organizationId}/findings/${finding.id}`}
+          className="font-mono underline"
+        >
+          {finding.referenceId}
+        </Link>
+      </Td>
+      <Td>{finding.description ?? t("thirdPartyFindingsPage.noDescription")}</Td>
+      <Td>
+        <Badge variant={getStatusVariant(finding.status)}>
+          {t(`findingsPage.status.${finding.status.toLowerCase()}`)}
+        </Badge>
+      </Td>
+      <Td>{t(`findingsPage.priority.${finding.priority.toLowerCase()}`)}</Td>
+    </Tr>
+  );
+}

--- a/apps/console/src/pages/organizations/third-parties/routes.ts
+++ b/apps/console/src/pages/organizations/third-parties/routes.ts
@@ -85,6 +85,11 @@ export const thirdPartyRoutes = [
         Fallback: LinkCardSkeleton,
         Component: lazy(() => import("./measures/ThirdPartyMeasuresPageLoader")),
       },
+      {
+        path: "findings",
+        Fallback: PageSkeleton,
+        Component: lazy(() => import("./findings/ThirdPartyFindingsPageLoader")),
+      },
     ],
   },
 ] satisfies AppRoute[];

--- a/packages/n8n-node/nodes/Probo/actions/finding/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/finding/update.operation.ts
@@ -174,6 +174,13 @@ export const description: INodeProperties[] = [
 				default: '',
 				description: 'The status of the finding',
 			},
+			{
+				displayName: 'Third Party IDs',
+				name: 'thirdPartyIds',
+				type: 'string',
+				default: '',
+				description: 'Comma-separated IDs of third parties linked to the finding',
+			},
 		],
 	},
 ];
@@ -195,6 +202,7 @@ export async function execute(
 		priority?: string;
 		riskId?: string;
 		effectivenessCheck?: string;
+		thirdPartyIds?: string;
 	};
 
 	const query = `
@@ -231,6 +239,11 @@ export async function execute(
 	if (additionalFields.priority !== undefined) input.priority = additionalFields.priority;
 	if (additionalFields.riskId !== undefined) input.riskId = additionalFields.riskId === '' ? null : additionalFields.riskId;
 	if (additionalFields.effectivenessCheck !== undefined) input.effectivenessCheck = additionalFields.effectivenessCheck === '' ? null : additionalFields.effectivenessCheck;
+	if (additionalFields.thirdPartyIds !== undefined) {
+		input.thirdPartyIds = additionalFields.thirdPartyIds === ''
+			? []
+			: additionalFields.thirdPartyIds.split(',').map(id => id.trim()).filter(Boolean);
+	}
 
 	const responseData = await proboApiRequest.call(this, query, { input });
 

--- a/pkg/cmd/finding/update/update.go
+++ b/pkg/cmd/finding/update/update.go
@@ -68,6 +68,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 		flagPriority         string
 		flagRiskID           string
 		flagEffectivenessChk string
+		flagThirdPartyIDs    []string
 	)
 
 	cmd := &cobra.Command{
@@ -181,6 +182,10 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
+			if cmd.Flags().Changed("third-party-id") {
+				input["thirdPartyIds"] = flagThirdPartyIDs
+			}
+
 			if len(input) == 1 {
 				return fmt.Errorf("at least one field must be specified for update")
 			}
@@ -221,6 +226,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagPriority, "priority", "", "Priority: LOW, MEDIUM, HIGH")
 	cmd.Flags().StringVar(&flagRiskID, "risk-id", "", "Associated risk ID")
 	cmd.Flags().StringVar(&flagEffectivenessChk, "effectiveness-check", "", "Effectiveness check")
+	cmd.Flags().StringSliceVar(&flagThirdPartyIDs, "third-party-id", nil, "Third party ID (repeatable)")
 
 	return cmd
 }

--- a/pkg/coredata/finding.go
+++ b/pkg/coredata/finding.go
@@ -566,6 +566,101 @@ WHERE
 	return count, nil
 }
 
+func (fs *Findings) LoadByThirdPartyID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	thirdPartyID gid.GID,
+	cursor *page.Cursor[FindingOrderField],
+	filter *FindingFilter,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	kind,
+	reference_id,
+	description,
+	source,
+	identified_on,
+	root_cause,
+	corrective_action,
+	owner_id,
+	due_date,
+	status,
+	priority,
+	risk_id,
+	effectiveness_check,
+	created_at,
+	updated_at
+FROM findings
+WHERE
+	%s
+	AND id IN (
+		SELECT finding_id
+		FROM finding_third_parties
+		WHERE third_party_id = @third_party_id
+	)
+	AND %s
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"third_party_id": thirdPartyID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query third party findings: %w", err)
+	}
+
+	findings, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[Finding])
+	if err != nil {
+		return fmt.Errorf("cannot collect third party findings: %w", err)
+	}
+
+	*fs = findings
+
+	return nil
+}
+
+func (fs *Findings) CountByThirdPartyID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	thirdPartyID gid.GID,
+	filter *FindingFilter,
+) (int, error) {
+	q := `
+SELECT COUNT(id)
+FROM findings
+WHERE
+	%s
+	AND id IN (
+		SELECT finding_id
+		FROM finding_third_parties
+		WHERE third_party_id = @third_party_id
+	)
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"third_party_id": thirdPartyID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+
+	var count int
+	if err := conn.QueryRow(ctx, q, args).Scan(&count); err != nil {
+		return 0, fmt.Errorf("cannot count third party findings: %w", err)
+	}
+
+	return count, nil
+}
+
 func (f Finding) GetGeneratedDocumentID(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/coredata/finding_third_party.go
+++ b/pkg/coredata/finding_third_party.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+type (
+	FindingThirdParty struct {
+		FindingID      gid.GID   `db:"finding_id"`
+		ThirdPartyID   gid.GID   `db:"third_party_id"`
+		OrganizationID gid.GID   `db:"organization_id"`
+		CreatedAt      time.Time `db:"created_at"`
+	}
+
+	FindingThirdParties []*FindingThirdParty
+)
+
+func (fs FindingThirdParties) Merge(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	findingID gid.GID,
+	organizationID gid.GID,
+	thirdPartyIDs []gid.GID,
+) error {
+	q := `
+WITH third_party_ids AS (
+	SELECT
+		unnest(@third_party_ids::text[]) AS third_party_id,
+		@tenant_id AS tenant_id,
+		@finding_id AS finding_id,
+		@organization_id AS organization_id,
+		@created_at::timestamptz AS created_at
+)
+MERGE INTO finding_third_parties AS tgt
+USING third_party_ids AS src
+ON tgt.tenant_id = src.tenant_id
+	AND tgt.finding_id = src.finding_id
+	AND tgt.third_party_id = src.third_party_id
+WHEN NOT MATCHED THEN
+	INSERT (tenant_id, finding_id, third_party_id, organization_id, created_at)
+	VALUES (src.tenant_id, src.finding_id, src.third_party_id, src.organization_id, src.created_at)
+WHEN NOT MATCHED BY SOURCE
+	AND tgt.tenant_id = @tenant_id AND tgt.finding_id = @finding_id
+	THEN DELETE
+`
+
+	args := pgx.StrictNamedArgs{
+		"tenant_id":       scope.GetTenantID(),
+		"finding_id":      findingID,
+		"organization_id": organizationID,
+		"created_at":      time.Now(),
+		"third_party_ids": thirdPartyIDs,
+	}
+
+	if _, err := conn.Exec(ctx, q, args); err != nil {
+		return fmt.Errorf("cannot merge finding third parties: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/migrations/20260803T115628Z.sql
+++ b/pkg/coredata/migrations/20260803T115628Z.sql
@@ -1,0 +1,28 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+CREATE TABLE finding_third_parties (
+    tenant_id       TEXT NOT NULL,
+    organization_id TEXT NOT NULL,
+    finding_id      TEXT NOT NULL REFERENCES findings(id) ON DELETE CASCADE,
+    third_party_id  TEXT NOT NULL REFERENCES third_parties(id) ON DELETE CASCADE,
+    created_at      TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (finding_id, third_party_id)
+);

--- a/pkg/coredata/third_party_filter.go
+++ b/pkg/coredata/third_party_filter.go
@@ -22,6 +22,7 @@ package coredata
 
 import (
 	"github.com/jackc/pgx/v5"
+	"go.probo.inc/probo/pkg/gid"
 )
 
 type (
@@ -31,6 +32,7 @@ type (
 		query                  *string
 		category               *ThirdPartyCategory
 		country                *CountryCode
+		findingID              *gid.GID
 	}
 )
 
@@ -50,6 +52,12 @@ func NewThirdPartyFilter(
 	}
 }
 
+func (f *ThirdPartyFilter) WithFindingID(findingID gid.GID) *ThirdPartyFilter {
+	f.findingID = &findingID
+
+	return f
+}
+
 func (f *ThirdPartyFilter) SQLArguments() pgx.StrictNamedArgs {
 	args := pgx.StrictNamedArgs{
 		"show_on_trust_center": nil,
@@ -57,6 +65,7 @@ func (f *ThirdPartyFilter) SQLArguments() pgx.StrictNamedArgs {
 		"level":                nil,
 		"filter_category":      nil,
 		"filter_country":       nil,
+		"filter_finding_id":    nil,
 	}
 
 	if f.showOnCompliancePortal != nil {
@@ -77,6 +86,10 @@ func (f *ThirdPartyFilter) SQLArguments() pgx.StrictNamedArgs {
 
 	if f.country != nil {
 		args["filter_country"] = string(*f.country)
+	}
+
+	if f.findingID != nil {
+		args["filter_finding_id"] = *f.findingID
 	}
 
 	return args
@@ -108,6 +121,15 @@ func (f *ThirdPartyFilter) SQLFragment() string {
 	AND CASE
 		WHEN @filter_country::text IS NOT NULL THEN
 			@filter_country::country_code = ANY(countries)
+		ELSE TRUE
+	END
+	AND CASE
+		WHEN @filter_finding_id::text IS NOT NULL THEN
+			id IN (
+				SELECT third_party_id
+				FROM finding_third_parties
+				WHERE finding_id = @filter_finding_id
+			)
 		ELSE TRUE
 	END
 )`

--- a/pkg/probo/finding_service.go
+++ b/pkg/probo/finding_service.go
@@ -66,6 +66,7 @@ type (
 		Priority           *coredata.FindingPriority
 		RiskID             **gid.GID
 		EffectivenessCheck **string
+		ThirdPartyIDs      []gid.GID
 	}
 )
 
@@ -104,6 +105,9 @@ func (r *UpdateFindingRequest) Validate() error {
 	v.Check(r.Priority, "priority", validator.OneOfSlice(coredata.FindingPriorities()))
 	v.Check(r.RiskID, "risk_id", validator.GID(coredata.RiskEntityType))
 	v.Check(r.EffectivenessCheck, "effectiveness_check", validator.SafeText(ContentMaxLength))
+	v.CheckEach(r.ThirdPartyIDs, "third_party_ids", func(index int, item any) {
+		v.Check(item, fmt.Sprintf("third_party_ids[%d]", index), validator.Required(), validator.GID(coredata.ThirdPartyEntityType))
+	})
 
 	return v.Error()
 }
@@ -281,6 +285,25 @@ func (s *FindingService) Update(
 
 			if err := finding.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update finding: %w", err)
+			}
+
+			if req.ThirdPartyIDs != nil {
+				if len(req.ThirdPartyIDs) > 0 {
+					var thirdParties coredata.ThirdParties
+					if err := thirdParties.LoadByIDs(ctx, conn, scope, req.ThirdPartyIDs); err != nil {
+						return fmt.Errorf("cannot load finding third parties: %w", err)
+					}
+					for _, thirdParty := range thirdParties {
+						if thirdParty.OrganizationID != finding.OrganizationID {
+							return fmt.Errorf("cannot update finding third parties: third party belongs to another organization")
+						}
+					}
+				}
+
+				var findingThirdParties coredata.FindingThirdParties
+				if err := findingThirdParties.Merge(ctx, conn, scope, finding.ID, finding.OrganizationID, req.ThirdPartyIDs); err != nil {
+					return fmt.Errorf("cannot update finding third parties: %w", err)
+				}
 			}
 
 			return nil
@@ -491,6 +514,59 @@ func (s FindingService) CountForAuditID(
 			count, err = findings.CountByAuditID(ctx, conn, scope, auditID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count findings: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (s FindingService) ListForThirdPartyID(
+	ctx context.Context,
+	scope coredata.Scoper,
+	thirdPartyID gid.GID,
+	cursor *page.Cursor[coredata.FindingOrderField],
+	filter *coredata.FindingFilter,
+) (*page.Page[*coredata.Finding, coredata.FindingOrderField], error) {
+	var findings coredata.Findings
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := findings.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID, cursor, filter); err != nil {
+				return fmt.Errorf("cannot load third party findings: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(findings, cursor), nil
+}
+
+func (s FindingService) CountForThirdPartyID(
+	ctx context.Context,
+	scope coredata.Scoper,
+	thirdPartyID gid.GID,
+	filter *coredata.FindingFilter,
+) (int, error) {
+	var count int
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) (err error) {
+			var findings coredata.Findings
+			count, err = findings.CountByThirdPartyID(ctx, conn, scope, thirdPartyID, filter)
+			if err != nil {
+				return fmt.Errorf("cannot count third party findings: %w", err)
 			}
 
 			return nil

--- a/pkg/server/api/console/v1/audit_resolvers.go
+++ b/pkg/server/api/console/v1/audit_resolvers.go
@@ -268,6 +268,42 @@ func (r *findingResolver) Audits(ctx context.Context, obj *types.Finding, first 
 	return types.NewAuditConnection(p, r, obj.ID), nil
 }
 
+// ThirdParties is the resolver for the thirdParties field.
+func (r *findingResolver) ThirdParties(ctx context.Context, obj *types.Finding, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ThirdPartyOrderBy) (*types.ThirdPartyConnection, error) {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList)
+	if err != nil {
+		return nil, err
+	}
+
+	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
+		Field:     coredata.ThirdPartyOrderFieldName,
+		Direction: page.OrderDirectionAsc,
+	}
+	if orderBy != nil {
+		pageOrderBy = page.OrderBy[coredata.ThirdPartyOrderField]{
+			Field:     orderBy.Field,
+			Direction: orderBy.Direction,
+		}
+	}
+
+	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
+	thirdPartyFilter := coredata.NewThirdPartyFilter(nil, nil, nil, nil, nil).WithFindingID(obj.ID)
+
+	p, err := r.probo.ThirdParties.ListForOrganizationID(
+		ctx,
+		scope,
+		obj.Organization.ID,
+		cursor,
+		thirdPartyFilter,
+	)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot list finding third parties", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewThirdPartyConnection(p, r, obj.ID, thirdPartyFilter), nil
+}
+
 // Owner is the resolver for the owner field.
 func (r *findingResolver) Owner(ctx context.Context, obj *types.Finding) (*types.Profile, error) {
 	if obj.Owner == nil {
@@ -360,6 +396,14 @@ func (r *findingConnectionResolver) TotalCount(ctx context.Context, obj *types.F
 		count, err := r.probo.Findings.CountForAuditID(ctx, scope, obj.ParentID, findingFilter)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count findings", log.Error(err))
+			return 0, gqlutils.Internal(ctx)
+		}
+
+		return count, nil
+	case *thirdPartyResolver:
+		count, err := r.probo.Findings.CountForThirdPartyID(ctx, scope, obj.ParentID, findingFilter)
+		if err != nil {
+			r.logger.ErrorCtx(ctx, "cannot count third party findings", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
 		}
 
@@ -590,6 +634,7 @@ func (r *mutationResolver) UpdateFinding(ctx context.Context, input types.Update
 		Priority:           input.Priority,
 		RiskID:             gqlutils.UnwrapOmittable(input.RiskID),
 		EffectivenessCheck: gqlutils.UnwrapOmittable(input.EffectivenessCheck),
+		ThirdPartyIDs:      input.ThirdPartyIds,
 	}
 
 	finding, err := r.probo.Findings.Update(ctx, scope, &req)

--- a/pkg/server/api/console/v1/graphql/audit.graphql
+++ b/pkg/server/api/console/v1/graphql/audit.graphql
@@ -203,6 +203,13 @@ type Finding implements Node {
         before: CursorKey
         orderBy: AuditOrder
     ): AuditConnection @goField(forceResolver: true)
+    thirdParties(
+        first: Int
+        after: CursorKey
+        last: Int
+        before: CursorKey
+        orderBy: ThirdPartyOrder
+    ): ThirdPartyConnection! @goField(forceResolver: true)
     identifiedOn: Datetime
     rootCause: String
     correctiveAction: String
@@ -345,6 +352,7 @@ input UpdateFindingInput {
     priority: FindingPriority
     riskId: ID @goField(omittable: true)
     effectivenessCheck: String @goField(omittable: true)
+    thirdPartyIds: [ID!]
 }
 
 input DeleteFindingInput {

--- a/pkg/server/api/console/v1/graphql/third_party.graphql
+++ b/pkg/server/api/console/v1/graphql/third_party.graphql
@@ -285,6 +285,15 @@ type ThirdParty implements Node {
         filter: MeasureFilter
     ): MeasureConnection! @goField(forceResolver: true)
 
+    findings(
+        first: Int
+        after: CursorKey
+        last: Int
+        before: CursorKey
+        orderBy: FindingOrder
+        filter: FindingFilter
+    ): FindingConnection! @goField(forceResolver: true)
+
     administrators: [Profile!]! @goField(forceResolver: true)
 
     statusPageUrl: String

--- a/pkg/server/api/console/v1/third_party_resolvers.go
+++ b/pkg/server/api/console/v1/third_party_resolvers.go
@@ -859,6 +859,48 @@ func (r *thirdPartyResolver) Measures(ctx context.Context, obj *types.ThirdParty
 	return types.NewMeasureConnection(page, r, obj.ID, measureFilter), nil
 }
 
+// Findings is the resolver for the findings field.
+func (r *thirdPartyResolver) Findings(ctx context.Context, obj *types.ThirdParty, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FindingOrder, filter *types.FindingFilter) (*types.FindingConnection, error) {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionFindingList)
+	if err != nil {
+		return nil, err
+	}
+
+	pageOrderBy := page.OrderBy[coredata.FindingOrderField]{
+		Field:     coredata.FindingOrderFieldCreatedAt,
+		Direction: page.OrderDirectionDesc,
+	}
+	if orderBy != nil {
+		pageOrderBy = page.OrderBy[coredata.FindingOrderField]{
+			Field:     orderBy.Field,
+			Direction: orderBy.Direction,
+		}
+	}
+
+	var (
+		kind     *coredata.FindingKind
+		status   *coredata.FindingStatus
+		priority *coredata.FindingPriority
+		ownerID  *gid.GID
+	)
+	if filter != nil {
+		kind = filter.Kind
+		status = filter.Status
+		priority = filter.Priority
+		ownerID = filter.OwnerID
+	}
+
+	findingFilter := coredata.NewFindingFilter(kind, status, priority, ownerID)
+	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
+	p, err := r.probo.Findings.ListForThirdPartyID(ctx, scope, obj.ID, cursor, findingFilter)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot list third party findings", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewFindingConnection(p, r, obj.ID, filter), nil
+}
+
 // Administrators is the resolver for the administrators field.
 func (r *thirdPartyResolver) Administrators(ctx context.Context, obj *types.ThirdParty) ([]*types.Profile, error) {
 	if _, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet); err != nil {
@@ -1135,6 +1177,25 @@ func (r *thirdPartyConnectionResolver) TotalCount(ctx context.Context, obj *type
 		count, err := r.probo.ThirdParties.CountForMeasureID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count thirdParties", log.Error(err))
+			return 0, gqlutils.Internal(ctx)
+		}
+
+		return count, nil
+	case *findingResolver:
+		finding, err := r.probo.Findings.Get(ctx, scope, obj.ParentID)
+		if err != nil {
+			r.logger.ErrorCtx(ctx, "cannot get finding for third party count", log.Error(err))
+			return 0, gqlutils.Internal(ctx)
+		}
+
+		count, err := r.probo.ThirdParties.CountForOrganizationID(
+			ctx,
+			scope,
+			finding.OrganizationID,
+			obj.Filters,
+		)
+		if err != nil {
+			r.logger.ErrorCtx(ctx, "cannot count finding third parties", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
 		}
 

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -935,6 +935,7 @@ func (r *Resolver) UpdateFindingTool(ctx context.Context, req *mcp.CallToolReque
 			Priority:           input.Priority,
 			RiskID:             UnwrapOmittable(input.RiskID),
 			EffectivenessCheck: UnwrapOmittable(input.EffectivenessCheck),
+			ThirdPartyIDs:      input.ThirdPartyIds,
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -3740,7 +3740,6 @@ components:
         effectiveness_check:
           type: string
           description: Effectiveness check
-
     AddFindingOutput:
       type: object
       required:
@@ -3806,6 +3805,11 @@ components:
           type: ["string", "null"]
           description: Effectiveness check
           go.probo.inc/mcpgen/omittable: true
+        third_party_ids:
+          type: array
+          items:
+            $ref: "#/components/schemas/GID"
+          description: Third parties linked to the finding
 
     UpdateFindingOutput:
       type: object


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- persist many-to-many links between findings and third parties
- expose linked third parties on findings and linked findings on third parties
- add finding management to the finding detail page and a paginated Findings tab to third-party details
- support third-party IDs in MCP, CLI, and n8n finding updates

## Testing
- `make relay`
- `npm --workspace @probo/console run check`
- `npm --workspace @probo/n8n-nodes-probo run lint`
- `go test ./pkg/coredata ./pkg/probo ./pkg/server/api/console/v1 ./pkg/server/api/mcp/v1 ./pkg/cmd/finding/update`
- `make go-fmt`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e93186f-a84c-447d-93bd-71fc9f5978a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e93186f-a84c-447d-93bd-71fc9f5978a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds many-to-many linking between findings and third parties. Includes UI to manage links, GraphQL support in both directions, and tool updates to set `thirdPartyIds` during finding updates.

### Coredata **`+232`** **`-0`**
- Added `finding_third_parties` table and merge logic to upsert links.
- Implemented `LoadByThirdPartyID`/`CountByThirdPartyID` for findings.
- Extended `ThirdPartyFilter` to filter by a linked finding.

### Service **`+76`** **`-0`**
- `UpdateFindingRequest` now accepts `ThirdPartyIDs` with validation and org checks.
- On update, merges link set for the finding.
- Added listing/counting of findings for a third party.

### GraphQL API **`+123`** **`-0`**
- Finding: new `thirdParties` connection.
- ThirdParty: new `findings` connection.
- `UpdateFindingInput` adds `thirdPartyIds`; resolvers handle listing and total counts.

### App: console **`+320`** **`-3`**
- Finding details: added `ThirdPartiesMultiSelectField` and i18n labels.
- Third party details: new “Findings” tab with paginated table and routes.
- Added loader and list item components; updated locale strings.

### prb (CLI) **`+6`** **`-0`**
- New repeatable `--third-party-id` flag; included in update payload when set.

### Package: n8n-node **`+13`** **`-0`**
- Finding update supports “Third Party IDs” (comma-separated) mapped to `thirdPartyIds`.

### MCP **`+6`** **`-1`**
- Update tool and spec now accept and forward `third_party_ids` for finding updates.

<sup>Written for commit 464703438500c759f24c181e719d2e92ede667e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

