### PR TITLE
Fix n8n Organization Get Many after ProfileFilter.state removal

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/organization/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/organization/getAll.operation.ts
@@ -97,7 +97,7 @@ export async function execute(
 	const memberships = await proboConnectApiRequestAllItems.call(
 		this,
 		query,
-		{ filter: { state: 'ACTIVE' } },
+		{ filter: { states: ['ACTIVE'] } },
 		(response: IDataObject) => {
 			const data = response?.data as IDataObject | undefined;
 			const viewer = data?.viewer as IDataObject | undefined;


### PR DESCRIPTION
Use states: ['ACTIVE'] instead of the removed state field so Get Many works again on servers that only accept the multi-value ProfileFilter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Organization “Get Many” action in the `n8n-node` Probo connector by switching to the multi-value `states: ['ACTIVE']` filter after `ProfileFilter.state` was removed. Restores compatibility with servers that require `states`.

### Package: n8n-node **`+1`** **`-1`**
- Replace `{ filter: { state: 'ACTIVE' } }` with `{ filter: { states: ['ACTIVE'] } }` in `getAll.operation.ts` so the memberships query works with the updated API schema.

<sup>Written for commit 146d9666b120e2db4013bc0193d452ca0d30a63d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

