### PR TITLE
Require compliance portal mailing list

### DIFF
--- a/pkg/complianceportal/management/portal_service.go
+++ b/pkg/complianceportal/management/portal_service.go
@@ -25,14 +25,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"mime"
 	"net/mail"
 	"path/filepath"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/jackc/pgx/v5"
 	"go.gearno.de/crypto/uuid"
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
@@ -217,7 +215,7 @@ func (s *Service) Create(
 				EntityName:           req.EntityName,
 				SearchEngineIndexing: coredata.SearchEngineIndexingNotIndexable,
 				Capabilities:         coredata.DefaultCompliancePortalCapabilities(),
-				MailingListID:        &mailingList.ID,
+				MailingListID:        mailingList.ID,
 				CreatedAt:            now,
 				UpdatedAt:            now,
 			}
@@ -937,12 +935,8 @@ func (s *Service) GetMailingList(
 				return fmt.Errorf("cannot load compliance portal: %w", err)
 			}
 
-			if portal.MailingListID == nil {
-				return nil
-			}
-
 			mailingList = &coredata.MailingList{}
-			if err := mailingList.LoadByID(ctx, conn, scope, *portal.MailingListID); err != nil {
+			if err := mailingList.LoadByID(ctx, conn, scope, portal.MailingListID); err != nil {
 				return fmt.Errorf("cannot load mailing list: %w", err)
 			}
 
@@ -1010,20 +1004,14 @@ func (s *Service) Delete(
 				}
 			}
 
-			mailingListID := portal.MailingListID
+			mailingList := &coredata.MailingList{ID: portal.MailingListID}
 
 			if err := portal.Delete(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot delete compliance portal: %w", err)
 			}
 
-			if mailingListID != nil {
-				q := fmt.Sprintf(`DELETE FROM mailing_lists WHERE %s AND id = @id`, scope.SQLFragment())
-				args := pgx.StrictNamedArgs{"id": *mailingListID}
-				maps.Copy(args, scope.SQLArguments())
-
-				if _, err := tx.Exec(ctx, q, args); err != nil {
-					return fmt.Errorf("cannot delete mailing list: %w", err)
-				}
+			if err := mailingList.Delete(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot delete mailing list: %w", err)
 			}
 
 			return nil

--- a/pkg/coredata/compliance_portal.go
+++ b/pkg/coredata/compliance_portal.go
@@ -44,7 +44,7 @@ type (
 		Slug                         string                       `db:"slug"`
 		SearchEngineIndexing         SearchEngineIndexing         `db:"search_engine_indexing"`
 		Capabilities                 CompliancePortalCapabilities `db:"capabilities"`
-		MailingListID                *gid.GID                     `db:"mailing_list_id"`
+		MailingListID                gid.GID                      `db:"mailing_list_id"`
 		LogoFileID                   *gid.GID                     `db:"logo_file_id"`
 		DarkLogoFileID               *gid.GID                     `db:"dark_logo_file_id"`
 		NonDisclosureAgreementFileID *gid.GID                     `db:"non_disclosure_agreement_file_id"`

--- a/pkg/coredata/mailing_list.go
+++ b/pkg/coredata/mailing_list.go
@@ -201,3 +201,29 @@ VALUES (
 
 	return nil
 }
+
+func (ml *MailingList) Delete(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM mailing_lists
+WHERE
+	%s
+	AND id = @id
+`
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id": ml.ID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete mailing list: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/mailing_list_update.go
+++ b/pkg/coredata/mailing_list_update.go
@@ -240,6 +240,55 @@ LIMIT 1;
 	return nil
 }
 
+func (mlu *MailingListUpdate) LoadSentByMailingListIDAndID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	mailingListID gid.GID,
+	id gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	mailing_list_id,
+	title,
+	body,
+	status,
+	created_at,
+	updated_at
+FROM mailing_list_updates
+WHERE
+	%s
+	AND mailing_list_id = @mailing_list_id
+	AND status = 'SENT'
+	AND id = @id
+LIMIT 1;
+`
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": id}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query mailing list update: %w", err)
+	}
+
+	result, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[MailingListUpdate])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect mailing list update: %w", err)
+	}
+
+	*mlu = result
+
+	return nil
+}
+
 func (mlul *MailingListUpdateItems) LoadSentByMailingListID(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/coredata/mailing_list_update.go
+++ b/pkg/coredata/mailing_list_update.go
@@ -267,7 +267,10 @@ LIMIT 1;
 `
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
-	args := pgx.StrictNamedArgs{"id": id}
+	args := pgx.StrictNamedArgs{
+		"mailing_list_id": mailingListID,
+		"id":              id,
+	}
 	maps.Copy(args, scope.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)

--- a/pkg/coredata/migrations/20260810T042836Z.sql
+++ b/pkg/coredata/migrations/20260810T042836Z.sql
@@ -1,0 +1,22 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TABLE compliance_portals
+    ALTER COLUMN mailing_list_id SET NOT NULL;

--- a/pkg/mailman/service.go
+++ b/pkg/mailman/service.go
@@ -707,6 +707,40 @@ func (s *Service) ListSentMailingListUpdates(
 	return page.NewPage(items, cursor), nil
 }
 
+func (s *Service) GetSentMailingListUpdate(
+	ctx context.Context,
+	mailingListID gid.GID,
+	id gid.GID,
+) (*coredata.MailingListUpdate, error) {
+	scope := coredata.NewScopeFromObjectID(mailingListID)
+
+	var mlu coredata.MailingListUpdate
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := mlu.LoadByID(ctx, conn, scope, id); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrMailingListUpdateNotFound
+				}
+
+				return fmt.Errorf("cannot load mailing list update: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if mlu.MailingListID != mailingListID || mlu.Status != coredata.MailingListUpdateStatusSent {
+		return nil, ErrMailingListUpdateNotFound
+	}
+
+	return &mlu, nil
+}
+
 func (s *Service) CountMailingListUpdates(
 	ctx context.Context,
 	mailingListID gid.GID,

--- a/pkg/mailman/service.go
+++ b/pkg/mailman/service.go
@@ -709,17 +709,16 @@ func (s *Service) ListSentMailingListUpdates(
 
 func (s *Service) GetSentMailingListUpdate(
 	ctx context.Context,
+	scope coredata.Scoper,
 	mailingListID gid.GID,
 	id gid.GID,
 ) (*coredata.MailingListUpdate, error) {
-	scope := coredata.NewScopeFromObjectID(mailingListID)
-
 	var mlu coredata.MailingListUpdate
 
 	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := mlu.LoadByID(ctx, conn, scope, id); err != nil {
+			if err := mlu.LoadSentByMailingListIDAndID(ctx, conn, scope, mailingListID, id); err != nil {
 				if errors.Is(err, coredata.ErrResourceNotFound) {
 					return ErrMailingListUpdateNotFound
 				}
@@ -732,10 +731,6 @@ func (s *Service) GetSentMailingListUpdate(
 	)
 	if err != nil {
 		return nil, err
-	}
-
-	if mlu.MailingListID != mailingListID || mlu.Status != coredata.MailingListUpdateStatusSent {
-		return nil, ErrMailingListUpdateNotFound
 	}
 
 	return &mlu, nil

--- a/pkg/server/api/complianceportal/v1/base_resolvers.go
+++ b/pkg/server/api/complianceportal/v1/base_resolvers.go
@@ -176,7 +176,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		return types.NewCompliancePortalFile(portalFile), nil
 
 	case coredata.MailingListUpdateEntityType:
-		update, err := r.mailman.GetSentMailingListUpdate(ctx, compliancePortal.MailingListID, id)
+		update, err := r.mailman.GetSentMailingListUpdate(ctx, scope, compliancePortal.MailingListID, id)
 		if err != nil {
 			if errors.Is(err, mailman.ErrMailingListUpdateNotFound) {
 				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)

--- a/pkg/server/api/complianceportal/v1/base_resolvers.go
+++ b/pkg/server/api/complianceportal/v1/base_resolvers.go
@@ -14,6 +14,7 @@ import (
 	"go.probo.inc/probo/pkg/complianceportal/visitor"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/mailman"
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/server/api/authn"
 	"go.probo.inc/probo/pkg/server/api/complianceportal"
@@ -173,6 +174,24 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 
 		return types.NewCompliancePortalFile(portalFile), nil
+
+	case coredata.MailingListUpdateEntityType:
+		if compliancePortal.MailingListID == nil {
+			return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+		}
+
+		update, err := r.mailman.GetSentMailingListUpdate(ctx, *compliancePortal.MailingListID, id)
+		if err != nil {
+			if errors.Is(err, mailman.ErrMailingListUpdateNotFound) {
+				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
+			}
+
+			r.logger.ErrorCtx(ctx, "cannot get mailing list update", log.Error(err))
+
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		return types.NewMailingListUpdate(update), nil
 
 	default:
 		return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)

--- a/pkg/server/api/complianceportal/v1/base_resolvers.go
+++ b/pkg/server/api/complianceportal/v1/base_resolvers.go
@@ -176,11 +176,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		return types.NewCompliancePortalFile(portalFile), nil
 
 	case coredata.MailingListUpdateEntityType:
-		if compliancePortal.MailingListID == nil {
-			return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
-		}
-
-		update, err := r.mailman.GetSentMailingListUpdate(ctx, *compliancePortal.MailingListID, id)
+		update, err := r.mailman.GetSentMailingListUpdate(ctx, compliancePortal.MailingListID, id)
 		if err != nil {
 			if errors.Is(err, mailman.ErrMailingListUpdateNotFound) {
 				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)

--- a/pkg/server/api/complianceportal/v1/compliance_portal_resolvers.go
+++ b/pkg/server/api/complianceportal/v1/compliance_portal_resolvers.go
@@ -282,16 +282,13 @@ func (r *compliancePortalResolver) NonDisclosureAgreement(ctx context.Context, o
 // ViewerSubscription is the resolver for the viewerSubscription field.
 func (r *compliancePortalResolver) ViewerSubscription(ctx context.Context, obj *types.CompliancePortal) (*types.MailingListSubscriber, error) {
 	compliancePortal := complianceportal.CompliancePortalFromContext(ctx)
-	if compliancePortal.MailingListID == nil {
-		return nil, nil
-	}
 
 	identity := authn.IdentityFromContext(ctx)
 	if identity == nil {
 		return nil, nil
 	}
 
-	subscriber, err := r.mailman.GetSubscriber(ctx, *compliancePortal.MailingListID, identity.EmailAddress)
+	subscriber, err := r.mailman.GetSubscriber(ctx, compliancePortal.MailingListID, identity.EmailAddress)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get mailing list subscription", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -540,17 +537,13 @@ func (r *compliancePortalResolver) Updates(ctx context.Context, obj *types.Compl
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	if tc.MailingListID == nil {
-		return &types.MailingListUpdateConnection{Edges: []*types.MailingListUpdateEdge{}, PageInfo: &types.PageInfo{}}, nil
-	}
-
 	pageOrderBy := page.OrderBy[coredata.MailingListUpdateOrderField]{
 		Field:     coredata.MailingListUpdateOrderFieldUpdatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	result, err := r.mailman.ListSentMailingListUpdates(ctx, *tc.MailingListID, cursor)
+	result, err := r.mailman.ListSentMailingListUpdates(ctx, tc.MailingListID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list mailing list updates", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/complianceportal/v1/mailing_list_resolvers.go
+++ b/pkg/server/api/complianceportal/v1/mailing_list_resolvers.go
@@ -21,16 +21,13 @@ import (
 // SubscribeToMailingList is the resolver for the subscribeToMailingList field.
 func (r *mutationResolver) SubscribeToMailingList(ctx context.Context) (*types.SubscribeToMailingListPayload, error) {
 	compliancePortal := complianceportal.CompliancePortalFromContext(ctx)
-	if compliancePortal.MailingListID == nil {
-		return nil, gqlutils.NotFoundf(ctx, "mailing list not found")
-	}
 
 	identity := authn.IdentityFromContext(ctx)
 
 	subscriber, err := r.mailman.CreateSubscriber(
 		ctx,
 		&mailman.CreateSubscriberRequest{
-			MailingListID: *compliancePortal.MailingListID,
+			MailingListID: compliancePortal.MailingListID,
 			Email:         identity.EmailAddress,
 			FullName:      identity.FullName,
 		},
@@ -57,13 +54,10 @@ func (r *mutationResolver) SubscribeToMailingList(ctx context.Context) (*types.S
 // UnsubscribeFromMailingList is the resolver for the unsubscribeFromMailingList field.
 func (r *mutationResolver) UnsubscribeFromMailingList(ctx context.Context) (*types.UnsubscribeFromMailingListPayload, error) {
 	compliancePortal := complianceportal.CompliancePortalFromContext(ctx)
-	if compliancePortal.MailingListID == nil {
-		return nil, gqlutils.NotFoundf(ctx, "mailing list not found")
-	}
 
 	identity := authn.IdentityFromContext(ctx)
 
-	subscriber, err := r.mailman.GetSubscriber(ctx, *compliancePortal.MailingListID, identity.EmailAddress)
+	subscriber, err := r.mailman.GetSubscriber(ctx, compliancePortal.MailingListID, identity.EmailAddress)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get mailing list subscription", log.Error(err))
 		return nil, gqlutils.Internal(ctx)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Require a mailing list for every compliance portal and fix broken update deep links. Make `mailing_list_id` non-null, scope update loads to SENT, and resolve `MailingListUpdate` nodes correctly.

### Coredata **`+101`** **`-1`**
- Migration: set `compliance_portals.mailing_list_id` NOT NULL.
- Model: `MailingListID` is now non-pointer.
- Add `MailingList.Delete(...)` to remove lists in scope.
- Add `MailingListUpdate.LoadSentByMailingListIDAndID(...)` for scoped SENT loads.

### GraphQL API **`+19`** **`-17`**
- Add `node(id:)` case for `MailingListUpdate`; scope to the portal’s list, restrict to SENT; 404 if not found.
- Remove nil checks and use required `MailingListID` in updates and subscription resolvers.

### Service **`+34`** **`-17`**
- Use non-pointer `MailingListID`; delete a portal’s mailing list via `coredata.MailingList.Delete(...)`.
- Add `mailman.GetSentMailingListUpdate(...)` using scope and SENT filter.

<sup>Written for commit 0ceafdccebf8349040356be5febdef319981fc39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

