### PR TITLE
Use compliance portal email in NDA consent text

### DIFF
--- a/pkg/complianceportal/visitor/service.go
+++ b/pkg/complianceportal/visitor/service.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
+	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/packages/emails"
 	"go.probo.inc/probo/pkg/complianceportal/management"
 	"go.probo.inc/probo/pkg/coredata"
@@ -41,7 +42,18 @@ import (
 	"go.probo.inc/probo/pkg/slack"
 )
 
-const NDAConsentText = "By clicking \"Review and sign\", I consent to sign this document electronically and agree that my electronic signature has the same legal validity as a handwritten signature. If you have questions about the NDA, please contact security@probo.com."
+const DefaultNDAContactEmail = "security@probo.com"
+
+func ndaConsentText(contactEmail string) string {
+	if contactEmail == "" {
+		contactEmail = DefaultNDAContactEmail
+	}
+
+	return fmt.Sprintf(
+		"By clicking \"Review and sign\", I consent to sign this document electronically and agree that my electronic signature has the same legal validity as a handwritten signature. If you have questions about the NDA, please contact %s.",
+		contactEmail,
+	)
+}
 
 type (
 	// Service is the visitor-facing compliance portal service. It exposes the
@@ -359,7 +371,7 @@ func (s *Service) ProvisionPortalMember(
 							DocumentType:   coredata.ElectronicSignatureDocumentTypeNDA,
 							FileID:         *compliancePage.NonDisclosureAgreementFileID,
 							SignerEmail:    identity.EmailAddress,
-							ConsentText:    NDAConsentText,
+							ConsentText:    ndaConsentText(ref.UnrefOrZero(compliancePage.Email)),
 						},
 					)
 					if err != nil {

--- a/pkg/complianceportal/visitor/service_test.go
+++ b/pkg/complianceportal/visitor/service_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package visitor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNdaConsentText(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"uses the portal contact email when set",
+		func(t *testing.T) {
+			t.Parallel()
+
+			text := ndaConsentText("compliance@acme.com")
+
+			assert.Contains(t, text, "please contact compliance@acme.com.")
+			assert.NotContains(t, text, DefaultNDAContactEmail)
+		},
+	)
+
+	t.Run(
+		"falls back to the default contact email when empty",
+		func(t *testing.T) {
+			t.Parallel()
+
+			text := ndaConsentText("")
+
+			assert.Contains(t, text, "please contact "+DefaultNDAContactEmail+".")
+		},
+	)
+
+	t.Run(
+		"fallback matches the previous hardcoded default text",
+		func(t *testing.T) {
+			t.Parallel()
+
+			const previousDefault = "By clicking \"Review and sign\", I consent to sign this document electronically and agree that my electronic signature has the same legal validity as a handwritten signature. If you have questions about the NDA, please contact security@probo.com."
+
+			assert.Equal(t, previousDefault, ndaConsentText(""))
+		},
+	)
+}


### PR DESCRIPTION
## Summary
- The NDA consent text visitors sign referenced a hardcoded contact address (`security@probo.com`), independent of the per-portal `Email` field admins can already configure on their compliance portal.
- `ndaConsentText` now interpolates `CompliancePortal.Email` when set, falling back to the previous default address otherwise.
- Added unit tests covering the set-email case, the empty-string fallback, and parity between the fallback and the previous hardcoded default — this text is embedded in a legally binding signed NDA record.

## Test plan
- [x] `go build ./pkg/complianceportal/...`
- [x] `go vet ./pkg/complianceportal/...`
- [x] `go test ./pkg/complianceportal/visitor/... -run TestNdaConsentText -v`
- [x] Manually set a portal's `Email` via `updateCompliancePortal` and confirm the NDA sign page shows it in the consent text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the portal’s configured contact email in the NDA consent text so visitors see the right address. Falls back to `security@probo.com` when the portal email is unset, with tests to lock in the behavior.

### Service **`+14`** **`-2`**
- Added `ndaConsentText(contactEmail string)` and `DefaultNDAContactEmail`.
- Pulled `CompliancePortal.Email` via `ref.UnrefOrZero(compliancePage.Email)` and used it in `ConsentText`.
- Replaced the hardcoded NDA string and imported `go.gearno.de/x/ref`.

### Tests **`+65`** **`-0`**
- Added unit tests for email interpolation, empty-string fallback, and parity with the previous default text.

<sup>Written for commit 1c7e7bbd3e4e9aeebc0e27a9f759e7ccb305311c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->