### PR TITLE
Use PDF viewer for evidence previews

### DIFF
--- a/apps/console/src/pages/organizations/measures/dialog/EvidencePreviewDialog.tsx
+++ b/apps/console/src/pages/organizations/measures/dialog/EvidencePreviewDialog.tsx
@@ -34,6 +34,7 @@ import { useTranslation } from "react-i18next";
 import { useLazyLoadQuery } from "react-relay";
 
 import type { EvidenceGraphFileQuery } from "#/__generated__/core/EvidenceGraphFileQuery.graphql";
+import { PDFPreview } from "#/components/documents/PDFPreview";
 import { evidenceFileQuery } from "#/hooks/graph/EvidenceGraph";
 
 type Props = {
@@ -157,11 +158,12 @@ function EvidencePreviewContent({
     );
   } else if (evidence.file.mimeType?.includes("pdf")) {
     preview = (
-      <iframe
-        src={evidence.file.downloadUrl}
-        className="w-full h-[70vh]"
-        title={evidence.file.fileName}
-      />
+      <div className="h-[70vh] overflow-hidden">
+        <PDFPreview
+          src={evidence.file.downloadUrl}
+          name={evidence.file.fileName}
+        />
+      </div>
     );
   } else {
     preview = (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- render PDF evidence files with the console PDF viewer
- preserve image, URI, and unsupported-file preview behavior
- expose the viewer's page navigation, zoom, and download controls
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eaac34ec-953d-43a5-b75c-82393ae46897?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eaac34ec-953d-43a5-b75c-82393ae46897&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render PDF evidence using the console PDF viewer to give users page navigation, zoom, and download controls. Image, URL, and unsupported file previews are unchanged.

### App: console **`+7`** **`-5`**
- Switched from an iframe to `PDFPreview` from `#/components/documents/PDFPreview`.
- Kept the existing preview height and container behavior.

<sup>Written for commit 22ebf47732f8ae3161fbca7aabbe1d3a11ab9ef5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

