### PR TITLE
Allow custom text in document watermarks

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -505,8 +505,7 @@
       "label": "Add watermark",
       "description": "Add a confidential watermark with custom text and a timestamp to all PDFs",
       "textLabel": "Watermark text",
-      "textPlaceholder": "Enter watermark text",
-      "byteCount": "{{count}} / {{max}} bytes"
+      "textPlaceholder": "Enter watermark text"
     },
     "notice": "The documents will be exported as individual PDFs in a ZIP file. You will receive an email when the export is ready for download.",
     "actions": {
@@ -547,8 +546,7 @@
       "label": "Add watermark",
       "description": "Add a confidential watermark with custom text and a timestamp",
       "textLabel": "Watermark text",
-      "textPlaceholder": "Enter watermark text",
-      "byteCount": "{{count}} / {{max}} bytes"
+      "textPlaceholder": "Enter watermark text"
     },
     "actions": {
       "download": "Download PDF",

--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -505,7 +505,8 @@
       "label": "Add watermark",
       "description": "Add a confidential watermark with custom text and a timestamp to all PDFs",
       "textLabel": "Watermark text",
-      "textPlaceholder": "Enter watermark text"
+      "textPlaceholder": "Enter watermark text",
+      "byteCount": "{{count}} / {{max}} bytes"
     },
     "notice": "The documents will be exported as individual PDFs in a ZIP file. You will receive an email when the export is ready for download.",
     "actions": {
@@ -546,7 +547,8 @@
       "label": "Add watermark",
       "description": "Add a confidential watermark with custom text and a timestamp",
       "textLabel": "Watermark text",
-      "textPlaceholder": "Enter watermark text"
+      "textPlaceholder": "Enter watermark text",
+      "byteCount": "{{count}} / {{max}} bytes"
     },
     "actions": {
       "download": "Download PDF",

--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -503,9 +503,9 @@
     },
     "watermark": {
       "label": "Add watermark",
-      "description": "Add confidential watermark with email and timestamp to all PDFs",
-      "emailLabel": "Watermark email",
-      "emailPlaceholder": "Enter email address"
+      "description": "Add a confidential watermark with custom text and a timestamp to all PDFs",
+      "textLabel": "Watermark text",
+      "textPlaceholder": "Enter watermark text"
     },
     "notice": "The documents will be exported as individual PDFs in a ZIP file. You will receive an email when the export is ready for download.",
     "actions": {
@@ -544,9 +544,9 @@
     },
     "watermark": {
       "label": "Add watermark",
-      "description": "Add confidential watermark with email and timestamp",
-      "emailLabel": "Watermark email",
-      "emailPlaceholder": "Enter email address"
+      "description": "Add a confidential watermark with custom text and a timestamp",
+      "textLabel": "Watermark text",
+      "textPlaceholder": "Enter watermark text"
     },
     "actions": {
       "download": "Download PDF",

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -1032,8 +1032,7 @@
       "label": "Ajouter un filigrane",
       "description": "Ajouter un filigrane confidentiel avec un texte personnalisé et un horodatage à tous les PDF",
       "textLabel": "Texte du filigrane",
-      "textPlaceholder": "Saisissez le texte du filigrane",
-      "byteCount": "{{count}} / {{max}} octets"
+      "textPlaceholder": "Saisissez le texte du filigrane"
     },
     "notice": "Les documents seront exportés sous forme de fichiers PDF individuels dans une archive ZIP. Vous recevrez un e-mail lorsque l’export sera prêt à être téléchargé.",
     "actions": {
@@ -1074,8 +1073,7 @@
       "label": "Ajouter un filigrane",
       "description": "Ajouter un filigrane confidentiel avec un texte personnalisé et un horodatage",
       "textLabel": "Texte du filigrane",
-      "textPlaceholder": "Saisissez le texte du filigrane",
-      "byteCount": "{{count}} / {{max}} octets"
+      "textPlaceholder": "Saisissez le texte du filigrane"
     },
     "actions": {
       "download": "Télécharger le PDF",

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -1030,9 +1030,9 @@
     },
     "watermark": {
       "label": "Ajouter un filigrane",
-      "description": "Ajouter un filigrane confidentiel avec e-mail et horodatage à tous les PDF",
-      "emailLabel": "E-mail du filigrane",
-      "emailPlaceholder": "Saisissez une adresse e-mail"
+      "description": "Ajouter un filigrane confidentiel avec un texte personnalisé et un horodatage à tous les PDF",
+      "textLabel": "Texte du filigrane",
+      "textPlaceholder": "Saisissez le texte du filigrane"
     },
     "notice": "Les documents seront exportés sous forme de fichiers PDF individuels dans une archive ZIP. Vous recevrez un e-mail lorsque l’export sera prêt à être téléchargé.",
     "actions": {
@@ -1071,9 +1071,9 @@
     },
     "watermark": {
       "label": "Ajouter un filigrane",
-      "description": "Ajouter un filigrane confidentiel avec l’e-mail et l’horodatage",
-      "emailLabel": "E-mail du filigrane",
-      "emailPlaceholder": "Saisir une adresse e-mail"
+      "description": "Ajouter un filigrane confidentiel avec un texte personnalisé et un horodatage",
+      "textLabel": "Texte du filigrane",
+      "textPlaceholder": "Saisissez le texte du filigrane"
     },
     "actions": {
       "download": "Télécharger le PDF",

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -1032,7 +1032,8 @@
       "label": "Ajouter un filigrane",
       "description": "Ajouter un filigrane confidentiel avec un texte personnalisé et un horodatage à tous les PDF",
       "textLabel": "Texte du filigrane",
-      "textPlaceholder": "Saisissez le texte du filigrane"
+      "textPlaceholder": "Saisissez le texte du filigrane",
+      "byteCount": "{{count}} / {{max}} octets"
     },
     "notice": "Les documents seront exportés sous forme de fichiers PDF individuels dans une archive ZIP. Vous recevrez un e-mail lorsque l’export sera prêt à être téléchargé.",
     "actions": {
@@ -1073,7 +1074,8 @@
       "label": "Ajouter un filigrane",
       "description": "Ajouter un filigrane confidentiel avec un texte personnalisé et un horodatage",
       "textLabel": "Texte du filigrane",
-      "textPlaceholder": "Saisissez le texte du filigrane"
+      "textPlaceholder": "Saisissez le texte du filigrane",
+      "byteCount": "{{count}} / {{max}} octets"
     },
     "actions": {
       "download": "Télécharger le PDF",

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -1034,9 +1034,9 @@
     },
     "watermark": {
       "label": "Watermerk toevoegen",
-      "description": "Voeg een vertrouwelijk watermerk toe met e-mailadres en tijdstempel aan alle PDF's",
-      "emailLabel": "E-mailadres watermerk",
-      "emailPlaceholder": "Voer e-mailadres in"
+      "description": "Voeg een vertrouwelijk watermerk met aangepaste tekst en een tijdstempel toe aan alle PDF's",
+      "textLabel": "Watermerktekst",
+      "textPlaceholder": "Voer watermerktekst in"
     },
     "notice": "De documenten worden geëxporteerd als afzonderlijke PDF's in een ZIP-bestand. U ontvangt een e-mail zodra de export gereed is om te downloaden.",
     "actions": {
@@ -1075,9 +1075,9 @@
     },
     "watermark": {
       "label": "Watermerk toevoegen",
-      "description": "Voeg een vertrouwelijk watermerk toe met e-mailadres en tijdstempel",
-      "emailLabel": "E-mailadres watermerk",
-      "emailPlaceholder": "Voer e-mailadres in"
+      "description": "Voeg een vertrouwelijk watermerk met aangepaste tekst en een tijdstempel toe",
+      "textLabel": "Watermerktekst",
+      "textPlaceholder": "Voer watermerktekst in"
     },
     "actions": {
       "download": "PDF downloaden",

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -1036,7 +1036,8 @@
       "label": "Watermerk toevoegen",
       "description": "Voeg een vertrouwelijk watermerk met aangepaste tekst en een tijdstempel toe aan alle PDF's",
       "textLabel": "Watermerktekst",
-      "textPlaceholder": "Voer watermerktekst in"
+      "textPlaceholder": "Voer watermerktekst in",
+      "byteCount": "{{count}} / {{max}} bytes"
     },
     "notice": "De documenten worden geëxporteerd als afzonderlijke PDF's in een ZIP-bestand. U ontvangt een e-mail zodra de export gereed is om te downloaden.",
     "actions": {
@@ -1077,7 +1078,8 @@
       "label": "Watermerk toevoegen",
       "description": "Voeg een vertrouwelijk watermerk met aangepaste tekst en een tijdstempel toe",
       "textLabel": "Watermerktekst",
-      "textPlaceholder": "Voer watermerktekst in"
+      "textPlaceholder": "Voer watermerktekst in",
+      "byteCount": "{{count}} / {{max}} bytes"
     },
     "actions": {
       "download": "PDF downloaden",

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -1036,8 +1036,7 @@
       "label": "Watermerk toevoegen",
       "description": "Voeg een vertrouwelijk watermerk met aangepaste tekst en een tijdstempel toe aan alle PDF's",
       "textLabel": "Watermerktekst",
-      "textPlaceholder": "Voer watermerktekst in",
-      "byteCount": "{{count}} / {{max}} bytes"
+      "textPlaceholder": "Voer watermerktekst in"
     },
     "notice": "De documenten worden geëxporteerd als afzonderlijke PDF's in een ZIP-bestand. U ontvangt een e-mail zodra de export gereed is om te downloaden.",
     "actions": {
@@ -1078,8 +1077,7 @@
       "label": "Watermerk toevoegen",
       "description": "Voeg een vertrouwelijk watermerk met aangepaste tekst en een tijdstempel toe",
       "textLabel": "Watermerktekst",
-      "textPlaceholder": "Voer watermerktekst in",
-      "byteCount": "{{count}} / {{max}} bytes"
+      "textPlaceholder": "Voer watermerktekst in"
     },
     "actions": {
       "download": "PDF downloaden",

--- a/apps/console/src/components/documents/BulkExportDialog.tsx
+++ b/apps/console/src/components/documents/BulkExportDialog.tsx
@@ -30,34 +30,20 @@ import {
 } from "@probo/ui";
 import { forwardRef, type ReactNode, useImperativeHandle } from "react";
 import { useTranslation } from "react-i18next";
-import { z } from "zod";
 
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 
-const maxWatermarkTextLength = 64;
-
-const bulkExportSchema = z.object({
-  withWatermark: z.boolean(),
-  watermarkText: z.string().refine(
-    value => new TextEncoder().encode(value).length <= maxWatermarkTextLength,
-    `Watermark text must not exceed ${maxWatermarkTextLength} bytes`,
-  ).optional().or(z.literal("")),
-  withSignatures: z.boolean(),
-}).refine((data) => {
-  if (data.withWatermark && (!data.watermarkText || data.watermarkText.trim() === "")) {
-    return false;
-  }
-  return true;
-}, {
-  message: "Please enter watermark text",
-  path: ["watermarkText"],
-});
-
-type BulkExportFormData = z.infer<typeof bulkExportSchema>;
+import {
+  getWatermarkTextLength,
+  maxWatermarkTextLength,
+  truncateWatermarkText,
+  type WatermarkExportFormData,
+  watermarkExportSchema,
+} from "./watermark";
 
 type Props = {
   children: ReactNode;
-  onExport: (options: BulkExportFormData) => Promise<void>;
+  onExport: (options: WatermarkExportFormData) => Promise<void>;
   isLoading?: boolean;
   defaultEmail: string;
   selectedCount: number;
@@ -74,17 +60,18 @@ export const BulkExportDialog = forwardRef<BulkExportDialogRef, Props>(
     const dialogRef = useDialogRef();
 
     const { register, handleSubmit, formState, watch, setValue } = useFormWithSchema(
-      bulkExportSchema,
+      watermarkExportSchema,
       {
         defaultValues: {
           withWatermark: false,
-          watermarkText: defaultEmail,
+          watermarkText: truncateWatermarkText(defaultEmail),
           withSignatures: true,
         },
       },
     );
 
     const watchWatermark = watch("withWatermark");
+    const watchWatermarkText = watch("watermarkText") ?? "";
     const watchSignatures = watch("withSignatures");
 
     useImperativeHandle(ref, () => ({
@@ -92,7 +79,7 @@ export const BulkExportDialog = forwardRef<BulkExportDialogRef, Props>(
       close: () => dialogRef.current?.close(),
     }));
 
-    const onSubmit = async (data: BulkExportFormData) => {
+    const onSubmit = async (data: WatermarkExportFormData) => {
       const options = {
         ...data,
         watermarkText: data.withWatermark ? data.watermarkText : undefined,
@@ -148,9 +135,12 @@ export const BulkExportDialog = forwardRef<BulkExportDialogRef, Props>(
                       label={t("bulkExportDialog.watermark.textLabel")}
                       {...register("watermarkText")}
                       type="text"
-                      maxLength={maxWatermarkTextLength}
                       placeholder={t("bulkExportDialog.watermark.textPlaceholder")}
                       error={formState.errors.watermarkText?.message}
+                      help={t("bulkExportDialog.watermark.byteCount", {
+                        count: getWatermarkTextLength(watchWatermarkText),
+                        max: maxWatermarkTextLength,
+                      })}
                       autoComplete="off"
                       required
                     />

--- a/apps/console/src/components/documents/BulkExportDialog.tsx
+++ b/apps/console/src/components/documents/BulkExportDialog.tsx
@@ -36,19 +36,16 @@ import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 
 const bulkExportSchema = z.object({
   withWatermark: z.boolean(),
-  watermarkEmail: z.string().optional().or(z.literal("")),
+  watermarkText: z.string().optional().or(z.literal("")),
   withSignatures: z.boolean(),
 }).refine((data) => {
-  if (data.withWatermark && (!data.watermarkEmail || data.watermarkEmail === "")) {
-    return false;
-  }
-  if (data.withWatermark && data.watermarkEmail && !z.string().email().safeParse(data.watermarkEmail).success) {
+  if (data.withWatermark && (!data.watermarkText || data.watermarkText.trim() === "")) {
     return false;
   }
   return true;
 }, {
-  message: "Please enter a valid email address",
-  path: ["watermarkEmail"],
+  message: "Please enter watermark text",
+  path: ["watermarkText"],
 });
 
 type BulkExportFormData = z.infer<typeof bulkExportSchema>;
@@ -76,7 +73,7 @@ export const BulkExportDialog = forwardRef<BulkExportDialogRef, Props>(
       {
         defaultValues: {
           withWatermark: false,
-          watermarkEmail: defaultEmail,
+          watermarkText: defaultEmail,
           withSignatures: true,
         },
       },
@@ -93,7 +90,7 @@ export const BulkExportDialog = forwardRef<BulkExportDialogRef, Props>(
     const onSubmit = async (data: BulkExportFormData) => {
       const options = {
         ...data,
-        watermarkEmail: data.withWatermark ? data.watermarkEmail : undefined,
+        watermarkText: data.withWatermark ? data.watermarkText : undefined,
       };
       await onExport(options);
       dialogRef.current?.close();
@@ -143,11 +140,11 @@ export const BulkExportDialog = forwardRef<BulkExportDialogRef, Props>(
                 {watchWatermark && (
                   <div className="ml-6">
                     <Field
-                      label={t("bulkExportDialog.watermark.emailLabel")}
-                      {...register("watermarkEmail")}
-                      type="email"
-                      placeholder={t("bulkExportDialog.watermark.emailPlaceholder")}
-                      error={formState.errors.watermarkEmail?.message}
+                      label={t("bulkExportDialog.watermark.textLabel")}
+                      {...register("watermarkText")}
+                      type="text"
+                      placeholder={t("bulkExportDialog.watermark.textPlaceholder")}
+                      error={formState.errors.watermarkText?.message}
                       autoComplete="off"
                       required
                     />

--- a/apps/console/src/components/documents/BulkExportDialog.tsx
+++ b/apps/console/src/components/documents/BulkExportDialog.tsx
@@ -34,9 +34,14 @@ import { z } from "zod";
 
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 
+const maxWatermarkTextLength = 64;
+
 const bulkExportSchema = z.object({
   withWatermark: z.boolean(),
-  watermarkText: z.string().optional().or(z.literal("")),
+  watermarkText: z.string().refine(
+    value => new TextEncoder().encode(value).length <= maxWatermarkTextLength,
+    `Watermark text must not exceed ${maxWatermarkTextLength} bytes`,
+  ).optional().or(z.literal("")),
   withSignatures: z.boolean(),
 }).refine((data) => {
   if (data.withWatermark && (!data.watermarkText || data.watermarkText.trim() === "")) {
@@ -143,6 +148,7 @@ export const BulkExportDialog = forwardRef<BulkExportDialogRef, Props>(
                       label={t("bulkExportDialog.watermark.textLabel")}
                       {...register("watermarkText")}
                       type="text"
+                      maxLength={maxWatermarkTextLength}
                       placeholder={t("bulkExportDialog.watermark.textPlaceholder")}
                       error={formState.errors.watermarkText?.message}
                       autoComplete="off"

--- a/apps/console/src/components/documents/BulkExportDialog.tsx
+++ b/apps/console/src/components/documents/BulkExportDialog.tsx
@@ -36,9 +36,6 @@ import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import {
   type ExportFormData,
   exportSchema,
-  getWatermarkTextLength,
-  maxWatermarkTextLength,
-  truncateWatermarkText,
 } from "./watermark";
 
 type Props = {
@@ -64,14 +61,13 @@ export const BulkExportDialog = forwardRef<BulkExportDialogRef, Props>(
       {
         defaultValues: {
           withWatermark: false,
-          watermarkText: truncateWatermarkText(defaultEmail),
+          watermarkText: defaultEmail,
           withSignatures: true,
         },
       },
     );
 
     const watchWatermark = watch("withWatermark");
-    const watchWatermarkText = watch("watermarkText") ?? "";
     const watchSignatures = watch("withSignatures");
 
     useImperativeHandle(ref, () => ({
@@ -82,7 +78,9 @@ export const BulkExportDialog = forwardRef<BulkExportDialogRef, Props>(
     const onSubmit = async (data: ExportFormData) => {
       const options = {
         ...data,
-        watermarkText: data.withWatermark ? data.watermarkText : undefined,
+        watermarkText: data.withWatermark && data.watermarkText !== defaultEmail
+          ? data.watermarkText
+          : undefined,
       };
       await onExport(options);
       dialogRef.current?.close();
@@ -137,10 +135,6 @@ export const BulkExportDialog = forwardRef<BulkExportDialogRef, Props>(
                       type="text"
                       placeholder={t("bulkExportDialog.watermark.textPlaceholder")}
                       error={formState.errors.watermarkText?.message}
-                      help={t("bulkExportDialog.watermark.byteCount", {
-                        count: getWatermarkTextLength(watchWatermarkText),
-                        max: maxWatermarkTextLength,
-                      })}
                       autoComplete="off"
                       required
                     />

--- a/apps/console/src/components/documents/BulkExportDialog.tsx
+++ b/apps/console/src/components/documents/BulkExportDialog.tsx
@@ -34,16 +34,16 @@ import { useTranslation } from "react-i18next";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 
 import {
+  type ExportFormData,
+  exportSchema,
   getWatermarkTextLength,
   maxWatermarkTextLength,
   truncateWatermarkText,
-  type WatermarkExportFormData,
-  watermarkExportSchema,
 } from "./watermark";
 
 type Props = {
   children: ReactNode;
-  onExport: (options: WatermarkExportFormData) => Promise<void>;
+  onExport: (options: ExportFormData) => Promise<void>;
   isLoading?: boolean;
   defaultEmail: string;
   selectedCount: number;
@@ -60,7 +60,7 @@ export const BulkExportDialog = forwardRef<BulkExportDialogRef, Props>(
     const dialogRef = useDialogRef();
 
     const { register, handleSubmit, formState, watch, setValue } = useFormWithSchema(
-      watermarkExportSchema,
+      exportSchema,
       {
         defaultValues: {
           withWatermark: false,
@@ -79,7 +79,7 @@ export const BulkExportDialog = forwardRef<BulkExportDialogRef, Props>(
       close: () => dialogRef.current?.close(),
     }));
 
-    const onSubmit = async (data: WatermarkExportFormData) => {
+    const onSubmit = async (data: ExportFormData) => {
       const options = {
         ...data,
         watermarkText: data.withWatermark ? data.watermarkText : undefined,

--- a/apps/console/src/components/documents/PdfDownloadDialog.tsx
+++ b/apps/console/src/components/documents/PdfDownloadDialog.tsx
@@ -36,9 +36,6 @@ import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import {
   type ExportFormData,
   exportSchema,
-  getWatermarkTextLength,
-  maxWatermarkTextLength,
-  truncateWatermarkText,
 } from "./watermark";
 
 type Props = {
@@ -62,13 +59,12 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
       = useFormWithSchema(exportSchema, {
         defaultValues: {
           withWatermark: false,
-          watermarkText: truncateWatermarkText(defaultEmail),
+          watermarkText: defaultEmail,
           withSignatures: true,
         },
       });
 
     const watchWatermark = watch("withWatermark");
-    const watchWatermarkText = watch("watermarkText") ?? "";
     const watchSignatures = watch("withSignatures");
 
     useImperativeHandle(ref, () => ({
@@ -79,7 +75,9 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
     const onSubmit = (data: ExportFormData) => {
       const options = {
         ...data,
-        watermarkText: data.withWatermark ? data.watermarkText : undefined,
+        watermarkText: data.withWatermark && data.watermarkText !== defaultEmail
+          ? data.watermarkText
+          : undefined,
       };
       onDownload(options);
       dialogRef.current?.close();
@@ -134,10 +132,6 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
                       type="text"
                       placeholder={t("pdfDownloadDialog.watermark.textPlaceholder")}
                       error={formState.errors.watermarkText?.message}
-                      help={t("pdfDownloadDialog.watermark.byteCount", {
-                        count: getWatermarkTextLength(watchWatermarkText),
-                        max: maxWatermarkTextLength,
-                      })}
                       autoComplete="off"
                       required
                     />

--- a/apps/console/src/components/documents/PdfDownloadDialog.tsx
+++ b/apps/console/src/components/documents/PdfDownloadDialog.tsx
@@ -34,9 +34,14 @@ import { z } from "zod";
 
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 
+const maxWatermarkTextLength = 64;
+
 const pdfDownloadSchema = z.object({
   withWatermark: z.boolean(),
-  watermarkText: z.string().optional().or(z.literal("")),
+  watermarkText: z.string().refine(
+    value => new TextEncoder().encode(value).length <= maxWatermarkTextLength,
+    `Watermark text must not exceed ${maxWatermarkTextLength} bytes`,
+  ).optional().or(z.literal("")),
   withSignatures: z.boolean(),
 }).refine((data) => {
   if (data.withWatermark && (!data.watermarkText || data.watermarkText.trim() === "")) {
@@ -140,6 +145,7 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
                       label={t("pdfDownloadDialog.watermark.textLabel")}
                       {...register("watermarkText")}
                       type="text"
+                      maxLength={maxWatermarkTextLength}
                       placeholder={t("pdfDownloadDialog.watermark.textPlaceholder")}
                       error={formState.errors.watermarkText?.message}
                       autoComplete="off"

--- a/apps/console/src/components/documents/PdfDownloadDialog.tsx
+++ b/apps/console/src/components/documents/PdfDownloadDialog.tsx
@@ -30,34 +30,20 @@ import {
 } from "@probo/ui";
 import { forwardRef, type ReactNode, useImperativeHandle } from "react";
 import { useTranslation } from "react-i18next";
-import { z } from "zod";
 
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 
-const maxWatermarkTextLength = 64;
-
-const pdfDownloadSchema = z.object({
-  withWatermark: z.boolean(),
-  watermarkText: z.string().refine(
-    value => new TextEncoder().encode(value).length <= maxWatermarkTextLength,
-    `Watermark text must not exceed ${maxWatermarkTextLength} bytes`,
-  ).optional().or(z.literal("")),
-  withSignatures: z.boolean(),
-}).refine((data) => {
-  if (data.withWatermark && (!data.watermarkText || data.watermarkText.trim() === "")) {
-    return false;
-  }
-  return true;
-}, {
-  message: "Please enter watermark text",
-  path: ["watermarkText"],
-});
-
-type PdfDownloadFormData = z.infer<typeof pdfDownloadSchema>;
+import {
+  getWatermarkTextLength,
+  maxWatermarkTextLength,
+  truncateWatermarkText,
+  type WatermarkExportFormData,
+  watermarkExportSchema,
+} from "./watermark";
 
 type Props = {
   children?: ReactNode;
-  onDownload: (options: PdfDownloadFormData) => void;
+  onDownload: (options: WatermarkExportFormData) => void;
   isLoading?: boolean;
   defaultEmail: string;
 };
@@ -73,15 +59,16 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
     const dialogRef = useDialogRef();
 
     const { register, handleSubmit, formState, watch, setValue }
-      = useFormWithSchema(pdfDownloadSchema, {
+      = useFormWithSchema(watermarkExportSchema, {
         defaultValues: {
           withWatermark: false,
-          watermarkText: defaultEmail,
+          watermarkText: truncateWatermarkText(defaultEmail),
           withSignatures: true,
         },
       });
 
     const watchWatermark = watch("withWatermark");
+    const watchWatermarkText = watch("watermarkText") ?? "";
     const watchSignatures = watch("withSignatures");
 
     useImperativeHandle(ref, () => ({
@@ -89,7 +76,7 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
       close: () => dialogRef.current?.close(),
     }));
 
-    const onSubmit = (data: PdfDownloadFormData) => {
+    const onSubmit = (data: WatermarkExportFormData) => {
       const options = {
         ...data,
         watermarkText: data.withWatermark ? data.watermarkText : undefined,
@@ -145,9 +132,12 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
                       label={t("pdfDownloadDialog.watermark.textLabel")}
                       {...register("watermarkText")}
                       type="text"
-                      maxLength={maxWatermarkTextLength}
                       placeholder={t("pdfDownloadDialog.watermark.textPlaceholder")}
                       error={formState.errors.watermarkText?.message}
+                      help={t("pdfDownloadDialog.watermark.byteCount", {
+                        count: getWatermarkTextLength(watchWatermarkText),
+                        max: maxWatermarkTextLength,
+                      })}
                       autoComplete="off"
                       required
                     />

--- a/apps/console/src/components/documents/PdfDownloadDialog.tsx
+++ b/apps/console/src/components/documents/PdfDownloadDialog.tsx
@@ -34,16 +34,16 @@ import { useTranslation } from "react-i18next";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 
 import {
+  type ExportFormData,
+  exportSchema,
   getWatermarkTextLength,
   maxWatermarkTextLength,
   truncateWatermarkText,
-  type WatermarkExportFormData,
-  watermarkExportSchema,
 } from "./watermark";
 
 type Props = {
   children?: ReactNode;
-  onDownload: (options: WatermarkExportFormData) => void;
+  onDownload: (options: ExportFormData) => void;
   isLoading?: boolean;
   defaultEmail: string;
 };
@@ -59,7 +59,7 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
     const dialogRef = useDialogRef();
 
     const { register, handleSubmit, formState, watch, setValue }
-      = useFormWithSchema(watermarkExportSchema, {
+      = useFormWithSchema(exportSchema, {
         defaultValues: {
           withWatermark: false,
           watermarkText: truncateWatermarkText(defaultEmail),
@@ -76,7 +76,7 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
       close: () => dialogRef.current?.close(),
     }));
 
-    const onSubmit = (data: WatermarkExportFormData) => {
+    const onSubmit = (data: ExportFormData) => {
       const options = {
         ...data,
         watermarkText: data.withWatermark ? data.watermarkText : undefined,

--- a/apps/console/src/components/documents/PdfDownloadDialog.tsx
+++ b/apps/console/src/components/documents/PdfDownloadDialog.tsx
@@ -36,12 +36,16 @@ import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 
 const pdfDownloadSchema = z.object({
   withWatermark: z.boolean(),
-  watermarkEmail: z
-    .string()
-    .email("Please enter a valid email address")
-    .optional()
-    .or(z.literal("")),
+  watermarkText: z.string().optional().or(z.literal("")),
   withSignatures: z.boolean(),
+}).refine((data) => {
+  if (data.withWatermark && (!data.watermarkText || data.watermarkText.trim() === "")) {
+    return false;
+  }
+  return true;
+}, {
+  message: "Please enter watermark text",
+  path: ["watermarkText"],
 });
 
 type PdfDownloadFormData = z.infer<typeof pdfDownloadSchema>;
@@ -67,7 +71,7 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
       = useFormWithSchema(pdfDownloadSchema, {
         defaultValues: {
           withWatermark: false,
-          watermarkEmail: defaultEmail,
+          watermarkText: defaultEmail,
           withSignatures: true,
         },
       });
@@ -83,7 +87,7 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
     const onSubmit = (data: PdfDownloadFormData) => {
       const options = {
         ...data,
-        watermarkEmail: data.withWatermark ? data.watermarkEmail : undefined,
+        watermarkText: data.withWatermark ? data.watermarkText : undefined,
       };
       onDownload(options);
       dialogRef.current?.close();
@@ -133,11 +137,11 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
                 {watchWatermark && (
                   <div className="ml-6">
                     <Field
-                      label={t("pdfDownloadDialog.watermark.emailLabel")}
-                      {...register("watermarkEmail")}
-                      type="email"
-                      placeholder={t("pdfDownloadDialog.watermark.emailPlaceholder")}
-                      error={formState.errors.watermarkEmail?.message}
+                      label={t("pdfDownloadDialog.watermark.textLabel")}
+                      {...register("watermarkText")}
+                      type="text"
+                      placeholder={t("pdfDownloadDialog.watermark.textPlaceholder")}
+                      error={formState.errors.watermarkText?.message}
                       autoComplete="off"
                       required
                     />

--- a/apps/console/src/components/documents/watermark.ts
+++ b/apps/console/src/components/documents/watermark.ts
@@ -24,7 +24,7 @@ export const maxWatermarkTextLength = 64;
 
 const textEncoder = new TextEncoder();
 
-export const watermarkExportSchema = z.object({
+export const exportSchema = z.object({
   withWatermark: z.boolean(),
   watermarkText: z.string().optional(),
   withSignatures: z.boolean(),
@@ -43,7 +43,7 @@ export const watermarkExportSchema = z.object({
   },
 );
 
-export type WatermarkExportFormData = z.infer<typeof watermarkExportSchema>;
+export type ExportFormData = z.infer<typeof exportSchema>;
 
 export function getWatermarkTextLength(watermarkText: string): number {
   return textEncoder.encode(watermarkText).length;

--- a/apps/console/src/components/documents/watermark.ts
+++ b/apps/console/src/components/documents/watermark.ts
@@ -20,46 +20,22 @@
 
 import { z } from "zod";
 
-export const maxWatermarkTextLength = 64;
-
-const textEncoder = new TextEncoder();
+const goWhitespacePattern = /^\p{White_Space}*$/u;
 
 export const exportSchema = z.object({
   withWatermark: z.boolean(),
   watermarkText: z.string().optional(),
   withSignatures: z.boolean(),
 }).refine(
-  data => !data.withWatermark || !!data.watermarkText?.trim(),
+  data => !data.withWatermark || !isWatermarkTextEmpty(data.watermarkText),
   {
     message: "Please enter watermark text",
-    path: ["watermarkText"],
-  },
-).refine(
-  data => !data.withWatermark
-    || getWatermarkTextLength(data.watermarkText ?? "") <= maxWatermarkTextLength,
-  {
-    message: `Watermark text must not exceed ${maxWatermarkTextLength} bytes`,
     path: ["watermarkText"],
   },
 );
 
 export type ExportFormData = z.infer<typeof exportSchema>;
 
-export function getWatermarkTextLength(watermarkText: string): number {
-  return textEncoder.encode(watermarkText).length;
-}
-
-export function truncateWatermarkText(watermarkText: string): string {
-  let truncated = "";
-
-  for (const character of watermarkText) {
-    const candidate = truncated + character;
-    if (getWatermarkTextLength(candidate) > maxWatermarkTextLength) {
-      break;
-    }
-
-    truncated = candidate;
-  }
-
-  return truncated;
+function isWatermarkTextEmpty(watermarkText: string | undefined): boolean {
+  return !watermarkText || goWhitespacePattern.test(watermarkText);
 }

--- a/apps/console/src/components/documents/watermark.ts
+++ b/apps/console/src/components/documents/watermark.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { z } from "zod";
+
+export const maxWatermarkTextLength = 64;
+
+const textEncoder = new TextEncoder();
+
+export const watermarkExportSchema = z.object({
+  withWatermark: z.boolean(),
+  watermarkText: z.string().optional(),
+  withSignatures: z.boolean(),
+}).refine(
+  data => !data.withWatermark || !!data.watermarkText?.trim(),
+  {
+    message: "Please enter watermark text",
+    path: ["watermarkText"],
+  },
+).refine(
+  data => !data.withWatermark
+    || getWatermarkTextLength(data.watermarkText ?? "") <= maxWatermarkTextLength,
+  {
+    message: `Watermark text must not exceed ${maxWatermarkTextLength} bytes`,
+    path: ["watermarkText"],
+  },
+);
+
+export type WatermarkExportFormData = z.infer<typeof watermarkExportSchema>;
+
+export function getWatermarkTextLength(watermarkText: string): number {
+  return textEncoder.encode(watermarkText).length;
+}
+
+export function truncateWatermarkText(watermarkText: string): string {
+  let truncated = "";
+
+  for (const character of watermarkText) {
+    const candidate = truncated + character;
+    if (getWatermarkTextLength(candidate) > maxWatermarkTextLength) {
+      break;
+    }
+
+    truncated = candidate;
+  }
+
+  return truncated;
+}

--- a/apps/console/src/pages/organizations/documents/_components/DocumentActionsDropdown.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/DocumentActionsDropdown.tsx
@@ -228,14 +228,14 @@ export function DocumentActionsDropdown(props: {
   const handleExportDocumentVersion = (options: {
     withWatermark: boolean;
     withSignatures: boolean;
-    watermarkEmail?: string;
+    watermarkText?: string;
   }) => {
     const input = {
       documentVersionId: version.id,
       withWatermark: options.withWatermark,
       withSignatures: options.withSignatures,
       ...(options.withWatermark
-        && options.watermarkEmail && { watermarkEmail: options.watermarkEmail }),
+        && options.watermarkText && { watermarkEmail: options.watermarkText }),
     };
 
     exportDocumentVersion({

--- a/apps/console/src/pages/organizations/documents/_components/DocumentActionsDropdown.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/DocumentActionsDropdown.tsx
@@ -235,7 +235,7 @@ export function DocumentActionsDropdown(props: {
       withWatermark: options.withWatermark,
       withSignatures: options.withSignatures,
       ...(options.withWatermark
-        && options.watermarkText && { watermarkEmail: options.watermarkText }),
+        && options.watermarkText && { watermarkText: options.watermarkText }),
     };
 
     exportDocumentVersion({

--- a/apps/console/src/pages/organizations/documents/_components/DocumentList.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/DocumentList.tsx
@@ -280,7 +280,7 @@ export function DocumentList(props: {
       documentIds: selection,
       withWatermark: options.withWatermark,
       withSignatures: options.withSignatures,
-      ...(options.withWatermark && options.watermarkText && { watermarkEmail: options.watermarkText }),
+      ...(options.withWatermark && options.watermarkText && { watermarkText: options.watermarkText }),
     };
     await bulkExportDocuments({ variables: { input } });
     clear();

--- a/apps/console/src/pages/organizations/documents/_components/DocumentList.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/DocumentList.tsx
@@ -274,13 +274,13 @@ export function DocumentList(props: {
   const handleBulkExport = async (options: {
     withWatermark: boolean;
     withSignatures: boolean;
-    watermarkEmail?: string;
+    watermarkText?: string;
   }) => {
     const input = {
       documentIds: selection,
       withWatermark: options.withWatermark,
       withSignatures: options.withSignatures,
-      ...(options.withWatermark && options.watermarkEmail && { watermarkEmail: options.watermarkEmail }),
+      ...(options.withWatermark && options.watermarkText && { watermarkEmail: options.watermarkText }),
     };
     await bulkExportDocuments({ variables: { input } });
     clear();

--- a/pkg/complianceportal/visitor/document_service.go
+++ b/pkg/complianceportal/visitor/document_service.go
@@ -90,7 +90,7 @@ func (s *Service) ExportDocumentPDF(
 		return nil, fmt.Errorf("cannot export document PDF: %w", err)
 	}
 
-	watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, email)
+	watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, email.String())
 	if err != nil {
 		return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 	}

--- a/pkg/complianceportal/visitor/document_service.go
+++ b/pkg/complianceportal/visitor/document_service.go
@@ -90,7 +90,8 @@ func (s *Service) ExportDocumentPDF(
 		return nil, fmt.Errorf("cannot export document PDF: %w", err)
 	}
 
-	watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, email.String())
+	watermarkText := pdfutils.TruncateWatermarkText(email.String())
+	watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, watermarkText)
 	if err != nil {
 		return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 	}

--- a/pkg/complianceportal/visitor/document_service.go
+++ b/pkg/complianceportal/visitor/document_service.go
@@ -91,6 +91,7 @@ func (s *Service) ExportDocumentPDF(
 	}
 
 	watermarkText := pdfutils.TruncateWatermarkText(email.String())
+
 	watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, watermarkText)
 	if err != nil {
 		return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)

--- a/pkg/complianceportal/visitor/portal_file_service.go
+++ b/pkg/complianceportal/visitor/portal_file_service.go
@@ -120,6 +120,7 @@ func (s *Service) ExportPortalFile(
 
 	if mimeType == "application/pdf" {
 		watermarkText := pdfutils.TruncateWatermarkText(email.String())
+
 		watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(fileData, watermarkText)
 		if err != nil {
 			return nil, "", fmt.Errorf("cannot add watermark to PDF: %w", err)

--- a/pkg/complianceportal/visitor/portal_file_service.go
+++ b/pkg/complianceportal/visitor/portal_file_service.go
@@ -119,7 +119,8 @@ func (s *Service) ExportPortalFile(
 	}
 
 	if mimeType == "application/pdf" {
-		watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(fileData, email.String())
+		watermarkText := pdfutils.TruncateWatermarkText(email.String())
+		watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(fileData, watermarkText)
 		if err != nil {
 			return nil, "", fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}

--- a/pkg/complianceportal/visitor/portal_file_service.go
+++ b/pkg/complianceportal/visitor/portal_file_service.go
@@ -119,7 +119,7 @@ func (s *Service) ExportPortalFile(
 	}
 
 	if mimeType == "application/pdf" {
-		watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(fileData, email)
+		watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(fileData, email.String())
 		if err != nil {
 			return nil, "", fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}

--- a/pkg/complianceportal/visitor/report_service.go
+++ b/pkg/complianceportal/visitor/report_service.go
@@ -102,7 +102,8 @@ func (s *Service) ExportReportPDF(
 		return nil, fmt.Errorf("cannot export report PDF: %w", err)
 	}
 
-	watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, email.String())
+	watermarkText := pdfutils.TruncateWatermarkText(email.String())
+	watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, watermarkText)
 	if err != nil {
 		return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 	}

--- a/pkg/complianceportal/visitor/report_service.go
+++ b/pkg/complianceportal/visitor/report_service.go
@@ -103,6 +103,7 @@ func (s *Service) ExportReportPDF(
 	}
 
 	watermarkText := pdfutils.TruncateWatermarkText(email.String())
+
 	watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, watermarkText)
 	if err != nil {
 		return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)

--- a/pkg/complianceportal/visitor/report_service.go
+++ b/pkg/complianceportal/visitor/report_service.go
@@ -102,7 +102,7 @@ func (s *Service) ExportReportPDF(
 		return nil, fmt.Errorf("cannot export report PDF: %w", err)
 	}
 
-	watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, email)
+	watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, email.String())
 	if err != nil {
 		return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 	}

--- a/pkg/coredata/export_job.go
+++ b/pkg/coredata/export_job.go
@@ -54,10 +54,10 @@ type (
 	ExportJobs []*ExportJob
 
 	DocumentExportArguments struct {
-		DocumentIDs    []gid.GID  `json:"document_ids"`
-		WithWatermark  bool       `json:"with_watermark"`
-		WatermarkEmail *mail.Addr `json:"watermark_email"`
-		WithSignatures bool       `json:"with_signatures"`
+		DocumentIDs    []gid.GID `json:"document_ids"`
+		WithWatermark  bool      `json:"with_watermark"`
+		WatermarkText  *string   `json:"watermark_email"`
+		WithSignatures bool      `json:"with_signatures"`
 	}
 
 	FrameworkExportArguments struct {

--- a/pkg/coredata/export_job.go
+++ b/pkg/coredata/export_job.go
@@ -56,7 +56,7 @@ type (
 	DocumentExportArguments struct {
 		DocumentIDs    []gid.GID `json:"document_ids"`
 		WithWatermark  bool      `json:"with_watermark"`
-		WatermarkText  *string   `json:"watermark_email"`
+		WatermarkText  *string   `json:"watermark_text"`
 		WithSignatures bool      `json:"with_signatures"`
 	}
 
@@ -73,6 +73,30 @@ type (
 var (
 	ErrNoExportJobAvailable = errors.New("no export job available")
 )
+
+func (a *DocumentExportArguments) UnmarshalJSON(data []byte) error {
+	var arguments struct {
+		DocumentIDs    []gid.GID `json:"document_ids"`
+		WithWatermark  bool      `json:"with_watermark"`
+		WatermarkText  *string   `json:"watermark_text"`
+		WatermarkEmail *string   `json:"watermark_email"`
+		WithSignatures bool      `json:"with_signatures"`
+	}
+
+	if err := json.Unmarshal(data, &arguments); err != nil {
+		return fmt.Errorf("cannot unmarshal document export arguments: %w", err)
+	}
+
+	a.DocumentIDs = arguments.DocumentIDs
+	a.WithWatermark = arguments.WithWatermark
+	a.WatermarkText = arguments.WatermarkText
+	if a.WatermarkText == nil {
+		a.WatermarkText = arguments.WatermarkEmail
+	}
+	a.WithSignatures = arguments.WithSignatures
+
+	return nil
+}
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
 func (ej *ExportJob) AuthorizationAttributes(

--- a/pkg/coredata/export_job.go
+++ b/pkg/coredata/export_job.go
@@ -93,6 +93,7 @@ func (a *DocumentExportArguments) UnmarshalJSON(data []byte) error {
 	if a.WatermarkText == nil {
 		a.WatermarkText = arguments.WatermarkEmail
 	}
+
 	a.WithSignatures = arguments.WithSignatures
 
 	return nil

--- a/pkg/coredata/export_job_test.go
+++ b/pkg/coredata/export_job_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestDocumentExportArguments_MarshalWatermarkText(t *testing.T) {
+	t.Parallel()
+
+	arguments := coredata.DocumentExportArguments{
+		WithWatermark:  true,
+		WatermarkText:  new("Internal use only"),
+		WithSignatures: true,
+	}
+
+	data, err := json.Marshal(arguments)
+
+	require.NoError(t, err)
+	assert.JSONEq(
+		t,
+		`{
+			"document_ids": null,
+			"with_watermark": true,
+			"watermark_text": "Internal use only",
+			"with_signatures": true
+		}`,
+		string(data),
+	)
+}
+
+func TestDocumentExportArguments_UnmarshalLegacyWatermarkEmail(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+		"document_ids": [],
+		"with_watermark": true,
+		"watermark_email": "recipient@example.com",
+		"with_signatures": false
+	}`)
+	var arguments coredata.DocumentExportArguments
+
+	err := json.Unmarshal(data, &arguments)
+
+	require.NoError(t, err)
+	require.NotNil(t, arguments.WatermarkText)
+	assert.Equal(t, "recipient@example.com", *arguments.WatermarkText)
+}

--- a/pkg/coredata/export_job_test.go
+++ b/pkg/coredata/export_job_test.go
@@ -62,6 +62,7 @@ func TestDocumentExportArguments_UnmarshalLegacyWatermarkEmail(t *testing.T) {
 		"watermark_email": "recipient@example.com",
 		"with_signatures": false
 	}`)
+
 	var arguments coredata.DocumentExportArguments
 
 	err := json.Unmarshal(data, &arguments)

--- a/pkg/pdfutils/pdfutils.go
+++ b/pkg/pdfutils/pdfutils.go
@@ -39,6 +39,7 @@ import (
 )
 
 const (
+	MaxWatermarkTextLength  = 64
 	watermarkFontSize       = 90
 	watermarkRotationDegree = -55.0
 	watermarkOpacity        = 0.1
@@ -68,6 +69,10 @@ func MergePDFs(pdfs ...[]byte) ([]byte, error) {
 }
 
 func AddConfidentialWithTimestamp(pdfData []byte, watermarkText string) ([]byte, error) {
+	if len(watermarkText) > MaxWatermarkTextLength {
+		return nil, fmt.Errorf("watermark text must not exceed %d bytes", MaxWatermarkTextLength)
+	}
+
 	reader := bytes.NewReader(pdfData)
 
 	watermarkLines := []string{

--- a/pkg/pdfutils/pdfutils.go
+++ b/pkg/pdfutils/pdfutils.go
@@ -71,12 +71,8 @@ func MergePDFs(pdfs ...[]byte) ([]byte, error) {
 }
 
 func AddConfidentialWithTimestamp(pdfData []byte, watermarkText string) ([]byte, error) {
-	if strings.TrimSpace(watermarkText) == "" {
-		return nil, fmt.Errorf("watermark text is required")
-	}
-
-	if len(watermarkText) > MaxWatermarkTextLength {
-		return nil, fmt.Errorf("watermark text must not exceed %d bytes", MaxWatermarkTextLength)
+	if err := ValidateWatermarkText(watermarkText); err != nil {
+		return nil, fmt.Errorf("cannot validate watermark text: %w", err)
 	}
 
 	reader := bytes.NewReader(pdfData)
@@ -119,6 +115,18 @@ func AddConfidentialWithTimestamp(pdfData []byte, watermarkText string) ([]byte,
 	}
 
 	return buf.Bytes(), nil
+}
+
+func ValidateWatermarkText(watermarkText string) error {
+	if strings.TrimSpace(watermarkText) == "" {
+		return fmt.Errorf("watermark text is required")
+	}
+
+	if len(watermarkText) > MaxWatermarkTextLength {
+		return fmt.Errorf("watermark text must not exceed %d bytes", MaxWatermarkTextLength)
+	}
+
+	return nil
 }
 
 func TruncateWatermarkText(watermarkText string) string {

--- a/pkg/pdfutils/pdfutils.go
+++ b/pkg/pdfutils/pdfutils.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/pdfcpu/pdfcpu/pkg/api"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/types"
-	"go.probo.inc/probo/pkg/mail"
 	"golang.org/x/image/font"
 	"golang.org/x/image/font/gofont/goregular"
 	"golang.org/x/image/font/opentype"
@@ -68,12 +67,12 @@ func MergePDFs(pdfs ...[]byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func AddConfidentialWithTimestamp(pdfData []byte, email mail.Addr) ([]byte, error) {
+func AddConfidentialWithTimestamp(pdfData []byte, watermarkText string) ([]byte, error) {
 	reader := bytes.NewReader(pdfData)
 
 	watermarkLines := []string{
 		"Confidential",
-		email.String(),
+		watermarkText,
 		time.Now().Format("2006-01-02"),
 	}
 

--- a/pkg/pdfutils/pdfutils.go
+++ b/pkg/pdfutils/pdfutils.go
@@ -28,7 +28,9 @@ import (
 	"image/png"
 	"io"
 	"math"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/pdfcpu/pdfcpu/pkg/api"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/types"
@@ -69,6 +71,10 @@ func MergePDFs(pdfs ...[]byte) ([]byte, error) {
 }
 
 func AddConfidentialWithTimestamp(pdfData []byte, watermarkText string) ([]byte, error) {
+	if strings.TrimSpace(watermarkText) == "" {
+		return nil, fmt.Errorf("watermark text is required")
+	}
+
 	if len(watermarkText) > MaxWatermarkTextLength {
 		return nil, fmt.Errorf("watermark text must not exceed %d bytes", MaxWatermarkTextLength)
 	}
@@ -113,6 +119,15 @@ func AddConfidentialWithTimestamp(pdfData []byte, watermarkText string) ([]byte,
 	}
 
 	return buf.Bytes(), nil
+}
+
+func TruncateWatermarkText(watermarkText string) string {
+	for len(watermarkText) > MaxWatermarkTextLength {
+		_, size := utf8.DecodeLastRuneInString(watermarkText)
+		watermarkText = watermarkText[:len(watermarkText)-size]
+	}
+
+	return watermarkText
 }
 
 func generateTextImage(lines []string) (*image.RGBA, error) {

--- a/pkg/pdfutils/pdfutils_test.go
+++ b/pkg/pdfutils/pdfutils_test.go
@@ -40,3 +40,62 @@ func TestAddConfidentialWithTimestamp_WatermarkTextTooLong(t *testing.T) {
 	assert.Nil(t, pdf)
 	assert.ErrorContains(t, err, "watermark text must not exceed 64 bytes")
 }
+
+func TestAddConfidentialWithTimestamp_WatermarkTextEmpty(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]string{
+		"empty":      "",
+		"whitespace": " \t\n",
+	}
+
+	for name, watermarkText := range testCases {
+		t.Run(
+			name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				pdf, err := pdfutils.AddConfidentialWithTimestamp(nil, watermarkText)
+
+				require.Error(t, err)
+				assert.Nil(t, pdf)
+				assert.ErrorContains(t, err, "watermark text is required")
+			},
+		)
+	}
+}
+
+func TestTruncateWatermarkText(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    string
+		expected string
+	}{
+		"within limit": {
+			input:    "recipient@example.com",
+			expected: "recipient@example.com",
+		},
+		"ASCII over limit": {
+			input:    strings.Repeat("a", pdfutils.MaxWatermarkTextLength+1),
+			expected: strings.Repeat("a", pdfutils.MaxWatermarkTextLength),
+		},
+		"multibyte rune at boundary": {
+			input:    strings.Repeat("a", pdfutils.MaxWatermarkTextLength-1) + "é",
+			expected: strings.Repeat("a", pdfutils.MaxWatermarkTextLength-1),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(
+			name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				actual := pdfutils.TruncateWatermarkText(testCase.input)
+
+				assert.Equal(t, testCase.expected, actual)
+			},
+		)
+	}
+}

--- a/pkg/pdfutils/pdfutils_test.go
+++ b/pkg/pdfutils/pdfutils_test.go
@@ -45,8 +45,9 @@ func TestAddConfidentialWithTimestamp_WatermarkTextEmpty(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]string{
-		"empty":      "",
-		"whitespace": " \t\n",
+		"empty":              "",
+		"ASCII whitespace":   " \t\n",
+		"Unicode whitespace": "\u0085",
 	}
 
 	for name, watermarkText := range testCases {

--- a/pkg/pdfutils/pdfutils_test.go
+++ b/pkg/pdfutils/pdfutils_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package pdfutils_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/pdfutils"
+)
+
+func TestAddConfidentialWithTimestamp_WatermarkTextTooLong(t *testing.T) {
+	t.Parallel()
+
+	watermarkText := strings.Repeat("a", pdfutils.MaxWatermarkTextLength+1)
+
+	pdf, err := pdfutils.AddConfidentialWithTimestamp(nil, watermarkText)
+
+	require.Error(t, err)
+	assert.Nil(t, pdf)
+	assert.ErrorContains(t, err, "watermark text must not exceed 64 bytes")
+}

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -2636,7 +2636,7 @@ func (o ExportPDFOptions) validate() error {
 		return nil
 	}
 
-	if o.WatermarkText == nil {
+	if o.WatermarkText == nil || strings.TrimSpace(*o.WatermarkText) == "" {
 		return fmt.Errorf("watermark text is required when with watermark is true")
 	}
 

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -1789,8 +1789,8 @@ func (s *DocumentService) RequestExport(
 	exportJob := &coredata.ExportJob{}
 
 	if options.WithWatermark {
-		if options.WatermarkEmail == nil {
-			return nil, fmt.Errorf("watermark email is required when with watermark is true")
+		if options.WatermarkText == nil {
+			return nil, fmt.Errorf("watermark text is required when with watermark is true")
 		}
 	}
 
@@ -1812,7 +1812,7 @@ func (s *DocumentService) RequestExport(
 		args := coredata.DocumentExportArguments{
 			DocumentIDs:    documentIDs,
 			WithWatermark:  options.WithWatermark,
-			WatermarkEmail: options.WatermarkEmail,
+			WatermarkText:  options.WatermarkText,
 			WithSignatures: options.WithSignatures,
 		}
 
@@ -2629,7 +2629,7 @@ func (s *DocumentService) CancelSignatureRequest(
 
 type ExportPDFOptions struct {
 	WithWatermark  bool
-	WatermarkEmail *mail.Addr
+	WatermarkText  *string
 	WithSignatures bool
 }
 
@@ -2703,7 +2703,7 @@ func (s *DocumentService) BuildAndUploadExport(ctx context.Context, scope coreda
 
 			exportOptions := ExportPDFOptions{
 				WithWatermark:  exportArgs.WithWatermark,
-				WatermarkEmail: exportArgs.WatermarkEmail,
+				WatermarkText:  exportArgs.WatermarkText,
 				WithSignatures: exportArgs.WithSignatures,
 			}
 
@@ -2804,7 +2804,7 @@ func exportDocumentPDF(
 	// applied after merging the signature page so all pages are watermarked.
 	generateOptions := options
 	generateOptions.WithWatermark = false
-	generateOptions.WatermarkEmail = nil
+	generateOptions.WatermarkText = nil
 
 	pdfData, err := generateDocumentPDF(ctx, svc, html2pdfConverter, conn, scope, version, generateOptions)
 	if err != nil {
@@ -2826,11 +2826,11 @@ func exportDocumentPDF(
 	}
 
 	if options.WithWatermark {
-		if options.WatermarkEmail == nil {
-			return nil, fmt.Errorf("watermark email is required with watermark enabled")
+		if options.WatermarkText == nil {
+			return nil, fmt.Errorf("watermark text is required with watermark enabled")
 		}
 
-		pdfData, err = pdfutils.AddConfidentialWithTimestamp(pdfData, *options.WatermarkEmail)
+		pdfData, err = pdfutils.AddConfidentialWithTimestamp(pdfData, *options.WatermarkText)
 		if err != nil {
 			return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}
@@ -2873,11 +2873,11 @@ func exportStoredPDF(
 	}
 
 	if options.WithWatermark {
-		if options.WatermarkEmail == nil {
-			return nil, fmt.Errorf("watermark email is required with watermark enabled")
+		if options.WatermarkText == nil {
+			return nil, fmt.Errorf("watermark text is required with watermark enabled")
 		}
 
-		pdfData, err = pdfutils.AddConfidentialWithTimestamp(pdfData, *options.WatermarkEmail)
+		pdfData, err = pdfutils.AddConfidentialWithTimestamp(pdfData, *options.WatermarkText)
 		if err != nil {
 			return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}
@@ -3095,11 +3095,11 @@ func generateDocumentPDF(
 	}
 
 	if options.WithWatermark {
-		if options.WatermarkEmail == nil {
-			return nil, fmt.Errorf("watermark email is required with watermark enabled")
+		if options.WatermarkText == nil {
+			return nil, fmt.Errorf("watermark text is required with watermark enabled")
 		}
 
-		watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, *options.WatermarkEmail)
+		watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, *options.WatermarkText)
 		if err != nil {
 			return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -1788,10 +1788,8 @@ func (s *DocumentService) RequestExport(
 
 	exportJob := &coredata.ExportJob{}
 
-	if options.WithWatermark {
-		if options.WatermarkText == nil {
-			return nil, fmt.Errorf("watermark text is required when with watermark is true")
-		}
+	if err := options.validate(); err != nil {
+		return nil, fmt.Errorf("cannot validate PDF export options: %w", err)
 	}
 
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, conn pg.Tx) error {
@@ -2633,12 +2631,32 @@ type ExportPDFOptions struct {
 	WithSignatures bool
 }
 
+func (o ExportPDFOptions) validate() error {
+	if !o.WithWatermark {
+		return nil
+	}
+
+	if o.WatermarkText == nil {
+		return fmt.Errorf("watermark text is required when with watermark is true")
+	}
+
+	if len(*o.WatermarkText) > pdfutils.MaxWatermarkTextLength {
+		return fmt.Errorf("watermark text must not exceed %d bytes", pdfutils.MaxWatermarkTextLength)
+	}
+
+	return nil
+}
+
 func (s *DocumentService) ExportPDF(
 	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 	options ExportPDFOptions,
 ) ([]byte, error) {
 	var data []byte
+
+	if err := options.validate(); err != nil {
+		return nil, fmt.Errorf("cannot validate PDF export options: %w", err)
+	}
 
 	err := s.svc.pg.WithTx(
 		ctx,
@@ -3116,6 +3134,10 @@ func (s *DocumentService) Export(
 	file io.Writer,
 	options ExportPDFOptions,
 ) (err error) {
+	if err := options.validate(); err != nil {
+		return fmt.Errorf("cannot validate PDF export options: %w", err)
+	}
+
 	archive := zip.NewWriter(file)
 
 	defer func() {

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -2636,12 +2636,12 @@ func (o ExportPDFOptions) validate() error {
 		return nil
 	}
 
-	if o.WatermarkText == nil || strings.TrimSpace(*o.WatermarkText) == "" {
+	if o.WatermarkText == nil {
 		return fmt.Errorf("watermark text is required when with watermark is true")
 	}
 
-	if len(*o.WatermarkText) > pdfutils.MaxWatermarkTextLength {
-		return fmt.Errorf("watermark text must not exceed %d bytes", pdfutils.MaxWatermarkTextLength)
+	if err := pdfutils.ValidateWatermarkText(*o.WatermarkText); err != nil {
+		return fmt.Errorf("cannot validate watermark text: %w", err)
 	}
 
 	return nil

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -1268,9 +1268,11 @@ func (r *mutationResolver) BulkExportDocuments(ctx context.Context, input types.
 	if watermarkText == nil && input.WatermarkEmail != nil {
 		watermarkText = new(pdfutils.TruncateWatermarkText(input.WatermarkEmail.String()))
 	}
+
 	if input.WithWatermark && watermarkText == nil {
 		watermarkText = new(pdfutils.TruncateWatermarkText(identity.EmailAddress.String()))
 	}
+
 	if input.WithWatermark {
 		if err := pdfutils.ValidateWatermarkText(*watermarkText); err != nil {
 			return nil, gqlutils.Invalid(ctx, err)
@@ -1581,10 +1583,12 @@ func (r *mutationResolver) ExportDocumentVersionPDF(ctx context.Context, input t
 	if watermarkText == nil && input.WatermarkEmail != nil {
 		watermarkText = new(pdfutils.TruncateWatermarkText(input.WatermarkEmail.String()))
 	}
+
 	if input.WithWatermark && watermarkText == nil {
 		identity := authn.IdentityFromContext(ctx)
 		watermarkText = new(pdfutils.TruncateWatermarkText(identity.EmailAddress.String()))
 	}
+
 	if input.WithWatermark {
 		if err := pdfutils.ValidateWatermarkText(*watermarkText); err != nil {
 			return nil, gqlutils.Invalid(ctx, err)

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -17,6 +17,7 @@ import (
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/page"
+	"go.probo.inc/probo/pkg/pdfutils"
 	"go.probo.inc/probo/pkg/probo"
 	"go.probo.inc/probo/pkg/resourcealias"
 	"go.probo.inc/probo/pkg/server/api/authn"
@@ -1266,7 +1267,7 @@ func (r *mutationResolver) BulkExportDocuments(ctx context.Context, input types.
 	options := probo.ExportPDFOptions{
 		WithWatermark:  input.WithWatermark,
 		WithSignatures: input.WithSignatures,
-		WatermarkText:  input.WatermarkEmail,
+		WatermarkText:  input.WatermarkText,
 	}
 
 	documentExport, exportErr := r.probo.Documents.RequestExport(ctx, scope, input.DocumentIds, identity.EmailAddress, identity.FullName, options)
@@ -1563,10 +1564,10 @@ func (r *mutationResolver) ExportDocumentVersionPDF(ctx context.Context, input t
 		return nil, err
 	}
 
-	watermarkText := input.WatermarkEmail
+	watermarkText := input.WatermarkText
 	if input.WithWatermark && watermarkText == nil {
 		identity := authn.IdentityFromContext(ctx)
-		watermarkText = new(identity.EmailAddress.String())
+		watermarkText = new(pdfutils.TruncateWatermarkText(identity.EmailAddress.String()))
 	}
 
 	options := probo.ExportPDFOptions{
@@ -1620,7 +1621,7 @@ func (r *mutationResolver) ExportEmployeeDocumentVersionPDF(ctx context.Context,
 	options := probo.ExportPDFOptions{
 		WithSignatures: false,
 		WithWatermark:  true,
-		WatermarkText:  new(identity.EmailAddress.String()),
+		WatermarkText:  new(pdfutils.TruncateWatermarkText(identity.EmailAddress.String())),
 	}
 
 	pdf, err := r.probo.Documents.ExportPDF(ctx, scope, input.DocumentVersionID, options)

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -1264,10 +1264,23 @@ func (r *mutationResolver) BulkExportDocuments(ctx context.Context, input types.
 	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
 	identity := authn.IdentityFromContext(ctx)
 
+	watermarkText := input.WatermarkText
+	if watermarkText == nil && input.WatermarkEmail != nil {
+		watermarkText = new(pdfutils.TruncateWatermarkText(input.WatermarkEmail.String()))
+	}
+	if input.WithWatermark && watermarkText == nil {
+		watermarkText = new(pdfutils.TruncateWatermarkText(identity.EmailAddress.String()))
+	}
+	if input.WithWatermark {
+		if err := pdfutils.ValidateWatermarkText(*watermarkText); err != nil {
+			return nil, gqlutils.Invalid(ctx, err)
+		}
+	}
+
 	options := probo.ExportPDFOptions{
 		WithWatermark:  input.WithWatermark,
 		WithSignatures: input.WithSignatures,
-		WatermarkText:  input.WatermarkText,
+		WatermarkText:  watermarkText,
 	}
 
 	documentExport, exportErr := r.probo.Documents.RequestExport(ctx, scope, input.DocumentIds, identity.EmailAddress, identity.FullName, options)
@@ -1565,9 +1578,17 @@ func (r *mutationResolver) ExportDocumentVersionPDF(ctx context.Context, input t
 	}
 
 	watermarkText := input.WatermarkText
+	if watermarkText == nil && input.WatermarkEmail != nil {
+		watermarkText = new(pdfutils.TruncateWatermarkText(input.WatermarkEmail.String()))
+	}
 	if input.WithWatermark && watermarkText == nil {
 		identity := authn.IdentityFromContext(ctx)
 		watermarkText = new(pdfutils.TruncateWatermarkText(identity.EmailAddress.String()))
+	}
+	if input.WithWatermark {
+		if err := pdfutils.ValidateWatermarkText(*watermarkText); err != nil {
+			return nil, gqlutils.Invalid(ctx, err)
+		}
 	}
 
 	options := probo.ExportPDFOptions{

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -1266,7 +1266,7 @@ func (r *mutationResolver) BulkExportDocuments(ctx context.Context, input types.
 	options := probo.ExportPDFOptions{
 		WithWatermark:  input.WithWatermark,
 		WithSignatures: input.WithSignatures,
-		WatermarkEmail: input.WatermarkEmail,
+		WatermarkText:  input.WatermarkEmail,
 	}
 
 	documentExport, exportErr := r.probo.Documents.RequestExport(ctx, scope, input.DocumentIds, identity.EmailAddress, identity.FullName, options)
@@ -1563,16 +1563,16 @@ func (r *mutationResolver) ExportDocumentVersionPDF(ctx context.Context, input t
 		return nil, err
 	}
 
-	watermarkEmail := input.WatermarkEmail
-	if input.WithWatermark && watermarkEmail == nil {
+	watermarkText := input.WatermarkEmail
+	if input.WithWatermark && watermarkText == nil {
 		identity := authn.IdentityFromContext(ctx)
-		watermarkEmail = &identity.EmailAddress
+		watermarkText = new(identity.EmailAddress.String())
 	}
 
 	options := probo.ExportPDFOptions{
 		WithSignatures: input.WithSignatures,
 		WithWatermark:  input.WithWatermark,
-		WatermarkEmail: watermarkEmail,
+		WatermarkText:  watermarkText,
 	}
 
 	pdf, err := r.probo.Documents.ExportPDF(ctx, scope, input.DocumentVersionID, options)
@@ -1620,7 +1620,7 @@ func (r *mutationResolver) ExportEmployeeDocumentVersionPDF(ctx context.Context,
 	options := probo.ExportPDFOptions{
 		WithSignatures: false,
 		WithWatermark:  true,
-		WatermarkEmail: &identity.EmailAddress,
+		WatermarkText:  new(identity.EmailAddress.String()),
 	}
 
 	pdf, err := r.probo.Documents.ExportPDF(ctx, scope, input.DocumentVersionID, options)

--- a/pkg/server/api/console/v1/graphql/document.graphql
+++ b/pkg/server/api/console/v1/graphql/document.graphql
@@ -622,7 +622,7 @@ input DeleteDocumentInput {
 input ExportDocumentVersionPDFInput {
     documentVersionId: ID!
     withWatermark: Boolean!
-    watermarkEmail: String
+    watermarkText: String
     withSignatures: Boolean!
 }
 
@@ -662,7 +662,7 @@ input BulkUnarchiveDocumentsInput {
 input BulkExportDocumentsInput {
     documentIds: [ID!]!
     withWatermark: Boolean!
-    watermarkEmail: String
+    watermarkText: String
     withSignatures: Boolean!
 }
 

--- a/pkg/server/api/console/v1/graphql/document.graphql
+++ b/pkg/server/api/console/v1/graphql/document.graphql
@@ -622,7 +622,7 @@ input DeleteDocumentInput {
 input ExportDocumentVersionPDFInput {
     documentVersionId: ID!
     withWatermark: Boolean!
-    watermarkEmail: EmailAddr
+    watermarkEmail: String
     withSignatures: Boolean!
 }
 
@@ -662,7 +662,7 @@ input BulkUnarchiveDocumentsInput {
 input BulkExportDocumentsInput {
     documentIds: [ID!]!
     withWatermark: Boolean!
-    watermarkEmail: EmailAddr
+    watermarkEmail: String
     withSignatures: Boolean!
 }
 

--- a/pkg/server/api/console/v1/graphql/document.graphql
+++ b/pkg/server/api/console/v1/graphql/document.graphql
@@ -623,6 +623,7 @@ input ExportDocumentVersionPDFInput {
     documentVersionId: ID!
     withWatermark: Boolean!
     watermarkText: String
+    watermarkEmail: EmailAddr @deprecated(reason: "Use watermarkText.")
     withSignatures: Boolean!
 }
 
@@ -663,6 +664,7 @@ input BulkExportDocumentsInput {
     documentIds: [ID!]!
     withWatermark: Boolean!
     watermarkText: String
+    watermarkEmail: EmailAddr @deprecated(reason: "Use watermarkText.")
     withSignatures: Boolean!
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- accept arbitrary text for optional document watermarks through `watermarkText`
- retain `watermarkEmail` as a deprecated v1 alias and keep already-queued `watermark_email` jobs readable
- enforce the 64-byte and non-empty constraints in one backend validator before document generation and PDF rendering
- align client empty-text validation with Go Unicode whitespace behavior and safely truncate system-derived emails

## Testing

- `go test ./pkg/complianceportal/visitor ./pkg/coredata ./pkg/server/api/console/v1`
- `make go-fmt`
- `npm --workspace @probo/console run check`
- ESLint on the changed document export components
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8be77f67-91f6-474d-9569-7b808749dcf6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8be77f67-91f6-474d-9569-7b808749dcf6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow custom watermark text for PDFs instead of requiring an email, with a strict 64-byte limit and non-empty validation. Keeps `watermarkEmail` as a deprecated alias, defaults to the requester’s email when needed (safely truncated), and surfaces validation errors cleanly.

### Coredata **`+29`** **`-4`**
- Switched `DocumentExportArguments` to `WatermarkText *string` and added `UnmarshalJSON` to accept `watermark_text` or legacy `watermark_email`.

### Service **`+78`** **`-23`**
- Added `ExportPDFOptions.validate()` and enforced text checks across export flows.
- `pkg/pdfutils`: `AddConfidentialWithTimestamp(string)` validates emptiness and 64-byte length; added `ValidateWatermarkText` and `TruncateWatermarkText` for safe multibyte truncation.

### GraphQL API **`+36`** **`-8`**
- Inputs now use `watermarkText: String`; keep `watermarkEmail` as a deprecated alias.
- Resolvers default to the requester’s email when needed, truncate via `pdfutils.TruncateWatermarkText`, and map backend validation failures to input errors.

### App: console **`+95`** **`-73`**
- Added `watermark.ts` with shared `exportSchema` and Unicode-whitespace empty checks aligned with Go.
- Dialogs and actions switched to `watermarkText`; send custom text only when different from the default email; updated locales.

### Tests **`+175`** **`-0`**
- Added `pkg/pdfutils` tests for empty/oversized text and truncation boundaries.
- Added `pkg/coredata` tests for legacy `watermark_email` parsing.

<sup>Written for commit e2329bbdcf4436d4b57c05ed3d6df42be4fd1baf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

