### PR TITLE
Add n8n Get Many for access review sources

### DIFF
--- a/packages/n8n-node/CHANGELOG.md
+++ b/packages/n8n-node/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `@probo/n8n-nodes-probo` package will be documented i
 
 ## Unreleased
 
+### Added
+
+- Access Review Source `Get Many` operation to list organization access review sources
+
 ## [0.213.0] - 2026-08-05
 
 ### Added

--- a/packages/n8n-node/nodes/Probo/Probo.node.ts
+++ b/packages/n8n-node/nodes/Probo/Probo.node.ts
@@ -84,6 +84,11 @@ export class Probo implements INodeType {
 						description: 'Manage access review campaigns',
 					},
 					{
+						name: 'Access Review Source',
+						value: 'accessReviewSource',
+						description: 'Manage access review sources',
+					},
+					{
 						name: 'Asset',
 						value: 'asset',
 						description: 'Manage assets',

--- a/packages/n8n-node/nodes/Probo/actions/accessReviewSource/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/accessReviewSource/getAll.operation.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { proboApiRequestAllItems } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Organization ID',
+		name: 'organizationId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['accessReviewSource'],
+				operation: ['getAll'],
+			},
+		},
+		default: '',
+		description: 'The ID of the organization',
+		required: true,
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: ['accessReviewSource'],
+				operation: ['getAll'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['accessReviewSource'],
+				operation: ['getAll'],
+				returnAll: [false],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+		},
+		default: 50,
+		description: 'Max number of results to return',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const organizationId = this.getNodeParameter('organizationId', itemIndex) as string;
+	const returnAll = this.getNodeParameter('returnAll', itemIndex) as boolean;
+	const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
+
+	const query = `
+		query GetAccessReviewSources($organizationId: ID!, $first: Int, $after: CursorKey) {
+			node(id: $organizationId) {
+				... on Organization {
+					accessReviewSources(first: $first, after: $after) {
+						edges {
+							node {
+								id
+								name
+								connectorId
+								connectionStatus
+								needsConfiguration
+								selectedOrganization
+								createdAt
+								updatedAt
+							}
+						}
+						pageInfo {
+							hasNextPage
+							endCursor
+						}
+					}
+				}
+			}
+		}
+	`;
+
+	const accessReviewSources = await proboApiRequestAllItems.call(
+		this,
+		query,
+		{ organizationId },
+		(response) => {
+			const data = response?.data as IDataObject | undefined;
+			const node = data?.node as IDataObject | undefined;
+			return node?.accessReviewSources as IDataObject | undefined;
+		},
+		returnAll,
+		limit,
+	);
+
+	return {
+		json: { accessReviewSources },
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/accessReviewSource/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/accessReviewSource/index.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import type { INodeProperties } from 'n8n-workflow';
+import * as getAllOp from './getAll.operation';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['accessReviewSource'],
+			},
+		},
+		options: [
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many access review sources',
+				action: 'Get many access review sources',
+			},
+		],
+		default: 'getAll',
+	},
+	...getAllOp.description,
+];
+
+export { getAllOp as getAll };

--- a/packages/n8n-node/nodes/Probo/actions/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/index.ts
@@ -20,6 +20,7 @@
 
 import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
 import * as accessReview from './accessReview';
+import * as accessReviewSource from './accessReviewSource';
 import * as asset from './asset';
 import * as audit from './audit';
 import * as auditLog from './auditLog';
@@ -66,6 +67,7 @@ export interface OperationModule {
 
 export const resources: Record<string, ResourceModule> = {
 	accessReview: accessReview as ResourceModule,
+	accessReviewSource: accessReviewSource as ResourceModule,
 	asset: asset as ResourceModule,
 	audit: audit as ResourceModule,
 	auditLog: auditLog as ResourceModule,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [ENG-700](https://linear.app/probo/issue/ENG-700/need-a-n8n-node-to-get-many-access-review-sources-connected)

## Summary

Adds an **Access Review Source** resource to the Probo n8n node with a **Get Many** operation, mirroring the existing GraphQL / MCP / CLI list surfaces for `Organization.accessReviewSources`.

## Changes

- New `accessReviewSource` resource under `packages/n8n-node`
- `Get Many` (`getAll`) lists sources for an organization with cursor pagination (`returnAll` / `limit`)
- Returns `id`, `name`, `connectorId`, `connectionStatus`, `needsConfiguration`, `selectedOrganization`, `createdAt`, `updatedAt` (skips bulky `csvData`)
- Registers the resource in `actions/index.ts` and the Probo node Resource dropdown
- Changelog entry under Unreleased

## Verification

- `npm -w @probo/n8n-nodes-probo run lint` — passed
- `npm -w @probo/n8n-nodes-probo run build` — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-700](https://linear.app/probo/issue/ENG-700/need-a-n8n-node-to-get-many-access-review-sources-connected)

<div><a href="https://cursor.com/agents/bc-5fd3a0db-4596-4412-a66d-bd6dc806bbad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fd3a0db-4596-4412-a66d-bd6dc806bbad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Access Review Source" resource to `@probo/n8n-nodes-probo` with a "Get Many" operation so workflows can list an organization’s sources and connection status. Implements ENG-700 and aligns with existing GraphQL/MCP/CLI list surfaces.

### Package: n8n-node **`+182`** **`-0`**
- New `accessReviewSource` resource with `getAll` operation.
- Cursor pagination via `returnAll` and `limit`.
- Returns id, name, connectorId, connectionStatus, needsConfiguration, selectedOrganization, createdAt, updatedAt.
- Registered in the Probo node resource selector and `actions/index.ts`; changelog updated.

<sup>Written for commit 5150424b4c186a468bedd1bdfa08b44998c33dc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

