### PR TITLE
Remove duplicate metadata from cookie policies

### DIFF
--- a/pkg/docgen/generator.go
+++ b/pkg/docgen/generator.go
@@ -478,7 +478,6 @@ type (
 	TrackerPolicyData struct {
 		OrganizationName  string
 		WebsiteOrigin     string
-		GeneratedAt       time.Time
 		PrivacyPolicyURL  string
 		ConsentExpiryDays int
 		Categories        []TrackerPolicyCategory

--- a/pkg/probo/templates/tracker_policy.md.tmpl
+++ b/pkg/probo/templates/tracker_policy.md.tmpl
@@ -1,7 +1,3 @@
-# Cookie and Tracking Technologies Policy for {{ .WebsiteOrigin }}
-
-_Last updated: {{ formatDate .GeneratedAt }}_
-
 This Cookie and Tracking Technologies Policy explains how {{ .OrganizationName }} ("we", "us", or "our") uses cookies and other tracking technologies to recognise you when you visit {{ .WebsiteOrigin }} (the "Website"). It explains what these technologies are and why we use them, as well as the rights and choices you have to control them.
 {{ if .PrivacyPolicyURL }}
 This policy is part of, and should be read together with, our [Privacy Policy]({{ .PrivacyPolicyURL }}).
@@ -51,7 +47,7 @@ Under the California Consumer Privacy Act, as amended by the California Privacy 
 
 {{ $section = add $section 1 }}## {{ $section }}. Changes to this policy
 
-We may update this policy from time to time to reflect changes to the trackers we use or for other operational, legal, or regulatory reasons. This policy is regenerated automatically when our tracker configuration changes, so please revisit it periodically. The date at the top indicates when it was last updated.
+We may update this policy from time to time to reflect changes to the trackers we use or for other operational, legal, or regulatory reasons. This policy is regenerated automatically when our tracker configuration changes, so please revisit it periodically. The publication date indicates when it was last updated.
 
 {{ $section = add $section 1 }}## {{ $section }}. Contact us
 

--- a/pkg/probo/tracker_policy_document.go
+++ b/pkg/probo/tracker_policy_document.go
@@ -41,9 +41,6 @@ import (
 var trackerPolicyTemplate = template.Must(
 	template.New("tracker_policy.md.tmpl").
 		Funcs(template.FuncMap{
-			"formatDate": func(t time.Time) string {
-				return t.Format("January 2, 2006")
-			},
 			"add": func(a, b int) int {
 				return a + b
 			},
@@ -254,7 +251,6 @@ func (s *GeneratedDocumentService) buildTrackerPolicyDocumentData(
 	return docgen.TrackerPolicyData{
 		OrganizationName:  organization.Name,
 		WebsiteOrigin:     banner.Origin,
-		GeneratedAt:       time.Now(),
 		PrivacyPolicyURL:  privacyPolicyURL,
 		ConsentExpiryDays: snapshot.ConsentExpiryDays,
 		Categories:        categories,

--- a/pkg/probo/tracker_policy_document_test.go
+++ b/pkg/probo/tracker_policy_document_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package probo_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/docgen"
+	"go.probo.inc/probo/pkg/probo"
+	"go.probo.inc/probo/pkg/prosemirror"
+)
+
+func TestBuildTrackerPolicyDocument_OmitsCoverMetadata(t *testing.T) {
+	t.Parallel()
+
+	content, err := probo.BuildTrackerPolicyDocument(
+		docgen.TrackerPolicyData{
+			OrganizationName:  "Acme",
+			WebsiteOrigin:     "https://example.com",
+			ConsentExpiryDays: 180,
+		},
+	)
+	require.NoError(t, err)
+
+	document, err := prosemirror.Parse(content)
+	require.NoError(t, err)
+	require.NotEmpty(t, document.Content)
+
+	assert.Equal(t, prosemirror.NodeParagraph, document.Content[0].Type)
+	assert.NotContains(t, content, "Policy for https://example.com")
+	assert.NotContains(t, content, "Last updated")
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the body title and last-updated line already rendered on the document cover
- remove the now-unused generated timestamp from tracker policy data
- add a regression test that ensures cover metadata is omitted from policy content

## Testing
- `go test ./pkg/probo ./pkg/docgen`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-689](https://linear.app/probo/issue/ENG-689/cookie-policy-content-duplicates-title-and-last-updated-date)

<div><a href="https://cursor.com/agents/bc-251aa543-2df5-4cd3-98eb-4a1b90a6dadd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-251aa543-2df5-4cd3-98eb-4a1b90a6dadd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove duplicate title and “Last updated” from the cookie policy body; metadata now appears only on the cover per ENG-689. Also removes unused fields and adds a regression test.

### Service **`+1`** **`-10`**
- Dropped the title and “Last updated” from `pkg/probo/templates/tracker_policy.md.tmpl`; wording now references the publication date.
- Removed `GeneratedAt` from `docgen.TrackerPolicyData` and stopped setting it.
- Deleted the `formatDate` template function.

### Tests **`+52`** **`-0`**
- Added `TestBuildTrackerPolicyDocument_OmitsCoverMetadata` to ensure the body starts with a paragraph and omits cover metadata.

<sup>Written for commit 01d25edfb60c2c65db4ca646358940a52265e83e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

