### PR TITLE
Make compliance portal rights requests optional

### DIFF
--- a/apps/compliance-portal/src/_locales/de-DE.json
+++ b/apps/compliance-portal/src/_locales/de-DE.json
@@ -83,7 +83,9 @@
     },
     "actions": {
       "backToCompliancePortal": "Zurück zum Compliance-Portal",
-      "tryAgain": "Erneut versuchen"
+      "tryAgain": "Erneut versuchen",
+      "contactSupport": "Support kontaktieren",
+      "requestAccess": "Zugang anfordern"
     },
     "inline": {
       "message": "Inhalt kann nicht geladen werden",

--- a/apps/compliance-portal/src/_locales/en-US.json
+++ b/apps/compliance-portal/src/_locales/en-US.json
@@ -81,19 +81,21 @@
     },
     "forbidden": {
       "title": "Access denied",
-      "description": "You don't have permission to view this page."
+      "description": "You don't have permission to view this page. Request access or go back to the compliance portal."
     },
     "serverError": {
       "title": "Something went wrong",
-      "description": "We hit an unexpected error. Please try again in a moment."
+      "description": "Something went wrong on our side. Try again, or contact support if the issue continues."
     },
     "generic": {
-      "title": "Something went wrong",
-      "description": "We hit an unexpected error. Please try again in a moment."
+      "title": "Unable to load page",
+      "description": "We couldn't load this page. Try again, or contact support if the issue continues."
     },
     "actions": {
       "backToCompliancePortal": "Back to compliance portal",
-      "tryAgain": "Try again"
+      "tryAgain": "Try again",
+      "contactSupport": "Contact support",
+      "requestAccess": "Request access"
     },
     "inline": {
       "message": "Unable to load content",

--- a/apps/compliance-portal/src/_locales/en-US.json
+++ b/apps/compliance-portal/src/_locales/en-US.json
@@ -1,7 +1,7 @@
 {
   "topBar": {
     "tagline": "Compliance Portal",
-    "getAccess": "Get Access",
+    "getAccess": "Request Access",
     "openMenu": "Open menu",
     "closeMenu": "Close menu",
     "menuTitle": "Menu",

--- a/apps/compliance-portal/src/_locales/es-ES.json
+++ b/apps/compliance-portal/src/_locales/es-ES.json
@@ -83,7 +83,9 @@
     },
     "actions": {
       "backToCompliancePortal": "Volver al portal de cumplimiento",
-      "tryAgain": "Reintentar"
+      "tryAgain": "Reintentar",
+      "contactSupport": "Contactar con soporte",
+      "requestAccess": "Solicitar acceso"
     },
     "inline": {
       "message": "No se ha podido cargar el contenido",

--- a/apps/compliance-portal/src/_locales/fr-FR.json
+++ b/apps/compliance-portal/src/_locales/fr-FR.json
@@ -1,7 +1,7 @@
 {
   "topBar": {
     "tagline": "Portail de conformité",
-    "getAccess": "Obtenir l'accès",
+    "getAccess": "Demander l'accès",
     "openMenu": "Ouvrir le menu",
     "closeMenu": "Fermer le menu",
     "menuTitle": "Menu",

--- a/apps/compliance-portal/src/_locales/fr-FR.json
+++ b/apps/compliance-portal/src/_locales/fr-FR.json
@@ -83,7 +83,9 @@
     },
     "actions": {
       "backToCompliancePortal": "Retour au portail de conformité",
-      "tryAgain": "Réessayer"
+      "tryAgain": "Réessayer",
+      "contactSupport": "Contacter le support",
+      "requestAccess": "Demander l'accès"
     },
     "inline": {
       "message": "Impossible de charger le contenu",

--- a/apps/compliance-portal/src/_locales/id-ID.json
+++ b/apps/compliance-portal/src/_locales/id-ID.json
@@ -83,7 +83,9 @@
     },
     "actions": {
       "backToCompliancePortal": "Kembali ke portal kepatuhan",
-      "tryAgain": "Coba lagi"
+      "tryAgain": "Coba lagi",
+      "contactSupport": "Hubungi dukungan",
+      "requestAccess": "Minta akses"
     },
     "inline": {
       "message": "Konten tidak dapat dimuat",

--- a/apps/compliance-portal/src/_locales/id-ID.json
+++ b/apps/compliance-portal/src/_locales/id-ID.json
@@ -1,7 +1,7 @@
 {
   "topBar": {
     "tagline": "Portal Kepatuhan",
-    "getAccess": "Dapatkan Akses",
+    "getAccess": "Minta akses",
     "openMenu": "Buka menu",
     "closeMenu": "Tutup menu",
     "menuTitle": "Menu",

--- a/apps/compliance-portal/src/_locales/it-IT.json
+++ b/apps/compliance-portal/src/_locales/it-IT.json
@@ -83,7 +83,9 @@
     },
     "actions": {
       "backToCompliancePortal": "Torna al portale di conformità",
-      "tryAgain": "Riprova"
+      "tryAgain": "Riprova",
+      "contactSupport": "Contatta il supporto",
+      "requestAccess": "Richiedi accesso"
     },
     "inline": {
       "message": "Impossibile caricare il contenuto",

--- a/apps/compliance-portal/src/_locales/ja-JP.json
+++ b/apps/compliance-portal/src/_locales/ja-JP.json
@@ -83,7 +83,9 @@
     },
     "actions": {
       "backToCompliancePortal": "コンプライアンスポータルに戻る",
-      "tryAgain": "もう一度試す"
+      "tryAgain": "もう一度試す",
+      "contactSupport": "サポートに連絡",
+      "requestAccess": "アクセスをリクエスト"
     },
     "inline": {
       "message": "コンテンツを読み込めません",

--- a/apps/compliance-portal/src/_locales/ko-KR.json
+++ b/apps/compliance-portal/src/_locales/ko-KR.json
@@ -83,7 +83,9 @@
     },
     "actions": {
       "backToCompliancePortal": "컴플라이언스 포털로 돌아가기",
-      "tryAgain": "다시 시도"
+      "tryAgain": "다시 시도",
+      "contactSupport": "지원팀에 문의",
+      "requestAccess": "액세스 요청"
     },
     "inline": {
       "message": "콘텐츠를 불러올 수 없습니다",

--- a/apps/compliance-portal/src/_locales/nl-NL.json
+++ b/apps/compliance-portal/src/_locales/nl-NL.json
@@ -93,7 +93,9 @@
     },
     "actions": {
       "backToCompliancePortal": "Terug naar het complianceportaal",
-      "tryAgain": "Opnieuw proberen"
+      "tryAgain": "Opnieuw proberen",
+      "contactSupport": "Contact opnemen met support",
+      "requestAccess": "Toegang aanvragen"
     },
     "inline": {
       "message": "Inhoud kan niet worden geladen",

--- a/apps/compliance-portal/src/_locales/pl-PL.json
+++ b/apps/compliance-portal/src/_locales/pl-PL.json
@@ -83,7 +83,9 @@
     },
     "actions": {
       "backToCompliancePortal": "Powrót do Portalu Zgodności",
-      "tryAgain": "Spróbuj ponownie"
+      "tryAgain": "Spróbuj ponownie",
+      "contactSupport": "Skontaktuj się z pomocą",
+      "requestAccess": "Poproś o dostęp"
     },
     "inline": {
       "message": "Nie można wczytać treści",

--- a/apps/compliance-portal/src/_locales/pl-PL.json
+++ b/apps/compliance-portal/src/_locales/pl-PL.json
@@ -1,7 +1,7 @@
 {
   "topBar": {
     "tagline": "Portal Zgodności",
-    "getAccess": "Uzyskaj dostęp",
+    "getAccess": "Poproś o dostęp",
     "openMenu": "Otwórz menu",
     "closeMenu": "Zamknij menu",
     "menuTitle": "Menu",

--- a/apps/compliance-portal/src/_locales/pt-PT.json
+++ b/apps/compliance-portal/src/_locales/pt-PT.json
@@ -1,7 +1,7 @@
 {
   "topBar": {
     "tagline": "Portal de Conformidade",
-    "getAccess": "Obter Acesso",
+    "getAccess": "Pedir acesso",
     "openMenu": "Abrir menu",
     "closeMenu": "Fechar menu",
     "menuTitle": "Menu",

--- a/apps/compliance-portal/src/_locales/pt-PT.json
+++ b/apps/compliance-portal/src/_locales/pt-PT.json
@@ -83,7 +83,9 @@
     },
     "actions": {
       "backToCompliancePortal": "Voltar ao portal de conformidade",
-      "tryAgain": "Tentar novamente"
+      "tryAgain": "Tentar novamente",
+      "contactSupport": "Contactar o suporte",
+      "requestAccess": "Pedir acesso"
     },
     "inline": {
       "message": "Não foi possível carregar o conteúdo",

--- a/apps/compliance-portal/src/_locales/tr-TR.json
+++ b/apps/compliance-portal/src/_locales/tr-TR.json
@@ -83,7 +83,9 @@
     },
     "actions": {
       "backToCompliancePortal": "Uyumluluk Portalına geri dön",
-      "tryAgain": "Tekrar dene"
+      "tryAgain": "Tekrar dene",
+      "contactSupport": "Destek ile iletişime geç",
+      "requestAccess": "Erişim iste"
     },
     "inline": {
       "message": "İçerik yüklenemedi",

--- a/apps/compliance-portal/src/_locales/uk-UA.json
+++ b/apps/compliance-portal/src/_locales/uk-UA.json
@@ -83,7 +83,9 @@
     },
     "actions": {
       "backToCompliancePortal": "Назад до порталу відповідності",
-      "tryAgain": "Спробувати ще раз"
+      "tryAgain": "Спробувати ще раз",
+      "contactSupport": "Зв’язатися з підтримкою",
+      "requestAccess": "Запитати доступ"
     },
     "inline": {
       "message": "Не вдалося завантажити вміст",

--- a/apps/compliance-portal/src/_locales/uk-UA.json
+++ b/apps/compliance-portal/src/_locales/uk-UA.json
@@ -1,7 +1,7 @@
 {
   "topBar": {
     "tagline": "Портал відповідності",
-    "getAccess": "Отримати доступ",
+    "getAccess": "Запитати доступ",
     "openMenu": "Відкрити меню",
     "closeMenu": "Закрити меню",
     "menuTitle": "Меню",

--- a/apps/compliance-portal/src/_locales/zh-CN.json
+++ b/apps/compliance-portal/src/_locales/zh-CN.json
@@ -1,7 +1,7 @@
 {
   "topBar": {
     "tagline": "合规门户",
-    "getAccess": "获取访问权限",
+    "getAccess": "申请访问",
     "openMenu": "打开菜单",
     "closeMenu": "关闭菜单",
     "menuTitle": "菜单",

--- a/apps/compliance-portal/src/_locales/zh-CN.json
+++ b/apps/compliance-portal/src/_locales/zh-CN.json
@@ -83,7 +83,9 @@
     },
     "actions": {
       "backToCompliancePortal": "返回合规门户",
-      "tryAgain": "重试"
+      "tryAgain": "重试",
+      "contactSupport": "联系支持",
+      "requestAccess": "申请访问"
     },
     "inline": {
       "message": "无法加载内容",

--- a/apps/compliance-portal/src/components/TopBar/TopBar.tsx
+++ b/apps/compliance-portal/src/components/TopBar/TopBar.tsx
@@ -71,7 +71,7 @@ export function TopBar({ queryKey }: TopBarProps) {
   const entityName = currentCompliancePortal.entityName;
   const logoUrl = currentCompliancePortal.themedLogoUrl ?? undefined;
   const navItems = TOP_BAR_NAV_ITEMS.filter(
-    (item) => item.to !== "/requests" || currentCompliancePortal.rightsRequestsEnabled,
+    item => item.to !== "/requests" || currentCompliancePortal.rightsRequestsEnabled,
   );
 
   const slots = topBar();

--- a/apps/compliance-portal/src/components/TopBar/TopBar.tsx
+++ b/apps/compliance-portal/src/components/TopBar/TopBar.tsx
@@ -46,6 +46,8 @@ const topBarFragment = graphql`
     currentCompliancePortal @required(action: THROW) {
       themedLogoUrl
       entityName
+      rightsRequestsEnabled
+      ...TopBarMobileNav_compliancePortal
     }
   }
 `;
@@ -68,6 +70,9 @@ export function TopBar({ queryKey }: TopBarProps) {
   const { currentCompliancePortal } = data;
   const entityName = currentCompliancePortal.entityName;
   const logoUrl = currentCompliancePortal.themedLogoUrl ?? undefined;
+  const navItems = TOP_BAR_NAV_ITEMS.filter(
+    (item) => item.to !== "/requests" || currentCompliancePortal.rightsRequestsEnabled,
+  );
 
   const slots = topBar();
   const homePath = localizedPath("/");
@@ -100,7 +105,7 @@ export function TopBar({ queryKey }: TopBarProps) {
         </RouterLink>
 
         <nav className={slots.nav()}>
-          {TOP_BAR_NAV_ITEMS.map((item) => {
+          {navItems.map((item) => {
             const to = localizedPath(item.to);
             return (
               <ButtonLink
@@ -135,7 +140,10 @@ export function TopBar({ queryKey }: TopBarProps) {
             : <TopBarUserMenu identityKey={data.viewer} />}
         </nav>
 
-        <TopBarMobileNav identityKey={data.viewer ?? null} />
+        <TopBarMobileNav
+          identityKey={data.viewer ?? null}
+          compliancePortalKey={currentCompliancePortal}
+        />
       </div>
     </header>
   );

--- a/apps/compliance-portal/src/components/TopBar/TopBarMobileNav.tsx
+++ b/apps/compliance-portal/src/components/TopBar/TopBarMobileNav.tsx
@@ -51,6 +51,7 @@ import { useDisplayMode } from "#/lib/displayMode/useDisplayMode";
 import { useLocalizedPath } from "#/lib/i18n/useLocale";
 import { useSubscribeDialog } from "#/lib/mailingList/subscribeDialogContext";
 
+import type { TopBarMobileNav_compliancePortal$key } from "./__generated__/TopBarMobileNav_compliancePortal.graphql";
 import type { TopBarMobileNav_identity$key } from "./__generated__/TopBarMobileNav_identity.graphql";
 import { LocaleSelect } from "./LocaleSelect";
 import { TOP_BAR_NAV_ITEMS } from "./navItems";
@@ -63,8 +64,15 @@ const topBarMobileNavFragment = graphql`
   }
 `;
 
+const topBarMobileNavCompliancePortalFragment = graphql`
+  fragment TopBarMobileNav_compliancePortal on CompliancePortal {
+    rightsRequestsEnabled
+  }
+`;
+
 interface TopBarMobileNavProps {
   identityKey: TopBarMobileNav_identity$key | null;
+  compliancePortalKey: TopBarMobileNav_compliancePortal$key;
 }
 
 function isActive(pathname: string, to: string): boolean {
@@ -73,7 +81,7 @@ function isActive(pathname: string, to: string): boolean {
 
 // Burger trigger + right-edge drawer listing the same nav and account actions as
 // the desktop TopBar.
-export function TopBarMobileNav({ identityKey }: TopBarMobileNavProps) {
+export function TopBarMobileNav({ identityKey, compliancePortalKey }: TopBarMobileNavProps) {
   const { t } = useTranslation();
   const { pathname } = useLocation();
   const { openSubscribe, isSubscribed, unsubscribe, isUnsubscribing } = useSubscribeDialog();
@@ -85,6 +93,10 @@ export function TopBarMobileNav({ identityKey }: TopBarMobileNavProps) {
   // transform and would break Base UI's modal inert cutout over the trigger.
   const drawerViewportRef = useRef<HTMLDivElement>(null);
   const identity = useFragment(topBarMobileNavFragment, identityKey);
+  const compliancePortal = useFragment(
+    topBarMobileNavCompliancePortalFragment,
+    compliancePortalKey,
+  );
   const localizedPath = useLocalizedPath();
 
   const barSlots = topBar();
@@ -92,6 +104,10 @@ export function TopBarMobileNav({ identityKey }: TopBarMobileNavProps) {
   const displayName = identity
     ? (identity.fullName.trim() || identity.email)
     : null;
+
+  const navItems = TOP_BAR_NAV_ITEMS.filter(
+    (item) => item.to !== "/requests" || compliancePortal.rightsRequestsEnabled,
+  );
 
   const close = () => setOpen(false);
 
@@ -130,7 +146,7 @@ export function TopBarMobileNav({ identityKey }: TopBarMobileNavProps) {
 
         <DrawerBody>
           <nav className="contents">
-            {TOP_BAR_NAV_ITEMS.map((item) => {
+            {navItems.map((item) => {
               const to = localizedPath(item.to);
               return (
                 <ButtonLink

--- a/apps/compliance-portal/src/components/TopBar/TopBarMobileNav.tsx
+++ b/apps/compliance-portal/src/components/TopBar/TopBarMobileNav.tsx
@@ -106,7 +106,7 @@ export function TopBarMobileNav({ identityKey, compliancePortalKey }: TopBarMobi
     : null;
 
   const navItems = TOP_BAR_NAV_ITEMS.filter(
-    (item) => item.to !== "/requests" || compliancePortal.rightsRequestsEnabled,
+    item => item.to !== "/requests" || compliancePortal.rightsRequestsEnabled,
   );
 
   const close = () => setOpen(false);

--- a/apps/compliance-portal/src/components/errors/GlobalError.tsx
+++ b/apps/compliance-portal/src/components/errors/GlobalError.tsx
@@ -14,14 +14,21 @@
 
 import { ForbiddenError, InternalServerError, UnAuthenticatedError } from "@probo/relay";
 import { Button } from "@probo/ui/src/v2/Button/Button";
+import { ButtonAnchor } from "@probo/ui/src/v2/Button/ButtonAnchor";
 import { ButtonLink } from "@probo/ui/src/v2/Button/ButtonLink";
 import { ErrorState } from "@probo/ui/src/v2/ErrorState/ErrorState";
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
+import { getSafeContinueUrl, redirectToInitiate } from "#/lib/auth/continueUrl";
 import { useLocalizedPath } from "#/lib/i18n/useLocale";
+import { usePortalContactEmail } from "#/lib/portal/portalContactContext";
 import { NotFoundError } from "#/lib/relay/errors";
 
+type ErrorKind = "notFound" | "forbidden" | "server" | "generic";
+
 interface ErrorContent {
+  kind: ErrorKind;
   code?: string;
   titleKey: string;
   descriptionKey: string;
@@ -34,7 +41,12 @@ function resolveContent(error: unknown): ErrorContent {
   const message = error instanceof Error ? error.message : "";
 
   if (error instanceof NotFoundError || message.includes("NOT_FOUND")) {
-    return { code: "404", titleKey: "errors.notFound.title", descriptionKey: "errors.notFound.description" };
+    return {
+      kind: "notFound",
+      code: "404",
+      titleKey: "errors.notFound.title",
+      descriptionKey: "errors.notFound.description",
+    };
   }
 
   if (
@@ -43,30 +55,123 @@ function resolveContent(error: unknown): ErrorContent {
     || message.includes("FORBIDDEN")
     || message.includes("UNAUTHENTICATED")
   ) {
-    return { code: "403", titleKey: "errors.forbidden.title", descriptionKey: "errors.forbidden.description" };
+    return {
+      kind: "forbidden",
+      code: "403",
+      titleKey: "errors.forbidden.title",
+      descriptionKey: "errors.forbidden.description",
+    };
   }
 
   if (error instanceof InternalServerError || message.includes("INTERNAL_SERVER_ERROR")) {
-    return { code: "500", titleKey: "errors.serverError.title", descriptionKey: "errors.serverError.description" };
+    return {
+      kind: "server",
+      code: "500",
+      titleKey: "errors.serverError.title",
+      descriptionKey: "errors.serverError.description",
+    };
   }
 
-  return { titleKey: "errors.generic.title", descriptionKey: "errors.generic.description" };
+  return {
+    kind: "generic",
+    titleKey: "errors.generic.title",
+    descriptionKey: "errors.generic.description",
+  };
 }
 
 interface GlobalErrorProps {
   error: unknown;
-  // When provided, a "Try again" secondary action is shown.
+  // When provided, a "Try again" action is available (500 / generic).
   onRetry?: () => void;
   // Full viewport (standalone) vs inside the app chrome (in-shell).
   fullPage?: boolean;
 }
 
 // Page-level error fallback: renders the v2 ErrorState with portal copy and
-// actions. Used by the route boundaries (root + page).
+// status-specific actions (Figma "Error message / Page").
 export function GlobalError({ error, onRetry, fullPage = false }: GlobalErrorProps) {
   const { t } = useTranslation();
   const localizedPath = useLocalizedPath();
-  const { code, titleKey, descriptionKey } = resolveContent(error);
+  const contactEmail = usePortalContactEmail();
+  const { kind, code, titleKey, descriptionKey } = resolveContent(error);
+
+  const contactSupport = contactEmail != null
+    ? (
+        <ButtonAnchor
+          href={`mailto:${contactEmail}`}
+          variant="soft"
+          color="neutral"
+          size={2}
+        >
+          {t("errors.actions.contactSupport")}
+        </ButtonAnchor>
+      )
+    : null;
+
+  const backHome = (variant: "solid" | "soft") => (
+    <ButtonLink
+      to={localizedPath("/")}
+      variant={variant}
+      color="neutral"
+      highContrast={variant === "solid"}
+      size={2}
+    >
+      {t("errors.actions.backToCompliancePortal")}
+    </ButtonLink>
+  );
+
+  const tryAgain = onRetry != null
+    ? (
+        <Button
+          variant="solid"
+          color="neutral"
+          highContrast
+          size={2}
+          onClick={onRetry}
+        >
+          {t("errors.actions.tryAgain")}
+        </Button>
+      )
+    : null;
+
+  let actions: ReactNode;
+  switch (kind) {
+    case "notFound":
+      actions = (
+        <>
+          {backHome("solid")}
+          {contactSupport}
+        </>
+      );
+      break;
+    case "forbidden":
+      actions = (
+        <>
+          <Button
+            variant="solid"
+            color="neutral"
+            highContrast
+            size={2}
+            onClick={() => {
+              redirectToInitiate(getSafeContinueUrl(window.location.href));
+            }}
+          >
+            {t("errors.actions.requestAccess")}
+          </Button>
+          {backHome("soft")}
+        </>
+      );
+      break;
+    case "server":
+    case "generic":
+      actions = (
+        <>
+          {tryAgain ?? backHome("solid")}
+          {contactSupport}
+        </>
+      );
+      break;
+  }
 
   return (
     <ErrorState
@@ -74,18 +179,7 @@ export function GlobalError({ error, onRetry, fullPage = false }: GlobalErrorPro
       code={code}
       title={t(titleKey)}
       description={t(descriptionKey)}
-      actions={(
-        <>
-          <ButtonLink to={localizedPath("/")} variant="solid" color="neutral" highContrast size={2}>
-            {t("errors.actions.backToCompliancePortal")}
-          </ButtonLink>
-          {onRetry && (
-            <Button variant="soft" color="neutral" size={2} onClick={onRetry}>
-              {t("errors.actions.tryAgain")}
-            </Button>
-          )}
-        </>
-      )}
+      actions={actions}
     />
   );
 }

--- a/apps/compliance-portal/src/lib/portal/portalContactContext.ts
+++ b/apps/compliance-portal/src/lib/portal/portalContactContext.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { createContext, useContext } from "react";
+
+// Optional portal contact email for in-shell chrome (error "Contact support").
+// Null outside MainLayout (standalone full-page errors).
+const PortalContactEmailContext = createContext<string | null>(null);
+
+export const PortalContactEmailProvider = PortalContactEmailContext.Provider;
+
+export function usePortalContactEmail(): string | null {
+  return useContext(PortalContactEmailContext);
+}

--- a/apps/compliance-portal/src/pages/MainLayout.tsx
+++ b/apps/compliance-portal/src/pages/MainLayout.tsx
@@ -30,6 +30,7 @@ import { UnsignedNDABanner } from "#/components/UnsignedNDABanner/UnsignedNDABan
 import { useResumeAccessRequest } from "#/lib/auth/useResumeAccessRequest";
 import { useEnsureViewerLocale } from "#/lib/i18n/useEnsureViewerLocale";
 import { SubscribeDialogProvider } from "#/lib/mailingList/SubscribeDialogProvider";
+import { PortalContactEmailProvider } from "#/lib/portal/portalContactContext";
 
 import type { MainLayoutQuery } from "./__generated__/MainLayoutQuery.graphql";
 
@@ -41,6 +42,7 @@ export const mainLayoutQuery = graphql`
       ...useEnsureViewerLocale_identity
     }
     currentCompliancePortal {
+      email
       ...UnsignedNDABanner_compliancePortal
     }
     ...TopBar_query
@@ -66,30 +68,32 @@ export function MainLayout({ queryRef }: MainLayoutProps) {
   // stage; every other page uses normal document flow so the footer sits after
   // content (and at the bottom of short pages via flex-1 main).
   return (
-    <SubscribeDialogProvider queryKey={data}>
-      <div
-        className={
-          isDocumentViewer
-            ? "flex h-dvh flex-col bg-sand-2"
-            : "flex min-h-dvh flex-col bg-sand-2"
-        }
-      >
-        <TopBar queryKey={data} />
-        <LocaleMismatchBanner identityKey={data.viewer ?? null} />
-        {data.viewer != null && data.currentCompliancePortal != null
-          ? <UnsignedNDABanner compliancePortalKey={data.currentCompliancePortal} />
-          : null}
+    <PortalContactEmailProvider value={data.currentCompliancePortal?.email ?? null}>
+      <SubscribeDialogProvider queryKey={data}>
         <div
           className={
             isDocumentViewer
-              ? "flex min-h-0 flex-1 flex-col overflow-hidden"
-              : "flex flex-1 flex-col"
+              ? "flex h-dvh flex-col bg-sand-2"
+              : "flex min-h-dvh flex-col bg-sand-2"
           }
         >
-          <Outlet />
+          <TopBar queryKey={data} />
+          <LocaleMismatchBanner identityKey={data.viewer ?? null} />
+          {data.viewer != null && data.currentCompliancePortal != null
+            ? <UnsignedNDABanner compliancePortalKey={data.currentCompliancePortal} />
+            : null}
+          <div
+            className={
+              isDocumentViewer
+                ? "flex min-h-0 flex-1 flex-col overflow-hidden"
+                : "flex flex-1 flex-col"
+            }
+          >
+            <Outlet />
+          </div>
+          {isDocumentViewer ? null : <PoweredBy label={t("footer.poweredBy")} />}
         </div>
-        {isDocumentViewer ? null : <PoweredBy label={t("footer.poweredBy")} />}
-      </div>
-    </SubscribeDialogProvider>
+      </SubscribeDialogProvider>
+    </PortalContactEmailProvider>
   );
 }

--- a/apps/compliance-portal/src/pages/documents/_locales/en-US.json
+++ b/apps/compliance-portal/src/pages/documents/_locales/en-US.json
@@ -22,7 +22,7 @@
   },
   "actions": {
     "view": "View",
-    "getAccess": "Get Access",
+    "getAccess": "Request Access",
     "requested": "Access requested"
   },
   "selection": {

--- a/apps/compliance-portal/src/pages/documents/_locales/fr-FR.json
+++ b/apps/compliance-portal/src/pages/documents/_locales/fr-FR.json
@@ -22,7 +22,7 @@
   },
   "actions": {
     "view": "Consulter",
-    "getAccess": "Obtenir l'accès",
+    "getAccess": "Demander l'accès",
     "requested": "Accès demandé"
   },
   "selection": {

--- a/apps/compliance-portal/src/pages/documents/_locales/id-ID.json
+++ b/apps/compliance-portal/src/pages/documents/_locales/id-ID.json
@@ -22,7 +22,7 @@
   },
   "actions": {
     "view": "Lihat",
-    "getAccess": "Dapatkan Akses",
+    "getAccess": "Minta Akses",
     "requested": "Akses telah diminta"
   },
   "selection": {

--- a/apps/compliance-portal/src/pages/documents/_locales/pl-PL.json
+++ b/apps/compliance-portal/src/pages/documents/_locales/pl-PL.json
@@ -22,7 +22,7 @@
   },
   "actions": {
     "view": "Wyświetl",
-    "getAccess": "Uzyskaj dostęp",
+    "getAccess": "Poproś o dostęp",
     "requested": "Poproszono o dostęp"
   },
   "selection": {

--- a/apps/compliance-portal/src/pages/documents/_locales/pt-PT.json
+++ b/apps/compliance-portal/src/pages/documents/_locales/pt-PT.json
@@ -22,7 +22,7 @@
   },
   "actions": {
     "view": "Ver",
-    "getAccess": "Obter Acesso",
+    "getAccess": "Pedir acesso",
     "requested": "Acesso solicitado"
   },
   "selection": {

--- a/apps/compliance-portal/src/pages/documents/_locales/uk-UA.json
+++ b/apps/compliance-portal/src/pages/documents/_locales/uk-UA.json
@@ -22,7 +22,7 @@
   },
   "actions": {
     "view": "Переглянути",
-    "getAccess": "Отримати доступ",
+    "getAccess": "Запитати доступ",
     "requested": "Доступ запитано"
   },
   "selection": {

--- a/apps/compliance-portal/src/pages/documents/_locales/zh-CN.json
+++ b/apps/compliance-portal/src/pages/documents/_locales/zh-CN.json
@@ -22,7 +22,7 @@
   },
   "actions": {
     "view": "查看",
-    "getAccess": "获取访问权限",
+    "getAccess": "申请访问权限",
     "requested": "已申请访问权限"
   },
   "selection": {

--- a/apps/compliance-portal/src/pages/requests/RequestsPage.tsx
+++ b/apps/compliance-portal/src/pages/requests/RequestsPage.tsx
@@ -35,16 +35,23 @@ import {
   NEW_REQUEST_PARAM,
   redirectToInitiate,
 } from "#/lib/auth/continueUrl";
+import { NotFoundError } from "#/lib/relay/errors";
 
 import type { RequestsPage_query$key } from "./__generated__/RequestsPage_query.graphql";
-import type { RequestsPageQuery } from "./__generated__/RequestsPageQuery.graphql";
+import type {
+  RequestsPageQuery$data,
+  RequestsPageQuery,
+} from "./__generated__/RequestsPageQuery.graphql";
 import type { RequestsPageRefetchQuery } from "./__generated__/RequestsPageRefetchQuery.graphql";
 import { NewRequestDialog } from "./_components/NewRequestDialog";
 import { RightsRequestListItem } from "./_components/RightsRequestListItem";
 import { requestsLayout } from "./variants";
 
 export const requestsPageQuery = graphql`
-  query RequestsPageQuery @throwOnFieldError {
+  query RequestsPageQuery {
+    currentCompliancePortal @required(action: THROW) {
+      rightsRequestsEnabled
+    }
     viewer {
       email
       fullName
@@ -59,7 +66,8 @@ const requestsPageFragment = graphql`
   @argumentDefinitions(
     first: { type: "Int", defaultValue: 50 }
     after: { type: "CursorKey" }
-  ) {
+  )
+  @throwOnFieldError {
     myRightsRequests(first: $first, after: $after)
     @connection(key: "RequestsPage_myRightsRequests") {
       __id
@@ -81,17 +89,34 @@ interface RequestsPageProps {
 // Request" flow gated behind sign-in for guests. Submission and the personal
 // list are scoped to the verified viewer's email server-side.
 export function RequestsPage({ queryRef }: RequestsPageProps) {
+  const data = usePreloadedQuery<RequestsPageQuery>(requestsPageQuery, queryRef);
+  const { currentCompliancePortal, viewer } = data;
+
+  // Disabled capability → explicit 404 before the list fragment is read (the
+  // API returns NOT_FOUND for myRightsRequests, which would otherwise surface
+  // as Relay's opaque field-error message).
+  if (!currentCompliancePortal.rightsRequestsEnabled) {
+    throw new NotFoundError();
+  }
+
+  return <RequestsPageContent queryKey={data} viewer={viewer} />;
+}
+
+interface RequestsPageContentProps {
+  queryKey: RequestsPage_query$key;
+  viewer: RequestsPageQuery$data["viewer"];
+}
+
+function RequestsPageContent({ queryKey, viewer }: RequestsPageContentProps) {
   const { t } = useTranslation("requests");
-  const root = usePreloadedQuery<RequestsPageQuery>(requestsPageQuery, queryRef);
   const { data, loadNext, hasNext, isLoadingNext, refetch } = usePaginationFragment<
     RequestsPageRefetchQuery,
     RequestsPage_query$key
-  >(requestsPageFragment, root);
+  >(requestsPageFragment, queryKey);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const [dialogOpen, setDialogOpen] = useState(false);
 
-  const viewer = root.viewer;
   const requests = data.myRightsRequests?.edges?.map(edge => edge.node) ?? [];
   const connectionId = data.myRightsRequests?.__id ?? "";
 

--- a/apps/compliance-portal/src/pages/requests/RequestsPage.tsx
+++ b/apps/compliance-portal/src/pages/requests/RequestsPage.tsx
@@ -44,7 +44,7 @@ import { RightsRequestListItem } from "./_components/RightsRequestListItem";
 import { requestsLayout } from "./variants";
 
 export const requestsPageQuery = graphql`
-  query RequestsPageQuery {
+  query RequestsPageQuery @throwOnFieldError {
     viewer {
       email
       fullName

--- a/apps/compliance-portal/src/pages/requests/RequestsPageError.tsx
+++ b/apps/compliance-portal/src/pages/requests/RequestsPageError.tsx
@@ -25,9 +25,10 @@ import { gateRedirectPath } from "#/lib/auth/continueUrl";
 import { NotFoundError } from "#/lib/relay/errors";
 
 // Relay's @throwOnFieldError discards the GraphQL extensions code and throws a
-// generic Error ("Unexpected response payload" / "Missing expected data"). On
-// this page that means the non-null myRightsRequests field failed — typically
-// NOT_FOUND when rights requests are disabled — so map it to the 404 UI.
+// generic Error ("Relay: Unexpected response payload" / "Missing expected
+// data"). On this page that usually means myRightsRequests failed with
+// NOT_FOUND (capability off) — map it to the 404 UI as a fallback when the
+// explicit rightsRequestsEnabled check did not run first.
 function isDisabledRequestsSurface(error: unknown): boolean {
   if (error instanceof NotFoundError) {
     return true;
@@ -45,7 +46,7 @@ function isDisabledRequestsSurface(error: unknown): boolean {
 }
 
 // Route ErrorBoundary for /requests. Renders inside MainLayout's Outlet so the
-// TopBar and footer stay visible.
+// TopBar and footer stay visible. Matches Figma "Page / 404 / App shell".
 export function RequestsPageError() {
   const error = useRouteError();
 
@@ -54,9 +55,13 @@ export function RequestsPageError() {
     return <Navigate replace to={gateRedirect} />;
   }
 
+  if (isDisabledRequestsSurface(error)) {
+    return <GlobalError error={new NotFoundError()} />;
+  }
+
   return (
     <GlobalError
-      error={isDisabledRequestsSurface(error) ? new NotFoundError() : error}
+      error={error}
       onRetry={() => window.location.reload()}
     />
   );

--- a/apps/compliance-portal/src/pages/requests/RequestsPageError.tsx
+++ b/apps/compliance-portal/src/pages/requests/RequestsPageError.tsx
@@ -24,25 +24,11 @@ import { GlobalError } from "#/components/errors/GlobalError";
 import { gateRedirectPath } from "#/lib/auth/continueUrl";
 import { NotFoundError } from "#/lib/relay/errors";
 
-// Relay's @throwOnFieldError discards the GraphQL extensions code and throws a
-// generic Error ("Relay: Unexpected response payload" / "Missing expected
-// data"). On this page that usually means myRightsRequests failed with
-// NOT_FOUND (capability off) — map it to the 404 UI as a fallback when the
-// explicit rightsRequestsEnabled check did not run first.
-function isDisabledRequestsSurface(error: unknown): boolean {
+function isNotFound(error: unknown): boolean {
   if (error instanceof NotFoundError) {
     return true;
   }
-  if (isRouteErrorResponse(error) && error.status === 404) {
-    return true;
-  }
-  if (!(error instanceof Error)) {
-    return false;
-  }
-  return (
-    error.message.includes("Unexpected response payload")
-    || error.message.includes("Missing expected data")
-  );
+  return isRouteErrorResponse(error) && error.status === 404;
 }
 
 // Route ErrorBoundary for /requests. Renders inside MainLayout's Outlet so the
@@ -55,7 +41,7 @@ export function RequestsPageError() {
     return <Navigate replace to={gateRedirect} />;
   }
 
-  if (isDisabledRequestsSurface(error)) {
+  if (isNotFound(error)) {
     return <GlobalError error={new NotFoundError()} />;
   }
 

--- a/apps/compliance-portal/src/pages/requests/RequestsPageError.tsx
+++ b/apps/compliance-portal/src/pages/requests/RequestsPageError.tsx
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { isRouteErrorResponse, Navigate, useRouteError } from "react-router";
+
+import { GlobalError } from "#/components/errors/GlobalError";
+import { gateRedirectPath } from "#/lib/auth/continueUrl";
+import { NotFoundError } from "#/lib/relay/errors";
+
+// Relay's @throwOnFieldError discards the GraphQL extensions code and throws a
+// generic Error ("Unexpected response payload" / "Missing expected data"). On
+// this page that means the non-null myRightsRequests field failed — typically
+// NOT_FOUND when rights requests are disabled — so map it to the 404 UI.
+function isDisabledRequestsSurface(error: unknown): boolean {
+  if (error instanceof NotFoundError) {
+    return true;
+  }
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return true;
+  }
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return (
+    error.message.includes("Unexpected response payload")
+    || error.message.includes("Missing expected data")
+  );
+}
+
+// Route ErrorBoundary for /requests. Renders inside MainLayout's Outlet so the
+// TopBar and footer stay visible.
+export function RequestsPageError() {
+  const error = useRouteError();
+
+  const gateRedirect = gateRedirectPath(error, window.location.href);
+  if (gateRedirect) {
+    return <Navigate replace to={gateRedirect} />;
+  }
+
+  return (
+    <GlobalError
+      error={isDisabledRequestsSurface(error) ? new NotFoundError() : error}
+      onRetry={() => window.location.reload()}
+    />
+  );
+}

--- a/apps/compliance-portal/src/pages/requests/routes.ts
+++ b/apps/compliance-portal/src/pages/requests/routes.ts
@@ -21,6 +21,7 @@
 import { lazy } from "@probo/react-lazy";
 import type { AppRoute } from "@probo/routes";
 
+import { RequestsPageError } from "./RequestsPageError";
 import { RequestsPageSkeleton } from "./RequestsPageSkeleton";
 
 export const requestRoutes = [
@@ -28,5 +29,6 @@ export const requestRoutes = [
     path: "requests",
     Fallback: RequestsPageSkeleton,
     Component: lazy(() => import("./RequestsPageLoader")),
+    ErrorBoundary: RequestsPageError,
   },
 ] satisfies AppRoute[];

--- a/apps/console/src/hooks/graph/CompliancePortalGraph.ts
+++ b/apps/console/src/hooks/graph/CompliancePortalGraph.ts
@@ -32,6 +32,7 @@ const updateCompliancePortalMutation = graphql`
         id
         active
         searchEngineIndexing
+        rightsRequestsEnabled
         entityName
         description
         websiteUrl

--- a/apps/console/src/pages/organizations/compliance-portals/_locales/en-US.json
+++ b/apps/console/src/pages/organizations/compliance-portals/_locales/en-US.json
@@ -477,6 +477,10 @@
       "title": "Search engine indexing",
       "description": "Allow search engines to index your compliance portal and make it discoverable",
       "disabledHint": "Activate your compliance portal first to enable search engine indexing"
+    },
+    "rightsRequests": {
+      "title": "Rights requests",
+      "description": "Let visitors submit data subject rights requests on your compliance portal"
     }
   },
   "slackSection": {

--- a/apps/console/src/pages/organizations/compliance-portals/_locales/fr-FR.json
+++ b/apps/console/src/pages/organizations/compliance-portals/_locales/fr-FR.json
@@ -480,6 +480,10 @@
       "title": "Indexation par les moteurs de recherche",
       "description": "Autorisez les moteurs de recherche à indexer votre portail de conformité et à la rendre repérable",
       "disabledHint": "Activez d’abord votre portail de conformité pour permettre l’indexation par les moteurs de recherche"
+    },
+    "rightsRequests": {
+      "title": "Demandes de droits",
+      "description": "Permettez aux visiteurs de soumettre des demandes relatives aux droits des personnes concernées sur votre portail de conformité"
     }
   },
   "slackSection": {

--- a/apps/console/src/pages/organizations/compliance-portals/_locales/nl-NL.json
+++ b/apps/console/src/pages/organizations/compliance-portals/_locales/nl-NL.json
@@ -195,7 +195,11 @@
   "statusSection": {
     "title": "Status van compliancepagina",
     "activation": { "title": "Compliancepagina activeren", "description": "Maak uw compliancepagina openbaar toegankelijk om het vertrouwen van klanten te vergroten" },
-    "indexing": { "title": "Indexering door zoekmachines", "description": "Sta toe dat zoekmachines uw compliancepagina indexeren en vindbaar maken", "disabledHint": "Activeer eerst uw compliancepagina om indexering door zoekmachines mogelijk te maken" }
+    "indexing": { "title": "Indexering door zoekmachines", "description": "Sta toe dat zoekmachines uw compliancepagina indexeren en vindbaar maken", "disabledHint": "Activeer eerst uw compliancepagina om indexering door zoekmachines mogelijk te maken" },
+    "rightsRequests": {
+      "title": "Rechtenverzoeken",
+      "description": "Laat bezoekers verzoeken om rechten van betrokkenen indienen op uw compliancepagina"
+    }
   },
   "slackSection": {
     "title": "Integraties",

--- a/apps/console/src/pages/organizations/compliance-portals/configuration/overview/_components/CompliancePortalStatusSection.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/configuration/overview/_components/CompliancePortalStatusSection.tsx
@@ -143,6 +143,7 @@ export function CompliancePortalStatusSection(props: {
             checked={compliancePortal.rightsRequestsEnabled}
             onChange={checked => void handleToggleRightsRequests(checked)}
             disabled={!compliancePortal.canUpdate}
+            aria-label={t("statusSection.rightsRequests.title")}
           />
         </div>
       </Card>

--- a/apps/console/src/pages/organizations/compliance-portals/configuration/overview/_components/CompliancePortalStatusSection.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/configuration/overview/_components/CompliancePortalStatusSection.tsx
@@ -31,6 +31,7 @@ const fragment = graphql`
     id
     active
     searchEngineIndexing
+    rightsRequestsEnabled
     canUpdate: permission(action: "compliance-portal:portal:update")
   }
 `;
@@ -66,6 +67,17 @@ export function CompliancePortalStatusSection(props: {
         input: {
           compliancePortalId: compliancePortal.id,
           searchEngineIndexing: indexable ? "INDEXABLE" : "NOT_INDEXABLE",
+        },
+      },
+    });
+  };
+
+  const handleToggleRightsRequests = async (rightsRequestsEnabled: boolean) => {
+    await updateCompliancePortal({
+      variables: {
+        input: {
+          compliancePortalId: compliancePortal.id,
+          rightsRequestsEnabled,
         },
       },
     });
@@ -118,6 +130,20 @@ export function CompliancePortalStatusSection(props: {
               }
             />
           </span>
+        </div>
+
+        <div className="flex items-center justify-between border-t border-border-solid pt-4">
+          <div className="space-y-1">
+            <h3 className="font-medium">{t("statusSection.rightsRequests.title")}</h3>
+            <p className="text-sm text-txt-tertiary">
+              {t("statusSection.rightsRequests.description")}
+            </p>
+          </div>
+          <Toggle
+            checked={compliancePortal.rightsRequestsEnabled}
+            onChange={checked => void handleToggleRightsRequests(checked)}
+            disabled={!compliancePortal.canUpdate}
+          />
         </div>
       </Card>
     </div>

--- a/packages/n8n-node/nodes/Probo/actions/compliancePortal/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/compliancePortal/create.operation.ts
@@ -68,6 +68,7 @@ export async function execute(
 						slug
 						active
 						searchEngineIndexing
+						rightsRequestsEnabled
 						entityName
 						description
 						websiteUrl

--- a/packages/n8n-node/nodes/Probo/actions/compliancePortal/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/compliancePortal/get.operation.ts
@@ -52,6 +52,7 @@ export async function execute(
 					slug
 					active
 					searchEngineIndexing
+					rightsRequestsEnabled
 					entityName
 					description
 					websiteUrl

--- a/packages/n8n-node/nodes/Probo/actions/compliancePortal/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/compliancePortal/getAll.operation.ts
@@ -87,6 +87,7 @@ export async function execute(
 								slug
 								active
 								searchEngineIndexing
+								rightsRequestsEnabled
 								entityName
 								description
 								websiteUrl

--- a/packages/n8n-node/nodes/Probo/actions/compliancePortal/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/compliancePortal/update.operation.ts
@@ -77,6 +77,33 @@ export const description: INodeProperties[] = [
 		description: 'Whether search engines should index the compliance portal',
 	},
 	{
+		displayName: 'Rights Requests Enabled',
+		name: 'rightsRequestsEnabled',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: ['compliancePortal'],
+				operation: ['update'],
+			},
+		},
+		options: [
+			{
+				name: '(Unchanged)',
+				value: '',
+			},
+			{
+				name: 'Enabled',
+				value: 'true',
+			},
+			{
+				name: 'Disabled',
+				value: 'false',
+			},
+		],
+		default: '',
+		description: 'Whether visitors can submit rights requests on the compliance portal',
+	},
+	{
 		displayName: 'Entity Name',
 		name: 'entityName',
 		type: 'string',
@@ -151,6 +178,7 @@ export async function execute(
 	const compliancePortalId = this.getNodeParameter('compliancePortalId', itemIndex) as string;
 	const active = this.getNodeParameter('active', itemIndex) as boolean | undefined;
 	const searchEngineIndexing = this.getNodeParameter('searchEngineIndexing', itemIndex, '') as string;
+	const rightsRequestsEnabled = this.getNodeParameter('rightsRequestsEnabled', itemIndex, '') as string;
 	const description = this.getNodeParameter('description', itemIndex, '') as string;
 	const websiteUrl = this.getNodeParameter('websiteUrl', itemIndex, '') as string;
 	const email = this.getNodeParameter('email', itemIndex, '') as string;
@@ -164,6 +192,7 @@ export async function execute(
 					id
 					active
 					searchEngineIndexing
+					rightsRequestsEnabled
 					entityName
 					description
 					websiteUrl
@@ -186,6 +215,8 @@ export async function execute(
 	};
 	if (active !== undefined) input.active = active;
 	if (searchEngineIndexing) input.searchEngineIndexing = searchEngineIndexing;
+	if (rightsRequestsEnabled === 'true') input.rightsRequestsEnabled = true;
+	if (rightsRequestsEnabled === 'false') input.rightsRequestsEnabled = false;
 
 	const responseData = await proboApiRequest.call(this, query, { input });
 

--- a/packages/ui/src/Atoms/Toggle/Toggle.tsx
+++ b/packages/ui/src/Atoms/Toggle/Toggle.tsx
@@ -24,14 +24,22 @@ const sizes = {
 } as const;
 
 type Props = {
-  checked: boolean;
-  onChange: (checked: boolean) => void;
-  disabled?: boolean;
-  size?: keyof typeof sizes;
-  title?: string;
+  "checked": boolean;
+  "onChange": (checked: boolean) => void;
+  "disabled"?: boolean;
+  "size"?: keyof typeof sizes;
+  "title"?: string;
+  "aria-label"?: string;
 };
 
-export function Toggle({ checked, onChange, disabled = false, size = "default", title }: Props) {
+export function Toggle({
+  checked,
+  onChange,
+  disabled = false,
+  size = "default",
+  title,
+  "aria-label": ariaLabel,
+}: Props) {
   const { track, thumb } = sizes[size];
   const travel = track.width - thumb - track.padding * 2;
 
@@ -40,6 +48,7 @@ export function Toggle({ checked, onChange, disabled = false, size = "default", 
       type="button"
       role="switch"
       aria-checked={checked}
+      aria-label={ariaLabel}
       disabled={disabled}
       title={title}
       onClick={() => !disabled && onChange(!checked)}

--- a/pkg/cmd/compliance-portal/update/update.go
+++ b/pkg/cmd/compliance-portal/update/update.go
@@ -36,6 +36,7 @@ mutation($input: UpdateCompliancePortalInput!) {
       id
       active
       searchEngineIndexing
+      rightsRequestsEnabled
       entityName
       description
       websiteUrl
@@ -49,28 +50,30 @@ mutation($input: UpdateCompliancePortalInput!) {
 type updateResponse struct {
 	UpdateCompliancePortal struct {
 		CompliancePortal struct {
-			ID                   string  `json:"id"`
-			Active               bool    `json:"active"`
-			SearchEngineIndexing string  `json:"searchEngineIndexing"`
-			EntityName           string  `json:"entityName"`
-			Description          *string `json:"description"`
-			WebsiteURL           *string `json:"websiteUrl"`
-			Email                *string `json:"email"`
-			HeadquarterAddress   *string `json:"headquarterAddress"`
+			ID                    string  `json:"id"`
+			Active                bool    `json:"active"`
+			SearchEngineIndexing  string  `json:"searchEngineIndexing"`
+			RightsRequestsEnabled bool    `json:"rightsRequestsEnabled"`
+			EntityName            string  `json:"entityName"`
+			Description           *string `json:"description"`
+			WebsiteURL            *string `json:"websiteUrl"`
+			Email                 *string `json:"email"`
+			HeadquarterAddress    *string `json:"headquarterAddress"`
 		} `json:"compliancePortal"`
 	} `json:"updateCompliancePortal"`
 }
 
 func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	var (
-		flagPortal               string
-		flagActive               bool
-		flagSearchEngineIndexing string
-		flagDescription          string
-		flagWebsiteURL           string
-		flagEmail                string
-		flagHeadquarterAddress   string
-		flagEntityName           string
+		flagPortal                string
+		flagActive                bool
+		flagSearchEngineIndexing  string
+		flagRightsRequestsEnabled bool
+		flagDescription           string
+		flagWebsiteURL            string
+		flagEmail                 string
+		flagHeadquarterAddress    string
+		flagEntityName            string
 	)
 
 	cmd := &cobra.Command{
@@ -80,7 +83,10 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
   prb compliance-portal update --active
 
   # Disable search engine indexing
-  prb compliance-portal update --search-engine-indexing NOT_INDEXABLE`,
+  prb compliance-portal update --search-engine-indexing NOT_INDEXABLE
+
+  # Disable rights requests on the portal
+  prb compliance-portal update --rights-requests-enabled=false`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := f.Config()
@@ -115,6 +121,10 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				}
 
 				input["searchEngineIndexing"] = flagSearchEngineIndexing
+			}
+
+			if cmd.Flags().Changed("rights-requests-enabled") {
+				input["rightsRequestsEnabled"] = flagRightsRequestsEnabled
 			}
 
 			if cmd.Flags().Changed("description") {
@@ -174,6 +184,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	_ = cmd.MarkFlagRequired("portal")
 	cmd.Flags().BoolVar(&flagActive, "active", false, "Enable or disable the compliance portal")
 	cmd.Flags().StringVar(&flagSearchEngineIndexing, "search-engine-indexing", "", "Search engine indexing: INDEXABLE, NOT_INDEXABLE")
+	cmd.Flags().BoolVar(&flagRightsRequestsEnabled, "rights-requests-enabled", false, "Enable or disable rights requests on the compliance portal")
 	cmd.Flags().StringVar(&flagDescription, "description", "", "Compliance page description")
 	cmd.Flags().StringVar(&flagWebsiteURL, "website-url", "", "Compliance page website URL")
 	cmd.Flags().StringVar(&flagEmail, "email", "", "Compliance page contact email")

--- a/pkg/complianceportal/management/portal_service.go
+++ b/pkg/complianceportal/management/portal_service.go
@@ -210,16 +210,16 @@ func (s *Service) Create(
 			}
 
 			portal = &coredata.CompliancePortal{
-				ID:                    gid.New(tenantID, coredata.CompliancePortalEntityType),
-				OrganizationID:        organization.ID,
-				TenantID:              tenantID,
-				Active:                false,
-				EntityName:            req.EntityName,
-				SearchEngineIndexing:  coredata.SearchEngineIndexingNotIndexable,
-				RightsRequestsEnabled: true,
-				MailingListID:         &mailingList.ID,
-				CreatedAt:             now,
-				UpdatedAt:             now,
+				ID:                   gid.New(tenantID, coredata.CompliancePortalEntityType),
+				OrganizationID:       organization.ID,
+				TenantID:             tenantID,
+				Active:               false,
+				EntityName:           req.EntityName,
+				SearchEngineIndexing: coredata.SearchEngineIndexingNotIndexable,
+				Capabilities:         coredata.DefaultCompliancePortalCapabilities(),
+				MailingListID:        &mailingList.ID,
+				CreatedAt:            now,
+				UpdatedAt:            now,
 			}
 
 			const maxSlugAttempts = 5
@@ -407,7 +407,7 @@ func (s *Service) Update(
 			}
 
 			if req.RightsRequestsEnabled != nil {
-				portal.RightsRequestsEnabled = *req.RightsRequestsEnabled
+				portal.Capabilities.RightsRequests = *req.RightsRequestsEnabled
 			}
 
 			if req.EntityName != nil {

--- a/pkg/complianceportal/management/portal_service.go
+++ b/pkg/complianceportal/management/portal_service.go
@@ -51,6 +51,7 @@ type (
 		Active                       *bool
 		Slug                         *string
 		SearchEngineIndexing         *coredata.SearchEngineIndexing
+		RightsRequestsEnabled        *bool
 		NonDisclosureAgreementFileID *gid.GID
 		EntityName                   *string
 		Description                  **string
@@ -209,15 +210,16 @@ func (s *Service) Create(
 			}
 
 			portal = &coredata.CompliancePortal{
-				ID:                   gid.New(tenantID, coredata.CompliancePortalEntityType),
-				OrganizationID:       organization.ID,
-				TenantID:             tenantID,
-				Active:               false,
-				EntityName:           req.EntityName,
-				SearchEngineIndexing: coredata.SearchEngineIndexingNotIndexable,
-				MailingListID:        &mailingList.ID,
-				CreatedAt:            now,
-				UpdatedAt:            now,
+				ID:                    gid.New(tenantID, coredata.CompliancePortalEntityType),
+				OrganizationID:        organization.ID,
+				TenantID:              tenantID,
+				Active:                false,
+				EntityName:            req.EntityName,
+				SearchEngineIndexing:  coredata.SearchEngineIndexingNotIndexable,
+				RightsRequestsEnabled: true,
+				MailingListID:         &mailingList.ID,
+				CreatedAt:             now,
+				UpdatedAt:             now,
 			}
 
 			const maxSlugAttempts = 5
@@ -402,6 +404,10 @@ func (s *Service) Update(
 
 			if req.SearchEngineIndexing != nil {
 				portal.SearchEngineIndexing = *req.SearchEngineIndexing
+			}
+
+			if req.RightsRequestsEnabled != nil {
+				portal.RightsRequestsEnabled = *req.RightsRequestsEnabled
 			}
 
 			if req.EntityName != nil {

--- a/pkg/complianceportal/visitor/errors.go
+++ b/pkg/complianceportal/visitor/errors.go
@@ -40,4 +40,5 @@ var (
 	ErrPortalFileNotVisible    = errors.New("portal file not visible")
 	ErrPortalReferenceNotFound = errors.New("portal reference not found")
 	ErrNoAccessTargets         = errors.New("at least one document, report, or file id is required")
+	ErrRightsRequestsDisabled  = errors.New("rights requests are disabled on this compliance portal")
 )

--- a/pkg/complianceportal/visitor/rights_request_service.go
+++ b/pkg/complianceportal/visitor/rights_request_service.go
@@ -91,6 +91,10 @@ func (s *Service) CreateRightsRequest(
 				return err
 			}
 
+			if !compliancePortal.RightsRequestsEnabled {
+				return ErrRightsRequestsDisabled
+			}
+
 			organization := &coredata.Organization{}
 			if err := organization.LoadByID(ctx, tx, scope, compliancePortal.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)

--- a/pkg/complianceportal/visitor/rights_request_service.go
+++ b/pkg/complianceportal/visitor/rights_request_service.go
@@ -91,7 +91,7 @@ func (s *Service) CreateRightsRequest(
 				return err
 			}
 
-			if !compliancePortal.RightsRequestsEnabled {
+			if !compliancePortal.Capabilities.RightsRequests {
 				return ErrRightsRequestsDisabled
 			}
 

--- a/pkg/complianceportal/visitor/rights_request_service_test.go
+++ b/pkg/complianceportal/visitor/rights_request_service_test.go
@@ -121,6 +121,7 @@ func TestRightsRequestService_CreateDisabledReturnsErr(t *testing.T) {
 	require.ErrorIs(t, err, ErrRightsRequestsDisabled)
 
 	var requestCount int
+
 	err = client.WithConn(
 		t.Context(),
 		func(ctx context.Context, conn pg.Querier) error {
@@ -135,6 +136,7 @@ func TestRightsRequestService_CreateDisabledReturnsErr(t *testing.T) {
 	assert.Equal(t, 0, requestCount)
 
 	var webhookCount int
+
 	err = client.WithConn(
 		t.Context(),
 		func(ctx context.Context, conn pg.Querier) error {

--- a/pkg/complianceportal/visitor/rights_request_service_test.go
+++ b/pkg/complianceportal/visitor/rights_request_service_test.go
@@ -142,12 +142,12 @@ func insertPortalRequestWebhookPortal(
 		TenantID:       organizationID.TenantID(),
 		Active:         true,
 		// Slugs are constrained to ^[a-z0-9_-]+$, so lowercase the base64url GID.
-		Slug:                  strings.ToLower(portalID.String()),
-		SearchEngineIndexing:  coredata.SearchEngineIndexingNotIndexable,
-		RightsRequestsEnabled: true,
-		EntityName:            "Portal Request Webhook",
-		CreatedAt:             now,
-		UpdatedAt:             now,
+		Slug:                 strings.ToLower(portalID.String()),
+		SearchEngineIndexing: coredata.SearchEngineIndexingNotIndexable,
+		Capabilities:         coredata.DefaultCompliancePortalCapabilities(),
+		EntityName:           "Portal Request Webhook",
+		CreatedAt:            now,
+		UpdatedAt:            now,
 	}
 
 	err := client.WithTx(

--- a/pkg/complianceportal/visitor/rights_request_service_test.go
+++ b/pkg/complianceportal/visitor/rights_request_service_test.go
@@ -142,11 +142,12 @@ func insertPortalRequestWebhookPortal(
 		TenantID:       organizationID.TenantID(),
 		Active:         true,
 		// Slugs are constrained to ^[a-z0-9_-]+$, so lowercase the base64url GID.
-		Slug:                 strings.ToLower(portalID.String()),
-		SearchEngineIndexing: coredata.SearchEngineIndexingNotIndexable,
-		EntityName:           "Portal Request Webhook",
-		CreatedAt:            now,
-		UpdatedAt:            now,
+		Slug:                  strings.ToLower(portalID.String()),
+		SearchEngineIndexing:  coredata.SearchEngineIndexingNotIndexable,
+		RightsRequestsEnabled: true,
+		EntityName:            "Portal Request Webhook",
+		CreatedAt:             now,
+		UpdatedAt:             now,
 	}
 
 	err := client.WithTx(

--- a/pkg/complianceportal/visitor/rights_request_service_test.go
+++ b/pkg/complianceportal/visitor/rights_request_service_test.go
@@ -43,7 +43,13 @@ func TestRightsRequestService_CreateEnqueuesWebhook(t *testing.T) {
 	organizationID := insertPortalRequestWebhookOrganization(t, client)
 	scope := coredata.NewScope(organizationID.TenantID())
 	insertPortalRequestWebhookSubscription(t, client, scope, organizationID)
-	compliancePortalID := insertPortalRequestWebhookPortal(t, client, scope, organizationID)
+	compliancePortalID := insertPortalRequestWebhookPortal(
+		t,
+		client,
+		scope,
+		organizationID,
+		coredata.DefaultCompliancePortalCapabilities(),
+	)
 
 	service := Service{pg: client}
 	dataSubject := "Jane Doe"
@@ -83,6 +89,65 @@ func TestRightsRequestService_CreateEnqueuesWebhook(t *testing.T) {
 	assert.Equal(t, dataSubject, *payload.DataSubject)
 	assert.Equal(t, contact, *payload.Contact)
 	assert.NotNil(t, payload.Deadline)
+}
+
+func TestRightsRequestService_CreateDisabledReturnsErr(t *testing.T) {
+	t.Parallel()
+
+	client := test.PGClient(t)
+	organizationID := insertPortalRequestWebhookOrganization(t, client)
+	scope := coredata.NewScope(organizationID.TenantID())
+	insertPortalRequestWebhookSubscription(t, client, scope, organizationID)
+	compliancePortalID := insertPortalRequestWebhookPortal(
+		t,
+		client,
+		scope,
+		organizationID,
+		coredata.CompliancePortalCapabilities{RightsRequests: false},
+	)
+
+	service := Service{pg: client}
+	dataSubject := "Jane Doe"
+	_, err := service.CreateRightsRequest(
+		t.Context(),
+		scope,
+		&CreateRightsRequest{
+			CompliancePortalID: compliancePortalID,
+			RequestType:        coredata.RightsRequestTypeAccess,
+			DataSubject:        &dataSubject,
+			Contact:            "jane@example.com",
+		},
+	)
+	require.ErrorIs(t, err, ErrRightsRequestsDisabled)
+
+	var requestCount int
+	err = client.WithConn(
+		t.Context(),
+		func(ctx context.Context, conn pg.Querier) error {
+			return conn.QueryRow(
+				ctx,
+				`SELECT COUNT(*) FROM rights_requests WHERE organization_id = $1`,
+				organizationID.String(),
+			).Scan(&requestCount)
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, requestCount)
+
+	var webhookCount int
+	err = client.WithConn(
+		t.Context(),
+		func(ctx context.Context, conn pg.Querier) error {
+			return conn.QueryRow(
+				ctx,
+				`SELECT COUNT(*) FROM webhook_data WHERE organization_id = $1 AND event_type = $2`,
+				organizationID.String(),
+				coredata.WebhookEventTypeRightRequestCreated.String(),
+			).Scan(&webhookCount)
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, webhookCount)
 }
 
 func insertPortalRequestWebhookOrganization(t *testing.T, client *pg.Client) gid.GID {
@@ -131,6 +196,7 @@ func insertPortalRequestWebhookPortal(
 	client *pg.Client,
 	scope coredata.Scoper,
 	organizationID gid.GID,
+	capabilities coredata.CompliancePortalCapabilities,
 ) gid.GID {
 	t.Helper()
 
@@ -144,7 +210,7 @@ func insertPortalRequestWebhookPortal(
 		// Slugs are constrained to ^[a-z0-9_-]+$, so lowercase the base64url GID.
 		Slug:                 strings.ToLower(portalID.String()),
 		SearchEngineIndexing: coredata.SearchEngineIndexingNotIndexable,
-		Capabilities:         coredata.DefaultCompliancePortalCapabilities(),
+		Capabilities:         capabilities,
 		EntityName:           "Portal Request Webhook",
 		CreatedAt:            now,
 		UpdatedAt:            now,

--- a/pkg/coredata/compliance_portal.go
+++ b/pkg/coredata/compliance_portal.go
@@ -43,6 +43,7 @@ type (
 		Active                       bool                 `db:"active"`
 		Slug                         string               `db:"slug"`
 		SearchEngineIndexing         SearchEngineIndexing `db:"search_engine_indexing"`
+		RightsRequestsEnabled        bool                 `db:"rights_requests_enabled"`
 		MailingListID                *gid.GID             `db:"mailing_list_id"`
 		LogoFileID                   *gid.GID             `db:"logo_file_id"`
 		DarkLogoFileID               *gid.GID             `db:"dark_logo_file_id"`
@@ -126,6 +127,7 @@ SELECT
 	active,
 	slug,
 	search_engine_indexing,
+	rights_requests_enabled,
 	non_disclosure_agreement_file_id,
 	default_domain_id,
 	custom_domain_id,
@@ -185,6 +187,7 @@ SELECT
 	active,
 	slug,
 	search_engine_indexing,
+	rights_requests_enabled,
 	non_disclosure_agreement_file_id,
 	default_domain_id,
 	custom_domain_id,
@@ -245,6 +248,7 @@ SELECT
 	active,
 	slug,
 	search_engine_indexing,
+	rights_requests_enabled,
 	non_disclosure_agreement_file_id,
 	default_domain_id,
 	custom_domain_id,
@@ -332,6 +336,7 @@ SELECT
 	active,
 	slug,
 	search_engine_indexing,
+	rights_requests_enabled,
 	non_disclosure_agreement_file_id,
 	default_domain_id,
 	custom_domain_id,
@@ -391,6 +396,7 @@ SELECT
 	active,
 	slug,
 	search_engine_indexing,
+	rights_requests_enabled,
 	non_disclosure_agreement_file_id,
 	default_domain_id,
 	custom_domain_id,
@@ -446,6 +452,7 @@ INSERT INTO compliance_portals (
 	active,
 	slug,
 	search_engine_indexing,
+	rights_requests_enabled,
 	non_disclosure_agreement_file_id,
 	default_domain_id,
 	custom_domain_id,
@@ -466,6 +473,7 @@ INSERT INTO compliance_portals (
 	@active,
 	@slug,
 	@search_engine_indexing,
+	@rights_requests_enabled,
 	@non_disclosure_agreement_file_id,
 	@default_domain_id,
 	@custom_domain_id,
@@ -489,6 +497,7 @@ INSERT INTO compliance_portals (
 		"active":                           tc.Active,
 		"slug":                             tc.Slug,
 		"search_engine_indexing":           tc.SearchEngineIndexing,
+		"rights_requests_enabled":          tc.RightsRequestsEnabled,
 		"non_disclosure_agreement_file_id": tc.NonDisclosureAgreementFileID,
 		"default_domain_id":                tc.DefaultDomainID,
 		"custom_domain_id":                 tc.CustomDomainID,
@@ -526,6 +535,7 @@ SET
 	active = @active,
 	slug = @slug,
 	search_engine_indexing = @search_engine_indexing,
+	rights_requests_enabled = @rights_requests_enabled,
 	logo_file_id = @logo_file_id,
 	dark_logo_file_id = @dark_logo_file_id,
 	non_disclosure_agreement_file_id = @non_disclosure_agreement_file_id,
@@ -551,6 +561,7 @@ WHERE
 		"active":                           tc.Active,
 		"slug":                             tc.Slug,
 		"search_engine_indexing":           tc.SearchEngineIndexing,
+		"rights_requests_enabled":          tc.RightsRequestsEnabled,
 		"non_disclosure_agreement_file_id": tc.NonDisclosureAgreementFileID,
 		"default_domain_id":                tc.DefaultDomainID,
 		"custom_domain_id":                 tc.CustomDomainID,

--- a/pkg/coredata/compliance_portal.go
+++ b/pkg/coredata/compliance_portal.go
@@ -37,26 +37,26 @@ import (
 
 type (
 	CompliancePortal struct {
-		ID                           gid.GID              `db:"id"`
-		OrganizationID               gid.GID              `db:"organization_id"`
-		TenantID                     gid.TenantID         `db:"tenant_id"`
-		Active                       bool                 `db:"active"`
-		Slug                         string               `db:"slug"`
-		SearchEngineIndexing         SearchEngineIndexing `db:"search_engine_indexing"`
-		RightsRequestsEnabled        bool                 `db:"rights_requests_enabled"`
-		MailingListID                *gid.GID             `db:"mailing_list_id"`
-		LogoFileID                   *gid.GID             `db:"logo_file_id"`
-		DarkLogoFileID               *gid.GID             `db:"dark_logo_file_id"`
-		NonDisclosureAgreementFileID *gid.GID             `db:"non_disclosure_agreement_file_id"`
-		DefaultDomainID              *gid.GID             `db:"default_domain_id"`
-		CustomDomainID               *gid.GID             `db:"custom_domain_id"`
-		EntityName                   string               `db:"entity_name"`
-		Description                  *string              `db:"description"`
-		WebsiteURL                   *string              `db:"website_url"`
-		Email                        *string              `db:"email"`
-		HeadquarterAddress           *string              `db:"headquarter_address"`
-		CreatedAt                    time.Time            `db:"created_at"`
-		UpdatedAt                    time.Time            `db:"updated_at"`
+		ID                           gid.GID                      `db:"id"`
+		OrganizationID               gid.GID                      `db:"organization_id"`
+		TenantID                     gid.TenantID                 `db:"tenant_id"`
+		Active                       bool                         `db:"active"`
+		Slug                         string                       `db:"slug"`
+		SearchEngineIndexing         SearchEngineIndexing         `db:"search_engine_indexing"`
+		Capabilities                 CompliancePortalCapabilities `db:"capabilities"`
+		MailingListID                *gid.GID                     `db:"mailing_list_id"`
+		LogoFileID                   *gid.GID                     `db:"logo_file_id"`
+		DarkLogoFileID               *gid.GID                     `db:"dark_logo_file_id"`
+		NonDisclosureAgreementFileID *gid.GID                     `db:"non_disclosure_agreement_file_id"`
+		DefaultDomainID              *gid.GID                     `db:"default_domain_id"`
+		CustomDomainID               *gid.GID                     `db:"custom_domain_id"`
+		EntityName                   string                       `db:"entity_name"`
+		Description                  *string                      `db:"description"`
+		WebsiteURL                   *string                      `db:"website_url"`
+		Email                        *string                      `db:"email"`
+		HeadquarterAddress           *string                      `db:"headquarter_address"`
+		CreatedAt                    time.Time                    `db:"created_at"`
+		UpdatedAt                    time.Time                    `db:"updated_at"`
 	}
 
 	CompliancePortals []*CompliancePortal
@@ -127,7 +127,7 @@ SELECT
 	active,
 	slug,
 	search_engine_indexing,
-	rights_requests_enabled,
+	capabilities,
 	non_disclosure_agreement_file_id,
 	default_domain_id,
 	custom_domain_id,
@@ -187,7 +187,7 @@ SELECT
 	active,
 	slug,
 	search_engine_indexing,
-	rights_requests_enabled,
+	capabilities,
 	non_disclosure_agreement_file_id,
 	default_domain_id,
 	custom_domain_id,
@@ -248,7 +248,7 @@ SELECT
 	active,
 	slug,
 	search_engine_indexing,
-	rights_requests_enabled,
+	capabilities,
 	non_disclosure_agreement_file_id,
 	default_domain_id,
 	custom_domain_id,
@@ -336,7 +336,7 @@ SELECT
 	active,
 	slug,
 	search_engine_indexing,
-	rights_requests_enabled,
+	capabilities,
 	non_disclosure_agreement_file_id,
 	default_domain_id,
 	custom_domain_id,
@@ -396,7 +396,7 @@ SELECT
 	active,
 	slug,
 	search_engine_indexing,
-	rights_requests_enabled,
+	capabilities,
 	non_disclosure_agreement_file_id,
 	default_domain_id,
 	custom_domain_id,
@@ -452,7 +452,7 @@ INSERT INTO compliance_portals (
 	active,
 	slug,
 	search_engine_indexing,
-	rights_requests_enabled,
+	capabilities,
 	non_disclosure_agreement_file_id,
 	default_domain_id,
 	custom_domain_id,
@@ -473,7 +473,7 @@ INSERT INTO compliance_portals (
 	@active,
 	@slug,
 	@search_engine_indexing,
-	@rights_requests_enabled,
+	@capabilities,
 	@non_disclosure_agreement_file_id,
 	@default_domain_id,
 	@custom_domain_id,
@@ -497,7 +497,7 @@ INSERT INTO compliance_portals (
 		"active":                           tc.Active,
 		"slug":                             tc.Slug,
 		"search_engine_indexing":           tc.SearchEngineIndexing,
-		"rights_requests_enabled":          tc.RightsRequestsEnabled,
+		"capabilities":                     tc.Capabilities,
 		"non_disclosure_agreement_file_id": tc.NonDisclosureAgreementFileID,
 		"default_domain_id":                tc.DefaultDomainID,
 		"custom_domain_id":                 tc.CustomDomainID,
@@ -535,7 +535,7 @@ SET
 	active = @active,
 	slug = @slug,
 	search_engine_indexing = @search_engine_indexing,
-	rights_requests_enabled = @rights_requests_enabled,
+	capabilities = @capabilities,
 	logo_file_id = @logo_file_id,
 	dark_logo_file_id = @dark_logo_file_id,
 	non_disclosure_agreement_file_id = @non_disclosure_agreement_file_id,
@@ -561,7 +561,7 @@ WHERE
 		"active":                           tc.Active,
 		"slug":                             tc.Slug,
 		"search_engine_indexing":           tc.SearchEngineIndexing,
-		"rights_requests_enabled":          tc.RightsRequestsEnabled,
+		"capabilities":                     tc.Capabilities,
 		"non_disclosure_agreement_file_id": tc.NonDisclosureAgreementFileID,
 		"default_domain_id":                tc.DefaultDomainID,
 		"custom_domain_id":                 tc.CustomDomainID,

--- a/pkg/coredata/compliance_portal_capabilities.go
+++ b/pkg/coredata/compliance_portal_capabilities.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+type CompliancePortalCapabilities struct {
+	RightsRequests bool `json:"rights_requests"`
+}
+
+func DefaultCompliancePortalCapabilities() CompliancePortalCapabilities {
+	return CompliancePortalCapabilities{
+		RightsRequests: true,
+	}
+}
+
+func (c CompliancePortalCapabilities) Value() (driver.Value, error) {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal compliance portal capabilities: %w", err)
+	}
+
+	return data, nil
+}
+
+func (c *CompliancePortalCapabilities) Scan(value any) error {
+	if value == nil {
+		*c = DefaultCompliancePortalCapabilities()
+
+		return nil
+	}
+
+	var data []byte
+
+	switch v := value.(type) {
+	case string:
+		data = []byte(v)
+	case []byte:
+		data = v
+	default:
+		return fmt.Errorf("cannot scan compliance portal capabilities: unsupported type %T", value)
+	}
+
+	if len(data) == 0 {
+		*c = DefaultCompliancePortalCapabilities()
+
+		return nil
+	}
+
+	if err := json.Unmarshal(data, c); err != nil {
+		return fmt.Errorf("cannot unmarshal compliance portal capabilities: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/migrations/20260806T100646Z.sql
+++ b/pkg/coredata/migrations/20260806T100646Z.sql
@@ -1,0 +1,25 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TABLE compliance_portals
+  ADD COLUMN rights_requests_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+ALTER TABLE compliance_portals
+  ALTER COLUMN rights_requests_enabled DROP DEFAULT;

--- a/pkg/coredata/migrations/20260806T100646Z.sql
+++ b/pkg/coredata/migrations/20260806T100646Z.sql
@@ -19,7 +19,7 @@
 -- SOFTWARE.
 
 ALTER TABLE compliance_portals
-  ADD COLUMN rights_requests_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+  ADD COLUMN capabilities JSONB NOT NULL DEFAULT '{"rights_requests": true}'::jsonb;
 
 ALTER TABLE compliance_portals
-  ALTER COLUMN rights_requests_enabled DROP DEFAULT;
+  ALTER COLUMN capabilities DROP DEFAULT;

--- a/pkg/server/api/complianceportal/v1/base_resolvers.go
+++ b/pkg/server/api/complianceportal/v1/base_resolvers.go
@@ -249,7 +249,7 @@ func (r *queryResolver) MyRightsRequests(ctx context.Context, first *int, after 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
 	compliancePage := complianceportal.CompliancePortalFromContext(ctx)
-	if !compliancePage.RightsRequestsEnabled {
+	if !compliancePage.Capabilities.RightsRequests {
 		return nil, gqlutils.NotFoundf(ctx, "rights requests are not available on this compliance portal")
 	}
 

--- a/pkg/server/api/complianceportal/v1/base_resolvers.go
+++ b/pkg/server/api/complianceportal/v1/base_resolvers.go
@@ -248,13 +248,17 @@ func (r *queryResolver) MyRightsRequests(ctx context.Context, first *int, after 
 	}
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
+	compliancePage := complianceportal.CompliancePortalFromContext(ctx)
+	if !compliancePage.RightsRequestsEnabled {
+		return nil, gqlutils.NotFoundf(ctx, "rights requests are not available on this compliance portal")
+	}
+
 	identity := authn.IdentityFromContext(ctx)
 	if identity == nil {
 		emptyPage := page.NewPage([]*coredata.RightsRequest{}, cursor)
 		return types.NewRightsRequestConnection(emptyPage), nil
 	}
 
-	compliancePage := complianceportal.CompliancePortalFromContext(ctx)
 	scope := coredata.NewScopeFromObjectID(compliancePage.OrganizationID)
 
 	result, err := r.visitor.ListRightsRequestsForCompliancePortalIDAndContact(

--- a/pkg/server/api/complianceportal/v1/graphql/compliance_portal.graphql
+++ b/pkg/server/api/complianceportal/v1/graphql/compliance_portal.graphql
@@ -1,6 +1,7 @@
 type CompliancePortal implements Node {
   id: ID!
   active: Boolean!
+  rightsRequestsEnabled: Boolean!
   slug: String!
   logo: File @goField(forceResolver: true)
   darkLogo: File @goField(forceResolver: true)

--- a/pkg/server/api/complianceportal/v1/rights_request_resolvers.go
+++ b/pkg/server/api/complianceportal/v1/rights_request_resolvers.go
@@ -47,6 +47,7 @@ func (r *mutationResolver) CreateRightsRequest(ctx context.Context, input types.
 		}
 
 		r.logger.ErrorCtx(ctx, "cannot create rights request", log.Error(err))
+
 		return nil, gqlutils.Internal(ctx)
 	}
 

--- a/pkg/server/api/complianceportal/v1/rights_request_resolvers.go
+++ b/pkg/server/api/complianceportal/v1/rights_request_resolvers.go
@@ -7,6 +7,7 @@ package complianceportal_v1
 
 import (
 	"context"
+	"errors"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/complianceportal/visitor"
@@ -41,6 +42,10 @@ func (r *mutationResolver) CreateRightsRequest(ctx context.Context, input types.
 		},
 	)
 	if err != nil {
+		if errors.Is(err, visitor.ErrRightsRequestsDisabled) {
+			return nil, gqlutils.NotFoundf(ctx, "rights requests are not available on this compliance portal")
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot create rights request", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}

--- a/pkg/server/api/complianceportal/v1/types/compliance_portal.go
+++ b/pkg/server/api/complianceportal/v1/types/compliance_portal.go
@@ -26,14 +26,15 @@ import (
 
 func NewCompliancePortal(cp *coredata.CompliancePortal) *CompliancePortal {
 	return &CompliancePortal{
-		ID:                 cp.ID,
-		Active:             cp.Active,
-		Slug:               cp.Slug,
-		EntityName:         cp.EntityName,
-		Description:        cp.Description,
-		WebsiteURL:         cp.WebsiteURL,
-		Email:              cp.Email,
-		HeadquarterAddress: cp.HeadquarterAddress,
+		ID:                    cp.ID,
+		Active:                cp.Active,
+		RightsRequestsEnabled: cp.RightsRequestsEnabled,
+		Slug:                  cp.Slug,
+		EntityName:            cp.EntityName,
+		Description:           cp.Description,
+		WebsiteURL:            cp.WebsiteURL,
+		Email:                 cp.Email,
+		HeadquarterAddress:    cp.HeadquarterAddress,
 	}
 }
 

--- a/pkg/server/api/complianceportal/v1/types/compliance_portal.go
+++ b/pkg/server/api/complianceportal/v1/types/compliance_portal.go
@@ -28,7 +28,7 @@ func NewCompliancePortal(cp *coredata.CompliancePortal) *CompliancePortal {
 	return &CompliancePortal{
 		ID:                    cp.ID,
 		Active:                cp.Active,
-		RightsRequestsEnabled: cp.RightsRequestsEnabled,
+		RightsRequestsEnabled: cp.Capabilities.RightsRequests,
 		Slug:                  cp.Slug,
 		EntityName:            cp.EntityName,
 		Description:           cp.Description,

--- a/pkg/server/api/console/v1/compliance_portal_resolvers.go
+++ b/pkg/server/api/console/v1/compliance_portal_resolvers.go
@@ -1262,14 +1262,15 @@ func (r *mutationResolver) UpdateCompliancePortal(ctx context.Context, input typ
 	compliancePortal, _, err := r.management.Update(
 		ctx, scope,
 		&management.UpdateRequest{
-			ID:                   input.CompliancePortalID,
-			Active:               input.Active,
-			SearchEngineIndexing: input.SearchEngineIndexing,
-			Description:          gqlutils.UnwrapOmittable(input.Description),
-			WebsiteURL:           gqlutils.UnwrapOmittable(input.WebsiteURL),
-			Email:                gqlutils.UnwrapOmittable(input.Email),
-			HeadquarterAddress:   gqlutils.UnwrapOmittable(input.HeadquarterAddress),
-			EntityName:           input.EntityName,
+			ID:                    input.CompliancePortalID,
+			Active:                input.Active,
+			SearchEngineIndexing:  input.SearchEngineIndexing,
+			RightsRequestsEnabled: input.RightsRequestsEnabled,
+			Description:           gqlutils.UnwrapOmittable(input.Description),
+			WebsiteURL:            gqlutils.UnwrapOmittable(input.WebsiteURL),
+			Email:                 gqlutils.UnwrapOmittable(input.Email),
+			HeadquarterAddress:    gqlutils.UnwrapOmittable(input.HeadquarterAddress),
+			EntityName:            input.EntityName,
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/console/v1/graphql/compliance_portal.graphql
+++ b/pkg/server/api/console/v1/graphql/compliance_portal.graphql
@@ -367,6 +367,7 @@ type CompliancePortal implements Node
     id: ID!
     active: Boolean!
     searchEngineIndexing: SearchEngineIndexing!
+    rightsRequestsEnabled: Boolean!
     logo: File @goField(forceResolver: true)
     darkLogo: File @goField(forceResolver: true)
     nda: File @goField(forceResolver: true)
@@ -915,6 +916,7 @@ input UpdateCompliancePortalInput {
     compliancePortalId: ID!
     active: Boolean
     searchEngineIndexing: SearchEngineIndexing
+    rightsRequestsEnabled: Boolean
     entityName: String
     description: String @goField(omittable: true)
     websiteUrl: String @goField(omittable: true)

--- a/pkg/server/api/console/v1/types/compliance_portal.go
+++ b/pkg/server/api/console/v1/types/compliance_portal.go
@@ -32,29 +32,30 @@ type (
 	CompliancePortalOrderBy OrderBy[coredata.CompliancePortalOrderField]
 
 	CompliancePortal struct {
-		ID                   gid.GID                              `json:"id"`
-		Active               bool                                 `json:"active"`
-		SearchEngineIndexing coredata.SearchEngineIndexing        `json:"searchEngineIndexing"`
-		Logo                 *File                                `json:"logo,omitempty"`
-		DarkLogo             *File                                `json:"darkLogo,omitempty"`
-		Nda                  *File                                `json:"nda,omitempty"`
-		Description          *string                              `json:"description,omitempty"`
-		WebsiteURL           *string                              `json:"websiteUrl,omitempty"`
-		Email                *string                              `json:"email,omitempty"`
-		HeadquarterAddress   *string                              `json:"headquarterAddress,omitempty"`
-		EntityName           string                               `json:"entityName"`
-		Slug                 string                               `json:"slug"`
-		CreatedAt            time.Time                            `json:"createdAt"`
-		UpdatedAt            time.Time                            `json:"updatedAt"`
-		Organization         *Organization                        `json:"organization"`
-		Accesses             *CompliancePortalAccessConnection    `json:"accesses"`
-		References           *CompliancePortalReferenceConnection `json:"references"`
-		ComplianceFrameworks *ComplianceFrameworkConnection       `json:"complianceFrameworks"`
-		CustomLinks          *ComplianceCustomLinkConnection      `json:"customLinks"`
-		MailingList          *MailingList                         `json:"mailingList,omitempty"`
-		DefaultDomain        *CustomDomain                        `json:"defaultDomain,omitempty"`
-		CustomDomain         *CustomDomain                        `json:"customDomain,omitempty"`
-		Permission           bool                                 `json:"permission"`
+		ID                    gid.GID                              `json:"id"`
+		Active                bool                                 `json:"active"`
+		SearchEngineIndexing  coredata.SearchEngineIndexing        `json:"searchEngineIndexing"`
+		RightsRequestsEnabled bool                                 `json:"rightsRequestsEnabled"`
+		Logo                  *File                                `json:"logo,omitempty"`
+		DarkLogo              *File                                `json:"darkLogo,omitempty"`
+		Nda                   *File                                `json:"nda,omitempty"`
+		Description           *string                              `json:"description,omitempty"`
+		WebsiteURL            *string                              `json:"websiteUrl,omitempty"`
+		Email                 *string                              `json:"email,omitempty"`
+		HeadquarterAddress    *string                              `json:"headquarterAddress,omitempty"`
+		EntityName            string                               `json:"entityName"`
+		Slug                  string                               `json:"slug"`
+		CreatedAt             time.Time                            `json:"createdAt"`
+		UpdatedAt             time.Time                            `json:"updatedAt"`
+		Organization          *Organization                        `json:"organization"`
+		Accesses              *CompliancePortalAccessConnection    `json:"accesses"`
+		References            *CompliancePortalReferenceConnection `json:"references"`
+		ComplianceFrameworks  *ComplianceFrameworkConnection       `json:"complianceFrameworks"`
+		CustomLinks           *ComplianceCustomLinkConnection      `json:"customLinks"`
+		MailingList           *MailingList                         `json:"mailingList,omitempty"`
+		DefaultDomain         *CustomDomain                        `json:"defaultDomain,omitempty"`
+		CustomDomain          *CustomDomain                        `json:"customDomain,omitempty"`
+		Permission            bool                                 `json:"permission"`
 	}
 
 	CompliancePortalConnection struct {
@@ -75,16 +76,17 @@ func NewCompliancePortal(tc *coredata.CompliancePortal) *CompliancePortal {
 		Organization: &Organization{
 			ID: tc.OrganizationID,
 		},
-		Active:               tc.Active,
-		SearchEngineIndexing: tc.SearchEngineIndexing,
-		Description:          tc.Description,
-		WebsiteURL:           tc.WebsiteURL,
-		Email:                tc.Email,
-		HeadquarterAddress:   tc.HeadquarterAddress,
-		EntityName:           tc.EntityName,
-		Slug:                 tc.Slug,
-		CreatedAt:            tc.CreatedAt,
-		UpdatedAt:            tc.UpdatedAt,
+		Active:                tc.Active,
+		SearchEngineIndexing:  tc.SearchEngineIndexing,
+		RightsRequestsEnabled: tc.RightsRequestsEnabled,
+		Description:           tc.Description,
+		WebsiteURL:            tc.WebsiteURL,
+		Email:                 tc.Email,
+		HeadquarterAddress:    tc.HeadquarterAddress,
+		EntityName:            tc.EntityName,
+		Slug:                  tc.Slug,
+		CreatedAt:             tc.CreatedAt,
+		UpdatedAt:             tc.UpdatedAt,
 	}
 
 	if tc.LogoFileID != nil {

--- a/pkg/server/api/console/v1/types/compliance_portal.go
+++ b/pkg/server/api/console/v1/types/compliance_portal.go
@@ -78,7 +78,7 @@ func NewCompliancePortal(tc *coredata.CompliancePortal) *CompliancePortal {
 		},
 		Active:                tc.Active,
 		SearchEngineIndexing:  tc.SearchEngineIndexing,
-		RightsRequestsEnabled: tc.RightsRequestsEnabled,
+		RightsRequestsEnabled: tc.Capabilities.RightsRequests,
 		Description:           tc.Description,
 		WebsiteURL:            tc.WebsiteURL,
 		Email:                 tc.Email,

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5027,6 +5027,10 @@ func (r *Resolver) UpdateCompliancePortalTool(ctx context.Context, req *mcp.Call
 		updateReq.SearchEngineIndexing = *sei
 	}
 
+	if rightsRequestsEnabled := UnwrapOmittable(input.RightsRequestsEnabled); rightsRequestsEnabled != nil {
+		updateReq.RightsRequestsEnabled = *rightsRequestsEnabled
+	}
+
 	updateReq.Description = UnwrapOmittable(input.Description)
 	updateReq.WebsiteURL = UnwrapOmittable(input.WebsiteURL)
 	updateReq.Email = UnwrapOmittable(input.Email)

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -9827,6 +9827,7 @@ components:
         - organization_id
         - active
         - search_engine_indexing
+        - rights_requests_enabled
         - entity_name
         - created_at
         - updated_at
@@ -9839,6 +9840,9 @@ components:
           type: boolean
         search_engine_indexing:
           $ref: "#/components/schemas/SearchEngineIndexing"
+        rights_requests_enabled:
+          type: boolean
+          description: Whether visitors can submit rights requests on the compliance portal
         logo:
           $ref: "#/components/schemas/File"
         dark_logo:
@@ -10118,6 +10122,12 @@ components:
             - $ref: "#/components/schemas/SearchEngineIndexing"
             - type: "null"
           description: Search engine indexing setting
+          go.probo.inc/mcpgen/omittable: true
+        rights_requests_enabled:
+          type:
+            - boolean
+            - "null"
+          description: Whether visitors can submit rights requests on the compliance portal
           go.probo.inc/mcpgen/omittable: true
         description:
           type:

--- a/pkg/server/api/mcp/v1/types/compliance_portal.go
+++ b/pkg/server/api/mcp/v1/types/compliance_portal.go
@@ -27,17 +27,18 @@ import (
 
 func NewCompliancePortal(tc *coredata.CompliancePortal) *CompliancePortal {
 	return &CompliancePortal{
-		ID:                   tc.ID,
-		OrganizationID:       tc.OrganizationID,
-		Active:               tc.Active,
-		SearchEngineIndexing: tc.SearchEngineIndexing,
-		EntityName:           tc.EntityName,
-		Description:          tc.Description,
-		WebsiteURL:           tc.WebsiteURL,
-		Email:                tc.Email,
-		HeadquarterAddress:   tc.HeadquarterAddress,
-		CreatedAt:            tc.CreatedAt,
-		UpdatedAt:            tc.UpdatedAt,
+		ID:                    tc.ID,
+		OrganizationID:        tc.OrganizationID,
+		Active:                tc.Active,
+		SearchEngineIndexing:  tc.SearchEngineIndexing,
+		RightsRequestsEnabled: tc.RightsRequestsEnabled,
+		EntityName:            tc.EntityName,
+		Description:           tc.Description,
+		WebsiteURL:            tc.WebsiteURL,
+		Email:                 tc.Email,
+		HeadquarterAddress:    tc.HeadquarterAddress,
+		CreatedAt:             tc.CreatedAt,
+		UpdatedAt:             tc.UpdatedAt,
 	}
 }
 

--- a/pkg/server/api/mcp/v1/types/compliance_portal.go
+++ b/pkg/server/api/mcp/v1/types/compliance_portal.go
@@ -31,7 +31,7 @@ func NewCompliancePortal(tc *coredata.CompliancePortal) *CompliancePortal {
 		OrganizationID:        tc.OrganizationID,
 		Active:                tc.Active,
 		SearchEngineIndexing:  tc.SearchEngineIndexing,
-		RightsRequestsEnabled: tc.RightsRequestsEnabled,
+		RightsRequestsEnabled: tc.Capabilities.RightsRequests,
 		EntityName:            tc.EntityName,
 		Description:           tc.Description,
 		WebsiteURL:            tc.WebsiteURL,


### PR DESCRIPTION
Closes [ENG-667](https://linear.app/probo/issue/ENG-667/right-request-enabledisable-compliance-portal)
Closes [ENG-675](https://linear.app/probo/issue/ENG-675/rename-get-access-to-request-access)

Customers can enable or disable the public Requests surface from the console overview. When off, the portal hides the nav item and treats /requests as not found.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make rights requests optional behind a rightsRequestsEnabled flag, per ENG-667; when disabled, the portal hides Requests and /requests returns 404. Aligns copy per ENG-675, adds a route-level error boundary and “Contact support”/“Request access” actions, and improves accessibility of the console toggle.

### App: compliance-portal **`+341`** **`-79`**
- Hide Requests in TopBar and mobile nav when disabled.
- Pre-check flag on /requests and throw 404; add a route ErrorBoundary and drop field-error-to-404 mapping.
- Upgrade error UI with “Contact support” (uses portal email) and “Request access”; add portal contact context.
- Rename “Get Access” to “Request Access” in TopBar and documents.

### App: console **`+41`** **`-1`**
- Add a rights requests toggle in Portal Status (permission-checked) with a screen‑reader label.
- Include the field in the update mutation and i18n.

### Package: n8n-node **`+34`** **`-0`**
- Expose rightsRequestsEnabled in create/get/getAll outputs.
- Add an update option and pass it to the mutation.

### Package: ui **`+15`** **`-6`**
- Add aria-label support to Toggle for accessibility.

### prb (CLI) **`+28`** **`-17`**
- Add `--rights-requests-enabled` to the `prb` update command.
- Include the field in the mutation/response; update help text.

### Service **`+11`** **`-0`**
- Default portal capabilities on creation; support updates to rights requests.
- Guard rights request creation and return a specific error when disabled.

### Coredata **`+132`** **`-19`**
- Store portal feature flags in `capabilities` JSONB with defaults and scan/value methods.
- Add a migration to create the `capabilities` column (default true, then drop default).

### GraphQL API **`+67`** **`-50`**
- Expose rightsRequestsEnabled on portal types and UpdateCompliancePortalInput (mapped from `capabilities`).
- Return NotFound from myRightsRequests and create mutations when disabled.

### MCP **`+26`** **`-11`**
- Add the flag to MCP types/spec and accept an omittable field in the Update Compliance Portal tool.

### Tests **`+70`** **`-1`**
- Cover the disabled-capability create path (no request/webhook when off).

<sup>Written for commit 60eddb82887a96b959d97636a71ae41b60259766. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





