### PR TITLE
Wrap Mermaid process edge labels in risk assessment diagrams

### DIFF
--- a/pkg/riskmanagement/mermaid.go
+++ b/pkg/riskmanagement/mermaid.go
@@ -239,7 +239,7 @@ func buildScopeMermaidChart(
 			continue
 		}
 
-		fmt.Fprintf(&b, "  %s -- \"%s\" --> %s\n", src, escapeMermaidLabel(p.Name), dst)
+		fmt.Fprintf(&b, "  %s -- \"%s\" --> %s\n", src, mermaidEdgeLabel(p.Name), dst)
 	}
 
 	processTarget := make(map[gid.GID]gid.GID, len(processes))
@@ -302,6 +302,8 @@ func mermaidNodeClass(t coredata.RiskAssessmentNodeType) string {
 	}
 }
 
+const mermaidEdgeLabelWrapWidth = 28
+
 var mermaidLabelReplacer = strings.NewReplacer(
 	"&", "&amp;",
 	`"`, "#quot;",
@@ -313,4 +315,46 @@ var mermaidLabelReplacer = strings.NewReplacer(
 
 func escapeMermaidLabel(s string) string {
 	return mermaidLabelReplacer.Replace(s)
+}
+
+// mermaidEdgeLabel escapes a process name and inserts <br> breaks so long
+// edge labels wrap. Mermaid's wrappingWidth only applies to nodes, not edges.
+func mermaidEdgeLabel(s string) string {
+	return strings.ReplaceAll(wrapWords(escapeMermaidLabel(s), mermaidEdgeLabelWrapWidth), "\n", "<br>")
+}
+
+func wrapWords(s string, width int) string {
+	if width <= 0 || len(s) <= width {
+		return s
+	}
+
+	words := strings.Fields(s)
+	if len(words) <= 1 {
+		return s
+	}
+
+	var (
+		b       strings.Builder
+		lineLen int
+	)
+
+	for _, word := range words {
+		if lineLen > 0 && lineLen+1+len(word) > width {
+			b.WriteByte('\n')
+
+			lineLen = 0
+		}
+
+		if lineLen > 0 {
+			b.WriteByte(' ')
+
+			lineLen++
+		}
+
+		b.WriteString(word)
+
+		lineLen += len(word)
+	}
+
+	return b.String()
 }

--- a/pkg/riskmanagement/mermaid_test.go
+++ b/pkg/riskmanagement/mermaid_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package riskmanagement
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrapWords(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		width    int
+		expected string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			width:    28,
+			expected: "",
+		},
+		{
+			name:     "short label stays on one line",
+			input:    "Store patient records",
+			width:    28,
+			expected: "Store patient records",
+		},
+		{
+			name:     "exact width boundary does not wrap",
+			input:    strings.Repeat("a", 28),
+			width:    28,
+			expected: strings.Repeat("a", 28),
+		},
+		{
+			name:     "packs words up to width then breaks",
+			input:    "Store patient conversation records",
+			width:    28,
+			expected: "Store patient conversation\nrecords",
+		},
+		{
+			name:     "single oversized word is left intact",
+			input:    "Supercalifragilisticexpialidocious",
+			width:    28,
+			expected: "Supercalifragilisticexpialidocious",
+		},
+		{
+			name:     "non-ascii counted in bytes not runes",
+			input:    "café café café café café",
+			width:    28,
+			expected: "café café café café\ncafé",
+		},
+		{
+			name:     "non-positive width returns input",
+			input:    "Store patient conversation records",
+			width:    0,
+			expected: "Store patient conversation records",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tt.expected, wrapWords(tt.input, tt.width))
+			},
+		)
+	}
+}
+
+func TestMermaidEdgeLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "short label unchanged",
+			input:    "Store patient records",
+			expected: "Store patient records",
+		},
+		{
+			name:     "long label uses br breaks",
+			input:    "Store patient conversation records",
+			expected: "Store patient conversation<br>records",
+		},
+		{
+			name:     "escapes html before inserting br",
+			input:    "Store patient <conversation> records now",
+			expected: "Store patient<br>&lt;conversation&gt; records<br>now",
+		},
+		{
+			name:     "literal underscore is preserved",
+			input:    "Data_Processing pipeline stage one two",
+			expected: "Data_Processing pipeline<br>stage one two",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tt.expected, mermaidEdgeLabel(tt.input))
+			},
+		)
+	}
+}


### PR DESCRIPTION
Long process names on flowchart edges were clipped as a single plain-text line. Emit them as Mermaid markdown strings so they participate in the existing markdownAutoWrap / wrappingWidth config.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap long edge labels in Mermaid risk diagrams by inserting `<br>` so long process names wrap and don’t clip. Labels are HTML-escaped to avoid Markdown interpretation; wrapping applies to edges since Mermaid’s wrappingWidth doesn’t affect them.

### Service **`+45`** **`-1`**
- Use `mermaidEdgeLabel(p.Name)` to escape text and insert `<br>` at word breaks (width 28) via new `wrapWords` and `mermaidEdgeLabelWrapWidth`, reusing `mermaidLabelReplacer`.

### Tests **`+133`** **`-0`**
- Add unit tests for `wrapWords` and `mermaidEdgeLabel` covering width boundaries, long words, HTML escaping, underscores, and non-ASCII cases.

<sup>Written for commit ada12b40e7fc6306710fa141f0cff867451e7c8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

