### PR TITLE
Fix locked document viewer access CTAs

### DIFF
--- a/apps/compliance-portal/src/pages/documents/DocumentViewerPage.tsx
+++ b/apps/compliance-portal/src/pages/documents/DocumentViewerPage.tsx
@@ -21,6 +21,8 @@
 import type { PreloadedQuery } from "react-relay";
 import { graphql, usePreloadedQuery } from "react-relay";
 
+import { useLocalizedPath } from "#/lib/i18n/useLocale";
+
 import type { DocumentViewerPageQuery } from "./__generated__/DocumentViewerPageQuery.graphql";
 import { DocumentViewer } from "./_components/DocumentViewer";
 import { useAccessRequest } from "./_lib/useAccessRequest";
@@ -35,16 +37,35 @@ export const documentViewerPageQuery = graphql`
         id
         title
         isUserAuthorized
+        access {
+          id
+          status
+        }
       }
       ... on CompliancePortalFile {
         id
         name
         isUserAuthorized
+        access {
+          id
+          status
+        }
       }
       ... on AuditReport {
         id
         fileName
         isUserAuthorized
+        access {
+          id
+          status
+        }
+      }
+    }
+    currentCompliancePortal {
+      nonDisclosureAgreement {
+        viewerSignature {
+          status
+        }
       }
     }
   }
@@ -59,16 +80,35 @@ interface ResolvedNode {
   id: string;
   title: string;
   isAuthorized: boolean;
+  requested: boolean;
 }
 
 function resolveNode(node: DocumentViewerPageQuery["response"]["aliasedNode"]): ResolvedNode {
   switch (node.__typename) {
     case "Document":
-      return { kind: "Document", id: node.id, title: node.title, isAuthorized: node.isUserAuthorized };
+      return {
+        kind: "Document",
+        id: node.id,
+        title: node.title,
+        isAuthorized: node.isUserAuthorized,
+        requested: node.access?.status === "REQUESTED",
+      };
     case "CompliancePortalFile":
-      return { kind: "CompliancePortalFile", id: node.id, title: node.name, isAuthorized: node.isUserAuthorized };
+      return {
+        kind: "CompliancePortalFile",
+        id: node.id,
+        title: node.name,
+        isAuthorized: node.isUserAuthorized,
+        requested: node.access?.status === "REQUESTED",
+      };
     case "AuditReport":
-      return { kind: "AuditReport", id: node.id, title: node.fileName, isAuthorized: node.isUserAuthorized };
+      return {
+        kind: "AuditReport",
+        id: node.id,
+        title: node.fileName,
+        isAuthorized: node.isUserAuthorized,
+        requested: node.access?.status === "REQUESTED",
+      };
     default:
       throw new Error(`Unexpected aliased node type: ${node.__typename}`);
   }
@@ -82,12 +122,24 @@ export function DocumentViewerPage({ queryRef }: DocumentViewerPageProps) {
   const node = resolveNode(data.aliasedNode);
   const { dataUri } = useDocumentExport(node.kind, node.id, node.isAuthorized);
   const { requestAccess, isRequesting } = useAccessRequest(node.kind, node.id);
+  const localizedPath = useLocalizedPath();
 
   if (!node.isAuthorized) {
+    const signature = data.currentCompliancePortal?.nonDisclosureAgreement?.viewerSignature;
+    const needsNda = signature != null && signature.status !== "COMPLETED";
+    const ndaHref = needsNda
+      ? `${localizedPath("/nda")}?continue=${encodeURIComponent(window.location.href)}`
+      : null;
+
     return (
       <DocumentViewer
         title={node.title}
-        locked={{ onGetAccess: requestAccess, isRequesting }}
+        locked={{
+          onGetAccess: requestAccess,
+          isRequesting,
+          requested: node.requested,
+          ndaHref,
+        }}
       />
     );
   }

--- a/apps/compliance-portal/src/pages/documents/_components/DocumentLocked.tsx
+++ b/apps/compliance-portal/src/pages/documents/_components/DocumentLocked.tsx
@@ -18,8 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { LockSimpleIcon } from "@phosphor-icons/react";
+import { ClockIcon, FileTextIcon, LockSimpleIcon } from "@phosphor-icons/react";
 import { Button } from "@probo/ui/src/v2/Button/Button";
+import { ButtonLink } from "@probo/ui/src/v2/Button/ButtonLink";
 import { useTranslation } from "react-i18next";
 
 import { EmptyState } from "#/components/EmptyState/EmptyState";
@@ -30,11 +31,59 @@ interface DocumentLockedProps {
   onGetAccess: () => void;
   // Whether the access request is in flight.
   isRequesting: boolean;
+  // Whether an access request is already pending for this document.
+  requested: boolean;
+  // Localized /nda?continue=… href when the visitor still needs to sign the
+  // portal NDA; null otherwise.
+  ndaHref: string | null;
 }
 
-// Shown when the viewer resolves a document the visitor may not access, with a
-// Get Access CTA that requests access (prompting sign-in first when needed).
-export function DocumentLocked({ onGetAccess, isRequesting }: DocumentLockedProps) {
+function LockedAction({
+  onGetAccess,
+  isRequesting,
+  requested,
+  ndaHref,
+}: DocumentLockedProps) {
+  const { t } = useTranslation("documents");
+  const { t: tRoot } = useTranslation();
+
+  if (requested) {
+    return (
+      <Button color="neutral" disabled iconStart={<ClockIcon />}>
+        {t("actions.requested")}
+      </Button>
+    );
+  }
+
+  if (ndaHref != null) {
+    return (
+      <ButtonLink
+        to={ndaHref}
+        color="neutral"
+        highContrast
+        iconStart={<FileTextIcon />}
+      >
+        {tRoot("nda.unsignedBanner.sign")}
+      </ButtonLink>
+    );
+  }
+
+  return (
+    <Button
+      color="neutral"
+      highContrast
+      loading={isRequesting}
+      iconStart={<LockSimpleIcon />}
+      onClick={onGetAccess}
+    >
+      {t("actions.getAccess")}
+    </Button>
+  );
+}
+
+// Shown when the viewer resolves a document the visitor may not access. CTA
+// priority: Access requested → Sign NDA → Get Access.
+export function DocumentLocked(props: DocumentLockedProps) {
   const { t } = useTranslation("documents");
 
   return (
@@ -43,17 +92,7 @@ export function DocumentLocked({ onGetAccess, isRequesting }: DocumentLockedProp
         icon={<LockSimpleIcon />}
         title={t("viewer.locked.title")}
         description={t("viewer.locked.description")}
-        action={(
-          <Button
-            color="neutral"
-            highContrast
-            loading={isRequesting}
-            iconStart={<LockSimpleIcon />}
-            onClick={onGetAccess}
-          >
-            {t("actions.getAccess")}
-          </Button>
-        )}
+        action={<LockedAction {...props} />}
       />
     </div>
   );

--- a/apps/compliance-portal/src/pages/documents/_components/DocumentLocked.tsx
+++ b/apps/compliance-portal/src/pages/documents/_components/DocumentLocked.tsx
@@ -47,14 +47,6 @@ function LockedAction({
   const { t } = useTranslation("documents");
   const { t: tRoot } = useTranslation();
 
-  if (requested) {
-    return (
-      <Button color="neutral" disabled iconStart={<ClockIcon />}>
-        {t("actions.requested")}
-      </Button>
-    );
-  }
-
   if (ndaHref != null) {
     return (
       <ButtonLink
@@ -65,6 +57,14 @@ function LockedAction({
       >
         {tRoot("nda.unsignedBanner.sign")}
       </ButtonLink>
+    );
+  }
+
+  if (requested) {
+    return (
+      <Button color="neutral" disabled iconStart={<ClockIcon />}>
+        {t("actions.requested")}
+      </Button>
     );
   }
 
@@ -82,7 +82,7 @@ function LockedAction({
 }
 
 // Shown when the viewer resolves a document the visitor may not access. CTA
-// priority: Access requested → Sign NDA → Get Access.
+// priority: Sign NDA → Access requested → Get Access.
 export function DocumentLocked(props: DocumentLockedProps) {
   const { t } = useTranslation("documents");
 

--- a/apps/compliance-portal/src/pages/documents/_components/DocumentViewer.tsx
+++ b/apps/compliance-portal/src/pages/documents/_components/DocumentViewer.tsx
@@ -46,6 +46,11 @@ interface DocumentViewerLocked {
   onGetAccess: () => void;
   // Whether the access request is in flight.
   isRequesting: boolean;
+  // Whether an access request is already pending for this document.
+  requested: boolean;
+  // Localized /nda?continue=… href when the visitor still needs to sign the
+  // portal NDA; null otherwise.
+  ndaHref: string | null;
 }
 
 interface DocumentViewerProps {
@@ -57,14 +62,15 @@ interface DocumentViewerProps {
   // File name used when downloading. Omitted when the viewer is locked.
   downloadName?: string;
   // When set, the header keeps the title (no toolbar) and the body shows the
-  // locked empty state with a Get Access CTA instead of the file preview.
+  // locked empty state (Access requested / Sign NDA / Get Access) instead of
+  // the file preview.
   locked?: DocumentViewerLocked;
 }
 
 // Full-page document viewer: a header band with the title and a toolbar
 // (page navigation + zoom for PDFs, copy link, download) above the scrollable
 // body. PDFs render with react-pdf, images inline, and anything else offers a
-// download. Locked visitors keep the title header and see a Get Access CTA in
+// download. Locked visitors keep the title header and see an access CTA in
 // place of the preview.
 export function DocumentViewer({ title, dataUri = null, downloadName = title, locked }: DocumentViewerProps) {
   const { t } = useTranslation("documents");
@@ -125,6 +131,8 @@ export function DocumentViewer({ title, dataUri = null, downloadName = title, lo
               <DocumentLocked
                 onGetAccess={locked.onGetAccess}
                 isRequesting={locked.isRequesting}
+                requested={locked.requested}
+                ndaHref={locked.ndaHref}
               />
             )
           : dataUri == null


### PR DESCRIPTION
The viewer always showed Get Access when unauthorized, even after a pending request. Respect access.status and surface Sign NDA when the portal NDA is still incomplete.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the locked document viewer CTAs to respect access status and NDA state. When unauthorized, the viewer now shows Sign NDA first if needed, Requested if a request is pending, otherwise Get Access.

### App: compliance-portal **`+120`** **`-21`**
- Query: add `access.status` to Document/File/Report; add NDA `viewerSignature.status`.
- Logic: derive `requested` and `ndaHref` (via `useLocalizedPath` with continue param) and pass to `DocumentViewer`.
- UI: CTA priority Sign NDA → Requested → Get Access (Sign NDA overrides pending request); adds `ButtonLink` from `@probo/ui` and icons from `@phosphor-icons/react`; updates `DocumentViewer` locked props.

<sup>Written for commit 21496b776100de8b4b1df1428f6f0b3f212684f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

