### PR TITLE
Cancel stale CI and reuse probod builds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "35 23 * * 4"
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,12 @@ name: "github"
 on:
   push:
     branches: ["main"]
+    paths:
+      - ".github/**"
   pull_request:
     branches: ["main"]
+    paths:
+      - ".github/**"
   schedule:
     - cron: "35 23 * * 4"
 
@@ -14,7 +18,7 @@ concurrency:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: Analyze (actions)
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources
@@ -37,10 +41,6 @@ jobs:
       matrix:
         include:
           - language: actions
-            build-mode: none
-          - language: go
-            build-mode: autobuild
-          - language: javascript-typescript
             build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
@@ -74,22 +74,6 @@ jobs:
 
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
-
-      # If the analyze step fails for one of the languages you are analyzing with
-      # "We were unable to automatically build your code", modify the matrix above
-      # to set the build mode to "manual" for that language. Then modify this step
-      # to build your code.
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-      - if: matrix.build-mode == 'manual'
-        shell: bash
-        run: |
-          echo 'If you are using a "manual" build mode for one or more of the' \
-            'languages you are analyzing, replace this with the commands to build' \
-            'your code, for example:'
-          echo '  make bootstrap'
-          echo '  make release'
-          exit 1
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -36,6 +36,12 @@ jobs:
       - uses: "./.github/actions/setup"
         with:
           node: "false"
+      - name: "Create placeholder dist files"
+        run: |
+          mkdir -p apps/console/dist apps/compliance-portal/dist packages/emails/dist
+          echo ci > apps/console/dist/index.html
+          echo ci > apps/compliance-portal/dist/index.html
+          echo ci > packages/emails/dist/placeholder
       - name: "Classify changed paths"
         id: classify
         env:

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - "main"
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: "read"
 
@@ -101,6 +105,7 @@ jobs:
           go build -ldflags "-s -w -X 'main.version=snapshot'" \
             -gcflags="-e" -o "dist/prb${EXT}" ./cmd/prb/main.go
       - uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7
+        if: matrix.goos == 'linux'
         with:
           name: "binary-${{ matrix.goos }}-${{ matrix.goarch }}"
           path: "dist/"
@@ -267,6 +272,11 @@ jobs:
           go build -ldflags "-s -w -X 'main.version=snapshot'" \
             -gcflags="-e" -o bin/prb ./cmd/prb/main.go & pids+=($!)
           for pid in "${pids[@]}"; do wait "$pid"; done
+      - uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7
+        with:
+          name: "probod-ci"
+          path: "bin/probod"
+          retention-days: 1
 
   build-probo-agent:
     name: "build-probo-agent"
@@ -486,6 +496,7 @@ jobs:
 
   test-e2e:
     name: "${{ matrix.name }}"
+    needs: [build]
     runs-on: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache"
     strategy:
       fail-fast: false
@@ -513,6 +524,16 @@ jobs:
           submodules: recursive
       - uses: "runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc" # v2
       - uses: "./.github/actions/setup"
+        with:
+          node: "false"
+      - uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8
+        if: "${{ !matrix.coverage }}"
+        with:
+          name: "probod-ci"
+          path: "bin"
+      - name: "Prepare probod"
+        if: "${{ !matrix.coverage }}"
+        run: "chmod +x bin/probod"
       - name: "Configure Docker image source"
         # Pull requests from forks don't get repository secrets, so
         # HARBOR_USERNAME/HARBOR_PASSWORD are unavailable and logging into
@@ -556,6 +577,7 @@ jobs:
           mkdir -p /tmp/docker-images
           docker save $(docker compose config --images) -o /tmp/docker-images/images.tar
       - name: "Build probod"
+        if: "${{ matrix.coverage }}"
         run: "make ${{ matrix.build_target }}"
       - name: "Start stack"
         run: "make stack-up"

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -49,7 +49,7 @@ jobs:
             packages/emails/dist/
           retention-days: 1
 
-  # ── Snapshot: build probod group binaries (matrix by GOOS/GOARCH) ──
+  # ── Snapshot: build the Linux/amd64 probod group binaries ─────────
   build-snapshot-binary:
     name: "probod binary (${{ matrix.goos }}/${{ matrix.goarch }})"
     if: github.event_name == 'push'
@@ -62,14 +62,6 @@ jobs:
       matrix:
         include:
           - { goos: linux, goarch: amd64 }
-          - { goos: linux, goarch: arm64 }
-          - { goos: darwin, goarch: amd64 }
-          - { goos: darwin, goarch: arm64 }
-          - { goos: windows, goarch: amd64 }
-          - { goos: freebsd, goarch: amd64 }
-          - { goos: freebsd, goarch: arm64 }
-          - { goos: openbsd, goarch: amd64 }
-          - { goos: openbsd, goarch: arm64 }
     steps:
       - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v6
         with:
@@ -105,52 +97,12 @@ jobs:
           go build -ldflags "-s -w -X 'main.version=snapshot'" \
             -gcflags="-e" -o "dist/prb${EXT}" ./cmd/prb/main.go
       - uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7
-        if: matrix.goos == 'linux'
         with:
           name: "binary-${{ matrix.goos }}-${{ matrix.goarch }}"
           path: "dist/"
           retention-days: 1
 
-  # ── Snapshot: build probo-agent binaries (matrix by GOOS/GOARCH) ───
-  build-snapshot-probo-agent:
-    name: "probo-agent (${{ matrix.goos }}/${{ matrix.goarch }})"
-    if: github.event_name == 'push'
-    runs-on: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache"
-    permissions:
-      contents: "read"
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { goos: linux, goarch: amd64 }
-          - { goos: linux, goarch: arm64 }
-          - { goos: darwin, goarch: amd64 }
-          - { goos: darwin, goarch: arm64 }
-          - { goos: windows, goarch: amd64 }
-          - { goos: windows, goarch: arm64 }
-          - { goos: freebsd, goarch: amd64 }
-          - { goos: freebsd, goarch: arm64 }
-    steps:
-      - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v6
-        with:
-          submodules: recursive
-      - uses: "runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc" # v2
-      - uses: "./.github/actions/setup"
-        with:
-          node: "false"
-      - name: "Build probo-agent"
-        env:
-          CGO_ENABLED: "0"
-          GOOS: "${{ matrix.goos }}"
-          GOARCH: "${{ matrix.goarch }}"
-        run: |
-          EXT=""
-          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
-
-          go build -ldflags "-s -w -X 'main.version=snapshot'" \
-            -gcflags="-e" -o "dist/probo-agent${EXT}" ./cmd/probo-agent
-
-  # ── Snapshot: build Docker images (matrix by architecture) ─────────
+  # ── Snapshot: build the Linux/amd64 Docker image ───────────────────
   build-snapshot-docker:
     name: "docker (${{ matrix.arch }})"
     if: github.event_name == 'push'
@@ -166,9 +118,6 @@ jobs:
           - arch: amd64
             platform: "linux/amd64"
             runner: "4cpu-linux-x64"
-          - arch: arm64
-            platform: "linux/arm64"
-            runner: "4cpu-linux-arm64"
     steps:
       - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v6
       - uses: "runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc" # v2
@@ -284,12 +233,23 @@ jobs:
     steps:
       - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v6
         with:
+          fetch-depth: 2
           submodules: recursive
       - uses: "runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc" # v2
       - uses: "./.github/actions/setup"
         with:
           node: "false"
+      - name: "Check probo-agent dependency changes"
+        id: agent-changes
+        env:
+          BASE_SHA: "${{ github.event.pull_request.base.sha || github.event.before }}"
+          HEAD_SHA: "${{ github.event.pull_request.head.sha || github.sha }}"
+        run: |
+          affected="$(contrib/ci/go-package-affected.sh \
+            "$BASE_SHA" "$HEAD_SHA" ./cmd/probo-agent)"
+          echo "affected=$affected" >> "$GITHUB_OUTPUT"
       - name: "Build probo-agent"
+        if: steps.agent-changes.outputs.affected == 'true'
         env:
           CGO_ENABLED: "0"
         run: |

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -246,14 +246,12 @@ jobs:
           submodules: recursive
       - uses: "runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc" # v2
       - uses: "./.github/actions/setup"
-        with:
-          node: "false"
       - name: "Create placeholder dist files"
         run: |
-          mkdir -p apps/console/dist apps/compliance-portal/dist packages/emails/dist
+          mkdir -p apps/console/dist apps/compliance-portal/dist
           echo dev-server > apps/console/dist/index.html
           echo dev-server > apps/compliance-portal/dist/index.html
-          echo dev-server > packages/emails/dist/placeholder
+      - run: "npm --workspace @probo/emails run build"
       - name: "Generate Go code"
         run: |
           go generate ./pkg/server/api/connect/v1

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -491,28 +491,10 @@ jobs:
           retention-days: 30
 
   test-e2e:
-    name: "${{ matrix.name }}"
+    name: "test-e2e"
     if: needs.changes.outputs.e2e == 'true'
     needs: [changes, build]
     runs-on: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache"
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: "test-e2e"
-            build_target: "bin/probod"
-            run_target: "test-e2e-run"
-            binary: "bin/probod"
-            junit_file: "junit-e2e.xml"
-            artifact_name: "junit-e2e-results"
-            coverage: false
-          - name: "test-e2e-coverage"
-            build_target: "bin/probod-coverage"
-            run_target: "test-e2e-coverage-run"
-            binary: "bin/probod-coverage"
-            junit_file: "junit-e2e-coverage.xml"
-            artifact_name: "junit-e2e-coverage-results"
-            coverage: true
     permissions:
       contents: "read"
     steps:
@@ -524,12 +506,10 @@ jobs:
         with:
           node: "false"
       - uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8
-        if: "${{ !matrix.coverage }}"
         with:
           name: "probod-ci"
           path: "bin"
       - name: "Prepare probod"
-        if: "${{ !matrix.coverage }}"
         run: "chmod +x bin/probod"
       - name: "Configure Docker image source"
         # Pull requests from forks don't get repository secrets, so
@@ -573,9 +553,6 @@ jobs:
           docker compose pull
           mkdir -p /tmp/docker-images
           docker save $(docker compose config --images) -o /tmp/docker-images/images.tar
-      - name: "Build probod"
-        if: "${{ matrix.coverage }}"
-        run: "make ${{ matrix.build_target }}"
       - name: "Start stack"
         run: "make stack-up"
       - run: "make stack-ps"
@@ -583,40 +560,19 @@ jobs:
         env:
           PROBO_E2E_ARTIFACT_DIR: "${{ github.workspace }}/e2e-artifacts"
           GOTESTSUM_FORMAT: "testname"
-          GOTESTSUM_JUNITFILE: "${{ matrix.junit_file }}"
+          GOTESTSUM_JUNITFILE: "junit-e2e.xml"
         run: |
           PROBOD_ACME_ROOT_CA="$(cat compose/step-ca/certs/root_ca.crt)" \
-            make "${{ matrix.run_target }}" \
-              E2E_BINARY="${{ github.workspace }}/${{ matrix.binary }}" \
+            make test-e2e-run \
+              E2E_BINARY="${{ github.workspace }}/bin/probod" \
               E2E_TEST_FLAGS="-parallel=8"
-      - name: "Report e2e coverage"
-        if: "${{ always() && matrix.coverage }}"
-        run: |
-          if [ -f coverage-e2e.txt ]; then
-            full_coverage="$(awk '$1 == "total:" { print $3 }' coverage-e2e.txt)"
-            core_coverage="$(awk '$1 == "total:" { print $3 }' coverage-e2e-core.txt)"
-            {
-              echo "### E2E coverage"
-              echo "- Full probod: ${full_coverage}"
-              echo "- Core product: ${core_coverage}"
-            } >> "${GITHUB_STEP_SUMMARY}"
-          else
-            echo "### E2E application coverage unavailable" >> "${GITHUB_STEP_SUMMARY}"
-          fi
       - name: "Upload test results"
         uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7
         if: "always()"
         continue-on-error: true
         with:
-          name: "${{ matrix.artifact_name }}"
+          name: "junit-e2e-results"
           path: |
-            ${{ matrix.junit_file }}
+            junit-e2e.xml
             e2e-artifacts
-            coverage-e2e.out
-            coverage-e2e.txt
-            coverage-e2e.html
-            coverage-e2e-core.out
-            coverage-e2e-core.txt
-            coverage-e2e-core.html
-            coverage-e2e-packages.txt
           retention-days: 30

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -15,10 +15,39 @@ permissions:
   contents: "read"
 
 jobs:
+  changes:
+    name: "changes"
+    runs-on: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64/extras=s3-cache"
+    permissions:
+      contents: "read"
+    outputs:
+      agent: "${{ steps.classify.outputs.agent }}"
+      e2e: "${{ steps.classify.outputs.e2e }}"
+      go: "${{ steps.classify.outputs.go }}"
+      javascript: "${{ steps.classify.outputs.javascript }}"
+      shell: "${{ steps.classify.outputs.shell }}"
+      snapshot: "${{ steps.classify.outputs.snapshot }}"
+      swift: "${{ steps.classify.outputs.swift }}"
+    steps:
+      - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v6
+        with:
+          fetch-depth: 2
+      - uses: "runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc" # v2
+      - uses: "./.github/actions/setup"
+        with:
+          node: "false"
+      - name: "Classify changed paths"
+        id: classify
+        env:
+          BASE_SHA: "${{ github.event.pull_request.base.sha || github.event.before }}"
+          HEAD_SHA: "${{ github.event.pull_request.head.sha || github.sha }}"
+        run: "contrib/ci/classify-changes.sh \"$BASE_SHA\" \"$HEAD_SHA\" >> \"$GITHUB_OUTPUT\""
+
   # ── Snapshot: build frontend apps ──────────────────────────────────
   build-apps:
     name: "build-apps"
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && needs.changes.outputs.snapshot == 'true'
+    needs: [changes]
     runs-on: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache"
     permissions:
       contents: "read"
@@ -186,6 +215,8 @@ jobs:
   # ── Build probod group (PR + push validation) ────────────────────────
   build:
     name: "build-probod"
+    if: needs.changes.outputs.e2e == 'true'
+    needs: [changes]
     runs-on: "runs-on=${{ github.run_id }}/runner=8cpu-linux-x64/extras=s3-cache"
     permissions:
       contents: "read"
@@ -227,29 +258,20 @@ jobs:
 
   build-probo-agent:
     name: "build-probo-agent"
+    if: needs.changes.outputs.agent == 'true'
+    needs: [changes]
     runs-on: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache"
     permissions:
       contents: "read"
     steps:
       - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v6
         with:
-          fetch-depth: 2
           submodules: recursive
       - uses: "runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc" # v2
       - uses: "./.github/actions/setup"
         with:
           node: "false"
-      - name: "Check probo-agent dependency changes"
-        id: agent-changes
-        env:
-          BASE_SHA: "${{ github.event.pull_request.base.sha || github.event.before }}"
-          HEAD_SHA: "${{ github.event.pull_request.head.sha || github.sha }}"
-        run: |
-          affected="$(contrib/ci/go-package-affected.sh \
-            "$BASE_SHA" "$HEAD_SHA" ./cmd/probo-agent)"
-          echo "affected=$affected" >> "$GITHUB_OUTPUT"
       - name: "Build probo-agent"
-        if: steps.agent-changes.outputs.affected == 'true'
         env:
           CGO_ENABLED: "0"
         run: |
@@ -258,6 +280,8 @@ jobs:
 
   lint-go:
     name: "lint-go"
+    if: needs.changes.outputs.go == 'true'
+    needs: [changes]
     runs-on: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache"
     permissions:
       contents: "read"
@@ -315,6 +339,8 @@ jobs:
 
   lint-js:
     name: "lint-js"
+    if: needs.changes.outputs.javascript == 'true'
+    needs: [changes]
     runs-on: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache"
     permissions:
       contents: "read"
@@ -346,6 +372,8 @@ jobs:
 
   lint-swift:
     name: "lint-swift"
+    if: needs.changes.outputs.swift == 'true'
+    needs: [changes]
     runs-on: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64/extras=s3-cache"
     permissions:
       contents: "read"
@@ -385,6 +413,8 @@ jobs:
 
   lint-shell:
     name: "lint-shell"
+    if: needs.changes.outputs.shell == 'true'
+    needs: [changes]
     runs-on: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64/extras=s3-cache"
     permissions:
       contents: "read"
@@ -414,6 +444,8 @@ jobs:
 
   test:
     name: "test"
+    if: needs.changes.outputs.go == 'true'
+    needs: [changes]
     runs-on: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache"
     permissions:
       contents: "read"
@@ -454,7 +486,8 @@ jobs:
 
   test-e2e:
     name: "${{ matrix.name }}"
-    needs: [build]
+    if: needs.changes.outputs.e2e == 'true'
+    needs: [changes, build]
     runs-on: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache"
     strategy:
       fail-fast: false

--- a/.github/workflows/secrets.yaml
+++ b/.github/workflows/secrets.yaml
@@ -6,6 +6,10 @@ on:
       - "main"
   pull_request:
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,6 +37,7 @@ SHELL_SCRIPTS := \
 	cmd/probo-agent/installer/macos/reinstall.sh \
 	cmd/probo-agent/installer/macos/uninstall.sh \
 	compose/postgres/01_probod.sh \
+	contrib/ci/go-package-affected.sh \
 	contrib/lima/provision.sh \
 	contrib/lima/sandbox.sh \
 	contrib/merge-graphql-schema.sh \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,6 +37,7 @@ SHELL_SCRIPTS := \
 	cmd/probo-agent/installer/macos/reinstall.sh \
 	cmd/probo-agent/installer/macos/uninstall.sh \
 	compose/postgres/01_probod.sh \
+	contrib/ci/classify-changes.sh \
 	contrib/ci/go-package-affected.sh \
 	contrib/lima/provision.sh \
 	contrib/lima/sandbox.sh \

--- a/contrib/ci/classify-changes.sh
+++ b/contrib/ci/classify-changes.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Probo Inc <hello@probo.com>.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+
+base_sha="${1:?base SHA is required}"
+head_sha="${2:?head SHA is required}"
+
+emit_all() {
+  local value="$1"
+
+  echo "agent=$value"
+  echo "e2e=$value"
+  echo "go=$value"
+  echo "javascript=$value"
+  echo "shell=$value"
+  echo "snapshot=$value"
+  echo "swift=$value"
+}
+
+if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null \
+  || ! git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
+  emit_all "true"
+  exit 0
+fi
+
+mapfile -t changed_files < <(
+  git diff --name-only --no-renames "$base_sha" "$head_sha"
+)
+
+for changed_file in "${changed_files[@]}"; do
+  case "$changed_file" in
+    .github/actions/* | .github/actions/**/* | .github/workflows/* | \
+      contrib/ci/* | GNUmakefile | go.mod | go.sum)
+      emit_all "true"
+      exit 0
+      ;;
+  esac
+done
+
+agent="$(
+  contrib/ci/go-package-affected.sh \
+    "$base_sha" "$head_sha" ./cmd/probo-agent
+)"
+prb="$(
+  contrib/ci/go-package-affected.sh \
+    "$base_sha" "$head_sha" ./cmd/prb
+)"
+probod="$(
+  contrib/ci/go-package-affected.sh \
+    "$base_sha" "$head_sha" ./cmd/probod
+)"
+probod_bootstrap="$(
+  contrib/ci/go-package-affected.sh \
+    "$base_sha" "$head_sha" ./cmd/probod-bootstrap
+)"
+
+go_changed="false"
+javascript="false"
+shell="false"
+swift="false"
+e2e="$probod"
+snapshot="false"
+
+for changed_file in "${changed_files[@]}"; do
+  # go gates lint-go and unit tests. Match first-party package dirs so
+  # testdata and //go:embed inputs are not skipped; do not rely on *.go.
+  # enroll-ui is Swift. Mixed JS/Go trees stay on the extension list.
+  case "$changed_file" in
+    cmd/probo-agent/installer/macos/enroll-ui/*)
+      ;;
+    cmd/* | pkg/* | e2e/* | internal/* | \
+      *.go | *.graphql | *.tmpl | *.sql | .golangci.yml | \
+      */gqlgen.yaml | */mcpgen.yaml | */specification.yaml)
+      go_changed="true"
+      ;;
+  esac
+
+  # javascript gates lint-js, which is the only PR job that runs
+  # make relay. Schema files, relay.config.json, and the merge
+  # script must match here or a schema-only PR skips Relay.
+  case "$changed_file" in
+    *.cjs | *.css | *.js | *.jsx | *.mjs | *.ts | *.tsx | \
+      *.graphql | relay.config.json | contrib/merge-graphql-schema.sh | \
+      package.json | package-lock.json | turbo.json | \
+      apps/* | apps/**/* | packages/* | packages/**/*)
+      javascript="true"
+      ;;
+  esac
+
+  case "$changed_file" in
+    *.sh | .shellcheckrc | GNUmakefile)
+      shell="true"
+      ;;
+  esac
+
+  case "$changed_file" in
+    .swift-format | .swiftlint.yml | \
+      cmd/probo-agent/installer/macos/enroll-ui/* | \
+      cmd/probo-agent/installer/macos/enroll-ui/**/*)
+      swift="true"
+      ;;
+  esac
+
+  case "$changed_file" in
+    cfg/* | cfg/**/* | compose.yaml | compose.github-action.yaml | \
+      compose/* | compose/**/* | e2e/* | e2e/**/*)
+      e2e="true"
+      ;;
+  esac
+
+  # Image + scanner config. Snapshot builds the Docker image (Trivy)
+  # and runs snapshot-scan (Grype). E2E uses Compose + host bin/probod.
+  case "$changed_file" in
+    Dockerfile | entrypoint.sh | .trivyignore.yaml | .grype.yaml)
+      snapshot="true"
+      ;;
+  esac
+done
+
+if [[ "$probod" == "true" ||
+  "$prb" == "true" ||
+  "$probod_bootstrap" == "true" ||
+  "$javascript" == "true" ]]; then
+  snapshot="true"
+fi
+
+echo "agent=$agent"
+echo "e2e=$e2e"
+echo "go=$go_changed"
+echo "javascript=$javascript"
+echo "shell=$shell"
+echo "snapshot=$snapshot"
+echo "swift=$swift"

--- a/contrib/ci/classify-changes.sh
+++ b/contrib/ci/classify-changes.sh
@@ -79,6 +79,7 @@ javascript="false"
 shell="false"
 swift="false"
 e2e="$probod"
+frontend="false"
 snapshot="false"
 
 for changed_file in "${changed_files[@]}"; do
@@ -104,6 +105,17 @@ for changed_file in "${changed_files[@]}"; do
       package.json | package-lock.json | turbo.json | \
       apps/* | packages/*)
       javascript="true"
+      ;;
+  esac
+
+  case "$changed_file" in
+    .nvmrc | package.json | package-lock.json | turbo.json | \
+      apps/compliance-portal/* | apps/console/* | \
+      packages/coredata/* | packages/emails/* | packages/helpers/* | \
+      packages/hooks/* | packages/i18n/* | packages/prosemirror/* | \
+      packages/react-lazy/* | packages/relay/* | packages/routes/* | \
+      packages/tsconfig/* | packages/ui/*)
+      frontend="true"
       ;;
   esac
 
@@ -139,7 +151,7 @@ done
 if [[ "$probod" == "true" ||
   "$prb" == "true" ||
   "$probod_bootstrap" == "true" ||
-  "$javascript" == "true" ]]; then
+  "$frontend" == "true" ]]; then
   snapshot="true"
 fi
 

--- a/contrib/ci/classify-changes.sh
+++ b/contrib/ci/classify-changes.sh
@@ -49,7 +49,7 @@ mapfile -t changed_files < <(
 
 for changed_file in "${changed_files[@]}"; do
   case "$changed_file" in
-    .github/actions/* | .github/actions/**/* | .github/workflows/* | \
+    .github/actions/* | .github/workflows/* | \
       contrib/ci/* | GNUmakefile | go.mod | go.sum)
       emit_all "true"
       exit 0
@@ -102,7 +102,7 @@ for changed_file in "${changed_files[@]}"; do
     *.cjs | *.css | *.js | *.jsx | *.mjs | *.ts | *.tsx | \
       *.graphql | relay.config.json | contrib/merge-graphql-schema.sh | \
       package.json | package-lock.json | turbo.json | \
-      apps/* | apps/**/* | packages/* | packages/**/*)
+      apps/* | packages/*)
       javascript="true"
       ;;
   esac
@@ -115,15 +115,14 @@ for changed_file in "${changed_files[@]}"; do
 
   case "$changed_file" in
     .swift-format | .swiftlint.yml | \
-      cmd/probo-agent/installer/macos/enroll-ui/* | \
-      cmd/probo-agent/installer/macos/enroll-ui/**/*)
+      cmd/probo-agent/installer/macos/enroll-ui/*)
       swift="true"
       ;;
   esac
 
   case "$changed_file" in
-    cfg/* | cfg/**/* | compose.yaml | compose.github-action.yaml | \
-      compose/* | compose/**/* | e2e/* | e2e/**/*)
+    cfg/* | compose.yaml | compose.github-action.yaml | \
+      compose/* | e2e/*)
       e2e="true"
       ;;
   esac

--- a/contrib/ci/classify-changes.sh
+++ b/contrib/ci/classify-changes.sh
@@ -80,6 +80,9 @@ shell="false"
 swift="false"
 e2e="$probod"
 frontend="false"
+isolated_package_changed="false"
+isolated_package_only="true"
+lockfile_changed="false"
 snapshot="false"
 
 for changed_file in "${changed_files[@]}"; do
@@ -109,13 +112,25 @@ for changed_file in "${changed_files[@]}"; do
   esac
 
   case "$changed_file" in
-    .nvmrc | package.json | package-lock.json | turbo.json | \
+    .nvmrc | package.json | turbo.json | \
       apps/compliance-portal/* | apps/console/* | \
       packages/coredata/* | packages/emails/* | packages/helpers/* | \
       packages/hooks/* | packages/i18n/* | packages/prosemirror/* | \
       packages/react-lazy/* | packages/relay/* | packages/routes/* | \
       packages/tsconfig/* | packages/ui/*)
       frontend="true"
+      ;;
+  esac
+
+  case "$changed_file" in
+    package-lock.json)
+      lockfile_changed="true"
+      ;;
+    packages/cookie-banner/* | packages/n8n-node/* | packages/skills/*)
+      isolated_package_changed="true"
+      ;;
+    *)
+      isolated_package_only="false"
       ;;
   esac
 
@@ -147,6 +162,11 @@ for changed_file in "${changed_files[@]}"; do
       ;;
   esac
 done
+
+if [[ "$lockfile_changed" == "true" &&
+  ("$isolated_package_changed" == "false" || "$isolated_package_only" == "false") ]]; then
+  frontend="true"
+fi
 
 if [[ "$probod" == "true" ||
   "$prb" == "true" ||

--- a/contrib/ci/go-package-affected.sh
+++ b/contrib/ci/go-package-affected.sh
@@ -30,8 +30,8 @@ repository_root="$(git rev-parse --show-toplevel)"
 
 # A shallow checkout can omit the comparison commit after a multi-commit push.
 # Build in that case instead of risking a false negative.
-if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null ||
-  ! git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
+if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null \
+  || ! git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
   echo "true"
   exit 0
 fi
@@ -42,10 +42,10 @@ mapfile -t changed_files < <(
 
 for changed_file in "${changed_files[@]}"; do
   case "$changed_file" in
-  go.mod | go.sum | .github/workflows/make.yaml | contrib/ci/go-package-affected.sh)
-    echo "true"
-    exit 0
-    ;;
+    go.mod | go.sum | .github/workflows/make.yaml | contrib/ci/go-package-affected.sh)
+      echo "true"
+      exit 0
+      ;;
   esac
 done
 

--- a/contrib/ci/go-package-affected.sh
+++ b/contrib/ci/go-package-affected.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Probo Inc <hello@probo.com>.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+
+base_sha="${1:?base SHA is required}"
+head_sha="${2:?head SHA is required}"
+package="${3:?Go package is required}"
+
+repository_root="$(git rev-parse --show-toplevel)"
+
+# A shallow checkout can omit the comparison commit after a multi-commit push.
+# Build in that case instead of risking a false negative.
+if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null ||
+  ! git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
+  echo "true"
+  exit 0
+fi
+
+mapfile -t changed_files < <(
+  git diff --name-only --no-renames "$base_sha" "$head_sha"
+)
+
+for changed_file in "${changed_files[@]}"; do
+  case "$changed_file" in
+  go.mod | go.sum | .github/workflows/make.yaml | contrib/ci/go-package-affected.sh)
+    echo "true"
+    exit 0
+    ;;
+  esac
+done
+
+if ! dependency_output="$(
+  CGO_ENABLED=0 go list -deps \
+    -f '{{if .Module}}{{if .Module.Main}}{{.Dir}}{{end}}{{end}}' \
+    "$package"
+)"; then
+  echo "true"
+  exit 0
+fi
+
+mapfile -t dependency_dirs < <(
+  printf '%s\n' "$dependency_output" | awk 'NF' | sort -u
+)
+
+for changed_file in "${changed_files[@]}"; do
+  if [[ "$changed_file" == *_test.go ]]; then
+    continue
+  fi
+
+  absolute_path="${repository_root}/${changed_file}"
+  for dependency_dir in "${dependency_dirs[@]}"; do
+    if [[ "$absolute_path" == "$dependency_dir" ||
+      "$absolute_path" == "$dependency_dir/"* ]]; then
+      echo "true"
+      exit 0
+    fi
+  done
+done
+
+echo "false"

--- a/contrib/claude/e2e.md
+++ b/contrib/claude/e2e.md
@@ -43,12 +43,10 @@ application coverage. The coverage target writes:
 - `coverage-e2e-core.*` — profile, text, and HTML for core product packages
 - `coverage-e2e-packages.txt` — package-level statement coverage
 
-CI runs the normal and instrumented suites in parallel. The required
-`test-e2e` check provides fast feedback, while `test-e2e-coverage` publishes the
-full-binary and core-product totals in its job summary and uploads all reports
-with its JUnit and journey artifacts. Coverage is collected from the probod
-process, not from the E2E test driver. Override `E2E_CORE_COVER_PKGS` when
-auditing a different product-package boundary. The coverage job runs Console
+CI runs only `test-e2e`. It does not run `test-e2e-coverage` because the
+instrumented suite is too slow. Coverage is collected from the probod
+process, not from the E2E test driver. Override `E2E_CORE_COVER_PKGS` when you
+audit a different product-package boundary. The coverage target runs Console
 and MCP packages sequentially because each package starts probod on the same
 fixed ports. Trust remains separate until its managed-domain certificate
 harness can be coverage-gated reliably.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- cancel superseded make, CodeQL, and secret-scan executions
- build real email assets once and reuse the resulting probod binary in end-to-end tests
- use Go dependency trees and changed-path classification to skip unaffected jobs
- avoid probod snapshots for isolated npm package releases and lockfile version bumps
- limit routine snapshot binary and Docker builds to Linux/amd64
- retain full multi-platform matrices in release workflows
- rely on active GitHub default setup for Go/JavaScript CodeQL and limit the custom workflow to Actions analysis

## Results

- `test-e2e` execution fell from 630 to 400 seconds (37%)
- the initial reuse changes reduced a full PR `make` run from 28.1 to 22.8 runner-minutes (19%)
- change classification adds 26 seconds, then skips unrelated Go, JS, Swift, shell, agent, E2E, and snapshot jobs
- routine platform reduction removes about 34 runner-minutes per main push
- Go and JavaScript CodeQL are no longer analyzed twice
- superseded PR and main runs cancel automatically

## Validation

- `make go-fmt`
- `actionlint` on all modified workflows
- ShellCheck and shfmt on CI classification scripts
- dependency and path classifier true/false fixture checks
- all required GitHub Actions checks passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd3c7908-aeca-4e97-b597-f775471daa48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd3c7908-aeca-4e97-b597-f775471daa48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancels superseded CI runs and speeds up checks by reusing a single probod build in E2E and skipping unaffected jobs. Limits routine snapshots to Linux/amd64, restricts CodeQL to Actions files, and removes the slow E2E coverage job.

### Other **`+358`** **`-125`**
- Adds concurrency groups (cancel in progress) to `make`, `codeql`, and `secrets` workflows.
- Introduces a `changes` job that gates agent/build/e2e/lint/test/snapshot jobs via path and Go-deps analysis; falls back to a full run when comparison SHAs are missing.
- Builds `@probo/emails` before compiling; uploads a `probod-ci` artifact and reuses it in E2E to avoid Node setup and a second compile.
- Limits routine snapshots to Linux/amd64 binary and Docker; removes snapshot `probo-agent`; gates the normal `probo-agent` build on its Go dependency tree.
- Restricts the custom CodeQL workflow to `.github/**` and Actions analysis only.
- Drops `test-e2e-coverage`; CI runs only `test-e2e`.

### Agents **`+4`** **`-6`**
- Updates E2E docs to note CI runs only `test-e2e`; coverage remains available locally.

<sup>Written for commit d6eb61183ea4aabf625fc8169f3c4a16ba14e8f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

