### PR TITLE
Skip oversized tracker identifiers on detect

### DIFF
--- a/pkg/cookiebanner/report_detected_trackers_test.go
+++ b/pkg/cookiebanner/report_detected_trackers_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cookiebanner
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/internal/test"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/page"
+)
+
+// TestReportDetectedTrackers_SkipsOversizedIdentifier asserts that a
+// storage key longer than MaxTrackerIdentifierLength is ignored
+// (PostgreSQL btree cannot index ~4KB values on
+// idx_tracker_patterns_unique_pattern_per_banner) while a normal peer
+// in the same report still inserts.
+func TestReportDetectedTrackers_SkipsOversizedIdentifier(t *testing.T) {
+	t.Parallel()
+
+	client := test.PGClient(t)
+	ctx := context.Background()
+	fx := seedWorkerFixture(t, ctx, client)
+	svc := NewService(client, false)
+
+	normalCookie := "_ga"
+	oversizedKey := strings.Repeat("a", MaxTrackerIdentifierLength+1)
+	source := coredata.CookieSourceScript
+
+	require.NoError(
+		t,
+		svc.ReportDetectedTrackers(
+			ctx,
+			fx.banner.ID,
+			ReportDetectedTrackersRequest{
+				Cookies: []DetectedCookie{
+					{
+						Name:   normalCookie,
+						Source: coredata.CookieSourceScript,
+					},
+				},
+				Storage: []DetectedStorageItem{
+					{
+						Key:         oversizedKey,
+						StorageType: coredata.TrackerTypeLocalStorage,
+						Source:      &source,
+					},
+				},
+			},
+		),
+	)
+
+	var normalPattern coredata.TrackerPattern
+
+	require.NoError(
+		t,
+		client.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				return normalPattern.LoadByBannerIDTypeAndPattern(
+					ctx,
+					conn,
+					fx.scope,
+					fx.banner.ID,
+					coredata.TrackerTypeCookie,
+					normalCookie,
+					nil,
+				)
+			},
+		),
+	)
+	assert.Equal(t, normalCookie, normalPattern.Pattern)
+
+	var oversizedPattern coredata.TrackerPattern
+
+	err := client.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			return oversizedPattern.LoadByBannerIDTypeAndPattern(
+				ctx,
+				conn,
+				fx.scope,
+				fx.banner.ID,
+				coredata.TrackerTypeLocalStorage,
+				oversizedKey,
+				nil,
+			)
+		},
+	)
+	require.ErrorIs(t, err, coredata.ErrResourceNotFound)
+
+	var patterns coredata.TrackerPatterns
+
+	require.NoError(
+		t,
+		client.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				loaded, err := page.LoadAll(
+					ctx,
+					page.OrderBy[coredata.TrackerPatternOrderField]{
+						Field:     coredata.TrackerPatternOrderFieldCreatedAt,
+						Direction: page.OrderDirectionAsc,
+					},
+					func(ctx context.Context, cursor *page.Cursor[coredata.TrackerPatternOrderField]) ([]*coredata.TrackerPattern, error) {
+						var batch coredata.TrackerPatterns
+						if err := batch.LoadByCookieBannerID(ctx, conn, fx.scope, fx.banner.ID, cursor, nil); err != nil {
+							return nil, err
+						}
+
+						return batch, nil
+					},
+				)
+				if err != nil {
+					return err
+				}
+
+				patterns = loaded
+
+				return nil
+			},
+		),
+	)
+	assert.Len(t, patterns, 1, "only the normal cookie pattern must be inserted")
+}
+
+// TestReportDetectedTrackers_AcceptsMaxLengthIdentifier pins the
+// boundary: an identifier of exactly MaxTrackerIdentifierLength bytes
+// is stored.
+func TestReportDetectedTrackers_AcceptsMaxLengthIdentifier(t *testing.T) {
+	t.Parallel()
+
+	client := test.PGClient(t)
+	ctx := context.Background()
+	fx := seedWorkerFixture(t, ctx, client)
+	svc := NewService(client, false)
+
+	maxLenKey := strings.Repeat("b", MaxTrackerIdentifierLength)
+	source := coredata.CookieSourceScript
+
+	require.NoError(
+		t,
+		svc.ReportDetectedTrackers(
+			ctx,
+			fx.banner.ID,
+			ReportDetectedTrackersRequest{
+				Storage: []DetectedStorageItem{
+					{
+						Key:         maxLenKey,
+						StorageType: coredata.TrackerTypeSessionStorage,
+						Source:      &source,
+					},
+				},
+			},
+		),
+	)
+
+	var pattern coredata.TrackerPattern
+
+	require.NoError(
+		t,
+		client.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				return pattern.LoadByBannerIDTypeAndPattern(
+					ctx,
+					conn,
+					fx.scope,
+					fx.banner.ID,
+					coredata.TrackerTypeSessionStorage,
+					maxLenKey,
+					nil,
+				)
+			},
+		),
+	)
+	assert.Equal(t, maxLenKey, pattern.Pattern)
+}

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -39,6 +39,8 @@ import (
 	"go.probo.inc/probo/pkg/validator"
 )
 
+const MaxTrackerIdentifierLength = 255
+
 type Service struct {
 	pg           *pg.Client
 	showBranding bool
@@ -373,7 +375,7 @@ func (r *CreateTrackerPatternRequest) Validate() error {
 			return s
 		}(),
 	))
-	v.Check(r.Pattern, "pattern", validator.Required(), validator.SafeTextNoNewLine(255))
+	v.Check(r.Pattern, "pattern", validator.Required(), validator.SafeTextNoNewLine(MaxTrackerIdentifierLength))
 	v.Check(string(r.MatchType), "match_type", validator.Required(), validator.OneOfSlice(
 		func() []string {
 			types := coredata.TrackerPatternMatchTypes()
@@ -408,7 +410,7 @@ func (r *CreateTrackerPatternRequest) Validate() error {
 
 		return nil
 	})
-	v.Check(r.DisplayName, "display_name", validator.Required(), validator.SafeTextNoNewLine(255))
+	v.Check(r.DisplayName, "display_name", validator.Required(), validator.SafeTextNoNewLine(MaxTrackerIdentifierLength))
 	v.Check(r.Description, "description", validator.SafeText(1000))
 
 	return v.Error()
@@ -2270,6 +2272,10 @@ func (s *Service) reportDetectedTracker(
 	inserted *int,
 	matchedPatternIDs *[]gid.GID,
 ) error {
+	if len(info.Identifier) > MaxTrackerIdentifierLength {
+		return nil
+	}
+
 	var matchedPattern coredata.TrackerPattern
 
 	err := matchedPattern.FindMatchingPattern(ctx, tx, scope, banner.ID, info.TrackerType, info.Identifier)

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -341,6 +341,7 @@ func (h *Handler) handleReportDetectedCookies(w http.ResponseWriter, r *http.Req
 				log.Int("identifier_length", len(name)),
 				log.String("sdk_version", sdkVersionFromContext(r.Context())),
 			)
+
 			continue
 		}
 
@@ -457,6 +458,7 @@ func (h *Handler) handleReportDetectedTrackers(w http.ResponseWriter, r *http.Re
 				log.Int("identifier_length", len(name)),
 				log.String("sdk_version", sdkVersionFromContext(r.Context())),
 			)
+
 			continue
 		}
 
@@ -499,6 +501,7 @@ func (h *Handler) handleReportDetectedTrackers(w http.ResponseWriter, r *http.Re
 				log.Int("identifier_length", len(key)),
 				log.String("sdk_version", sdkVersionFromContext(r.Context())),
 			)
+
 			continue
 		}
 

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -332,6 +332,18 @@ func (h *Handler) handleReportDetectedCookies(w http.ResponseWriter, r *http.Req
 			continue
 		}
 
+		if len(name) > cookiebanner.MaxTrackerIdentifierLength {
+			h.logger.InfoCtx(
+				r.Context(),
+				"skipping oversized detected cookie name",
+				log.String("banner_id", bannerID.String()),
+				log.String("tracker_type", string(coredata.TrackerTypeCookie)),
+				log.Int("identifier_length", len(name)),
+				log.String("sdk_version", sdkVersionFromContext(r.Context())),
+			)
+			continue
+		}
+
 		var source coredata.CookieSource
 
 		switch strings.TrimSpace(c.Source) {
@@ -436,6 +448,18 @@ func (h *Handler) handleReportDetectedTrackers(w http.ResponseWriter, r *http.Re
 			continue
 		}
 
+		if len(name) > cookiebanner.MaxTrackerIdentifierLength {
+			h.logger.InfoCtx(
+				r.Context(),
+				"skipping oversized detected cookie name",
+				log.String("banner_id", bannerID.String()),
+				log.String("tracker_type", string(coredata.TrackerTypeCookie)),
+				log.Int("identifier_length", len(name)),
+				log.String("sdk_version", sdkVersionFromContext(r.Context())),
+			)
+			continue
+		}
+
 		var source coredata.CookieSource
 
 		switch strings.TrimSpace(c.Source) {
@@ -463,6 +487,18 @@ func (h *Handler) handleReportDetectedTrackers(w http.ResponseWriter, r *http.Re
 	for _, s := range body.Storage {
 		key := strings.TrimSpace(s.Key)
 		if key == "" {
+			continue
+		}
+
+		if len(key) > cookiebanner.MaxTrackerIdentifierLength {
+			h.logger.InfoCtx(
+				r.Context(),
+				"skipping oversized detected storage key",
+				log.String("banner_id", bannerID.String()),
+				log.String("storage_type", strings.TrimSpace(s.StorageType)),
+				log.Int("identifier_length", len(key)),
+				log.String("sdk_version", sdkVersionFromContext(r.Context())),
+			)
 			continue
 		}
 


### PR DESCRIPTION
Closes [ENG-728](https://linear.app/probo/issue/ENG-728/tracker-pattern-insert-fails-due-to-pg-index-size)

PostgreSQL btree rejects index rows over ~2704 bytes, so a ~4KB cookie or storage key from the SDK failed the unique pattern insert and aborted the whole detection batch. Cap identifiers at 255 bytes to match manual create validation and drop the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip oversized tracker identifiers during detection to prevent PostgreSQL index failures from aborting the batch. Caps identifiers at 255 bytes to match manual create limits and addresses ENG-728.

### Tests **`+201`** **`-0`**
- Verifies storage keys longer than `MaxTrackerIdentifierLength` are ignored while a valid peer in the same report still inserts.
- Pins the boundary: accepts identifiers exactly at the limit.

### GraphQL API **`+39`** **`-0`**
- Skips and logs oversized cookie names and storage keys in `handleReportDetectedCookies` and `handleReportDetectedTrackers`.

### Service **`+8`** **`-2`**
- Introduces `MaxTrackerIdentifierLength = 255` and reuses it in request validation.
- Adds an early-return in `reportDetectedTracker` when the identifier exceeds the limit.

<sup>Written for commit c940eef09a5026632774397bd557480a61956835. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

