### PR TITLE
Treat refresh token as offline_access for OAuth reconnects

### DIFF
--- a/pkg/accessreview/source_missing_scopes_test.go
+++ b/pkg/accessreview/source_missing_scopes_test.go
@@ -109,4 +109,50 @@ func TestMissingOAuthScopesForConnector(t *testing.T) {
 
 		assert.Empty(t, missingOAuthScopesForConnector(dbConnector, required))
 	})
+
+	t.Run("refresh token satisfies offline_access even when omitted from scope", func(t *testing.T) {
+		t.Parallel()
+
+		// Microsoft's v2 token response returns Graph scopes (and often
+		// openid/profile) but never offline_access, despite issuing a
+		// refresh token. Existing connections may also lack it in Scope.
+		requiredWithOffline := []string{
+			"openid",
+			"offline_access",
+			"https://graph.microsoft.com/User.Read.All",
+		}
+
+		dbConnector := coredata.Connector{
+			Protocol: coredata.ConnectorProtocolOAuth2,
+			Connection: &connector.OAuth2Connection{
+				RefreshToken: "rt",
+				Scope:        "openid User.Read.All",
+			},
+		}
+
+		assert.Empty(t, missingOAuthScopesForConnector(dbConnector, requiredWithOffline))
+	})
+
+	t.Run("offline_access still missing without refresh token", func(t *testing.T) {
+		t.Parallel()
+
+		requiredWithOffline := []string{
+			"openid",
+			"offline_access",
+			"https://graph.microsoft.com/User.Read.All",
+		}
+
+		dbConnector := coredata.Connector{
+			Protocol: coredata.ConnectorProtocolOAuth2,
+			Connection: &connector.OAuth2Connection{
+				Scope: "openid User.Read.All",
+			},
+		}
+
+		assert.Equal(
+			t,
+			[]string{"offline_access"},
+			missingOAuthScopesForConnector(dbConnector, requiredWithOffline),
+		)
+	})
 }

--- a/pkg/accessreview/source_service.go
+++ b/pkg/accessreview/source_service.go
@@ -673,7 +673,27 @@ func missingOAuthScopesForConnector(
 		granted = dbConnector.Connection.Scopes()
 	}
 
+	// Microsoft (and similar OIDC providers) omit offline_access from the
+	// token scope echo even when a refresh token was issued. Treat a
+	// refresh token as proof of that grant for missing-scope checks only —
+	// never synthesize it into Connection.Scopes(), which reconnect uses
+	// to build the next authorize request (Google rejects offline_access).
+	if connectionHasRefreshToken(dbConnector.Connection) {
+		granted = connector.UnionScopes(granted, []string{"offline_access"})
+	}
+
 	return connector.MissingScopes(required, granted)
+}
+
+func connectionHasRefreshToken(c connector.Connection) bool {
+	switch conn := c.(type) {
+	case *connector.OAuth2Connection:
+		return conn.RefreshToken != ""
+	case *connector.SlackConnection:
+		return conn.RefreshToken != ""
+	default:
+		return false
+	}
 }
 
 // AutoSelectDefaultOrganization picks the first workspace/org a freshly linked

--- a/pkg/connector/oauth2.go
+++ b/pkg/connector/oauth2.go
@@ -32,6 +32,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -475,6 +476,18 @@ func (c *OAuth2Connector) CompleteWithState(ctx context.Context, r *http.Request
 		// requested scope. Fall back to what we asked for so
 		// subsequent reconnect diffs have a meaningful base.
 		grantedScope = FormatScopeString(payload.Data.RequestedScopes)
+	}
+
+	// Microsoft's identity platform v2 token endpoint never echoes
+	// offline_access in the scope field even when a refresh token was
+	// issued (see https://learn.microsoft.com/en-us/answers/questions/806413).
+	// Only backfill when the client actually requested that OIDC scope —
+	// Google uses access_type=offline instead and rejects offline_access
+	// on authorize (invalid_scope).
+	if rawToken.RefreshToken != "" && slices.Contains(payload.Data.RequestedScopes, "offline_access") {
+		grantedScope = FormatScopeString(
+			UnionScopes(ParseScopeString(grantedScope), []string{"offline_access"}),
+		)
 	}
 
 	oauth2Conn := OAuth2Connection{

--- a/pkg/connector/oauth2_test.go
+++ b/pkg/connector/oauth2_test.go
@@ -571,6 +571,106 @@ func TestCompleteWithState_ScopeFallback(t *testing.T) {
 	assert.Equal(t, []string{"read:user", "write:user"}, returnedState.RequestedScopes)
 }
 
+// TestCompleteWithState_OfflineAccessFromRefreshToken verifies that when a
+// provider that requested offline_access (Microsoft identity platform v2)
+// returns a refresh_token but omits offline_access from the scope field, we
+// persist offline_access. Providers that use access_type=offline (Google)
+// must not get offline_access written into Scope — reconnect unions
+// Scopes() into the next authorize request, and Google rejects that scope.
+func TestCompleteWithState_OfflineAccessFromRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	newConnector := func(tokenURL string) *OAuth2Connector {
+		return &OAuth2Connector{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/cb",
+			AuthURL:      "https://provider.example.com/authorize",
+			TokenURL:     tokenURL,
+			HTTPClient:   httpclient.DefaultClient(httpclient.WithSSRFProtection(), httpclient.WithSSRFAllowLoopback()),
+		}
+	}
+
+	t.Run("backfills when offline_access was requested", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(
+				`{"access_token":"at","refresh_token":"rt","expires_in":3600,"token_type":"Bearer","scope":"openid profile User.Read.All"}`,
+			))
+		}))
+		defer server.Close()
+
+		c := newConnector(server.URL)
+		orgID := gid.New(gid.NewTenantID(), 0)
+		stateToken, err := statelesstoken.NewToken(
+			c.ClientSecret,
+			OAuth2TokenType,
+			OAuth2TokenTTL,
+			OAuth2State{
+				OrganizationID:  orgID.String(),
+				Provider:        "MICROSOFT365",
+				RequestedScopes: []string{"openid", "profile", "offline_access", "https://graph.microsoft.com/User.Read.All"},
+			},
+		)
+		require.NoError(t, err)
+
+		conn, _, err := c.CompleteWithState(
+			context.Background(),
+			httptest.NewRequest(http.MethodGet, "https://example.com/cb?code=the-code&state="+stateToken, nil),
+		)
+		require.NoError(t, err)
+
+		oauth2Conn, ok := conn.(*OAuth2Connection)
+		require.True(t, ok, "expected *OAuth2Connection, got %T", conn)
+
+		assert.Equal(t, "rt", oauth2Conn.RefreshToken)
+		assert.Equal(t, "User.Read.All offline_access openid profile", oauth2Conn.Scope)
+		assert.Equal(t, []string{"User.Read.All", "offline_access", "openid", "profile"}, oauth2Conn.Scopes())
+	})
+
+	t.Run("does not invent offline_access for access_type=offline providers", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(
+				`{"access_token":"at","refresh_token":"rt","expires_in":3600,"token_type":"Bearer","scope":"https://www.googleapis.com/auth/analytics.readonly"}`,
+			))
+		}))
+		defer server.Close()
+
+		c := newConnector(server.URL)
+		orgID := gid.New(gid.NewTenantID(), 0)
+		stateToken, err := statelesstoken.NewToken(
+			c.ClientSecret,
+			OAuth2TokenType,
+			OAuth2TokenTTL,
+			OAuth2State{
+				OrganizationID:  orgID.String(),
+				Provider:        "GOOGLE_ANALYTICS",
+				RequestedScopes: []string{"https://www.googleapis.com/auth/analytics.readonly"},
+			},
+		)
+		require.NoError(t, err)
+
+		conn, _, err := c.CompleteWithState(
+			context.Background(),
+			httptest.NewRequest(http.MethodGet, "https://example.com/cb?code=the-code&state="+stateToken, nil),
+		)
+		require.NoError(t, err)
+
+		oauth2Conn, ok := conn.(*OAuth2Connection)
+		require.True(t, ok, "expected *OAuth2Connection, got %T", conn)
+
+		assert.Equal(t, "rt", oauth2Conn.RefreshToken)
+		assert.Equal(t, "https://www.googleapis.com/auth/analytics.readonly", oauth2Conn.Scope)
+		assert.Equal(t, []string{"https://www.googleapis.com/auth/analytics.readonly"}, oauth2Conn.Scopes())
+		assert.NotContains(t, oauth2Conn.Scopes(), "offline_access")
+	})
+}
+
 // TestInitiateWithState_PKCE verifies that connectors with RequiresPKCE=true
 // embed the S256 challenge in the authorization URL (RFC 7636 §4.3) and
 // persist a random nonce (not the verifier) in the signed state token, so


### PR DESCRIPTION
Microsoft's v2 token response omits offline_access from scope even when a refresh token is issued, so MS365 reconnect always looked incomplete.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat refresh tokens as proof of offline_access for OAuth reconnects and missing-scope checks. Fixes incomplete Microsoft 365 reconnects and avoids unnecessary re-consent, without adding offline_access for providers that don’t use it.

### Service **`+33`** **`-0`**
- On token exchange, if a refresh token is issued and `offline_access` was requested, persist `offline_access` in `Scope` (handles Microsoft v2 omission).
- Access review treats a refresh token as proof of `offline_access` for missing-scope checks without synthesizing it into `Connection.Scopes()` (keeps Google flows valid).

### Tests **`+146`** **`-0`**
- Added access review tests: refresh token satisfies `offline_access`; still missing without a refresh token.
- Added connector tests: backfill `offline_access` for Microsoft v2 when requested; do not add it for Google (`access_type=offline`).

<sup>Written for commit 7700e24d926bcf3453fb03bd712492e76279ce7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

