### PR TITLE
Expose source identity on MCP access entries

### DIFF
--- a/packages/skills/skills/access-review/references/mcp-tools.md
+++ b/packages/skills/skills/access-review/references/mcp-tools.md
@@ -27,7 +27,9 @@ List entries for a campaign. Primary data source for this command.
 | `size` | Page size; use `50` per batch |
 | `cursor` | Resume pagination; store in notes file as `last_cursor` |
 
-Returns `entries[]` and `next_cursor`.
+Returns `entries[]` and `next_cursor`. Each entry includes `source_name` and
+nullable `connector_id`; use these fields to identify the source tool. Never
+infer the tool from account IDs, roles, email patterns, or other entry data.
 
 ### `getAccessReviewStatistics`
 
@@ -72,6 +74,7 @@ Do not call unless the user explicitly asks for campaign setup:
 
 | Field | Review use |
 | --- | --- |
+| `source_name`, `connector_id` | Authoritative source tool; do not infer it from account data |
 | `email`, `full_name` | Identity |
 | `roles`, `job_title` | Access level |
 | `is_admin` | Heightened scrutiny |

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -3459,10 +3459,11 @@ func (r *Resolver) ListAccessEntriesTool(ctx context.Context, req *mcp.CallToolR
 	}
 
 	var (
-		scope      *coredata.Scope
-		campaignID gid.GID
-		sourceID   *gid.GID
-		err        error
+		scope       *coredata.Scope
+		campaignID  gid.GID
+		sourceID    *gid.GID
+		sourcesByID = map[gid.GID]*coredata.AccessReviewCampaignSource{}
+		err         error
 	)
 
 	if input.AccessReviewCampaignSourceID != nil {
@@ -3478,6 +3479,7 @@ func (r *Resolver) ListAccessEntriesTool(ctx context.Context, req *mcp.CallToolR
 
 		campaignID = campaignSource.AccessReviewCampaignID
 		sourceID = input.AccessReviewCampaignSourceID
+		sourcesByID[campaignSource.ID] = campaignSource
 	} else {
 		scope, err = r.Authorize(ctx, *input.CampaignID, accessreview.ActionEntryList)
 		if err != nil {
@@ -3485,6 +3487,15 @@ func (r *Resolver) ListAccessEntriesTool(ctx context.Context, req *mcp.CallToolR
 		}
 
 		campaignID = *input.CampaignID
+
+		campaignSources, err := r.accessReview.ListCampaignSources(ctx, scope, campaignID)
+		if err != nil {
+			panic(fmt.Errorf("cannot list campaign sources: %w", err))
+		}
+
+		for _, campaignSource := range campaignSources {
+			sourcesByID[campaignSource.ID] = campaignSource
+		}
 	}
 
 	pageOrderBy := page.OrderBy[coredata.AccessReviewEntryOrderField]{
@@ -3535,7 +3546,7 @@ func (r *Resolver) ListAccessEntriesTool(ctx context.Context, req *mcp.CallToolR
 		}
 	}
 
-	return nil, types.NewListAccessEntriesOutput(p), nil
+	return nil, types.NewListAccessEntriesOutput(p, sourcesByID), nil
 }
 
 // GetAccessReviewStatisticsTool handles the getAccessReviewCampaignStatistics tool
@@ -3578,8 +3589,13 @@ func (r *Resolver) RecordAccessReviewEntryDecisionTool(ctx context.Context, req 
 		return nil, types.RecordAccessReviewEntryDecisionOutput{}, fmt.Errorf("cannot record decision: %w", err)
 	}
 
+	source, err := r.accessReview.GetCampaignSource(ctx, scope, entry.AccessReviewCampaignSourceID)
+	if err != nil {
+		panic(fmt.Errorf("cannot get campaign source: %w", err))
+	}
+
 	return nil, types.RecordAccessReviewEntryDecisionOutput{
-		AccessEntry: types.NewAccessReviewEntry(entry),
+		AccessEntry: types.NewAccessReviewEntry(entry, source),
 	}, nil
 }
 
@@ -3598,13 +3614,18 @@ func (r *Resolver) RecordAccessReviewEntryDecisionsTool(ctx context.Context, req
 	}
 
 	// Authorize each entry individually to prevent cross-org bypass.
-	for _, d := range input.Decisions {
-		if _, err := r.Authorize(ctx, d.AccessReviewEntryID, accessreview.ActionEntryDecide); err != nil {
+	var scope *coredata.Scope
+
+	for i, d := range input.Decisions {
+		authorizedScope, err := r.Authorize(ctx, d.AccessReviewEntryID, accessreview.ActionEntryDecide)
+		if err != nil {
 			return nil, types.RecordAccessReviewEntryDecisionsOutput{}, err
 		}
-	}
 
-	scope := coredata.NewScopeFromObjectID(input.Decisions[0].AccessReviewEntryID)
+		if i == 0 {
+			scope = authorizedScope
+		}
+	}
 
 	identity := authn.IdentityFromContext(ctx)
 	if identity == nil {
@@ -3628,9 +3649,23 @@ func (r *Resolver) RecordAccessReviewEntryDecisionsTool(ctx context.Context, req
 		return nil, types.RecordAccessReviewEntryDecisionsOutput{}, fmt.Errorf("cannot record decisions: %w", err)
 	}
 
+	sourcesByID := map[gid.GID]*coredata.AccessReviewCampaignSource{}
+	for _, e := range entries {
+		if _, ok := sourcesByID[e.AccessReviewCampaignSourceID]; ok {
+			continue
+		}
+
+		source, err := r.accessReview.GetCampaignSource(ctx, scope, e.AccessReviewCampaignSourceID)
+		if err != nil {
+			panic(fmt.Errorf("cannot get campaign source: %w", err))
+		}
+
+		sourcesByID[e.AccessReviewCampaignSourceID] = source
+	}
+
 	accessEntries := make([]*types.AccessReviewEntry, len(entries))
 	for i, e := range entries {
-		accessEntries[i] = types.NewAccessReviewEntry(e)
+		accessEntries[i] = types.NewAccessReviewEntry(e, sourcesByID[e.AccessReviewCampaignSourceID])
 	}
 
 	return nil, types.RecordAccessReviewEntryDecisionsOutput{
@@ -3955,8 +3990,13 @@ func (r *Resolver) FlagAccessReviewEntryTool(ctx context.Context, req *mcp.CallT
 		return nil, types.FlagAccessReviewEntryOutput{}, fmt.Errorf("cannot flag access entry: %w", err)
 	}
 
+	source, err := r.accessReview.GetCampaignSource(ctx, scope, entry.AccessReviewCampaignSourceID)
+	if err != nil {
+		panic(fmt.Errorf("cannot get campaign source: %w", err))
+	}
+
 	return nil, types.FlagAccessReviewEntryOutput{
-		AccessEntry: types.NewAccessReviewEntry(entry),
+		AccessEntry: types.NewAccessReviewEntry(entry, source),
 	}, nil
 }
 

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -8219,6 +8219,8 @@ components:
         - id
         - campaign_id
         - access_review_campaign_source_id
+        - source_name
+        - connector_id
         - email
         - full_name
         - roles
@@ -8243,6 +8245,14 @@ components:
         access_review_campaign_source_id:
           $ref: "#/components/schemas/GID"
           description: Per-campaign source snapshot ID
+        source_name:
+          type: string
+          description: Name of the campaign source (connector or CSV) the entry belongs to, e.g. "Google Workspace" or "Cursor". Use this to label which tool an account came from instead of inferring it from the account data.
+        connector_id:
+          anyOf:
+            - $ref: "#/components/schemas/GID"
+            - type: "null"
+          description: ID of the connector backing the campaign source, or null for CSV/manually uploaded sources
         email:
           type: string
           description: User email

--- a/pkg/server/api/mcp/v1/types/access_review.go
+++ b/pkg/server/api/mcp/v1/types/access_review.go
@@ -22,6 +22,7 @@ package types
 
 import (
 	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -72,7 +73,10 @@ func NewAccessReviewCampaign(c *coredata.AccessReviewCampaign) *AccessReviewCamp
 	}
 }
 
-func NewAccessReviewEntry(e *coredata.AccessReviewEntry) *AccessReviewEntry {
+func NewAccessReviewEntry(
+	e *coredata.AccessReviewEntry,
+	source *coredata.AccessReviewCampaignSource,
+) *AccessReviewEntry {
 	roles := e.Roles
 	if roles == nil {
 		roles = []string{}
@@ -82,6 +86,8 @@ func NewAccessReviewEntry(e *coredata.AccessReviewEntry) *AccessReviewEntry {
 		ID:                           e.ID,
 		CampaignID:                   e.AccessReviewCampaignID,
 		AccessReviewCampaignSourceID: e.AccessReviewCampaignSourceID,
+		SourceName:                   source.Name,
+		ConnectorID:                  source.ConnectorID,
 		Email:                        e.Email,
 		FullName:                     e.FullName,
 		Roles:                        roles,
@@ -131,10 +137,11 @@ func NewListAccessReviewCampaignsOutput(
 
 func NewListAccessEntriesOutput(
 	p *page.Page[*coredata.AccessReviewEntry, coredata.AccessReviewEntryOrderField],
+	sourcesByID map[gid.GID]*coredata.AccessReviewCampaignSource,
 ) ListAccessEntriesOutput {
 	entries := make([]*AccessReviewEntry, 0, len(p.Data))
 	for _, e := range p.Data {
-		entries = append(entries, NewAccessReviewEntry(e))
+		entries = append(entries, NewAccessReviewEntry(e, sourcesByID[e.AccessReviewCampaignSourceID]))
 	}
 
 	var nextCursor *page.CursorKey

--- a/pkg/server/api/mcp/v1/types/access_review_test.go
+++ b/pkg/server/api/mcp/v1/types/access_review_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/server/api/mcp/v1/types"
+)
+
+func TestNewAccessReviewEntry_SourceIdentity(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	connectorID := gid.New(tenantID, coredata.ConnectorEntityType)
+	entry := &coredata.AccessReviewEntry{
+		AccessReviewCampaignSourceID: gid.New(
+			tenantID,
+			coredata.AccessReviewCampaignSourceEntityType,
+		),
+	}
+
+	tests := map[string]struct {
+		source            *coredata.AccessReviewCampaignSource
+		expectedName      string
+		expectedConnector *gid.GID
+	}{
+		"connector source": {
+			source: &coredata.AccessReviewCampaignSource{
+				Name:        "Cursor",
+				ConnectorID: &connectorID,
+			},
+			expectedName:      "Cursor",
+			expectedConnector: &connectorID,
+		},
+		"manual source": {
+			source: &coredata.AccessReviewCampaignSource{
+				Name: "Uploaded CSV",
+			},
+			expectedName: "Uploaded CSV",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(
+			name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				actual := types.NewAccessReviewEntry(entry, test.source)
+
+				assert.Equal(t, test.expectedName, actual.SourceName)
+				assert.Equal(t, test.expectedConnector, actual.ConnectorID)
+			},
+		)
+	}
+}
+
+func TestNewAccessReviewEntry_ManualSourceIncludesNullConnectorID(t *testing.T) {
+	t.Parallel()
+
+	actual := types.NewAccessReviewEntry(
+		&coredata.AccessReviewEntry{},
+		&coredata.AccessReviewCampaignSource{Name: "Uploaded CSV"},
+	)
+
+	data, err := json.Marshal(actual)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(data, &payload))
+	assert.Contains(t, payload, "connector_id")
+	assert.Nil(t, payload["connector_id"])
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add authoritative `source_name` and nullable `connector_id` fields to MCP access review entries
- populate source identity for list, decision, batch-decision, and flag responses
- instruct the access-review skill to use source identity instead of inferring tools from account metadata
- cover connector-backed and manual sources with converter tests

## Testing
- `go test ./pkg/server/api/mcp/v1/types ./pkg/server/api/mcp/v1`
- `go vet ./pkg/server/api/mcp/v1/types ./pkg/server/api/mcp/v1`
- `make go-fmt`
- `go generate ./pkg/server/api/mcp/v1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ef15afd-4b33-40ea-a89e-5d92eecc8724?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ef15afd-4b33-40ea-a89e-5d92eecc8724&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose source identity on MCP access review entries by adding `source_name` and nullable `connector_id`. Responses now include the source tool for list, decide, batch decide, and flag operations to avoid inferring from account data.

### MCP **`+71`** **`-14`**
- Add `source_name` and `connector_id` to the AccessReviewEntry schema.
- Populate source info for list, decision, batch-decision, and flag responses by loading campaign sources.
- Update constructors and list output to carry source context.

### Tests **`+97`** **`-0`**
- Add tests for connector-backed and manual sources to verify `source_name` and `connector_id`.
- Confirm manual sources serialize `connector_id: null`.

### Package: skills **`+4`** **`-1`**
- Update `mcp-tools` reference to document the new fields.
- Direct the `access-review` skill to use source fields and not infer the tool from account data.

<sup>Written for commit 150620dd13fb8c4643182bfa12f8884c4aabccd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

