### PR TITLE
Eng 724 admin flag UI

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1593,6 +1593,7 @@
     "status": { "draft": "Draft", "in_progress": "In progress", "pending_actions": "Pending actions", "completed": "Completed", "cancelled": "Cancelled", "active": "Active", "disabled": "Disabled" },
     "fetchStatus": { "success": "Success", "failed": "Failed", "fetching": "Fetching", "queued": "Queued" },
     "mfaStatus": { "enabled": "Enabled", "disabled": "Disabled", "unknown": "Unknown" },
+    "accountStatus": { "active": "Active", "disabled": "Disabled", "unknown": "Unknown" },
     "authMethod": { "sso": "SSO", "password": "Password", "api_key": "API key", "service_account": "Service account", "unknown": "Unknown" },
     "decisions": { "pending": "Pending", "approved": "Approved", "revoke": "Revoked", "defer": "Modified", "escalate": "Escalated" },
     "flags": { "orphaned": "Orphan account", "dormant": "Dormant", "terminated_user": "Terminated user", "contractor_expired": "Contractor expired", "excessive": "Excessive privileges", "sod_conflict": "SoD conflict", "privileged_access": "Privileged access", "role_creep": "Role creep", "no_business_justification": "No justification", "out_of_department": "Out of department", "shared_account": "Shared account", "inactive": "Inactive", "role_mismatch": "Role mismatch", "new": "New", "none": "None" },
@@ -1609,7 +1610,8 @@
       "allConnectors": "All connectors",
       "allMfa": "All MFA",
       "allAuthMethods": "All auth methods",
-      "allAdmin": "All admins"
+      "allAdmin": "All admins",
+      "allAccountStatuses": "All statuses"
     },
     "columns": { "name": "Name", "email": "Email", "role": "Role", "admin": "Admin", "status": "Status", "mfa": "MFA", "authMethod": "Auth", "lastLogin": "Last login", "flag": "Flag", "decision": "Decision" },
     "values": { "yes": "Yes", "no": "No", "unknown": "Unknown" },

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -3118,6 +3118,11 @@
       "disabled": "Désactivé",
       "unknown": "Inconnu"
     },
+    "accountStatus": {
+      "active": "Actif",
+      "disabled": "Désactivé",
+      "unknown": "Inconnu"
+    },
     "authMethod": {
       "sso": "SSO",
       "password": "Mot de passe",
@@ -3186,7 +3191,8 @@
       "allConnectors": "Tous les connecteurs",
       "allMfa": "Tous les MFA",
       "allAuthMethods": "Toutes les méthodes d’auth",
-      "allAdmin": "Tous les administrateurs"
+      "allAdmin": "Tous les administrateurs",
+      "allAccountStatuses": "Tous les statuts"
     },
     "columns": {
       "name": "Nom",

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -3135,6 +3135,11 @@
       "disabled": "Uitgeschakeld",
       "unknown": "Onbekend"
     },
+    "accountStatus": {
+      "active": "Actief",
+      "disabled": "Uitgeschakeld",
+      "unknown": "Onbekend"
+    },
     "authMethod": {
       "sso": "SSO",
       "password": "Wachtwoord",
@@ -3203,7 +3208,8 @@
       "allConnectors": "Alle connectoren",
       "allMfa": "Alle MFA",
       "allAuthMethods": "Alle authenticatiemethoden",
-      "allAdmin": "Alle beheerders"
+      "allAdmin": "Alle beheerders",
+      "allAccountStatuses": "Alle statussen"
     },
     "columns": {
       "name": "Naam",

--- a/apps/console/src/pages/organizations/access-reviews/_components/accessReviewHelpers.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/_components/accessReviewHelpers.tsx
@@ -292,18 +292,20 @@ export function AuthMethodStatus({
   );
 }
 
-export function BooleanStatusIcon({
-  value,
+// Spelled out rather than a check/cross icon: next to MFA a green check reads as
+// "compliant", but holding admin rights is the risk signal a reviewer looks for.
+export function AdminStatus({
+  isAdmin,
   trueLabel,
   falseLabel,
   unknownLabel,
 }: {
-  value: boolean | null | undefined;
+  isAdmin: boolean | null | undefined;
   trueLabel: string;
   falseLabel: string;
   unknownLabel: string;
 }) {
-  if (value == null) {
+  if (isAdmin == null) {
     return (
       <span role="img" aria-label={unknownLabel} title={unknownLabel} className="inline-flex text-txt-tertiary">
         <IconCircleQuestionmark size={16} />
@@ -311,17 +313,17 @@ export function BooleanStatusIcon({
     );
   }
 
-  if (value) {
+  if (isAdmin) {
     return (
-      <span role="img" aria-label={trueLabel} title={trueLabel} className="inline-flex text-txt-success">
-        <IconCircleCheck size={16} />
+      <span aria-label={trueLabel} title={trueLabel} className="text-xs font-medium text-txt-warning">
+        {trueLabel}
       </span>
     );
   }
 
   return (
-    <span role="img" aria-label={falseLabel} title={falseLabel} className="inline-flex text-txt-danger">
-      <IconCircleX size={16} />
+    <span aria-label={falseLabel} title={falseLabel} className="text-xs text-txt-tertiary">
+      {falseLabel}
     </span>
   );
 }

--- a/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
@@ -225,6 +225,7 @@ export default function CampaignDetailPage({ queryRef }: Props) {
   const [mfaFilter, setMfaFilter] = useState<string[]>([]);
   const [authMethodFilter, setAuthMethodFilter] = useState<string[]>([]);
   const [adminFilter, setAdminFilter] = useState<string[]>([]);
+  const [activeFilter, setActiveFilter] = useState<string[]>([]);
   const [sourceMatches, setSourceMatches] = useState<Record<string, SourceMatches>>({});
   const [, startTransition] = useTransition();
 
@@ -260,6 +261,12 @@ export default function CampaignDetailPage({ queryRef }: Props) {
   const handleAdminFilterChange = useCallback(
     (value: string[]) => {
       startTransition(() => setAdminFilter(value));
+    },
+    [],
+  );
+  const handleActiveFilterChange = useCallback(
+    (value: string[]) => {
+      startTransition(() => setActiveFilter(value));
     },
     [],
   );
@@ -330,14 +337,16 @@ export default function CampaignDetailPage({ queryRef }: Props) {
     mfa: mfaFilter,
     authMethod: authMethodFilter,
     admin: adminFilter,
-  }), [appliedEmailFilter, connectorFilter, mfaFilter, authMethodFilter, adminFilter]);
+    active: activeFilter,
+  }), [appliedEmailFilter, connectorFilter, mfaFilter, authMethodFilter, adminFilter, activeFilter]);
   const deferredFilters = useDeferredValue(filters);
 
   const hasActiveFilters = deferredFilters.email !== ""
     || deferredFilters.connectorIds.length > 0
     || deferredFilters.mfa.length > 0
     || deferredFilters.authMethod.length > 0
-    || deferredFilters.admin.length > 0;
+    || deferredFilters.admin.length > 0
+    || deferredFilters.active.length > 0;
 
   // Each source section paginates on its own and reports the entries it shows,
   // so the page can still offer select-all and shift-range across connectors.
@@ -859,6 +868,8 @@ export default function CampaignDetailPage({ queryRef }: Props) {
           onAuthMethodFilterChange={handleAuthMethodFilterChange}
           adminFilter={adminFilter}
           onAdminFilterChange={handleAdminFilterChange}
+          activeFilter={activeFilter}
+          onActiveFilterChange={handleActiveFilterChange}
         />
       )}
 

--- a/apps/console/src/pages/organizations/access-reviews/campaigns/_components/AccessEntriesToolbar.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/_components/AccessEntriesToolbar.tsx
@@ -35,6 +35,8 @@ type Props = {
   onAuthMethodFilterChange: (value: string[]) => void;
   adminFilter: ReadonlyArray<string>;
   onAdminFilterChange: (value: string[]) => void;
+  activeFilter: ReadonlyArray<string>;
+  onActiveFilterChange: (value: string[]) => void;
 };
 
 // Filter row styled like the compliance-portal subprocessors toolbar:
@@ -51,6 +53,8 @@ export function AccessEntriesToolbar({
   onAuthMethodFilterChange,
   adminFilter,
   onAdminFilterChange,
+  activeFilter,
+  onActiveFilterChange,
 }: Props) {
   const { t } = useTranslation();
 
@@ -102,6 +106,18 @@ export function AccessEntriesToolbar({
           ]}
           value={adminFilter}
           onChange={onAdminFilterChange}
+        />
+      </div>
+      <div className="w-40 max-sm:w-full">
+        <FilterMultiSelect
+          placeholder={t("campaignDetailPage.filters.allAccountStatuses")}
+          options={[
+            { value: "ACTIVE", label: t("campaignDetailPage.accountStatus.active") },
+            { value: "DISABLED", label: t("campaignDetailPage.accountStatus.disabled") },
+            { value: "UNKNOWN", label: t("campaignDetailPage.accountStatus.unknown") },
+          ]}
+          value={activeFilter}
+          onChange={onActiveFilterChange}
         />
       </div>
       <div className="min-w-60 flex-1 max-sm:w-full max-sm:min-w-0">

--- a/apps/console/src/pages/organizations/access-reviews/campaigns/_components/AccessEntryListItem.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/_components/AccessEntryListItem.tsx
@@ -26,8 +26,8 @@ import { graphql, useFragment } from "react-relay";
 import type { AccessEntryListItem_entry$key } from "#/__generated__/core/AccessEntryListItem_entry.graphql";
 
 import {
+  AdminStatus,
   AuthMethodStatus,
-  BooleanStatusIcon,
   decisionBadgeVariant,
   flagBadgeVariant,
   LastLoginStatus,
@@ -160,8 +160,8 @@ export function AccessEntryListItem({
       <div className={trailing()}>
         <div className={status()}>
           <span className={statusLabel()}>{t("campaignDetailPage.columns.admin")}</span>
-          <BooleanStatusIcon
-            value={entry.isAdmin}
+          <AdminStatus
+            isAdmin={entry.isAdmin}
             trueLabel={t("campaignDetailPage.values.yes")}
             falseLabel={t("campaignDetailPage.values.no")}
             unknownLabel={t("campaignDetailPage.values.unknown")}

--- a/apps/console/src/pages/organizations/access-reviews/campaigns/_components/AccessEntrySourceSection.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/_components/AccessEntrySourceSection.tsx
@@ -70,6 +70,7 @@ const accessEntrySourceSectionEntryFragment = graphql`
     email
     fullName
     isAdmin
+    active
     mfaStatus
     authMethod
   }
@@ -81,6 +82,7 @@ export type EntryFilters = {
   mfa: ReadonlyArray<string>;
   authMethod: ReadonlyArray<string>;
   admin: ReadonlyArray<string>;
+  active: ReadonlyArray<string>;
 };
 
 // What the section contributes to the page-wide selection: the entries it
@@ -119,6 +121,17 @@ function entryMatchesFilters(
   if (filters.admin.length > 0) {
     const adminValue = entry.isAdmin ? "YES" : "NO";
     if (!filters.admin.includes(adminValue)) {
+      return false;
+    }
+  }
+
+  if (filters.active.length > 0) {
+    const activeValue = entry.active == null
+      ? "UNKNOWN"
+      : entry.active
+        ? "ACTIVE"
+        : "DISABLED";
+    if (!filters.active.includes(activeValue)) {
       return false;
     }
   }
@@ -168,7 +181,8 @@ export function AccessEntrySourceSection({
   const hasEntryFilters = filters.email !== ""
     || filters.mfa.length > 0
     || filters.authMethod.length > 0
-    || filters.admin.length > 0;
+    || filters.admin.length > 0
+    || filters.active.length > 0;
 
   const matchedEntries = useMemo(
     () => source.entries.edges


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an account status filter to access review campaigns and switches the admin indicator to Yes/No text. This helps reviewers isolate disabled accounts and avoid mistaking non-admins for errors, aligning with Linear ENG-724.

### App: console **`+75`** **`-18`**
- Added account status filter (Active/Disabled/Unknown) in the toolbar; wired through CampaignDetailPage and source filtering; entry fragment now includes active; hasActiveFilters updated.
- Replaced admin icon with text via new AdminStatus component; updated entry row to use it.
- Added i18n strings for en/fr/nl, including “All statuses”.

<sup>Written for commit 44f887bcc1b4a0232a383cbc3cb529f5d7e32e56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

