### PR TITLE
Fix updates failing to load in compliance portal

### DIFF
--- a/pkg/mailman/service.go
+++ b/pkg/mailman/service.go
@@ -707,6 +707,40 @@ func (s *Service) ListSentMailingListUpdates(
 	return page.NewPage(items, cursor), nil
 }
 
+func (s *Service) GetSentMailingListUpdate(
+	ctx context.Context,
+	mailingListID gid.GID,
+	id gid.GID,
+) (*coredata.MailingListUpdate, error) {
+	scope := coredata.NewScopeFromObjectID(mailingListID)
+
+	var mlu coredata.MailingListUpdate
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := mlu.LoadByID(ctx, conn, scope, id); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrMailingListUpdateNotFound
+				}
+
+				return fmt.Errorf("cannot load mailing list update: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if mlu.MailingListID != mailingListID || mlu.Status != coredata.MailingListUpdateStatusSent {
+		return nil, ErrMailingListUpdateNotFound
+	}
+
+	return &mlu, nil
+}
+
 func (s *Service) CountMailingListUpdates(
 	ctx context.Context,
 	mailingListID gid.GID,

--- a/pkg/server/api/complianceportal/v1/base_resolvers.go
+++ b/pkg/server/api/complianceportal/v1/base_resolvers.go
@@ -14,6 +14,7 @@ import (
 	"go.probo.inc/probo/pkg/complianceportal/visitor"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/mailman"
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/server/api/authn"
 	"go.probo.inc/probo/pkg/server/api/complianceportal"
@@ -173,6 +174,24 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 
 		return types.NewCompliancePortalFile(portalFile), nil
+
+	case coredata.MailingListUpdateEntityType:
+		if compliancePortal.MailingListID == nil {
+			return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+		}
+
+		update, err := r.mailman.GetSentMailingListUpdate(ctx, *compliancePortal.MailingListID, id)
+		if err != nil {
+			if errors.Is(err, mailman.ErrMailingListUpdateNotFound) {
+				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+			}
+
+			r.logger.ErrorCtx(ctx, "cannot get mailing list update", log.Error(err))
+
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		return types.NewMailingListUpdate(update), nil
 
 	default:
 		return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)


### PR DESCRIPTION
## Summary
- The compliance portal's `node(id:)` resolver (`pkg/server/api/complianceportal/v1/base_resolvers.go`) had a type-switch over GID entity types covering `Document`, `Framework`, `File`, `Audit`, `ThirdParty`, `CompliancePortal`, `CompliancePortalReference`, and `CompliancePortalFile` — but no case for `MailingListUpdateEntityType`, even though `MailingListUpdate` implements `Node` and shows up fine in list views.
- Every mailing list update deep link (e.g. from an email notification) hit the `default:` branch and 404'd with `"node ... not found"`, regardless of whether the record existed — surfaced to visitors as a generic "Unable to load page" error.
- Added the missing case, plus a new `mailman.Service.GetSentMailingListUpdate` method that loads an update scoped to the visited portal's mailing list and restricted to `SENT` status — mirroring the existing security posture of `ListSentMailingListUpdates` (visitors must not see `DRAFT`/`ENQUEUED`/`PROCESSING` updates just by guessing/leaking an ID).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/mailman/... ./pkg/server/api/complianceportal/...`
- [x] `go test ./pkg/mailman/... ./pkg/server/api/complianceportal/...`
- [x] Verified locally end-to-end: created an org, a compliance portal, and a sent mailing list update, then opened the update's detail page in the compliance-portal app — it loaded correctly instead of showing the generic error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken mailing list update deep links in the compliance portal by resolving `MailingListUpdate` nodes and scoping lookups to the portal’s mailing list and `SENT` status. Users can now open update detail pages from email notifications without 404s.

### GraphQL API **`+19`** **`-0`**
- Add `MailingListUpdateEntityType` to the compliance-portal `node(id:)` resolver in `pkg/server/api/complianceportal/v1/base_resolvers.go`.
- Scope lookups to the visited portal’s `MailingListID` and return 404 for missing or non-`SENT` updates; log and surface internal errors appropriately.

### Service **`+34`** **`-0`**
- Add `mailman.Service.GetSentMailingListUpdate(ctx, mailingListID, id)` in `pkg/mailman/service.go` to load an update within a mailing list scope.
- Return `ErrMailingListUpdateNotFound` when the update is missing, belongs to a different list, or is not `SENT`, matching `ListSentMailingListUpdates` security.

<sup>Written for commit 3ee92cbba8f8a0d6502b03f7c238b80757955920. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

