### PR TITLE
Fix npm audit vulnerabilities in dompurify, js-yaml, and mermaid.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12216,9 +12216,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -15315,9 +15315,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -16633,9 +16633,9 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
@@ -23238,7 +23238,7 @@
       "license": "MIT",
       "dependencies": {
         "@tiptap/pm": "^3.29.2",
-        "dompurify": "^3.4.10",
+        "dompurify": "^3.4.13",
         "marked": "^18.0.7"
       },
       "devDependencies": {
@@ -23439,7 +23439,7 @@
         "@tiptap/starter-kit": "^3.29.2",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "mermaid": "^11.15.0",
+        "mermaid": "^11.16.1",
         "react-dropzone": "^20.0.0",
         "react-i18next": "^17.0.11",
         "react-intersection-observer": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,9 @@
     "n8n-workflow": {
       "uuid": "$uuid"
     },
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "glob": "^13.0.6",
-    "postcss": "8.5.23",
-    "react-router": "^8.3.0"
+    "postcss": "8.5.23"
   },
   "allowScripts": {
     "esbuild": true,

--- a/packages/prosemirror/package.json
+++ b/packages/prosemirror/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tiptap/pm": "^3.29.2",
-    "dompurify": "^3.4.10",
+    "dompurify": "^3.4.13",
     "marked": "^18.0.7"
   },
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,7 +36,7 @@
     "@tiptap/starter-kit": "^3.29.2",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "mermaid": "^11.15.0",
+    "mermaid": "^11.16.1",
     "react-dropzone": "^20.0.0",
     "react-i18next": "^17.0.11",
     "react-intersection-observer": "^11.0.0",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates `dompurify`, `js-yaml`, and `mermaid` to fix npm audit vulnerabilities. Clears audit warnings and removes the root `react-router` dependency.

### Package: prosemirror **`+1`** **`-1`**
- Bumped `dompurify` to ^3.4.13.

### Package: ui **`+1`** **`-1`**
- Bumped `mermaid` to ^11.16.1.

### Other **`+13`** **`-14`**
- Bumped root `js-yaml` to ^4.3.1 and removed `react-router`.
- Updated `package-lock.json` to lock new versions of `dompurify`, `js-yaml`, and `mermaid`.

<sup>Written for commit f6ca5a499b78e4cd8cfe97760f77b170a2889287. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

