### PR TITLE
Read campaign access entries in n8n

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/accessReview/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/accessReview/index.ts
@@ -27,6 +27,7 @@ import * as updateOp from './update.operation';
 import * as startOp from './start.operation';
 import * as closeOp from './close.operation';
 import * as cancelOp from './cancel.operation';
+import * as readEntriesOp from './readEntries.operation';
 
 export const description: INodeProperties[] = [
 	{
@@ -77,6 +78,12 @@ export const description: INodeProperties[] = [
 				action: 'Get many access review campaigns',
 			},
 			{
+				name: 'Read Campaign Access Entries',
+				value: 'readEntries',
+				description: 'Read the access entries for an access review campaign',
+				action: 'Read campaign access entries',
+			},
+			{
 				name: 'Start',
 				value: 'start',
 				description: 'Start an access review campaign',
@@ -99,6 +106,7 @@ export const description: INodeProperties[] = [
 	...startOp.description,
 	...closeOp.description,
 	...cancelOp.description,
+	...readEntriesOp.description,
 ];
 
 export {
@@ -110,4 +118,5 @@ export {
 	startOp as start,
 	closeOp as close,
 	cancelOp as cancel,
+	readEntriesOp as readEntries,
 };

--- a/packages/n8n-node/nodes/Probo/actions/accessReview/readEntries.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/accessReview/readEntries.operation.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import type { IDataObject, IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+import { proboApiRequestAllItems } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Access Review Campaign ID',
+		name: 'accessReviewCampaignId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['accessReview'],
+				operation: ['readEntries'],
+			},
+		},
+		default: '',
+		description: 'The ID of the access review campaign',
+		required: true,
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: ['accessReview'],
+				operation: ['readEntries'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['accessReview'],
+				operation: ['readEntries'],
+				returnAll: [false],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+		},
+		default: 50,
+		description: 'Max number of results to return',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const accessReviewCampaignId = this.getNodeParameter('accessReviewCampaignId', itemIndex) as string;
+	const returnAll = this.getNodeParameter('returnAll', itemIndex) as boolean;
+	const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
+
+	const query = `
+		query ReadAccessReviewCampaignEntries(
+			$accessReviewCampaignId: ID!
+			$first: Int
+			$after: CursorKey
+		) {
+			node(id: $accessReviewCampaignId) {
+				... on AccessReviewCampaign {
+					entries(first: $first, after: $after) {
+						edges {
+							node {
+								id
+								email
+								fullName
+								roles
+								jobTitle
+								isAdmin
+								active
+								mfaStatus
+								authMethod
+								accountType
+								lastLogin
+								accountCreatedAt
+								externalId
+								incrementalTag
+								flags
+								flagReasons
+								decision
+								decisionNote
+								decidedBy
+								decidedAt
+								campaignSource {
+									id
+									name
+								}
+								createdAt
+								updatedAt
+							}
+						}
+						pageInfo {
+							hasNextPage
+							endCursor
+						}
+					}
+				}
+			}
+		}
+	`;
+
+	const accessReviewEntries = await proboApiRequestAllItems.call(
+		this,
+		query,
+		{ accessReviewCampaignId },
+		(response) => {
+			const data = response?.data as IDataObject | undefined;
+			const node = data?.node as IDataObject | undefined;
+			return node?.entries as IDataObject | undefined;
+		},
+		returnAll,
+		limit,
+	);
+
+	return {
+		json: { accessReviewEntries },
+		pairedItem: { item: itemIndex },
+	};
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a `Read Campaign Access Entries` operation to the n8n access review resource
- paginate campaign entries with Return All and Limit controls
- return account, source, flag, and review-decision details for each entry

## Testing
- `npm -w @probo/n8n-nodes-probo run lint`
- `npm -w @probo/n8n-nodes-probo run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-725](https://linear.app/probo/issue/ENG-725/add-n8n-node-to-read-campaign-access-entries)

<div><a href="https://cursor.com/agents/bc-9a0f8d6c-ff80-4f0e-8e32-9b3af0e0e9de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a0f8d6c-ff80-4f0e-8e32-9b3af0e0e9de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Read Campaign Access Entries operation to the `n8n-node` Probo Access Review resource. It paginates results and returns account, source, flag, and decision details to satisfy ENG-725.

### Package: n8n-node **`+154`** **`-0`**
- Registered `readEntries` in the access review actions index.
- Implemented GraphQL query with pagination (Return All/Limit) via `proboApiRequestAllItems`.
- Returns entry data: account fields, flags and reasons, review decision and note, and campaign source.

<sup>Written for commit 1bcbf4ddccb30122706a8c094bb0cb7e50c16032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

