### PR TITLE
Store SCIM event request and response bodies

### DIFF
--- a/e2e/console/scim_event_test.go
+++ b/e2e/console/scim_event_test.go
@@ -15,12 +15,189 @@
 package console_test
 
 import (
+	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
 	"go.probo.inc/probo/e2e/internal/testutil"
 )
+
+type scimEventNode struct {
+	ID           string  `json:"id"`
+	Method       string  `json:"method"`
+	Path         string  `json:"path"`
+	StatusCode   int     `json:"statusCode"`
+	UserName     string  `json:"userName"`
+	RequestBody  *string `json:"requestBody"`
+	ResponseBody *string `json:"responseBody"`
+	ErrorMessage *string `json:"errorMessage"`
+}
+
+func listSCIMEvents(t *testing.T, owner *testutil.Client, configID string) []scimEventNode {
+	t.Helper()
+
+	const query = `
+		query($id: ID!) {
+			node(id: $id) {
+				... on SCIMConfiguration {
+					events(first: 50, orderBy: { field: CREATED_AT, direction: DESC }) {
+						edges {
+							node {
+								id
+								method
+								path
+								statusCode
+								userName
+								requestBody
+								responseBody
+								errorMessage
+							}
+						}
+					}
+				}
+			}
+		}
+	`
+
+	var result struct {
+		Node struct {
+			Events struct {
+				Edges []struct {
+					Node scimEventNode `json:"node"`
+				} `json:"edges"`
+			} `json:"events"`
+		} `json:"node"`
+	}
+
+	err := owner.ExecuteConnect(query, map[string]any{"id": configID}, &result)
+	require.NoError(t, err)
+
+	events := make([]scimEventNode, 0, len(result.Node.Events.Edges))
+	for _, edge := range result.Node.Events.Edges {
+		events = append(events, edge.Node)
+	}
+
+	return events
+}
+
+func findSCIMEvent(t *testing.T, events []scimEventNode, method string, userName string) scimEventNode {
+	t.Helper()
+
+	for _, event := range events {
+		if event.Method == method && event.UserName == userName {
+			return event
+		}
+	}
+
+	t.Fatalf("SCIM event not found for method=%s userName=%s", method, userName)
+	return scimEventNode{}
+}
+
+func requireJSONContains(t *testing.T, raw *string, key string, want any) {
+	t.Helper()
+
+	require.NotNil(t, raw)
+	require.NotEmpty(t, *raw)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(*raw), &payload))
+	assert.Equal(t, want, payload[key])
+}
+
+func TestSCIMEvent_StoresPayload(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	sc := newSCIMClient(t, owner)
+
+	email := factory.SafeEmail()
+	externalID := "ext-event-" + factory.SafeName("")
+
+	body, status := sc.createUser(email, "Event User", externalID, true)
+	require.Equal(t, http.StatusCreated, status, body)
+
+	var created map[string]any
+	require.NoError(t, json.Unmarshal([]byte(body), &created))
+	userID := created["id"].(string)
+
+	body, status = sc.replaceUser(userID, email, "Event User Updated", externalID, true)
+	require.Equal(t, http.StatusOK, status, body)
+
+	body, status = sc.patchUser(userID, []map[string]any{
+		{
+			"op":    "replace",
+			"path":  "active",
+			"value": false,
+		},
+	})
+	require.Equal(t, http.StatusOK, status, body)
+
+	body, status = sc.getUser(userID)
+	require.Equal(t, http.StatusOK, status, body)
+
+	events := listSCIMEvents(t, owner, sc.configID)
+
+	t.Run("create stores request and response bodies", func(t *testing.T) {
+		t.Parallel()
+
+		event := findSCIMEvent(t, events, "POST", email)
+		assert.Equal(t, 201, event.StatusCode)
+		assert.Equal(t, "/Users", event.Path)
+		requireJSONContains(t, event.RequestBody, "userName", email)
+		requireJSONContains(t, event.ResponseBody, "userName", email)
+		requireJSONContains(t, event.ResponseBody, "id", userID)
+	})
+
+	t.Run("replace stores request and response bodies", func(t *testing.T) {
+		t.Parallel()
+
+		event := findSCIMEvent(t, events, "PUT", email)
+		assert.Equal(t, 200, event.StatusCode)
+		assert.Equal(t, "/Users/"+userID, event.Path)
+		requireJSONContains(t, event.RequestBody, "userName", email)
+		requireJSONContains(t, event.RequestBody, "displayName", "Event User Updated")
+		requireJSONContains(t, event.ResponseBody, "id", userID)
+	})
+
+	t.Run("patch stores request and response bodies", func(t *testing.T) {
+		t.Parallel()
+
+		event := findSCIMEvent(t, events, "PATCH", email)
+		assert.Equal(t, 200, event.StatusCode)
+		assert.Equal(t, "/Users/"+userID, event.Path)
+
+		require.NotNil(t, event.RequestBody)
+		var request map[string]any
+		require.NoError(t, json.Unmarshal([]byte(*event.RequestBody), &request))
+
+		ops, ok := request["Operations"].([]any)
+		require.True(t, ok)
+		require.Len(t, ops, 1)
+
+		op, ok := ops[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "replace", op["op"])
+		assert.Equal(t, "active", op["path"])
+		assert.Equal(t, false, op["value"])
+
+		requireJSONContains(t, event.ResponseBody, "id", userID)
+		requireJSONContains(t, event.ResponseBody, "active", false)
+	})
+
+	t.Run("get stores response body without request body", func(t *testing.T) {
+		t.Parallel()
+
+		event := findSCIMEvent(t, events, "GET", email)
+		assert.Equal(t, 200, event.StatusCode)
+		assert.Equal(t, "/Users/"+userID, event.Path)
+		assert.Nil(t, event.RequestBody)
+		requireJSONContains(t, event.ResponseBody, "id", userID)
+		requireJSONContains(t, event.ResponseBody, "userName", email)
+	})
+}
 
 func TestSCIMEvent_Export(t *testing.T) {
 	t.Parallel()

--- a/e2e/console/scim_event_test.go
+++ b/e2e/console/scim_event_test.go
@@ -93,6 +93,7 @@ func findSCIMEvent(t *testing.T, events []scimEventNode, method string, userName
 	}
 
 	t.Fatalf("SCIM event not found for method=%s among %d events", method, len(events))
+
 	return scimEventNode{}
 }
 

--- a/e2e/console/scim_event_test.go
+++ b/e2e/console/scim_event_test.go
@@ -92,11 +92,11 @@ func findSCIMEvent(t *testing.T, events []scimEventNode, method string, userName
 		}
 	}
 
-	t.Fatalf("SCIM event not found for method=%s userName=%s", method, userName)
+	t.Fatalf("SCIM event not found for method=%s among %d events", method, len(events))
 	return scimEventNode{}
 }
 
-func requireJSONContains(t *testing.T, raw *string, key string, want any) {
+func decodeJSON(t *testing.T, raw *string) map[string]any {
 	t.Helper()
 
 	require.NotNil(t, raw)
@@ -104,7 +104,14 @@ func requireJSONContains(t *testing.T, raw *string, key string, want any) {
 
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal([]byte(*raw), &payload))
-	assert.Equal(t, want, payload[key])
+
+	return payload
+}
+
+func requireJSONContains(t *testing.T, raw *string, key string, want any) {
+	t.Helper()
+
+	assert.Equal(t, want, decodeJSON(t, raw)[key])
 }
 
 func TestSCIMEvent_StoresPayload(t *testing.T) {
@@ -149,6 +156,12 @@ func TestSCIMEvent_StoresPayload(t *testing.T) {
 		requireJSONContains(t, event.RequestBody, "userName", email)
 		requireJSONContains(t, event.ResponseBody, "userName", email)
 		requireJSONContains(t, event.ResponseBody, "id", userID)
+
+		// The stored response is the payload served to the client, so it carries
+		// the envelope fields the SCIM server adds.
+		response := decodeJSON(t, event.ResponseBody)
+		assert.Contains(t, response, "schemas")
+		assert.Contains(t, response, "meta")
 	})
 
 	t.Run("replace stores request and response bodies", func(t *testing.T) {
@@ -169,11 +182,7 @@ func TestSCIMEvent_StoresPayload(t *testing.T) {
 		assert.Equal(t, 200, event.StatusCode)
 		assert.Equal(t, "/Users/"+userID, event.Path)
 
-		require.NotNil(t, event.RequestBody)
-		var request map[string]any
-		require.NoError(t, json.Unmarshal([]byte(*event.RequestBody), &request))
-
-		ops, ok := request["Operations"].([]any)
+		ops, ok := decodeJSON(t, event.RequestBody)["Operations"].([]any)
 		require.True(t, ok)
 		require.Len(t, ops, 1)
 

--- a/e2e/console/scim_test.go
+++ b/e2e/console/scim_test.go
@@ -81,10 +81,8 @@ func newSCIMClient(t testing.TB, owner *testutil.Client) *scimClient {
 	}
 }
 
-func (sc *scimClient) createUser(userName, fullName, externalID string, active bool) (string, int) {
-	sc.t.Helper()
-
-	payload := map[string]any{
+func buildUserPayload(userName, fullName, externalID string, active bool) map[string]any {
+	return map[string]any{
 		"schemas":    []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
 		"userName":   userName,
 		"active":     active,
@@ -98,8 +96,12 @@ func (sc *scimClient) createUser(userName, fullName, externalID string, active b
 			{"value": userName, "primary": true},
 		},
 	}
+}
 
-	return sc.doRequest("POST", "/Users", payload)
+func (sc *scimClient) createUser(userName, fullName, externalID string, active bool) (string, int) {
+	sc.t.Helper()
+
+	return sc.doRequest("POST", "/Users", buildUserPayload(userName, fullName, externalID, active))
 }
 
 func (sc *scimClient) listUsers() (string, int) {
@@ -120,22 +122,7 @@ func (sc *scimClient) deleteUser(id string) (string, int) {
 func (sc *scimClient) replaceUser(id, userName, fullName, externalID string, active bool) (string, int) {
 	sc.t.Helper()
 
-	payload := map[string]any{
-		"schemas":    []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
-		"userName":   userName,
-		"active":     active,
-		"externalId": externalID,
-		"name": map[string]any{
-			"givenName":  "Test",
-			"familyName": "User",
-		},
-		"displayName": fullName,
-		"emails": []map[string]any{
-			{"value": userName, "primary": true},
-		},
-	}
-
-	return sc.doRequest("PUT", "/Users/"+id, payload)
+	return sc.doRequest("PUT", "/Users/"+id, buildUserPayload(userName, fullName, externalID, active))
 }
 
 func (sc *scimClient) patchUser(id string, operations []map[string]any) (string, int) {

--- a/e2e/console/scim_test.go
+++ b/e2e/console/scim_test.go
@@ -38,6 +38,7 @@ type scimClient struct {
 	client   *http.Client
 	token    string
 	endpoint string
+	configID string
 }
 
 func newSCIMClient(t testing.TB, owner *testutil.Client) *scimClient {
@@ -69,12 +70,14 @@ func newSCIMClient(t testing.TB, owner *testutil.Client) *scimClient {
 	require.NoError(t, err, "GraphQL request failed")
 
 	require.NotEmpty(t, result.CreateSCIMConfiguration.Token)
+	require.NotEmpty(t, result.CreateSCIMConfiguration.ScimConfiguration.ID)
 
 	return &scimClient{
 		t:        t,
 		client:   &http.Client{},
 		token:    result.CreateSCIMConfiguration.Token,
 		endpoint: testutil.GetBaseURL() + "/api/connect/v1/scim/2.0",
+		configID: result.CreateSCIMConfiguration.ScimConfiguration.ID,
 	}
 }
 
@@ -112,6 +115,38 @@ func (sc *scimClient) getUser(id string) (string, int) {
 func (sc *scimClient) deleteUser(id string) (string, int) {
 	sc.t.Helper()
 	return sc.doRequest("DELETE", "/Users/"+id, nil)
+}
+
+func (sc *scimClient) replaceUser(id, userName, fullName, externalID string, active bool) (string, int) {
+	sc.t.Helper()
+
+	payload := map[string]any{
+		"schemas":    []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+		"userName":   userName,
+		"active":     active,
+		"externalId": externalID,
+		"name": map[string]any{
+			"givenName":  "Test",
+			"familyName": "User",
+		},
+		"displayName": fullName,
+		"emails": []map[string]any{
+			{"value": userName, "primary": true},
+		},
+	}
+
+	return sc.doRequest("PUT", "/Users/"+id, payload)
+}
+
+func (sc *scimClient) patchUser(id string, operations []map[string]any) (string, int) {
+	sc.t.Helper()
+
+	payload := map[string]any{
+		"schemas":    []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+		"Operations": operations,
+	}
+
+	return sc.doRequest("PATCH", "/Users/"+id, payload)
 }
 
 func (sc *scimClient) doRequest(method, path string, payload any) (string, int) {

--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -1016,10 +1016,22 @@ func (s *Service) LogEvent(
 	ipAddress net.IP,
 	statusCode int,
 	errorMessage *string,
+	requestBody *string,
+	responseBody *string,
 ) {
 	scope := coredata.NewScopeFromObjectID(config.OrganizationID)
 
-	event := s.createEvent(config, method, path, userName, ipAddress, statusCode, errorMessage)
+	event := s.createEvent(
+		config,
+		method,
+		path,
+		userName,
+		ipAddress,
+		statusCode,
+		errorMessage,
+		requestBody,
+		responseBody,
+	)
 
 	err := s.pg.WithTx(
 		ctx,
@@ -1045,6 +1057,8 @@ func (s *Service) createEvent(
 	ipAddress net.IP,
 	statusCode int,
 	errorMessage *string,
+	requestBody *string,
+	responseBody *string,
 ) *coredata.SCIMEvent {
 	event := &coredata.SCIMEvent{
 		ID:                  gid.New(config.OrganizationID.TenantID(), coredata.SCIMEventEntityType),
@@ -1052,6 +1066,8 @@ func (s *Service) createEvent(
 		SCIMConfigurationID: config.ID,
 		Method:              method,
 		Path:                path,
+		RequestBody:         requestBody,
+		ResponseBody:        responseBody,
 		StatusCode:          statusCode,
 		ErrorMessage:        errorMessage,
 		IPAddress:           ipAddress,

--- a/pkg/server/api/connect/v1/resolver.go
+++ b/pkg/server/api/connect/v1/resolver.go
@@ -131,7 +131,15 @@ func NewMux(
 
 	// SCIM 2.0 endpoints - these use their own bearer token authentication
 	scimServer := NewSCIMServer(scimHandler)
-	r.Mount("/scim/2.0", http.StripPrefix("/scim/2.0", scimHandler.BearerTokenMiddleware(scimServer)))
+	r.Mount(
+		"/scim/2.0",
+		http.StripPrefix(
+			"/scim/2.0",
+			scimHandler.BearerTokenMiddleware(
+				scimHandler.EventLoggingMiddleware(scimServer),
+			),
+		),
+	)
 
 	// OAuth2 / OpenID Connect server endpoints.
 

--- a/pkg/server/api/connect/v1/scim_handler.go
+++ b/pkg/server/api/connect/v1/scim_handler.go
@@ -21,9 +21,11 @@
 package connect_v1
 
 import (
+	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 
@@ -54,21 +56,28 @@ type (
 		handler *SCIMHandler
 	}
 
-	scimRequestContext struct {
-		ctx          context.Context
-		config       *coredata.SCIMConfiguration
-		ipAddress    net.IP
-		method       string
-		path         string
+	// scimEventRecorder collects the parts of a SCIM audit event that only the
+	// resource handler knows about. The event itself is written by
+	// EventLoggingMiddleware once the response has been served.
+	scimEventRecorder struct {
+		handled      bool
 		userName     string
-		requestBody  *string
-		responseBody *string
-		handler      *scimResourceHandler
+		errorMessage *string
+	}
+
+	// scimResponseRecorder captures the status code and body served to the
+	// provisioning client so the audit event stores the exact response.
+	scimResponseRecorder struct {
+		http.ResponseWriter
+
+		statusCode int
+		body       bytes.Buffer
 	}
 )
 
 var (
-	scimConfigCtxKey = &ctxKey{name: "scim_config"}
+	scimConfigCtxKey        = &ctxKey{name: "scim_config"}
+	scimEventRecorderCtxKey = &ctxKey{name: "scim_event_recorder"}
 )
 
 func NewSCIMHandler(iam *iam.Service, logger *log.Logger) *SCIMHandler {
@@ -78,6 +87,48 @@ func NewSCIMHandler(iam *iam.Service, logger *log.Logger) *SCIMHandler {
 func scimConfigFromContext(ctx context.Context) *coredata.SCIMConfiguration {
 	config, _ := ctx.Value(scimConfigCtxKey).(*coredata.SCIMConfiguration)
 	return config
+}
+
+func scimEventRecorderFromContext(ctx context.Context) *scimEventRecorder {
+	recorder, _ := ctx.Value(scimEventRecorderCtxKey).(*scimEventRecorder)
+	return recorder
+}
+
+// markHandled flags the request as one of our resource operations, which is what
+// makes it eligible for a SCIM audit event. Discovery endpoints served directly
+// by the SCIM server never reach a resource handler and stay unlogged.
+func (rec *scimEventRecorder) markHandled() {
+	if rec == nil {
+		return
+	}
+
+	rec.handled = true
+}
+
+func (rec *scimEventRecorder) setUserName(userName string) {
+	if rec == nil {
+		return
+	}
+
+	rec.userName = userName
+}
+
+func (rec *scimEventRecorder) setErrorMessage(errorMessage string) {
+	if rec == nil {
+		return
+	}
+
+	rec.errorMessage = &errorMessage
+}
+
+func (rr *scimResponseRecorder) WriteHeader(statusCode int) {
+	rr.statusCode = statusCode
+	rr.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (rr *scimResponseRecorder) Write(b []byte) (int, error) {
+	rr.body.Write(b)
+	return rr.ResponseWriter.Write(b)
 }
 
 // NewSCIMServer creates a new SCIM server using elimity-com/scim
@@ -156,149 +207,162 @@ func (h *SCIMHandler) BearerTokenMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func (rc *scimRequestContext) logAndWrapError(err error, logMsg string) error {
-	if scimErr, ok := errors.AsType[scimerrors.ScimError](err); ok {
-		errMsg := scimErr.Detail
-
-		// Don't reference profileID for 404 errors - the resource doesn't exist
-		userName := rc.userName
-		if scimErr.Status == http.StatusNotFound {
-			userName = ""
+// EventLoggingMiddleware records a SCIM audit event for every resource
+// operation, storing the request and response bodies exactly as they were
+// exchanged with the provisioning client. It must run after
+// BearerTokenMiddleware, which resolves the SCIM configuration.
+func (h *SCIMHandler) EventLoggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		config := scimConfigFromContext(r.Context())
+		if config == nil {
+			next.ServeHTTP(w, r)
+			return
 		}
 
-		rc.handler.handler.iam.SCIMService.LogEvent(
-			rc.ctx,
-			rc.config,
-			rc.method,
-			rc.path,
-			userName,
-			rc.ipAddress,
-			scimErr.Status,
-			&errMsg,
-			rc.requestBody,
-			rc.responseBody,
+		requestBody, err := drainRequestBody(r)
+		if err != nil {
+			h.logger.ErrorCtx(r.Context(), "cannot read SCIM request body", log.Error(err))
+			httpserver.RenderError(w, http.StatusBadRequest, errors.New("cannot read request body"))
+
+			return
+		}
+
+		recorder := &scimEventRecorder{}
+		responseRecorder := &scimResponseRecorder{ResponseWriter: w, statusCode: http.StatusOK}
+
+		ctx := context.WithValue(r.Context(), scimEventRecorderCtxKey, recorder)
+		next.ServeHTTP(responseRecorder, r.WithContext(ctx))
+
+		if !recorder.handled {
+			return
+		}
+
+		h.iam.SCIMService.LogEvent(
+			r.Context(),
+			config,
+			r.Method,
+			requestPath(r),
+			recorder.userName,
+			getIPAddress(r),
+			responseRecorder.statusCode,
+			recorder.errorMessage,
+			bodyOrNil(requestBody),
+			bodyOrNil(responseRecorder.body.Bytes()),
 		)
+	})
+}
+
+// recordError turns a service error into the error returned to the provisioning
+// client, and records its detail on the audit event. Unexpected errors are
+// logged and reported as an opaque internal error.
+func (h *scimResourceHandler) recordError(
+	ctx context.Context,
+	recorder *scimEventRecorder,
+	err error,
+	logMsg string,
+) error {
+	if scimErr, ok := errors.AsType[scimerrors.ScimError](err); ok {
+		recorder.setErrorMessage(scimErr.Detail)
 
 		return err
 	}
 
-	rc.handler.handler.logger.ErrorCtx(rc.ctx, logMsg, log.Error(err))
-
-	errMsg := "internal server error"
-	rc.handler.handler.iam.SCIMService.LogEvent(
-		rc.ctx,
-		rc.config,
-		rc.method,
-		rc.path,
-		rc.userName,
-		rc.ipAddress,
-		500,
-		&errMsg,
-		rc.requestBody,
-		rc.responseBody,
-	)
+	h.handler.logger.ErrorCtx(ctx, logMsg, log.Error(err))
+	recorder.setErrorMessage("internal server error")
 
 	return scimerrors.ScimErrorInternal
 }
 
-func (rc *scimRequestContext) logSuccess(statusCode int) {
-	rc.handler.handler.iam.SCIMService.LogEvent(
-		rc.ctx,
-		rc.config,
-		rc.method,
-		rc.path,
-		rc.userName,
-		rc.ipAddress,
-		statusCode,
-		nil,
-		rc.requestBody,
-		rc.responseBody,
-	)
+// drainRequestBody reads the request body so it can be stored on the audit
+// event, and restores it for the SCIM server to consume.
+func drainRequestBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read request body: %w", err)
+	}
+
+	_ = r.Body.Close()
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	return body, nil
+}
+
+func requestPath(r *http.Request) string {
+	if r.URL.RawQuery == "" {
+		return r.URL.Path
+	}
+
+	return r.URL.Path + "?" + r.URL.RawQuery
+}
+
+func bodyOrNil(body []byte) *string {
+	if len(body) == 0 {
+		return nil
+	}
+
+	s := string(body)
+
+	return &s
 }
 
 func (h *scimResourceHandler) Create(r *http.Request, attributes scim.ResourceAttributes) (scim.Resource, error) {
-	rc := &scimRequestContext{
-		ctx:         r.Context(),
-		config:      scimConfigFromContext(r.Context()),
-		ipAddress:   getIPAddress(r),
-		method:      "POST",
-		path:        "/Users",
-		requestBody: marshalSCIMPayload(attributes),
-		handler:     h,
-	}
+	ctx := r.Context()
+	recorder := scimEventRecorderFromContext(ctx)
+	recorder.markHandled()
 
-	resource, err := h.handler.iam.SCIMService.CreateUser(rc.ctx, rc.config, attributes)
+	resource, err := h.handler.iam.SCIMService.CreateUser(ctx, scimConfigFromContext(ctx), attributes)
 	if err != nil {
-		return scim.Resource{}, rc.logAndWrapError(err, "cannot create user")
+		return scim.Resource{}, h.recordError(ctx, recorder, err, "cannot create user")
 	}
 
-	rc.userName = resource.Attributes["userName"].(string)
-	rc.responseBody = marshalSCIMResource(resource)
-
-	rc.logSuccess(201)
+	recorder.setUserName(resource.Attributes["userName"].(string))
 
 	return resource, nil
 }
 
 func (h *scimResourceHandler) Get(r *http.Request, id string) (scim.Resource, error) {
-	rc := &scimRequestContext{
-		ctx:       r.Context(),
-		config:    scimConfigFromContext(r.Context()),
-		ipAddress: getIPAddress(r),
-		method:    "GET",
-		path:      "/Users/" + id,
-		handler:   h,
-	}
+	ctx := r.Context()
+	recorder := scimEventRecorderFromContext(ctx)
+	recorder.markHandled()
 
 	profileID, err := gid.ParseGID(id)
 	if err != nil {
-		return scim.Resource{}, rc.logAndWrapError(scimerrors.ScimErrorResourceNotFound(id), "invalid profile ID")
+		return scim.Resource{}, h.recordError(ctx, recorder, scimerrors.ScimErrorResourceNotFound(id), "invalid profile ID")
 	}
 
-	resource, err := h.handler.iam.SCIMService.GetUser(rc.ctx, rc.config, profileID)
+	resource, err := h.handler.iam.SCIMService.GetUser(ctx, scimConfigFromContext(ctx), profileID)
 	if err != nil {
-		return scim.Resource{}, rc.logAndWrapError(err, "cannot get user")
+		return scim.Resource{}, h.recordError(ctx, recorder, err, "cannot get user")
 	}
 
-	rc.userName = resource.Attributes["userName"].(string)
-	rc.responseBody = marshalSCIMResource(resource)
-
-	rc.logSuccess(200)
+	recorder.setUserName(resource.Attributes["userName"].(string))
 
 	return resource, nil
 }
 
 func (h *scimResourceHandler) GetAll(r *http.Request, params scim.ListRequestParams) (scim.Page, error) {
-	path := "/Users"
-	if r.URL.RawQuery != "" {
-		path += "?" + r.URL.RawQuery
-	}
-
-	rc := &scimRequestContext{
-		ctx:       r.Context(),
-		config:    scimConfigFromContext(r.Context()),
-		ipAddress: getIPAddress(r),
-		method:    "GET",
-		path:      path,
-		handler:   h,
-	}
+	ctx := r.Context()
+	recorder := scimEventRecorderFromContext(ctx)
+	recorder.markHandled()
 
 	var filterExpr scimfilter.Expression
 
 	if params.FilterValidator != nil {
 		if err := params.FilterValidator.Validate(); err != nil {
-			return scim.Page{}, rc.logAndWrapError(scimerrors.ScimErrorBadRequest(err.Error()), "invalid filter")
+			return scim.Page{}, h.recordError(ctx, recorder, scimerrors.ScimErrorBadRequest(err.Error()), "invalid filter")
 		}
 
 		filterExpr = params.FilterValidator.GetFilter()
 	}
 
-	resources, totalCount, err := h.handler.iam.SCIMService.ListUsers(rc.ctx, rc.config, filterExpr, params.StartIndex, params.Count)
+	resources, totalCount, err := h.handler.iam.SCIMService.ListUsers(ctx, scimConfigFromContext(ctx), filterExpr, params.StartIndex, params.Count)
 	if err != nil {
-		return scim.Page{}, rc.logAndWrapError(err, "cannot list users")
+		return scim.Page{}, h.recordError(ctx, recorder, err, "cannot list users")
 	}
-
-	rc.logSuccess(200)
 
 	return scim.Page{
 		TotalResults: totalCount,
@@ -307,86 +371,58 @@ func (h *scimResourceHandler) GetAll(r *http.Request, params scim.ListRequestPar
 }
 
 func (h *scimResourceHandler) Replace(r *http.Request, id string, attributes scim.ResourceAttributes) (scim.Resource, error) {
-	rc := &scimRequestContext{
-		ctx:         r.Context(),
-		config:      scimConfigFromContext(r.Context()),
-		ipAddress:   getIPAddress(r),
-		method:      "PUT",
-		path:        "/Users/" + id,
-		requestBody: marshalSCIMPayload(attributes),
-		handler:     h,
-	}
+	ctx := r.Context()
+	recorder := scimEventRecorderFromContext(ctx)
+	recorder.markHandled()
 
 	profileID, err := gid.ParseGID(id)
 	if err != nil {
-		return scim.Resource{}, rc.logAndWrapError(scimerrors.ScimErrorResourceNotFound(id), "invalid profile ID")
+		return scim.Resource{}, h.recordError(ctx, recorder, scimerrors.ScimErrorResourceNotFound(id), "invalid profile ID")
 	}
 
-	resource, err := h.handler.iam.SCIMService.ReplaceUser(rc.ctx, rc.config, profileID, attributes)
+	resource, err := h.handler.iam.SCIMService.ReplaceUser(ctx, scimConfigFromContext(ctx), profileID, attributes)
 	if err != nil {
-		return scim.Resource{}, rc.logAndWrapError(err, "cannot update user")
+		return scim.Resource{}, h.recordError(ctx, recorder, err, "cannot update user")
 	}
 
-	rc.userName = resource.Attributes["userName"].(string)
-	rc.responseBody = marshalSCIMResource(resource)
-
-	rc.logSuccess(200)
+	recorder.setUserName(resource.Attributes["userName"].(string))
 
 	return resource, nil
 }
 
 func (h *scimResourceHandler) Patch(r *http.Request, id string, operations []scim.PatchOperation) (scim.Resource, error) {
-	rc := &scimRequestContext{
-		ctx:         r.Context(),
-		config:      scimConfigFromContext(r.Context()),
-		ipAddress:   getIPAddress(r),
-		method:      "PATCH",
-		path:        "/Users/" + id,
-		requestBody: marshalSCIMPatchOperations(operations),
-		handler:     h,
-	}
+	ctx := r.Context()
+	recorder := scimEventRecorderFromContext(ctx)
+	recorder.markHandled()
 
 	profileID, err := gid.ParseGID(id)
 	if err != nil {
-		return scim.Resource{}, rc.logAndWrapError(scimerrors.ScimErrorResourceNotFound(id), "invalid profile ID")
+		return scim.Resource{}, h.recordError(ctx, recorder, scimerrors.ScimErrorResourceNotFound(id), "invalid profile ID")
 	}
 
-	resource, err := h.handler.iam.SCIMService.PatchUser(rc.ctx, rc.config, profileID, operations)
+	resource, err := h.handler.iam.SCIMService.PatchUser(ctx, scimConfigFromContext(ctx), profileID, operations)
 	if err != nil {
-		return scim.Resource{}, rc.logAndWrapError(err, "cannot patch user")
+		return scim.Resource{}, h.recordError(ctx, recorder, err, "cannot patch user")
 	}
 
-	rc.userName = resource.Attributes["userName"].(string)
-	rc.responseBody = marshalSCIMResource(resource)
-
-	rc.logSuccess(200)
+	recorder.setUserName(resource.Attributes["userName"].(string))
 
 	return resource, nil
 }
 
 func (h *scimResourceHandler) Delete(r *http.Request, id string) error {
-	rc := &scimRequestContext{
-		ctx:       r.Context(),
-		config:    scimConfigFromContext(r.Context()),
-		ipAddress: getIPAddress(r),
-		method:    "DELETE",
-		path:      "/Users/" + id,
-		handler:   h,
-	}
+	ctx := r.Context()
+	recorder := scimEventRecorderFromContext(ctx)
+	recorder.markHandled()
 
 	profileID, err := gid.ParseGID(id)
 	if err != nil {
-		return rc.logAndWrapError(scimerrors.ScimErrorResourceNotFound(id), "invalid profile ID")
+		return h.recordError(ctx, recorder, scimerrors.ScimErrorResourceNotFound(id), "invalid profile ID")
 	}
 
-	err = h.handler.iam.SCIMService.DeleteUser(rc.ctx, rc.config, profileID)
-	if err != nil {
-		return rc.logAndWrapError(err, "cannot delete user")
+	if err := h.handler.iam.SCIMService.DeleteUser(ctx, scimConfigFromContext(ctx), profileID); err != nil {
+		return h.recordError(ctx, recorder, err, "cannot delete user")
 	}
-
-	rc.userName = ""
-
-	rc.logSuccess(204)
 
 	return nil
 }
@@ -397,62 +433,4 @@ func getIPAddress(r *http.Request) net.IP {
 	}
 
 	return net.IPv4(127, 0, 0, 1)
-}
-
-func marshalSCIMPayload(v any) *string {
-	if v == nil {
-		return nil
-	}
-
-	body, err := json.Marshal(v)
-	if err != nil {
-		return nil
-	}
-
-	s := string(body)
-
-	return &s
-}
-
-func marshalSCIMResource(resource scim.Resource) *string {
-	payload := map[string]any{
-		"id": resource.ID,
-	}
-
-	for key, value := range resource.Attributes {
-		payload[key] = value
-	}
-
-	if resource.ExternalID.Present() {
-		payload["externalId"] = resource.ExternalID.Value()
-	}
-
-	return marshalSCIMPayload(payload)
-}
-
-func marshalSCIMPatchOperations(operations []scim.PatchOperation) *string {
-	ops := make([]map[string]any, 0, len(operations))
-
-	for _, operation := range operations {
-		op := map[string]any{
-			"op": operation.Op,
-		}
-
-		if operation.Path != nil {
-			op["path"] = operation.Path.String()
-		}
-
-		if operation.Value != nil {
-			op["value"] = operation.Value
-		}
-
-		ops = append(ops, op)
-	}
-
-	return marshalSCIMPayload(
-		map[string]any{
-			"schemas":    []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
-			"Operations": ops,
-		},
-	)
 }

--- a/pkg/server/api/connect/v1/scim_handler.go
+++ b/pkg/server/api/connect/v1/scim_handler.go
@@ -22,6 +22,7 @@ package connect_v1
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"net/http"
@@ -54,13 +55,15 @@ type (
 	}
 
 	scimRequestContext struct {
-		ctx       context.Context
-		config    *coredata.SCIMConfiguration
-		ipAddress net.IP
-		method    string
-		path      string
-		userName  string
-		handler   *scimResourceHandler
+		ctx          context.Context
+		config       *coredata.SCIMConfiguration
+		ipAddress    net.IP
+		method       string
+		path         string
+		userName     string
+		requestBody  *string
+		responseBody *string
+		handler      *scimResourceHandler
 	}
 )
 
@@ -163,7 +166,18 @@ func (rc *scimRequestContext) logAndWrapError(err error, logMsg string) error {
 			userName = ""
 		}
 
-		rc.handler.handler.iam.SCIMService.LogEvent(rc.ctx, rc.config, rc.method, rc.path, userName, rc.ipAddress, scimErr.Status, &errMsg)
+		rc.handler.handler.iam.SCIMService.LogEvent(
+			rc.ctx,
+			rc.config,
+			rc.method,
+			rc.path,
+			userName,
+			rc.ipAddress,
+			scimErr.Status,
+			&errMsg,
+			rc.requestBody,
+			rc.responseBody,
+		)
 
 		return err
 	}
@@ -171,23 +185,46 @@ func (rc *scimRequestContext) logAndWrapError(err error, logMsg string) error {
 	rc.handler.handler.logger.ErrorCtx(rc.ctx, logMsg, log.Error(err))
 
 	errMsg := "internal server error"
-	rc.handler.handler.iam.SCIMService.LogEvent(rc.ctx, rc.config, rc.method, rc.path, rc.userName, rc.ipAddress, 500, &errMsg)
+	rc.handler.handler.iam.SCIMService.LogEvent(
+		rc.ctx,
+		rc.config,
+		rc.method,
+		rc.path,
+		rc.userName,
+		rc.ipAddress,
+		500,
+		&errMsg,
+		rc.requestBody,
+		rc.responseBody,
+	)
 
 	return scimerrors.ScimErrorInternal
 }
 
 func (rc *scimRequestContext) logSuccess(statusCode int) {
-	rc.handler.handler.iam.SCIMService.LogEvent(rc.ctx, rc.config, rc.method, rc.path, rc.userName, rc.ipAddress, statusCode, nil)
+	rc.handler.handler.iam.SCIMService.LogEvent(
+		rc.ctx,
+		rc.config,
+		rc.method,
+		rc.path,
+		rc.userName,
+		rc.ipAddress,
+		statusCode,
+		nil,
+		rc.requestBody,
+		rc.responseBody,
+	)
 }
 
 func (h *scimResourceHandler) Create(r *http.Request, attributes scim.ResourceAttributes) (scim.Resource, error) {
 	rc := &scimRequestContext{
-		ctx:       r.Context(),
-		config:    scimConfigFromContext(r.Context()),
-		ipAddress: getIPAddress(r),
-		method:    "POST",
-		path:      "/Users",
-		handler:   h,
+		ctx:         r.Context(),
+		config:      scimConfigFromContext(r.Context()),
+		ipAddress:   getIPAddress(r),
+		method:      "POST",
+		path:        "/Users",
+		requestBody: marshalSCIMPayload(attributes),
+		handler:     h,
 	}
 
 	resource, err := h.handler.iam.SCIMService.CreateUser(rc.ctx, rc.config, attributes)
@@ -196,6 +233,7 @@ func (h *scimResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 	}
 
 	rc.userName = resource.Attributes["userName"].(string)
+	rc.responseBody = marshalSCIMResource(resource)
 
 	rc.logSuccess(201)
 
@@ -223,6 +261,7 @@ func (h *scimResourceHandler) Get(r *http.Request, id string) (scim.Resource, er
 	}
 
 	rc.userName = resource.Attributes["userName"].(string)
+	rc.responseBody = marshalSCIMResource(resource)
 
 	rc.logSuccess(200)
 
@@ -269,12 +308,13 @@ func (h *scimResourceHandler) GetAll(r *http.Request, params scim.ListRequestPar
 
 func (h *scimResourceHandler) Replace(r *http.Request, id string, attributes scim.ResourceAttributes) (scim.Resource, error) {
 	rc := &scimRequestContext{
-		ctx:       r.Context(),
-		config:    scimConfigFromContext(r.Context()),
-		ipAddress: getIPAddress(r),
-		method:    "PUT",
-		path:      "/Users/" + id,
-		handler:   h,
+		ctx:         r.Context(),
+		config:      scimConfigFromContext(r.Context()),
+		ipAddress:   getIPAddress(r),
+		method:      "PUT",
+		path:        "/Users/" + id,
+		requestBody: marshalSCIMPayload(attributes),
+		handler:     h,
 	}
 
 	profileID, err := gid.ParseGID(id)
@@ -288,6 +328,7 @@ func (h *scimResourceHandler) Replace(r *http.Request, id string, attributes sci
 	}
 
 	rc.userName = resource.Attributes["userName"].(string)
+	rc.responseBody = marshalSCIMResource(resource)
 
 	rc.logSuccess(200)
 
@@ -296,12 +337,13 @@ func (h *scimResourceHandler) Replace(r *http.Request, id string, attributes sci
 
 func (h *scimResourceHandler) Patch(r *http.Request, id string, operations []scim.PatchOperation) (scim.Resource, error) {
 	rc := &scimRequestContext{
-		ctx:       r.Context(),
-		config:    scimConfigFromContext(r.Context()),
-		ipAddress: getIPAddress(r),
-		method:    "PATCH",
-		path:      "/Users/" + id,
-		handler:   h,
+		ctx:         r.Context(),
+		config:      scimConfigFromContext(r.Context()),
+		ipAddress:   getIPAddress(r),
+		method:      "PATCH",
+		path:        "/Users/" + id,
+		requestBody: marshalSCIMPatchOperations(operations),
+		handler:     h,
 	}
 
 	profileID, err := gid.ParseGID(id)
@@ -315,6 +357,7 @@ func (h *scimResourceHandler) Patch(r *http.Request, id string, operations []sci
 	}
 
 	rc.userName = resource.Attributes["userName"].(string)
+	rc.responseBody = marshalSCIMResource(resource)
 
 	rc.logSuccess(200)
 
@@ -354,4 +397,62 @@ func getIPAddress(r *http.Request) net.IP {
 	}
 
 	return net.IPv4(127, 0, 0, 1)
+}
+
+func marshalSCIMPayload(v any) *string {
+	if v == nil {
+		return nil
+	}
+
+	body, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+
+	s := string(body)
+
+	return &s
+}
+
+func marshalSCIMResource(resource scim.Resource) *string {
+	payload := map[string]any{
+		"id": resource.ID,
+	}
+
+	for key, value := range resource.Attributes {
+		payload[key] = value
+	}
+
+	if resource.ExternalID.Present() {
+		payload["externalId"] = resource.ExternalID.Value()
+	}
+
+	return marshalSCIMPayload(payload)
+}
+
+func marshalSCIMPatchOperations(operations []scim.PatchOperation) *string {
+	ops := make([]map[string]any, 0, len(operations))
+
+	for _, operation := range operations {
+		op := map[string]any{
+			"op": operation.Op,
+		}
+
+		if operation.Path != nil {
+			op["path"] = operation.Path.String()
+		}
+
+		if operation.Value != nil {
+			op["value"] = operation.Value
+		}
+
+		ops = append(ops, op)
+	}
+
+	return marshalSCIMPayload(
+		map[string]any{
+			"schemas":    []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+			"Operations": ops,
+		},
+	)
 }

--- a/pkg/server/api/connect/v1/scim_handler.go
+++ b/pkg/server/api/connect/v1/scim_handler.go
@@ -23,11 +23,13 @@ package connect_v1
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/elimity-com/scim"
 	scimerrors "github.com/elimity-com/scim/errors"
@@ -73,6 +75,11 @@ type (
 		statusCode int
 		body       bytes.Buffer
 	}
+)
+
+const (
+	scimPasswordAttribute = "password"
+	scimRedactedValue     = "[REDACTED]"
 )
 
 var (
@@ -246,8 +253,8 @@ func (h *SCIMHandler) EventLoggingMiddleware(next http.Handler) http.Handler {
 			getIPAddress(r),
 			responseRecorder.statusCode,
 			recorder.errorMessage,
-			bodyOrNil(requestBody),
-			bodyOrNil(responseRecorder.body.Bytes()),
+			bodyOrNil(redactSCIMCredentials(requestBody)),
+			bodyOrNil(redactSCIMCredentials(responseRecorder.body.Bytes())),
 		)
 	})
 }
@@ -307,6 +314,63 @@ func bodyOrNil(body []byte) *string {
 	s := string(body)
 
 	return &s
+}
+
+// redactSCIMCredentials strips credentials from a captured SCIM body. The core
+// User schema defines a write-only "password" attribute that provisioning
+// clients may send even though SCIM-managed profiles never carry one, and a
+// stored credential would turn the audit trail into a breach. Bodies without a
+// credential are returned untouched so they stay byte-identical to the wire.
+func redactSCIMCredentials(body []byte) []byte {
+	if !bytes.Contains(bytes.ToLower(body), []byte(scimPasswordAttribute)) {
+		return body
+	}
+
+	var payload any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		// A body that mentions a credential but cannot be parsed cannot be
+		// redacted, so store nothing rather than risk persisting it.
+		return nil
+	}
+
+	redacted, err := json.Marshal(redactSCIMValue(payload))
+	if err != nil {
+		return nil
+	}
+
+	return redacted
+}
+
+func redactSCIMValue(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, nested := range v {
+			if strings.EqualFold(key, scimPasswordAttribute) {
+				v[key] = scimRedactedValue
+				continue
+			}
+
+			v[key] = redactSCIMValue(nested)
+		}
+
+		// A PATCH operation carries its target in "path" and the credential in
+		// "value", so the attribute name never appears as a key.
+		if path, ok := v["path"].(string); ok && strings.EqualFold(path, scimPasswordAttribute) {
+			if _, ok := v["value"]; ok {
+				v["value"] = scimRedactedValue
+			}
+		}
+
+		return v
+	case []any:
+		for i, nested := range v {
+			v[i] = redactSCIMValue(nested)
+		}
+
+		return v
+	default:
+		return value
+	}
 }
 
 func (h *scimResourceHandler) Create(r *http.Request, attributes scim.ResourceAttributes) (scim.Resource, error) {

--- a/pkg/server/api/connect/v1/scim_handler.go
+++ b/pkg/server/api/connect/v1/scim_handler.go
@@ -319,58 +319,92 @@ func bodyOrNil(body []byte) *string {
 // redactSCIMCredentials strips credentials from a captured SCIM body. The core
 // User schema defines a write-only "password" attribute that provisioning
 // clients may send even though SCIM-managed profiles never carry one, and a
-// stored credential would turn the audit trail into a breach. Bodies without a
-// credential are returned untouched so they stay byte-identical to the wire.
+// stored credential would turn the audit trail into a breach.
+//
+// A body that carries no credential is returned untouched, so it stays
+// byte-identical to the wire. Redacting one requires re-serializing, which
+// reorders object keys.
 func redactSCIMCredentials(body []byte) []byte {
-	if !bytes.Contains(bytes.ToLower(body), []byte(scimPasswordAttribute)) {
+	if len(body) == 0 {
 		return body
 	}
 
+	// UseNumber keeps numeric attributes as their literal representation;
+	// decoding into float64 would silently round large integers.
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+
 	var payload any
-	if err := json.Unmarshal(body, &payload); err != nil {
-		// A body that mentions a credential but cannot be parsed cannot be
-		// redacted, so store nothing rather than risk persisting it.
-		return nil
+	if err := decoder.Decode(&payload); err != nil {
+		// A body we cannot parse cannot be redacted structurally, so fall back
+		// to dropping it when it looks like it mentions a credential at all.
+		if bytes.Contains(bytes.ToLower(body), []byte(scimPasswordAttribute)) {
+			return nil
+		}
+
+		return body
 	}
 
-	redacted, err := json.Marshal(redactSCIMValue(payload))
+	var redacted bool
+
+	value := redactSCIMValue(payload, &redacted)
+	if !redacted {
+		return body
+	}
+
+	out, err := json.Marshal(value)
 	if err != nil {
 		return nil
 	}
 
-	return redacted
+	return out
 }
 
-func redactSCIMValue(value any) any {
+func redactSCIMValue(value any, redacted *bool) any {
 	switch v := value.(type) {
 	case map[string]any:
 		for key, nested := range v {
-			if strings.EqualFold(key, scimPasswordAttribute) {
+			if isSCIMPasswordAttribute(key) {
 				v[key] = scimRedactedValue
+				*redacted = true
+
 				continue
 			}
 
-			v[key] = redactSCIMValue(nested)
+			v[key] = redactSCIMValue(nested, redacted)
 		}
 
 		// A PATCH operation carries its target in "path" and the credential in
 		// "value", so the attribute name never appears as a key.
-		if path, ok := v["path"].(string); ok && strings.EqualFold(path, scimPasswordAttribute) {
+		if path, ok := v["path"].(string); ok && isSCIMPasswordAttribute(path) {
 			if _, ok := v["value"]; ok {
 				v["value"] = scimRedactedValue
+				*redacted = true
 			}
 		}
 
 		return v
 	case []any:
 		for i, nested := range v {
-			v[i] = redactSCIMValue(nested)
+			v[i] = redactSCIMValue(nested, redacted)
 		}
 
 		return v
 	default:
 		return value
 	}
+}
+
+// isSCIMPasswordAttribute reports whether an attribute name or PATCH path
+// targets the password. SCIM attributes may be qualified by their schema URN
+// (urn:ietf:params:scim:schemas:core:2.0:User:password), so only the trailing
+// segment identifies the attribute.
+func isSCIMPasswordAttribute(name string) bool {
+	if i := strings.LastIndex(name, ":"); i >= 0 {
+		name = name[i+1:]
+	}
+
+	return strings.EqualFold(name, scimPasswordAttribute)
 }
 
 func (h *scimResourceHandler) Create(r *http.Request, attributes scim.ResourceAttributes) (scim.Resource, error) {

--- a/pkg/server/api/connect/v1/scim_handler_test.go
+++ b/pkg/server/api/connect/v1/scim_handler_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package connect_v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactSCIMCredentials(t *testing.T) {
+	t.Parallel()
+
+	t.Run("leaves a credential-free body byte-identical", func(t *testing.T) {
+		t.Parallel()
+
+		body := []byte(`{"userName":"a@example.com","name":{"givenName":"A"}}`)
+
+		assert.Equal(t, body, redactSCIMCredentials(body))
+	})
+
+	t.Run("redacts a user password attribute", func(t *testing.T) {
+		t.Parallel()
+
+		got := redactSCIMCredentials([]byte(`{"userName":"a@example.com","password":"s3cret"}`))
+
+		assert.JSONEq(t, `{"userName":"a@example.com","password":"[REDACTED]"}`, string(got))
+	})
+
+	t.Run("redacts a password regardless of attribute casing", func(t *testing.T) {
+		t.Parallel()
+
+		got := redactSCIMCredentials([]byte(`{"Password":"s3cret"}`))
+
+		assert.JSONEq(t, `{"Password":"[REDACTED]"}`, string(got))
+	})
+
+	t.Run("redacts a password nested in an extension", func(t *testing.T) {
+		t.Parallel()
+
+		got := redactSCIMCredentials([]byte(`{"urn:example":{"password":"s3cret"}}`))
+
+		assert.JSONEq(t, `{"urn:example":{"password":"[REDACTED]"}}`, string(got))
+	})
+
+	t.Run("redacts a patch operation targeting the password", func(t *testing.T) {
+		t.Parallel()
+
+		got := redactSCIMCredentials([]byte(`{"Operations":[{"op":"replace","path":"password","value":"s3cret"}]}`))
+
+		assert.JSONEq(
+			t,
+			`{"Operations":[{"op":"replace","path":"password","value":"[REDACTED]"}]}`,
+			string(got),
+		)
+	})
+
+	t.Run("keeps other patch operations intact", func(t *testing.T) {
+		t.Parallel()
+
+		got := redactSCIMCredentials([]byte(`{"Operations":[{"op":"replace","path":"password","value":"s3cret"},{"op":"replace","path":"active","value":false}]}`))
+
+		assert.JSONEq(
+			t,
+			`{"Operations":[{"op":"replace","path":"password","value":"[REDACTED]"},{"op":"replace","path":"active","value":false}]}`,
+			string(got),
+		)
+	})
+
+	t.Run("drops a credential-bearing body that cannot be parsed", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Nil(t, redactSCIMCredentials([]byte(`{"password":"s3cret"`)))
+	})
+
+	t.Run("keeps a malformed body without a credential", func(t *testing.T) {
+		t.Parallel()
+
+		body := []byte(`{"userName":`)
+
+		assert.Equal(t, body, redactSCIMCredentials(body))
+	})
+
+	t.Run("never leaks the credential", func(t *testing.T) {
+		t.Parallel()
+
+		bodies := []string{
+			`{"password":"s3cret"}`,
+			`{"PASSWORD":"s3cret"}`,
+			`{"Operations":[{"op":"add","path":"Password","value":"s3cret"}]}`,
+		}
+
+		for _, body := range bodies {
+			got := redactSCIMCredentials([]byte(body))
+			require.NotNil(t, got, body)
+			assert.NotContains(t, string(got), "s3cret", body)
+		}
+	})
+}

--- a/pkg/server/api/connect/v1/scim_handler_test.go
+++ b/pkg/server/api/connect/v1/scim_handler_test.go
@@ -62,6 +62,50 @@ func TestRedactSCIMCredentials(t *testing.T) {
 		assert.JSONEq(t, `{"urn:example":{"password":"[REDACTED]"}}`, string(got))
 	})
 
+	t.Run("redacts a fully qualified password attribute", func(t *testing.T) {
+		t.Parallel()
+
+		got := redactSCIMCredentials(
+			[]byte(`{"urn:ietf:params:scim:schemas:core:2.0:User:password":"s3cret"}`),
+		)
+
+		assert.JSONEq(
+			t,
+			`{"urn:ietf:params:scim:schemas:core:2.0:User:password":"[REDACTED]"}`,
+			string(got),
+		)
+	})
+
+	t.Run("redacts a patch operation using a fully qualified path", func(t *testing.T) {
+		t.Parallel()
+
+		got := redactSCIMCredentials(
+			[]byte(`{"Operations":[{"op":"replace","path":"urn:ietf:params:scim:schemas:core:2.0:User:password","value":"s3cret"}]}`),
+		)
+
+		assert.NotContains(t, string(got), "s3cret")
+		assert.Contains(t, string(got), scimRedactedValue)
+	})
+
+	t.Run("leaves a body that merely mentions the word untouched", func(t *testing.T) {
+		t.Parallel()
+
+		body := []byte(`{"userName":"password@example.com","displayName":"Password Reset Bot"}`)
+
+		assert.Equal(t, body, redactSCIMCredentials(body))
+	})
+
+	t.Run("preserves large integers when redacting", func(t *testing.T) {
+		t.Parallel()
+
+		got := redactSCIMCredentials(
+			[]byte(`{"employeeNumber":9007199254740993,"password":"s3cret"}`),
+		)
+
+		assert.Contains(t, string(got), "9007199254740993")
+		assert.NotContains(t, string(got), "s3cret")
+	})
+
 	t.Run("redacts a patch operation targeting the password", func(t *testing.T) {
 		t.Parallel()
 
@@ -107,6 +151,9 @@ func TestRedactSCIMCredentials(t *testing.T) {
 			`{"password":"s3cret"}`,
 			`{"PASSWORD":"s3cret"}`,
 			`{"Operations":[{"op":"add","path":"Password","value":"s3cret"}]}`,
+			`{"urn:ietf:params:scim:schemas:core:2.0:User:password":"s3cret"}`,
+			`{"Operations":[{"op":"add","path":"urn:ietf:params:scim:schemas:core:2.0:User:Password","value":"s3cret"}]}`,
+			`{"emails":[{"value":"a@example.com"}],"password":"s3cret"}`,
 		}
 
 		for _, body := range bodies {


### PR DESCRIPTION
## Summary
- Persist SCIM request and response bodies on audit events (`request_body` / `response_body`) for create, replace, patch, and get
- Wire payloads through `LogEvent` from the Connect SCIM handler
- Add e2e coverage that asserts stored JSON payloads for those operations

## Test plan
- [x] `TestSCIMEvent_StoresPayload` e2e (create/replace/patch/get payload assertions)
- [ ] Create/replace/patch a SCIM user via `/api/connect/v1/scim/2.0` and confirm GraphQL `SCIMEvent.requestBody` / `responseBody` are populated
- [ ] Confirm GET events store response body only (no request body)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store SCIM request and response bodies on audit events directly from the wire. Credentials are safely redacted (including fully qualified paths), while non-credential bodies remain byte-identical and preserve large integers.

### GraphQL API **`+297`** **`-112`**
- Add EventLoggingMiddleware to capture exact request/response bodies and status; events are written after the response; mounted after BearerTokenMiddleware.
- Harden redaction: match trailing attribute segment (handles schema-URN paths), use UseNumber to keep large ints, avoid re-encoding when no redaction, and drop only malformed credential-bearing bodies.

### Service **`+17`** **`-1`**
- Extend LogEvent/createEvent to persist requestBody and responseBody on SCIMEvent.

### Tests **`+379`** **`-5`**
- e2e assertions for stored JSON on create/replace/patch/get.
- Unit tests for credential redaction, including fully qualified paths, case-insensitive matches, patch ops, large integers, and no credential leakage.

<sup>Written for commit ce0eac68638baf1b2dc9edfecf2ca00fd2fb130d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

