### PR TITLE
Fix compliance portal asset URLs on nested routes

### DIFF
--- a/apps/compliance-portal/vite.config.ts
+++ b/apps/compliance-portal/vite.config.ts
@@ -108,7 +108,11 @@ export default defineConfig(({ mode, command }) => {
         },
       },
     },
-    base: "./",
+    // Absolute base: host-routed SPA lives at site root (`/:lang/...`). A
+    // relative base (`./`) makes nested routes request `/en/documents/assets/`
+    // instead of `/assets/`, so the SPA fallback serves HTML and browsers
+    // block JS/CSS for the wrong MIME type.
+    base: "/",
     server: {
       port: 5174,
       proxy: proxyTarget


### PR DESCRIPTION
Relative Vite base made deep links like /en/documents/... request chunks under the route path, so the SPA fallback served HTML.

<img width="1443" height="744" alt="Capture d’écran 2026-08-06 à 09 57 00" src="https://github.com/user-attachments/assets/c11fd461-bb27-481c-a1dc-7d05ef9c5dc2" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets the `vite` base to `/` in the compliance portal to fix asset URLs on nested routes. Deep links now load JS/CSS from `/assets/*` instead of nested paths, preventing HTML fallback and MIME errors.

### App: compliance-portal **`+5`** **`-1`**
- Change `base` from `./` to `/` and document the nested route issue.

<sup>Written for commit 602027d14e5f1bbbf7d4b071931209570694d881. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





