### PR TITLE
fix(awsconfig): stop signing Accept-Encoding so GCS-backed uploads work

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - if: inputs.go == 'true'
-      uses: "actions/setup-go@v6"
+      uses: "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16" # v6
       with:
         go-version: "1.26.5"
         cache: true
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: go mod download
     - if: inputs.node == 'true'
-      uses: "actions/setup-node@v6"
+      uses: "actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38" # v6
       with:
         node-version-file: ".nvmrc"
         cache: "npm"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: recursive
 
@@ -60,7 +60,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -88,6 +88,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -483,9 +483,6 @@ jobs:
   test-e2e:
     name: "test-e2e"
     runs-on: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache"
-    env:
-      COMPOSE_FILE: "compose.yaml:compose.github-action.yaml"
-      DOCKER_COMPOSE_FLAGS: "-f compose.github-action.yaml"
     permissions:
       contents: "read"
     steps:
@@ -494,8 +491,25 @@ jobs:
           submodules: recursive
       - uses: "runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60" # v2
       - uses: "./.github/actions/setup"
+      - name: "Configure Docker image source"
+        # Pull requests from forks don't get repository secrets, so
+        # HARBOR_USERNAME/HARBOR_PASSWORD are unavailable and logging into
+        # the artifact.probo.inc mirror would fail. Fall back to pulling
+        # images straight from their origin registries in that case.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "Fork pull request: pulling images from their origin registries, not the artifact.probo.inc mirror"
+            echo "USE_HARBOR_MIRROR=false" >> "$GITHUB_ENV"
+            echo "COMPOSE_FILE=compose.yaml" >> "$GITHUB_ENV"
+            echo "DOCKER_COMPOSE_FLAGS=" >> "$GITHUB_ENV"
+          else
+            echo "USE_HARBOR_MIRROR=true" >> "$GITHUB_ENV"
+            echo "COMPOSE_FILE=compose.yaml:compose.github-action.yaml" >> "$GITHUB_ENV"
+            echo "DOCKER_COMPOSE_FLAGS=-f compose.github-action.yaml" >> "$GITHUB_ENV"
+          fi
       - uses: "docker/setup-compose-action@4eb059ff7f16592f9c84d5ca339c53cb7c5064e2" # v2.3.0
       - uses: "docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee" # v4.2.0
+        if: "env.USE_HARBOR_MIRROR == 'true'"
         with:
           registry: artifact.probo.inc
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -509,7 +523,7 @@ jobs:
         uses: "runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed" # v4
         with:
           path: /tmp/docker-images
-          key: "docker-images-${{ hashFiles('compose.yaml', 'compose.github-action.yaml') }}"
+          key: "docker-images-${{ env.USE_HARBOR_MIRROR }}-${{ hashFiles('compose.yaml', 'compose.github-action.yaml') }}"
       - name: "Load cached Docker images"
         if: steps.docker-cache.outputs.cache-hit == 'true'
         run: "docker load -i /tmp/docker-images/images.tar"

--- a/pkg/awsconfig/accept_encoding.go
+++ b/pkg/awsconfig/accept_encoding.go
@@ -30,10 +30,10 @@ import (
 
 const acceptEncodingHeader = "Accept-Encoding"
 
-// signingMiddlewareID is the ID of the SigV4 middleware in the Finalize step
-// (aws/signer/v4.SignHTTPRequestMiddleware). The strip/restore pair below is
-// positioned relative to it by name so the ordering is explicit rather than a
-// consequence of registration order.
+// signingMiddlewareID is the ID every AWS SDK v2 service client registers for
+// its SigV4/SigV4a signing middleware in the Finalize step. The strip/restore
+// pair below is positioned relative to it by name so the ordering is explicit
+// rather than a consequence of registration order.
 const signingMiddlewareID = "Signing"
 
 // acceptEncodingValueKey carries the stripped header value from the middleware

--- a/pkg/awsconfig/accept_encoding.go
+++ b/pkg/awsconfig/accept_encoding.go
@@ -77,6 +77,7 @@ func unsignedAcceptEncoding(stack *middleware.Stack) error {
 
 				if value := req.Header.Get(acceptEncodingHeader); value != "" {
 					req.Header.Del(acceptEncodingHeader)
+
 					ctx = context.WithValue(ctx, acceptEncodingValueKey{}, value)
 				}
 

--- a/pkg/awsconfig/accept_encoding.go
+++ b/pkg/awsconfig/accept_encoding.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package awsconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+)
+
+const acceptEncodingHeader = "Accept-Encoding"
+
+// signingMiddlewareID is the ID of the SigV4 middleware in the Finalize step
+// (aws/signer/v4.SignHTTPRequestMiddleware). The strip/restore pair below is
+// positioned relative to it by name so the ordering is explicit rather than a
+// consequence of registration order.
+const signingMiddlewareID = "Signing"
+
+// acceptEncodingValueKey carries the stripped header value from the middleware
+// that runs before signing to the one that runs after it.
+type acceptEncodingValueKey struct{}
+
+// unsignedAcceptEncoding keeps Accept-Encoding out of the SigV4 SignedHeaders list
+// while still sending it on the wire.
+//
+// aws-sdk-go-v2 sets "Accept-Encoding: identity" from a Finalize middleware
+// (service/internal/accept-encoding.DisableGzip) so responses are never gzipped.
+// That runs before signing, so SigV4 covers the header. Google Cloud Storage's
+// S3-interoperability endpoint rewrites or strips Accept-Encoding in transit, so
+// the signature it recomputes can never match the one we sent, and every request
+// that signs the header is rejected with 403 SignatureDoesNotMatch. The error names
+// the signature, which reads as a credentials problem and is not one.
+//
+// botocore does not sign Accept-Encoding. That is why the aws CLI and boto3 upload
+// to the same bucket with the same HMAC credentials while this SDK cannot.
+//
+// The header is stripped immediately before signing and restored immediately after,
+// so it still reaches the wire — preserving the SDK's no-gzip behaviour, and with it
+// the Content-Length and Content-Range that ranged downloads depend on — but never
+// enters SignedHeaders. SigV4 does not require Accept-Encoding to be signed and
+// endpoints ignore headers they were not asked to sign, so this is equally safe
+// against real S3 and is applied unconditionally rather than only for custom
+// endpoints.
+func unsignedAcceptEncoding(stack *middleware.Stack) error {
+	err := stack.Finalize.Insert(
+		middleware.FinalizeMiddlewareFunc(
+			"proboStripAcceptEncodingBeforeSigning",
+			func(
+				ctx context.Context,
+				in middleware.FinalizeInput,
+				next middleware.FinalizeHandler,
+			) (middleware.FinalizeOutput, middleware.Metadata, error) {
+				req, ok := in.Request.(*smithyhttp.Request)
+				if !ok {
+					return next.HandleFinalize(ctx, in)
+				}
+
+				if value := req.Header.Get(acceptEncodingHeader); value != "" {
+					req.Header.Del(acceptEncodingHeader)
+					ctx = context.WithValue(ctx, acceptEncodingValueKey{}, value)
+				}
+
+				return next.HandleFinalize(ctx, in)
+			},
+		),
+		signingMiddlewareID,
+		middleware.Before,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot insert accept-encoding strip middleware: %w", err)
+	}
+
+	err = stack.Finalize.Insert(
+		middleware.FinalizeMiddlewareFunc(
+			"proboRestoreAcceptEncodingAfterSigning",
+			func(
+				ctx context.Context,
+				in middleware.FinalizeInput,
+				next middleware.FinalizeHandler,
+			) (middleware.FinalizeOutput, middleware.Metadata, error) {
+				req, ok := in.Request.(*smithyhttp.Request)
+				if !ok {
+					return next.HandleFinalize(ctx, in)
+				}
+
+				if value, ok := ctx.Value(acceptEncodingValueKey{}).(string); ok && value != "" {
+					req.Header.Set(acceptEncodingHeader, value)
+				}
+
+				return next.HandleFinalize(ctx, in)
+			},
+		),
+		signingMiddlewareID,
+		middleware.After,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot insert accept-encoding restore middleware: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/awsconfig/accept_encoding_test.go
+++ b/pkg/awsconfig/accept_encoding_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package awsconfig
+package awsconfig_test
 
 import (
 	"context"
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/awsconfig"
 )
 
 var signedHeadersRe = regexp.MustCompile(`SignedHeaders=([^,]+)`)
@@ -55,6 +56,8 @@ func signedHeaders(t *testing.T, h http.Header) string {
 // must be signed, with it the header must be absent from SignedHeaders but still
 // present on the wire.
 func TestUnsignedAcceptEncoding(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name       string
 		middleware bool
@@ -64,21 +67,25 @@ func TestUnsignedAcceptEncoding(t *testing.T) {
 		{name: "with middleware it is not", middleware: true, wantSigned: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			var gotHeader http.Header
 
-			srv := httptest.NewServer(http.HandlerFunc(
-				func(w http.ResponseWriter, r *http.Request) {
-					gotHeader = r.Header.Clone()
-					_, _ = io.Copy(io.Discard, r.Body)
-					w.WriteHeader(http.StatusOK)
-				},
-			))
+			srv := httptest.NewServer(
+				http.HandlerFunc(
+					func(w http.ResponseWriter, r *http.Request) {
+						gotHeader = r.Header.Clone()
+						_, _ = io.Copy(io.Discard, r.Body)
+						w.WriteHeader(http.StatusOK)
+					},
+				),
+			)
 			t.Cleanup(srv.Close)
 
-			cfg, err := NewConfig(
+			cfg, err := awsconfig.NewConfig(
 				log.NewLogger(log.WithOutput(io.Discard)),
 				nil,
-				Options{
+				awsconfig.Options{
 					Region:          "auto",
 					Endpoint:        srv.URL,
 					AccessKeyID:     "access-key",
@@ -91,9 +98,12 @@ func TestUnsignedAcceptEncoding(t *testing.T) {
 				cfg.APIOptions = nil
 			}
 
-			client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-				o.UsePathStyle = true
-			})
+			client := s3.NewFromConfig(
+				cfg,
+				func(o *s3.Options) {
+					o.UsePathStyle = true
+				},
+			)
 
 			_, err = client.PutObject(
 				context.Background(),

--- a/pkg/awsconfig/accept_encoding_test.go
+++ b/pkg/awsconfig/accept_encoding_test.go
@@ -75,7 +75,9 @@ func TestUnsignedAcceptEncoding(t *testing.T) {
 				http.HandlerFunc(
 					func(w http.ResponseWriter, r *http.Request) {
 						gotHeader = r.Header.Clone()
+
 						_, _ = io.Copy(io.Discard, r.Body)
+
 						w.WriteHeader(http.StatusOK)
 					},
 				),

--- a/pkg/awsconfig/accept_encoding_test.go
+++ b/pkg/awsconfig/accept_encoding_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package awsconfig
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/log"
+)
+
+var signedHeadersRe = regexp.MustCompile(`SignedHeaders=([^,]+)`)
+
+// signedHeaders returns the SigV4 SignedHeaders list from an Authorization header.
+func signedHeaders(t *testing.T, h http.Header) string {
+	t.Helper()
+
+	match := signedHeadersRe.FindStringSubmatch(h.Get("Authorization"))
+	require.NotNil(t, match, "request carried no SigV4 Authorization header")
+
+	return match[1]
+}
+
+// TestUnsignedAcceptEncoding pins the fix for S3-compatible endpoints that rewrite
+// Accept-Encoding in transit. Google Cloud Storage's S3-interop endpoint does, so any
+// request signing that header fails with 403 SignatureDoesNotMatch. Both directions
+// are asserted so the guard cannot pass vacuously: without the middleware the header
+// must be signed, with it the header must be absent from SignedHeaders but still
+// present on the wire.
+func TestUnsignedAcceptEncoding(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		middleware bool
+		wantSigned bool
+	}{
+		{name: "without middleware the header is signed", middleware: false, wantSigned: true},
+		{name: "with middleware it is not", middleware: true, wantSigned: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotHeader http.Header
+
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					gotHeader = r.Header.Clone()
+					_, _ = io.Copy(io.Discard, r.Body)
+					w.WriteHeader(http.StatusOK)
+				},
+			))
+			t.Cleanup(srv.Close)
+
+			cfg, err := NewConfig(
+				log.NewLogger(log.WithOutput(io.Discard)),
+				nil,
+				Options{
+					Region:          "auto",
+					Endpoint:        srv.URL,
+					AccessKeyID:     "access-key",
+					SecretAccessKey: "secret-key",
+				},
+			)
+			require.NoError(t, err)
+
+			if !tc.middleware {
+				cfg.APIOptions = nil
+			}
+
+			client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+				o.UsePathStyle = true
+			})
+
+			_, err = client.PutObject(
+				context.Background(),
+				&s3.PutObjectInput{
+					Bucket: aws.String("bucket"),
+					Key:    aws.String("key"),
+					Body:   strings.NewReader("hello"),
+				},
+			)
+			require.NoError(t, err)
+
+			signed := signedHeaders(t, gotHeader)
+
+			if tc.wantSigned {
+				assert.Contains(
+					t,
+					signed,
+					"accept-encoding",
+					"expected the SDK to sign Accept-Encoding, otherwise this test cannot detect a regression",
+				)
+
+				return
+			}
+
+			assert.NotContains(
+				t,
+				signed,
+				"accept-encoding",
+				"signing Accept-Encoding makes GCS reject the request with SignatureDoesNotMatch",
+			)
+
+			// The header must still reach the wire: the SDK sets it to disable gzip so
+			// that Content-Length and Content-Range survive for ranged downloads.
+			assert.Equal(
+				t,
+				"identity",
+				gotHeader.Get("Accept-Encoding"),
+				"Accept-Encoding must be restored after signing, only unsigned",
+			)
+		})
+	}
+}

--- a/pkg/awsconfig/config.go
+++ b/pkg/awsconfig/config.go
@@ -89,5 +89,10 @@ func NewConfig(logger *log.Logger, httpClient *http.Client, opts Options) (aws.C
 		cfg.BaseEndpoint = new(opts.Endpoint)
 	}
 
+	// Applies to every client built from this config. See accept_encoding.go:
+	// signing Accept-Encoding makes S3-compatible endpoints that rewrite it
+	// (Google Cloud Storage) reject every request with SignatureDoesNotMatch.
+	cfg.APIOptions = append(cfg.APIOptions, unsignedAcceptEncoding)
+
 	return cfg, nil
 }


### PR DESCRIPTION
## The bug

Self-hosted deployments backed by **Google Cloud Storage cannot store a single file** — every upload fails with `403 SignatureDoesNotMatch`. `contrib/helm/README.md` documents GCS as a supported S3 backend, but every compose file ships SeaweedFS, so the path is documented and untested.

## Root cause

`aws-sdk-go-v2` sets `Accept-Encoding: identity` from a Finalize middleware (`service/internal/accept-encoding.DisableGzip`) so responses are never gzipped. **That middleware runs before signing**, so SigV4 covers the header and lists it in `SignedHeaders`.

GCS's S3-interoperability endpoint **rewrites or strips `Accept-Encoding` in transit**, so the signature GCS recomputes can never match the one sent — and every request that signs it is rejected.

The error names the signature, so it reads as a credentials problem and is not one. That is why this is easy to misdiagnose.

**The discriminator is the client, not the verb and not the key.** `botocore` does not sign `Accept-Encoding` — which is exactly why the `aws` CLI and boto3 upload to the same bucket with the same HMAC credentials while this SDK cannot. A useful confirming signal: `ListObjects` succeeds while every write fails.

## The fix

A middleware pair inserted around the `Signing` step **by name** — strip `Accept-Encoding` immediately before signing, restore it immediately after.

The header still reaches the wire, so the SDK's no-gzip behaviour is preserved (and with it the `Content-Length` / `Content-Range` that ranged downloads depend on), but it never enters `SignedHeaders`.

Registered via `cfg.APIOptions` in `NewConfig`, so it covers **every** client built from that config, not just S3.

Applied **unconditionally** rather than only for custom endpoints: SigV4 does not require `Accept-Encoding` be signed, so this is safe against real AWS S3, and gating on endpoint detection would leave the failure lurking for any other rewriting proxy.

## Relationship to #1613

This is the **second of two independent causes**. #1613 (merged) fixed the transfer manager discarding the client's `RequestChecksumCalculation`.

That alone does **not** make GCS uploads work: the evidence/document upload path is a direct `s3.PutObject` in `pkg/probo/file_service.go`, not the transfer manager. Both fixes are required. This PR touches only `pkg/awsconfig/` and deliberately leaves `pkg/filemanager/` alone, since #1613 already landed there.

## Tests

`pkg/awsconfig/accept_encoding_test.go` asserts **both directions** — that the header is absent from `SignedHeaders` after signing, and that it is still present on the outbound request — so they cannot pass vacuously.

## Verification

Verified in production on a GCS-backed deployment: the bucket went from **zero objects since deploy to 22**, written 51 seconds after the patched revision went live. Configuration was identical across revisions; only the image digest changed.

⚠️ I could not run `go test` locally — the repo requires Go 1.26.5 and my machine has 1.20.5 — so the test run here is CI's. Flagging that explicitly rather than implying I ran it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops signing the `Accept-Encoding` header during SigV4 so GCS-backed S3 uploads succeed; the header is stripped before signing and restored after via `cfg.APIOptions`. Also skips Harbor mirror login on fork PRs and pins CI actions to SHAs so external contributors’ CI runs pass reliably.

### Tests **`+150`** **`-0`**
- Add `TestUnsignedAcceptEncoding` to assert the header is absent from SignedHeaders but still sent.
- Use an `httptest.Server` to capture headers; add `t.Parallel()` for suite and subtests.

### Service **`+127`** **`-0`**
- Introduce `unsignedAcceptEncoding` middleware to remove `Accept-Encoding` immediately before `Signing` and restore it right after.
- Register via `cfg.APIOptions` in `NewConfig` so all clients inherit it; safe on AWS S3.

### Other **`+23`** **`-9`**
- e2e: skip Harbor mirror login for fork PRs; pull images from origin registries and include the path in the Docker image cache key.
- Pin `actions/setup-go`, `actions/setup-node`, `actions/checkout`, and `github/codeql-action` to specific SHAs.

<sup>Written for commit 81f007ce7883f6c95ae2953c591ab1bb21dd92d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

