### PR TITLE
Ship @probo/skills as an Agent Plugins 1.0.0 package

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -360,6 +360,8 @@ jobs:
         with:
           go: "false"
       - uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
+      - name: "Validate @probo/skills"
+        run: npm --workspace @probo/skills run validate
       - name: "Generate Relay artifacts"
         run: make relay
       - name: "Run eslint"

--- a/contrib/claude/release/skills.md
+++ b/contrib/claude/release/skills.md
@@ -7,10 +7,16 @@ After confirming commits below, follow the
 
 - **Tag pattern**: `@probo/skills/v*`
 - **Version source**: `packages/skills/package.json`
-- **Version bump**: `npm --workspace @probo/skills version <X.Y.Z> --no-git-tag-version`
+- **Version bump**: `npm --workspace @probo/skills version <X.Y.Z> --no-git-tag-version`,
+  then set the same version in `packages/skills/plugin.json`,
+  `packages/skills/.claude-plugin/plugin.json`, and
+  `packages/skills/.codex-plugin/plugin.json`
 - **Validate**: `npm --workspace @probo/skills run validate`
 - **Changelog**: `packages/skills/CHANGELOG.md`
 - **Files to stage**: `packages/skills/package.json`,
+  `packages/skills/plugin.json`,
+  `packages/skills/.claude-plugin/plugin.json`,
+  `packages/skills/.codex-plugin/plugin.json`,
   `packages/skills/CHANGELOG.md`, `package-lock.json`
 - **Workflow**: `.github/workflows/release-npm-skills.yaml`
 - **Path filter**: `packages/skills`
@@ -27,5 +33,7 @@ If empty or non-user-facing only, do not release this track.
 ## Notes
 
 There is no build step. Run `validate` after the version bump to catch manifest
-or structural errors before tagging. CI runs the same validation, publishes to
-npm with provenance + SBOM, and creates a GitHub Release.
+or structural errors before tagging — it fails when the plugin manifests drift
+from `package.json`, and when the Agent Plugins or Agent Skills contracts are
+violated. CI runs the same validation, publishes to npm with provenance + SBOM,
+and creates a GitHub Release.

--- a/contrib/claude/skills.md
+++ b/contrib/claude/skills.md
@@ -1,9 +1,10 @@
 # Agent skills (`packages/skills`)
 
 npm package [`@probo/skills`](../../packages/skills) ships multi-agent
-compliance skills and agent plugin wiring powered by the Probo MCP API.
-Compatible with **Claude Code**, **Codex**, **OpenCode**, and **Cursor** (via
-MCP + skills). See [`COMPATIBILITY.md`](../../packages/skills/COMPATIBILITY.md).
+compliance skills and agent plugin wiring powered by the Probo MCP API. It is an
+[Agent Plugins 1.0.0](https://agent-plugins.org/) package, and also carries
+client-specific manifests for **Claude Code**, **Codex**, **OpenCode**, and
+**Cursor**. See [`COMPATIBILITY.md`](../../packages/skills/COMPATIBILITY.md).
 
 ## What this package ships
 
@@ -11,8 +12,10 @@ A **skills package** bundling:
 
 | Component | Role |
 | --- | --- |
+| `plugin.json` | Agent Plugins manifest (portable, spec §5) |
+| `mcp.json` | Agent Plugins MCP configuration (portable, spec §7.2) |
 | `skills/` | Agent Skills–compatible workflow instructions |
-| `.mcp.json` | Connects agents to Probo (`/mcp/v1`, OAuth 2.0) |
+| `.mcp.json` | Claude Code / Codex mirror of `mcp.json` (`type: http`) |
 | `commands/` | Explicit slash commands (e.g. `access-review`, Claude Code only) |
 | `agents/` | Optional specialized subagents |
 | `hooks/` | Optional event automation |
@@ -34,6 +37,12 @@ Published to npm as `@probo/skills`. Agent-specific manifests (`.claude-plugin/`
 .agents/plugins/marketplace.json   # repo root — Codex catalog for getprobo/probo
 
 packages/skills/
+  plugin.json             # Agent Plugins manifest (required, spec §5)
+  mcp.json                # Agent Plugins MCP configuration (spec §7.2)
+  skills/
+    <skill-name>/
+      SKILL.md
+      references/
   .claude-plugin/
     plugin.json           # Claude Code manifest (required)
     marketplace.json      # Claude marketplace catalog (npm)
@@ -41,11 +50,7 @@ packages/skills/
     marketplace.json      # Codex catalog when marketplace root is the package
   .codex-plugin/
     plugin.json           # Codex manifest
-  .mcp.json               # Probo MCP server wiring
-  skills/
-    <skill-name>/
-      SKILL.md
-      references/
+  .mcp.json               # Claude Code / Codex MCP wiring
   commands/
   agents/
   hooks/
@@ -54,36 +59,62 @@ packages/skills/
   CHANGELOG.md
 ```
 
-Only `plugin.json` belongs inside `.claude-plugin/`. All other directories
-must sit at the package root.
+`plugin.json`, `mcp.json`, and `skills/` are the fixed portable locations — a
+conformant client reads nothing else. Only the Claude manifest belongs inside
+`.claude-plugin/`; all other directories must sit at the package root.
 
-## plugin.json rules
+## Agent Plugins rules
 
-Claude Code validates the manifest strictly. Common pitfalls:
+The portable manifest and MCP configuration use **closed** schemas: any extra
+top-level field is a violation, and client-specific data belongs under
+`extensions` keyed by reverse-domain namespace.
+
+| Rule | Detail |
+| --- | --- |
+| `$schema` | Required in both files; must be the canonical `…/schemas/1.0.0/{plugin,mcp}.schema.json` identifier, and the versions must match |
+| `name` | 1–64 chars, lowercase alphanumeric plus `-` and `.`, alphanumeric at both ends, no `--` or `..` |
+| Transports | `stdio`, `streamable-http`, `sse` — Claude's `http` keyword is not portable |
+| Remote URLs | Absolute, literal HTTPS, no userinfo or fragment. **No placeholder or env-var expansion**, so a self-hosted Probo URL cannot ship in the package |
+| `headers` | Visible package data — never put credentials there. Probo MCP is OAuth 2.0 only |
+| Skills | Immediate children of `skills/` containing `SKILL.md`; frontmatter `name` must match the directory name |
+
+## Claude plugin.json rules
+
+Claude Code validates its own manifest strictly. Common pitfalls:
 
 | Field | Expected type | Notes |
 | --- | --- | --- |
 | `name` | string | Skill namespace (`probo` → `/probo:open-source-compliance`) |
 | `repository` | string URL | **Not** the npm-style `{ type, url }` object |
 | `bugs` | string URL | **Not** the npm-style `{ url }` object |
-| `version` | string | Bump on every release when using explicit versioning |
+| `version` | string | Must match `package.json`; validation enforces it |
 
 Run `npm --workspace @probo/skills run validate` before publishing.
 
 ## Probo MCP configuration
 
-The package `.mcp.json` expects one environment variable:
+Both hosted instances ship as literal endpoints, in `mcp.json`
+(`streamable-http`) and mirrored in `.mcp.json` (`http`):
 
-- `PROBO_BASE_URL` — instance root URL
+| Server | Endpoint |
+| --- | --- |
+| `probo-us` | `https://us.probo.com/api/mcp/v1` |
+| `probo-eu` | `https://eu.probo.com/api/mcp/v1` |
 
-Authentication is OAuth 2.0 only. Users complete sign-in via `/mcp` or
-`claude mcp login probo`. Do not document API keys or bearer tokens in the
-plugin config — a pre-set `Authorization` header prevents Claude Code from
-starting the OAuth flow.
+The MCP API is mounted at `<instance-root>/api/mcp/v1` (`/api` prefix included
+— `/mcp/v1` hits the console SPA). Self-hosted instances are added in the agent
+because the spec forbids expansion in remote URLs.
+
+Authentication is OAuth 2.0 only, discovered from
+`/.well-known/oauth-protected-resource` on the instance root. Users complete
+sign-in via `/mcp` or `claude mcp login probo-us`. Do not document API keys or
+bearer tokens in the plugin config — a pre-set `Authorization` header prevents
+Claude Code from starting the OAuth flow.
 
 ## Adding a skill
 
-1. Create `skills/<name>/SKILL.md` with YAML frontmatter (`name`, `description`).
+1. Create `skills/<name>/SKILL.md` with YAML frontmatter (`name` matching the
+   directory, `description` under 1024 chars).
 2. Add `references/` for detailed workflow docs loaded on demand.
 3. Validate and test:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23404,7 +23404,7 @@
     },
     "packages/skills": {
       "name": "@probo/skills",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT"
     },
     "packages/tsconfig": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23405,7 +23405,10 @@
     "packages/skills": {
       "name": "@probo/skills",
       "version": "0.3.0",
-      "license": "MIT"
+      "license": "MIT",
+      "devDependencies": {
+        "js-yaml": "^4.3.1"
+      }
     },
     "packages/tsconfig": {
       "name": "@probo/tsconfig",

--- a/packages/skills/.claude-plugin/plugin.json
+++ b/packages/skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "probo",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Open-source compliance workflows powered by Probo MCP (Claude Code, Codex, OpenCode)",
   "author": {
     "name": "Probo Inc",

--- a/packages/skills/.claude-plugin/plugin.json
+++ b/packages/skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "probo",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "description": "Open-source compliance workflows powered by Probo MCP (Claude Code, Codex, OpenCode)",
   "author": {
     "name": "Probo Inc",

--- a/packages/skills/.codex-plugin/plugin.json
+++ b/packages/skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "probo",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Open-source compliance workflows powered by Probo MCP (Codex, OpenCode, Claude Code)",
   "author": {
     "name": "Probo Inc",

--- a/packages/skills/CHANGELOG.md
+++ b/packages/skills/CHANGELOG.md
@@ -5,6 +5,41 @@ this file.
 
 ## Unreleased
 
+### Added
+
+- Agent Plugins 1.0.0 portable package: `plugin.json` and `mcp.json` at the
+  package root, both declaring the canonical
+  `https://agent-plugins.org/schemas/1.0.0/…` schema identifiers, so any
+  conformant client can load the skills and Probo MCP servers without
+  client-specific wiring
+- Both hosted Probo instances ship as Streamable HTTP servers: `probo-us`
+  (`https://us.probo.com/api/mcp/v1`) and `probo-eu`
+  (`https://eu.probo.com/api/mcp/v1`)
+- Validation of the Agent Plugins manifest and MCP schemas (closed field sets,
+  plugin name constraints, transport variants, literal HTTPS URLs, no
+  credential headers), of Agent Skills frontmatter (`name` matching the skill
+  directory, `description` and `compatibility` length limits), and of
+  `.mcp.json` parity with `mcp.json`
+
+### Fixed
+
+- MCP endpoint path: the Probo MCP API is served at `<instance-root>/api/mcp/v1`.
+  The previous `/mcp/v1` path returned the console HTML page instead of the MCP
+  endpoint, so no bundled server could connect
+
+### Changed
+
+- **Breaking:** MCP configuration no longer reads `PROBO_BASE_URL`. Agent
+  Plugins performs no placeholder expansion in remote MCP URLs, so the hosted
+  regional endpoints are declared literally. Self-hosted users add their
+  instance in the agent, e.g.
+  `claude mcp add --transport http probo https://probo.example.com/api/mcp/v1`
+- Skills select a region instead of assuming a single `probo` server, and
+  discover it by calling a list tool on each connected server when the region
+  is unknown
+- Client manifest versions (`.claude-plugin/`, `.codex-plugin/`) track
+  `package.json`, which validation now enforces
+
 ## [0.2.2] - 2026-08-04
 
 ### Fixed

--- a/packages/skills/CHANGELOG.md
+++ b/packages/skills/CHANGELOG.md
@@ -19,15 +19,22 @@ this file.
   (`https://eu.probo.com/api/mcp/v1`)
 - Validation of the Agent Plugins manifest and MCP schemas (closed field sets,
   plugin name constraints, transport variants, literal HTTPS URLs, no
-  credential headers), of Agent Skills frontmatter (`name` matching the skill
-  directory, `description` and `compatibility` length limits), and of
-  `.mcp.json` parity with `mcp.json`
+  credential headers under any capitalization), of Agent Skills frontmatter
+  (parsed as YAML, `name` matching the skill directory, `description`,
+  `compatibility`, and `metadata` types and length limits), and of `.mcp.json`
+  parity with `mcp.json`. Optional fields must be absent rather than `null`,
+  which the portable schemas reject
 
 ### Fixed
 
 - MCP endpoint path: the Probo MCP API is served at `<instance-root>/api/mcp/v1`.
   The previous `/mcp/v1` path returned the console HTML page instead of the MCP
   endpoint, so no bundled server could connect
+- `access-review` skill: region discovery uses `listOrganizations`, which takes
+  no required input. It previously called `listAccessReviewCampaigns`, which
+  requires the `organization_id` that discovery is meant to establish, so the
+  step could not be executed as written. Resolving the organization before the
+  campaign is now explicit, and the reference documents `listOrganizations`
 
 ### Changed
 

--- a/packages/skills/CHANGELOG.md
+++ b/packages/skills/CHANGELOG.md
@@ -21,9 +21,9 @@ this file.
   plugin name constraints, transport variants, literal HTTPS URLs, no
   credential headers under any capitalization), of Agent Skills frontmatter
   (parsed as YAML, `name` matching the skill directory, `description`,
-  `compatibility`, and `metadata` types and length limits), and of `.mcp.json`
-  parity with `mcp.json`. Optional fields must be absent rather than `null`,
-  which the portable schemas reject
+  `compatibility`, and `metadata` types, plus length limits for `description`
+  and `compatibility`), and of `.mcp.json` parity with `mcp.json`. Optional
+  fields must be absent rather than `null`, which the portable schemas reject
 
 ### Fixed
 
@@ -33,8 +33,10 @@ this file.
 - `access-review` skill: region discovery uses `listOrganizations`, which takes
   no required input. It previously called `listAccessReviewCampaigns`, which
   requires the `organization_id` that discovery is meant to establish, so the
-  step could not be executed as written. Resolving the organization before the
-  campaign is now explicit, and the reference documents `listOrganizations`
+  step could not be executed as written. If several servers return accessible
+  organizations, the skill now selects only a unique server/organization pair
+  and otherwise asks the user to choose. Resolving the organization before the
+  campaign is explicit, and the reference documents `listOrganizations`
 
 ### Changed
 

--- a/packages/skills/CHANGELOG.md
+++ b/packages/skills/CHANGELOG.md
@@ -5,6 +5,8 @@ this file.
 
 ## Unreleased
 
+## [0.3.0] - 2026-08-10
+
 ### Added
 
 - Agent Plugins 1.0.0 portable package: `plugin.json` and `mcp.json` at the

--- a/packages/skills/CHANGELOG.md
+++ b/packages/skills/CHANGELOG.md
@@ -30,13 +30,15 @@ this file.
 - MCP endpoint path: the Probo MCP API is served at `<instance-root>/api/mcp/v1`.
   The previous `/mcp/v1` path returned the console HTML page instead of the MCP
   endpoint, so no bundled server could connect
-- `access-review` skill: region discovery uses `listOrganizations`, which takes
-  no required input. It previously called `listAccessReviewCampaigns`, which
-  requires the `organization_id` that discovery is meant to establish, so the
-  step could not be executed as written. If several servers return accessible
-  organizations, the skill now selects only a unique server/organization pair
-  and otherwise asks the user to choose. Resolving the organization before the
-  campaign is explicit, and the reference documents `listOrganizations`
+- `access-review` skill: server and organization selection are now separate
+  preconditions, so both are resolved whichever one is ambiguous — a single
+  self-hosted server serving several organizations included. Discovery uses
+  `listOrganizations`, which takes no required input; it previously called
+  `listAccessReviewCampaigns`, which requires the `organization_id` that
+  discovery is meant to establish, so the step could not be executed as written.
+  A merely non-empty result never settles the region, and anything short of a
+  unique match asks the user. The reference documents both uses of
+  `listOrganizations`
 
 ### Changed
 

--- a/packages/skills/COMPATIBILITY.md
+++ b/packages/skills/COMPATIBILITY.md
@@ -22,31 +22,69 @@ SOFTWARE.
 
 # Multi-agent compatibility
 
-`@probo/skills` targets **Claude Code**, **Codex**, **OpenCode**, and
-other MCP-capable agents (including **Cursor**). The portable core is Probo
-MCP plus Agent Skills–compatible `SKILL.md` files.
+`@probo/skills` is an [Agent Plugins 1.0.0](https://agent-plugins.org/)
+package. The portable core is `plugin.json`, Agent Skills under `skills/`, and
+Probo MCP servers in `mcp.json`. Client-specific manifests carry the same
+components to **Claude Code**, **Codex**, **OpenCode**, and **Cursor** until
+those clients load the portable package directly.
+
+## Portable package (Agent Plugins 1.0.0)
+
+```
+plugin.json    # $schema + plugin identity (spec §5)
+skills/        # one directory per skill, each with SKILL.md (spec §7.1)
+mcp.json       # $schema + mcpServers (spec §7.2)
+```
+
+Both documents declare
+`https://agent-plugins.org/schemas/1.0.0/{plugin,mcp}.schema.json`, and the
+spec requires the two versions to match.
+
+Commands, marketplace catalogs, and the client manifests are outside the v1
+format — Agent Plugins v1 standardizes only skills and MCP servers. Clients
+ignore the extra files.
+
+## Probo MCP servers
+
+`mcp.json` ships both hosted instances as Streamable HTTP servers:
+
+| Server | Endpoint |
+| --- | --- |
+| `probo-us` | `https://us.probo.com/api/mcp/v1` |
+| `probo-eu` | `https://eu.probo.com/api/mcp/v1` |
+
+Connect the server for your region. Skills that need to discover the region
+call `listOrganizations` on each connected server and keep the one that returns
+the target organization.
+
+Authentication is **OAuth 2.0** only, discovered from
+`/.well-known/oauth-protected-resource` on the instance root. Never configure a
+static bearer token: Agent Plugins treats `headers` as visible package data,
+and a pre-set `Authorization` header also stops Claude Code from starting the
+OAuth flow.
+
+### Self-hosted instances
+
+Agent Plugins 1.0.0 performs no placeholder or environment-variable expansion
+in remote MCP URLs (spec §7.2.1), so a self-hosted endpoint cannot ship in the
+package. Add it in the agent:
+
+```bash
+claude mcp add --transport http probo https://probo.example.com/api/mcp/v1
+codex mcp add --transport http probo https://probo.example.com/api/mcp/v1
+```
+
+The MCP path is always `<instance-root>/api/mcp/v1`.
 
 ## What works where
 
-| Component | Claude Code | Codex | OpenCode | Cursor |
-| --- | --- | --- | --- | --- |
-| Probo MCP (OAuth) | ✅ Plugin `.mcp.json` | ✅ `.codex-plugin` + `.mcp.json` | ✅ Manual MCP config | ✅ IDE MCP settings |
-| Skills (`SKILL.md`) | ✅ `skills/` | ✅ `skills/` via `.codex-plugin` | ✅ `.opencode/skills/` or `.claude/skills/` | ✅ Copy/symlink to `.cursor/skills/` |
-| Commands | ✅ `commands/` → `/probo:…` | ⚠️ Use skills instead | ⚠️ Native `skill` tool | ❌ Use skill or rules |
-| Plugin manifest | `.claude-plugin/` | `.codex-plugin/` | Discovery paths (no manifest) | No native manifest |
-| Marketplace catalog | `.claude-plugin/marketplace.json` (repo root or package) | `.agents/plugins/marketplace.json` (repo root or package) | — | — |
-
-## Probo MCP (all agents)
-
-Set the instance URL:
-
-```bash
-export PROBO_BASE_URL="https://your-probo-instance.example.com"
-```
-
-Endpoint: `${PROBO_BASE_URL}/mcp/v1` (HTTP, OAuth 2.0). Do not configure a
-static bearer token — OAuth discovery uses
-`/.well-known/oauth-protected-resource`.
+| Component | Agent Plugins client | Claude Code | Codex | OpenCode | Cursor |
+| --- | --- | --- | --- | --- | --- |
+| Probo MCP (OAuth) | ✅ `mcp.json` | ✅ `.mcp.json` | ✅ `.codex-plugin` + `.mcp.json` | ✅ Manual MCP config | ✅ IDE MCP settings |
+| Skills (`SKILL.md`) | ✅ `skills/` | ✅ `skills/` | ✅ `skills/` via `.codex-plugin` | ✅ `.opencode/skills/` or `.claude/skills/` | ✅ Copy/symlink to `.cursor/skills/` |
+| Commands | ❌ Outside v1 | ✅ `commands/` → `/probo:…` | ⚠️ Use skills instead | ⚠️ Native `skill` tool | ❌ Use skill or rules |
+| Plugin manifest | `plugin.json` | `.claude-plugin/` | `.codex-plugin/` | Discovery paths (no manifest) | No native manifest |
+| Marketplace catalog | — | `.claude-plugin/marketplace.json` (repo root or package) | `.agents/plugins/marketplace.json` (repo root or package) | — | — |
 
 ### Claude Code
 
@@ -58,7 +96,7 @@ claude plugin marketplace add getprobo/probo
 # or, from a local clone:
 claude plugin marketplace add .
 claude plugin install probo@probo
-claude mcp login probo   # or /mcp in session
+claude mcp login probo-us   # or /mcp in session
 /probo:access-review Q3 GitHub review
 ```
 
@@ -67,7 +105,7 @@ claude mcp login probo   # or /mcp in session
 ```bash
 claude plugin marketplace add ./packages/skills/.claude-plugin
 claude plugin install probo@probo
-claude mcp login probo
+claude mcp login probo-us
 ```
 
 Or install the plugin directory directly:
@@ -86,7 +124,7 @@ codex plugin marketplace add getprobo/probo
 # or, from a local clone:
 codex plugin marketplace add .
 codex plugin install probo@probo
-codex mcp login probo
+codex mcp login probo-us
 ```
 
 **From the package directory** (catalog at
@@ -95,14 +133,14 @@ codex mcp login probo
 ```bash
 codex plugin marketplace add ./packages/skills
 codex plugin install probo@probo
-codex mcp login probo
+codex mcp login probo-us
 ```
 
 Or install the plugin directory directly:
 
 ```bash
 codex plugin install ./packages/skills
-codex mcp login probo
+codex mcp login probo-us
 ```
 
 Skills load from `./skills/` via `.codex-plugin/plugin.json`. The repo-root
@@ -126,12 +164,14 @@ ln -s ../../packages/skills/skills/open-source-compliance .opencode/skills/open-
 [`opencode-claude-code-bridge`](https://www.npmjs.com/package/opencode-claude-code-bridge)
 to import Claude plugins and MCP configs into OpenCode.
 
-Configure Probo MCP in `opencode.json` or global OpenCode MCP settings, then
-authenticate. Invoke via the native `skill` tool (`access-review`).
+Configure a Probo MCP server in `opencode.json` or global OpenCode MCP
+settings, then authenticate. Invoke via the native `skill` tool
+(`access-review`).
 
 ### Cursor
 
-1. Add Probo MCP in Cursor settings (HTTP URL: `${PROBO_BASE_URL}/mcp/v1`,
+1. Add a Probo MCP server in Cursor settings (HTTP URL:
+   `https://us.probo.com/api/mcp/v1` or `https://eu.probo.com/api/mcp/v1`,
    OAuth).
 2. Copy or symlink skills into `.cursor/skills/`:
 
@@ -146,9 +186,11 @@ Reference the skill in chat or add a Cursor rule pointing at the skill.
 
 | Path | Portable? |
 | --- | --- |
+| `plugin.json` | ✅ Agent Plugins manifest (spec §5) |
+| `mcp.json` | ✅ Agent Plugins MCP configuration (spec §7.2) |
 | `skills/<name>/SKILL.md` | ✅ Agent Skills standard |
 | `skills/<name>/references/*.md` | ✅ Relative to skill directory |
-| `.mcp.json` with `${PROBO_BASE_URL}` | ✅ Standard env var |
+| `.mcp.json` | Claude Code and Codex mirror of `mcp.json` (`type: http`) |
 | `${CLAUDE_PLUGIN_ROOT}` | ❌ Claude Code only — avoid in skill bodies |
 | `commands/*.md` | Claude Code slash commands only |
 
@@ -159,13 +201,15 @@ directory is discovered, regardless of which agent loads it.
 
 ```
 @probo/skills/
+  plugin.json                        # Agent Plugins manifest
+  mcp.json                           # Agent Plugins MCP configuration
+  skills/                            # Shared skills (all agents)
+  commands/                          # Claude Code commands only
+  .mcp.json                          # Claude Code / Codex MCP wiring
   .claude-plugin/plugin.json         # Claude Code manifest
   .claude-plugin/marketplace.json    # Claude marketplace (npm)
   .codex-plugin/plugin.json          # Codex manifest
   .agents/plugins/marketplace.json   # Codex marketplace (package-local)
-  .mcp.json                          # Shared MCP wiring
-  skills/                            # Shared skills (all agents)
-  commands/                          # Claude Code commands only
 ```
 
 Repo root (monorepo / `getprobo/probo` Git installs):
@@ -174,3 +218,14 @@ Repo root (monorepo / `getprobo/probo` Git installs):
 .claude-plugin/marketplace.json      # Claude marketplace → packages/skills
 .agents/plugins/marketplace.json     # Codex marketplace → packages/skills
 ```
+
+## Validation
+
+```bash
+npm --workspace @probo/skills run validate
+```
+
+`scripts/validate.mjs` enforces the Agent Plugins closed manifest and MCP
+schemas (canonical `$schema` values, plugin name constraints, transport
+variants, literal HTTPS URLs, no credential headers), Agent Skills frontmatter
+rules, and that `.mcp.json` stays in lockstep with `mcp.json`.

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -1,20 +1,49 @@
 # @probo/skills
 
-Multi-agent compliance skills for open-source GRC workflows. Ships Agent
-Skills–compatible instructions and wires agents to the [Probo MCP
-API](https://github.com/getprobo/probo/tree/main/pkg/server/api/mcp/v1) via
+Multi-agent compliance skills for open-source GRC workflows. Ships an
+[Agent Plugins 1.0.0](https://agent-plugins.org/) package: Agent
+Skills–compatible instructions plus portable MCP wiring to the [Probo MCP
+API](https://github.com/getprobo/probo/tree/main/pkg/server/api/mcp/v1) over
 OAuth 2.0.
 
-**Supported agents:** Claude Code, Codex, OpenCode, Cursor (MCP + skills).
+**Supported agents:** any Agent Plugins client, plus Claude Code, Codex,
+OpenCode, and Cursor through their own plugin or MCP configuration.
 
-Marketplace catalogs: `.claude-plugin/marketplace.json` at the repo root or
-under `packages/skills/` (Claude Code), `.agents/plugins/marketplace.json` at
-the repo root or under `packages/skills/` (Codex). See
+The portable package is `plugin.json`, `skills/`, and `mcp.json` at the package
+root. Client-specific manifests (`.claude-plugin/`, `.codex-plugin/`,
+`.mcp.json`) and marketplace catalogs sit alongside it. See
 [COMPATIBILITY.md](./COMPATIBILITY.md).
+
+## Probo MCP servers
+
+Both hosted Probo instances ship in `mcp.json`; connect the one for your
+region and sign in with OAuth 2.0.
+
+| Server | Endpoint |
+| --- | --- |
+| `probo-us` | `https://us.probo.com/api/mcp/v1` |
+| `probo-eu` | `https://eu.probo.com/api/mcp/v1` |
+
+Agent Plugins 1.0.0 defines no placeholder expansion for remote MCP URLs, so a
+self-hosted instance is added in the agent instead of in the package:
+
+```bash
+claude mcp add --transport http probo https://probo.example.com/api/mcp/v1
+```
+
+No API token or bearer header belongs in any of these configs. Probo MCP
+authenticates with OAuth 2.0, discovered from
+`/.well-known/oauth-protected-resource` on the instance root.
 
 ## Install
 
-### From GitHub or npm
+### Agent Plugins client
+
+Point the client at the package root (`packages/skills` in a clone, or the
+installed `@probo/skills` directory). It reads `plugin.json`, discovers the
+skills under `skills/`, and loads both servers from `mcp.json`.
+
+### Claude Code
 
 **From GitHub** (repo-root catalog at `.claude-plugin/marketplace.json`):
 
@@ -23,6 +52,7 @@ claude plugin marketplace add getprobo/probo
 # or, from a local clone:
 claude plugin marketplace add .
 claude plugin install probo@probo
+claude mcp login probo-us   # or /mcp in session
 ```
 
 **From the package directory** (catalog at
@@ -34,35 +64,6 @@ claude plugin marketplace add ./packages/skills/.claude-plugin
 claude plugin install probo@probo
 ```
 
-When consuming the published package, the package-level marketplace entry
-resolves `@probo/skills` from npm (see
-`packages/skills/.claude-plugin/marketplace.json`).
-
-### Configure Probo MCP
-
-Set your Probo instance URL before starting Claude Code:
-
-```bash
-export PROBO_BASE_URL="https://your-probo-instance.example.com"
-```
-
-The plugin `.mcp.json` connects to `${PROBO_BASE_URL}/mcp/v1`. Probo MCP
-authenticates with **OAuth 2.0** — no API token or bearer header is required in
-the plugin config. On first use, sign in from Claude Code:
-
-```text
-/mcp
-```
-
-Or from your shell:
-
-```bash
-claude mcp login probo
-```
-
-Claude Code discovers Probo's authorization server via
-`/.well-known/oauth-protected-resource` and stores tokens securely.
-
 ### Local development
 
 ```bash
@@ -73,9 +74,10 @@ claude --plugin-dir ./packages/skills
 
 | Component | Location | Purpose |
 | --- | --- | --- |
-| MCP | `.mcp.json` | Probo API connection |
+| Manifest | `plugin.json` | Agent Plugins 1.0.0 plugin identity |
+| MCP | `mcp.json` | Portable hosted Probo servers |
 | Skills | `skills/` | Compliance workflows |
-| Commands | `commands/` | `access-review`, `missing-signatures` — semi-auto workflows |
+| Commands | `commands/` | `access-review`, `missing-signatures` — semi-auto workflows (Claude Code) |
 
 Skills: `/probo:<skill-name>` (e.g. `/probo:open-source-compliance`, `/probo:missing-signatures`).
 

--- a/packages/skills/mcp.json
+++ b/packages/skills/mcp.json
@@ -1,11 +1,12 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
   "mcpServers": {
     "probo-us": {
-      "type": "http",
+      "type": "streamable-http",
       "url": "https://us.probo.com/api/mcp/v1"
     },
     "probo-eu": {
-      "type": "http",
+      "type": "streamable-http",
       "url": "https://eu.probo.com/api/mcp/v1"
     }
   }

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -37,6 +37,9 @@
     "open-source"
   ],
   "license": "MIT",
+  "devDependencies": {
+    "js-yaml": "^4.3.1"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/getprobo/probo.git",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -18,6 +18,8 @@
     ".agents",
     "skills",
     "commands",
+    "plugin.json",
+    "mcp.json",
     ".mcp.json",
     "README.md",
     "COMPATIBILITY.md"
@@ -25,6 +27,7 @@
   "keywords": [
     "claude-code",
     "agent-skills",
+    "agent-plugins",
     "codex",
     "opencode",
     "probo",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@probo/skills",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Multi-agent compliance skills for open-source GRC (Claude Code, Codex, OpenCode) powered by Probo MCP",
   "private": false,
   "scripts": {

--- a/packages/skills/plugin.json
+++ b/packages/skills/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "probo",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Open-source compliance workflows powered by the Probo MCP API",
   "author": {
     "name": "Probo Inc",

--- a/packages/skills/plugin.json
+++ b/packages/skills/plugin.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "probo",
   "version": "0.2.2",
-  "description": "Open-source compliance workflows powered by Probo MCP (Codex, OpenCode, Claude Code)",
+  "description": "Open-source compliance workflows powered by the Probo MCP API",
   "author": {
     "name": "Probo Inc",
-    "email": "hello@probo.com"
+    "email": "hello@probo.com",
+    "url": "https://www.probo.com"
   },
   "homepage": "https://github.com/getprobo/probo/tree/main/packages/skills",
   "repository": "https://github.com/getprobo/probo",
@@ -14,8 +16,7 @@
     "compliance",
     "grc",
     "mcp",
+    "agent-skills",
     "open-source"
-  ],
-  "skills": "./skills/",
-  "mcpServers": "./.mcp.json"
+  ]
 }

--- a/packages/skills/scripts/validate.mjs
+++ b/packages/skills/scripts/validate.mjs
@@ -18,13 +18,51 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 
+const AGENT_PLUGINS_VERSION = "1.0.0";
+const PLUGIN_SCHEMA_ID = `https://agent-plugins.org/schemas/${AGENT_PLUGINS_VERSION}/plugin.schema.json`;
+const MCP_SCHEMA_ID = `https://agent-plugins.org/schemas/${AGENT_PLUGINS_VERSION}/mcp.schema.json`;
+
+// Agent Plugins 1.0.0 §5.2 and §7.2.1 define closed schemas: any other
+// top-level field is a violation.
+const MANIFEST_FIELDS = new Set([
+  "$schema",
+  "name",
+  "version",
+  "description",
+  "author",
+  "homepage",
+  "repository",
+  "license",
+  "keywords",
+  "extensions",
+]);
+const AUTHOR_FIELDS = new Set(["name", "email", "url"]);
+const REMOTE_SERVER_FIELDS = new Set(["type", "url", "headers"]);
+const STDIO_SERVER_FIELDS = new Set(["type", "command", "args", "env", "cwd"]);
+
+// §5.5 plugin name and Agent Skills `name` constraints.
+const PLUGIN_NAME_PATTERN = /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+const SKILL_NAME_PATTERN = /^(?!.*--)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+// Header names that would turn visible package data into a credential
+// (§7.2.1 forbids secrets in `headers`).
+const CREDENTIAL_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "x-api-key",
+  "x-auth-token",
+]);
+
 const requiredPaths = [
+  "plugin.json",
+  "mcp.json",
   ".claude-plugin/plugin.json",
   ".claude-plugin/marketplace.json",
   ".codex-plugin/plugin.json",
@@ -35,12 +73,15 @@ const requiredPaths = [
   "skills/access-review/SKILL.md",
   "skills/missing-signatures/SKILL.md",
   "skills/open-source-compliance/SKILL.md",
+  "skills/compliance-portal-commitments/SKILL.md",
   "skills/access-review/references/mcp-tools.md",
   "skills/access-review/references/decision-rubric.md",
   "skills/access-review/references/notes-format.md",
   "skills/missing-signatures/references/mcp-tools.md",
   "skills/missing-signatures/references/report-format.md",
   "skills/missing-signatures/references/notes-format.md",
+  "skills/compliance-portal-commitments/references/voice.md",
+  "skills/compliance-portal-commitments/references/portal-mechanics.md",
   "COMPATIBILITY.md",
 ];
 
@@ -76,6 +117,12 @@ function requireNonEmptyString(label, field, value) {
   return true;
 }
 
+function requireOptionalString(label, field, value) {
+  if (value != null && typeof value !== "string") {
+    fail(`${label}: ${field} must be a string`);
+  }
+}
+
 for (const relativePath of requiredPaths) {
   const absolutePath = join(root, relativePath);
   if (!existsSync(absolutePath)) {
@@ -83,20 +130,324 @@ for (const relativePath of requiredPaths) {
   }
 }
 
-const manifestPath = join(root, ".claude-plugin/plugin.json");
-const codexManifestPath = join(root, ".codex-plugin/plugin.json");
+const packageJsonPath = join(root, "package.json");
+const packageJson = existsSync(packageJsonPath)
+  ? readJsonObject("package.json", packageJsonPath)
+  : undefined;
+const packageName = packageJson?.name ?? null;
+const packageVersion = packageJson?.version ?? null;
 
-for (const [label, path] of [
-  ["plugin.json", manifestPath],
-  [".codex-plugin/plugin.json", codexManifestPath],
-]) {
+// --- Agent Plugins 1.0.0 portable package ---------------------------------
+
+function validateAgentPluginsManifest(label, path) {
   if (!existsSync(path)) {
-    continue;
+    return;
   }
+
   const manifest = readJsonObject(label, path);
   if (manifest === undefined) {
-    continue;
+    return;
   }
+
+  for (const field of Object.keys(manifest)) {
+    if (!MANIFEST_FIELDS.has(field)) {
+      fail(`${label}: unknown top-level field "${field}" (schema is closed)`);
+    }
+  }
+
+  if (manifest.$schema !== PLUGIN_SCHEMA_ID) {
+    fail(`${label}: $schema must be "${PLUGIN_SCHEMA_ID}"`);
+  }
+
+  if (requireNonEmptyString(label, "name", manifest.name)) {
+    if (manifest.name.length > 64 || !PLUGIN_NAME_PATTERN.test(manifest.name)) {
+      fail(
+        `${label}: name "${manifest.name}" must be 1-64 lowercase alphanumeric, "-", or "." characters, start and end alphanumeric, without "--" or ".."`,
+      );
+    }
+  }
+
+  for (const field of ["version", "description", "homepage", "repository", "license"]) {
+    requireOptionalString(label, field, manifest[field]);
+  }
+
+  if (manifest.author != null) {
+    if (typeof manifest.author !== "object" || Array.isArray(manifest.author)) {
+      fail(`${label}: author must be an object`);
+    } else {
+      for (const field of Object.keys(manifest.author)) {
+        if (!AUTHOR_FIELDS.has(field)) {
+          fail(`${label}: author has unknown field "${field}"`);
+        } else {
+          requireOptionalString(label, `author.${field}`, manifest.author[field]);
+        }
+      }
+    }
+  }
+
+  if (manifest.keywords != null) {
+    if (
+      !Array.isArray(manifest.keywords) ||
+      manifest.keywords.some((keyword) => typeof keyword !== "string")
+    ) {
+      fail(`${label}: keywords must be an array of strings`);
+    }
+  }
+
+  if (manifest.extensions != null) {
+    if (typeof manifest.extensions !== "object" || Array.isArray(manifest.extensions)) {
+      fail(`${label}: extensions must be an object keyed by reverse-domain namespace`);
+    }
+  }
+
+  if (packageVersion != null && manifest.version !== packageVersion) {
+    fail(`${label}: version must match package.json version (${packageVersion})`);
+  }
+}
+
+function validateRemoteURL(label, rawURL) {
+  if (rawURL.includes("${")) {
+    fail(
+      `${label}: url must be a literal URL — Agent Plugins clients do not expand placeholders in remote URLs`,
+    );
+    return;
+  }
+
+  let url;
+  try {
+    url = new URL(rawURL);
+  } catch {
+    fail(`${label}: url must be an absolute URL`);
+    return;
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    fail(`${label}: url must use http or https`);
+    return;
+  }
+
+  if (url.username !== "" || url.password !== "") {
+    fail(`${label}: url must not contain user information`);
+  }
+
+  if (url.hash !== "") {
+    fail(`${label}: url must not contain a fragment`);
+  }
+
+  const loopback =
+    url.hostname === "localhost" ||
+    url.hostname === "127.0.0.1" ||
+    url.hostname === "[::1]";
+  if (url.protocol === "http:" && !loopback) {
+    fail(`${label}: non-loopback url must use https`);
+  }
+}
+
+function validateHeaders(label, headers) {
+  if (typeof headers !== "object" || Array.isArray(headers)) {
+    fail(`${label}: headers must be an object of strings`);
+    return;
+  }
+
+  const seen = new Set();
+  for (const [name, value] of Object.entries(headers)) {
+    const lowercased = name.toLowerCase();
+    if (seen.has(lowercased)) {
+      fail(`${label}: header "${name}" is declared more than once under different casing`);
+    }
+    seen.add(lowercased);
+
+    if (typeof value !== "string") {
+      fail(`${label}: header "${name}" must be a string`);
+    }
+
+    if (CREDENTIAL_HEADERS.has(lowercased)) {
+      fail(
+        `${label}: header "${name}" would embed a credential in visible package data — Probo MCP uses OAuth 2.0`,
+      );
+    }
+  }
+}
+
+function validateAgentPluginsMcp(label, path) {
+  if (!existsSync(path)) {
+    return;
+  }
+
+  const config = readJsonObject(label, path);
+  if (config === undefined) {
+    return;
+  }
+
+  for (const field of Object.keys(config)) {
+    if (field !== "$schema" && field !== "mcpServers") {
+      fail(`${label}: unknown top-level field "${field}" (schema is closed)`);
+    }
+  }
+
+  if (config.$schema !== MCP_SCHEMA_ID) {
+    fail(`${label}: $schema must be "${MCP_SCHEMA_ID}"`);
+  }
+
+  if (
+    config.mcpServers == null ||
+    typeof config.mcpServers !== "object" ||
+    Array.isArray(config.mcpServers)
+  ) {
+    fail(`${label}: mcpServers must be an object`);
+    return undefined;
+  }
+
+  for (const [name, server] of Object.entries(config.mcpServers)) {
+    const serverLabel = `${label} mcpServers.${name}`;
+
+    if (server == null || typeof server !== "object" || Array.isArray(server)) {
+      fail(`${serverLabel}: server configuration must be an object`);
+      continue;
+    }
+
+    if (server.type === "streamable-http" || server.type === "sse") {
+      for (const field of Object.keys(server)) {
+        if (!REMOTE_SERVER_FIELDS.has(field)) {
+          fail(`${serverLabel}: unknown field "${field}" for a ${server.type} server`);
+        }
+      }
+      if (requireNonEmptyString(serverLabel, "url", server.url)) {
+        validateRemoteURL(serverLabel, server.url);
+      }
+      if (server.headers != null) {
+        validateHeaders(serverLabel, server.headers);
+      }
+      continue;
+    }
+
+    if (server.type === "stdio") {
+      for (const field of Object.keys(server)) {
+        if (!STDIO_SERVER_FIELDS.has(field)) {
+          fail(`${serverLabel}: unknown field "${field}" for a stdio server`);
+        }
+      }
+      requireNonEmptyString(serverLabel, "command", server.command);
+      continue;
+    }
+
+    fail(`${serverLabel}: type must be "stdio", "streamable-http", or "sse"`);
+  }
+
+  return config.mcpServers;
+}
+
+// --- Agent Skills ---------------------------------------------------------
+
+// Reads one scalar from SKILL.md frontmatter. Supports plain scalars and the
+// block forms (`|`, `>`) the skills use, which is all the Agent Skills
+// frontmatter fields need — a full YAML parser would add a dependency to a
+// package that otherwise ships no code.
+function readFrontmatterScalar(frontmatter, key) {
+  const lines = frontmatter.split("\n");
+  const index = lines.findIndex((line) => line.startsWith(`${key}:`));
+  if (index === -1) {
+    return undefined;
+  }
+
+  const inline = lines[index].slice(`${key}:`.length).trim();
+  if (inline !== "" && !inline.startsWith("|") && !inline.startsWith(">")) {
+    return inline.replace(/^["'](.*)["']$/, "$1");
+  }
+
+  const block = [];
+  for (const line of lines.slice(index + 1)) {
+    if (line.trim() !== "" && !/^\s/.test(line)) {
+      break;
+    }
+    block.push(line.trim());
+  }
+
+  return block.join(" ").trim();
+}
+
+function validateSkill(name, skillDirectory) {
+  const label = `skills/${name}/SKILL.md`;
+  const skillPath = join(skillDirectory, "SKILL.md");
+
+  if (!existsSync(skillPath) || !statSync(skillPath).isFile()) {
+    fail(`${label}: every immediate child of skills/ must contain a SKILL.md file`);
+    return;
+  }
+
+  const content = readFileSync(skillPath, "utf8");
+  const match = /^---\n([\s\S]*?)\n---\n/.exec(content);
+  if (match === null) {
+    fail(`${label}: must start with YAML frontmatter delimited by "---"`);
+    return;
+  }
+
+  const frontmatter = match[1];
+  const skillName = readFrontmatterScalar(frontmatter, "name");
+  const description = readFrontmatterScalar(frontmatter, "description");
+  const compatibility = readFrontmatterScalar(frontmatter, "compatibility");
+
+  if (skillName === undefined || skillName === "") {
+    fail(`${label}: frontmatter must declare a non-empty name`);
+  } else {
+    if (skillName !== name) {
+      fail(`${label}: frontmatter name "${skillName}" must match the directory name "${name}"`);
+    }
+    if (skillName.length > 64 || !SKILL_NAME_PATTERN.test(skillName)) {
+      fail(
+        `${label}: name "${skillName}" must be 1-64 lowercase alphanumeric or "-" characters, start and end alphanumeric, without "--"`,
+      );
+    }
+  }
+
+  if (description === undefined || description === "") {
+    fail(`${label}: frontmatter must declare a non-empty description`);
+  } else if (description.length > 1024) {
+    fail(`${label}: description must be at most 1024 characters (found ${description.length})`);
+  }
+
+  if (compatibility !== undefined && compatibility.length > 500) {
+    fail(`${label}: compatibility must be at most 500 characters (found ${compatibility.length})`);
+  }
+}
+
+function validateSkills(skillsDirectory) {
+  if (!existsSync(skillsDirectory)) {
+    fail("missing required directory: skills/");
+    return;
+  }
+
+  if (!statSync(skillsDirectory).isDirectory()) {
+    fail("skills/ must be a directory");
+    return;
+  }
+
+  const entries = readdirSync(skillsDirectory, { withFileTypes: true }).filter((entry) =>
+    entry.isDirectory(),
+  );
+
+  if (entries.length === 0) {
+    fail("skills/ must contain at least one skill directory");
+    return;
+  }
+
+  for (const entry of entries) {
+    validateSkill(entry.name, join(skillsDirectory, entry.name));
+  }
+}
+
+// --- Client-specific manifests and catalogs -------------------------------
+
+function validateClientManifest(label, path) {
+  if (!existsSync(path)) {
+    return;
+  }
+
+  const manifest = readJsonObject(label, path);
+  if (manifest === undefined) {
+    return;
+  }
+
   requireNonEmptyString(label, "name", manifest.name);
   if (manifest.repository != null && typeof manifest.repository !== "string") {
     fail(`${label}: repository must be a string URL, not an object`);
@@ -104,12 +455,10 @@ for (const [label, path] of [
   if (manifest.bugs != null && typeof manifest.bugs !== "string") {
     fail(`${label}: bugs must be a string URL, not an object`);
   }
+  if (packageVersion != null && manifest.version !== packageVersion) {
+    fail(`${label}: version must match package.json version (${packageVersion})`);
+  }
 }
-
-const packageJsonPath = join(root, "package.json");
-const packageName = existsSync(packageJsonPath)
-  ? readJsonObject("package.json", packageJsonPath)?.name
-  : null;
 
 function validateClaudeMarketplace(label, path) {
   if (!existsSync(path)) {
@@ -212,6 +561,55 @@ function validateCodexMarketplace(label, path) {
   }
 }
 
+// The client-specific `.mcp.json` must stay in lockstep with the portable
+// `mcp.json`; only the transport keyword differs (`http` is the Claude Code
+// and Codex spelling of MCP Streamable HTTP).
+function validateClientMcpParity(label, path, portableServers) {
+  if (!existsSync(path)) {
+    return;
+  }
+
+  const config = readJsonObject(label, path);
+  if (config === undefined || portableServers === undefined) {
+    return;
+  }
+
+  const servers = config.mcpServers;
+  if (servers == null || typeof servers !== "object" || Array.isArray(servers)) {
+    fail(`${label}: mcpServers must be an object`);
+    return;
+  }
+
+  const portableNames = Object.keys(portableServers).sort().join(", ");
+  const clientNames = Object.keys(servers).sort().join(", ");
+  if (portableNames !== clientNames) {
+    fail(`${label}: servers (${clientNames}) must match mcp.json servers (${portableNames})`);
+    return;
+  }
+
+  for (const [name, server] of Object.entries(servers)) {
+    const serverLabel = `${label} mcpServers.${name}`;
+    const portable = portableServers[name];
+
+    if (server?.headers?.Authorization != null) {
+      fail(`${serverLabel}: must use OAuth 2.0, not headers.Authorization`);
+    }
+
+    if (portable?.type === "streamable-http" && server?.type !== "http") {
+      fail(`${serverLabel}: type must be "http" to match the portable streamable-http server`);
+    }
+
+    if (server?.url !== portable?.url) {
+      fail(`${serverLabel}: url must match mcp.json (${portable?.url})`);
+    }
+  }
+}
+
+validateAgentPluginsManifest("plugin.json", join(root, "plugin.json"));
+const portableServers = validateAgentPluginsMcp("mcp.json", join(root, "mcp.json"));
+validateSkills(join(root, "skills"));
+validateClientManifest(".claude-plugin/plugin.json", join(root, ".claude-plugin/plugin.json"));
+validateClientManifest(".codex-plugin/plugin.json", join(root, ".codex-plugin/plugin.json"));
 validateClaudeMarketplace(
   ".claude-plugin/marketplace.json",
   join(root, ".claude-plugin/marketplace.json"),
@@ -220,19 +618,7 @@ validateCodexMarketplace(
   ".agents/plugins/marketplace.json",
   join(root, ".agents/plugins/marketplace.json"),
 );
-
-const mcpPath = join(root, ".mcp.json");
-if (existsSync(mcpPath)) {
-  const mcpConfig = readJsonObject(".mcp.json", mcpPath);
-  if (mcpConfig !== undefined) {
-    const servers = mcpConfig.mcpServers ?? {};
-    for (const [name, config] of Object.entries(servers)) {
-      if (config?.headers?.Authorization != null) {
-        fail(`.mcp.json: ${name} must use OAuth 2.0, not headers.Authorization`);
-      }
-    }
-  }
-}
+validateClientMcpParity(".mcp.json", join(root, ".mcp.json"), portableServers);
 
 if (failed) {
   process.exit(1);

--- a/packages/skills/scripts/validate.mjs
+++ b/packages/skills/scripts/validate.mjs
@@ -21,6 +21,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { load as parseYaml } from "js-yaml";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -117,8 +118,11 @@ function requireNonEmptyString(label, field, value) {
   return true;
 }
 
+// An absent field is allowed; an explicit null is not. The portable schemas are
+// typed, so `"description": null` is a violation a client would reject even
+// though the key is optional.
 function requireOptionalString(label, field, value) {
-  if (value != null && typeof value !== "string") {
+  if (value !== undefined && typeof value !== "string") {
     fail(`${label}: ${field} must be a string`);
   }
 }
@@ -171,8 +175,12 @@ function validateAgentPluginsManifest(label, path) {
     requireOptionalString(label, field, manifest[field]);
   }
 
-  if (manifest.author != null) {
-    if (typeof manifest.author !== "object" || Array.isArray(manifest.author)) {
+  if (manifest.author !== undefined) {
+    if (
+      manifest.author === null ||
+      typeof manifest.author !== "object" ||
+      Array.isArray(manifest.author)
+    ) {
       fail(`${label}: author must be an object`);
     } else {
       for (const field of Object.keys(manifest.author)) {
@@ -185,7 +193,7 @@ function validateAgentPluginsManifest(label, path) {
     }
   }
 
-  if (manifest.keywords != null) {
+  if (manifest.keywords !== undefined) {
     if (
       !Array.isArray(manifest.keywords) ||
       manifest.keywords.some((keyword) => typeof keyword !== "string")
@@ -194,8 +202,12 @@ function validateAgentPluginsManifest(label, path) {
     }
   }
 
-  if (manifest.extensions != null) {
-    if (typeof manifest.extensions !== "object" || Array.isArray(manifest.extensions)) {
+  if (manifest.extensions !== undefined) {
+    if (
+      manifest.extensions === null ||
+      typeof manifest.extensions !== "object" ||
+      Array.isArray(manifest.extensions)
+    ) {
       fail(`${label}: extensions must be an object keyed by reverse-domain namespace`);
     }
   }
@@ -244,7 +256,7 @@ function validateRemoteURL(label, rawURL) {
 }
 
 function validateHeaders(label, headers) {
-  if (typeof headers !== "object" || Array.isArray(headers)) {
+  if (headers === null || typeof headers !== "object" || Array.isArray(headers)) {
     fail(`${label}: headers must be an object of strings`);
     return;
   }
@@ -315,7 +327,7 @@ function validateAgentPluginsMcp(label, path) {
       if (requireNonEmptyString(serverLabel, "url", server.url)) {
         validateRemoteURL(serverLabel, server.url);
       }
-      if (server.headers != null) {
+      if (server.headers !== undefined) {
         validateHeaders(serverLabel, server.headers);
       }
       continue;
@@ -339,33 +351,6 @@ function validateAgentPluginsMcp(label, path) {
 
 // --- Agent Skills ---------------------------------------------------------
 
-// Reads one scalar from SKILL.md frontmatter. Supports plain scalars and the
-// block forms (`|`, `>`) the skills use, which is all the Agent Skills
-// frontmatter fields need — a full YAML parser would add a dependency to a
-// package that otherwise ships no code.
-function readFrontmatterScalar(frontmatter, key) {
-  const lines = frontmatter.split("\n");
-  const index = lines.findIndex((line) => line.startsWith(`${key}:`));
-  if (index === -1) {
-    return undefined;
-  }
-
-  const inline = lines[index].slice(`${key}:`.length).trim();
-  if (inline !== "" && !inline.startsWith("|") && !inline.startsWith(">")) {
-    return inline.replace(/^["'](.*)["']$/, "$1");
-  }
-
-  const block = [];
-  for (const line of lines.slice(index + 1)) {
-    if (line.trim() !== "" && !/^\s/.test(line)) {
-      break;
-    }
-    block.push(line.trim());
-  }
-
-  return block.join(" ").trim();
-}
-
 function validateSkill(name, skillDirectory) {
   const label = `skills/${name}/SKILL.md`;
   const skillPath = join(skillDirectory, "SKILL.md");
@@ -376,18 +361,31 @@ function validateSkill(name, skillDirectory) {
   }
 
   const content = readFileSync(skillPath, "utf8");
-  const match = /^---\n([\s\S]*?)\n---\n/.exec(content);
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n/.exec(content);
   if (match === null) {
     fail(`${label}: must start with YAML frontmatter delimited by "---"`);
     return;
   }
 
-  const frontmatter = match[1];
-  const skillName = readFrontmatterScalar(frontmatter, "name");
-  const description = readFrontmatterScalar(frontmatter, "description");
-  const compatibility = readFrontmatterScalar(frontmatter, "compatibility");
+  // Parse the frontmatter the way a client does. Reading the fields with
+  // string matching would accept documents that fail to load at all, which is
+  // the failure this check exists to catch.
+  let frontmatter;
+  try {
+    frontmatter = parseYaml(match[1]);
+  } catch (error) {
+    fail(`${label}: frontmatter is not valid YAML: ${error.message}`);
+    return;
+  }
 
-  if (skillName === undefined || skillName === "") {
+  if (frontmatter === null || typeof frontmatter !== "object" || Array.isArray(frontmatter)) {
+    fail(`${label}: frontmatter must be a YAML mapping`);
+    return;
+  }
+
+  const { name: skillName, description, compatibility, metadata } = frontmatter;
+
+  if (typeof skillName !== "string" || skillName.length === 0) {
     fail(`${label}: frontmatter must declare a non-empty name`);
   } else {
     if (skillName !== name) {
@@ -400,15 +398,36 @@ function validateSkill(name, skillDirectory) {
     }
   }
 
-  if (description === undefined || description === "") {
+  if (typeof description !== "string" || description.length === 0) {
     fail(`${label}: frontmatter must declare a non-empty description`);
   } else if (description.length > 1024) {
     fail(`${label}: description must be at most 1024 characters (found ${description.length})`);
   }
 
-  if (compatibility !== undefined && compatibility.length > 500) {
-    fail(`${label}: compatibility must be at most 500 characters (found ${compatibility.length})`);
+  if (compatibility !== undefined) {
+    if (typeof compatibility !== "string" || compatibility.length === 0) {
+      fail(`${label}: compatibility must be a non-empty string`);
+    } else if (compatibility.length > 500) {
+      fail(
+        `${label}: compatibility must be at most 500 characters (found ${compatibility.length})`,
+      );
+    }
   }
+
+  if (metadata !== undefined) {
+    if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) {
+      fail(`${label}: metadata must be a mapping of string keys to string values`);
+    } else {
+      for (const [key, value] of Object.entries(metadata)) {
+        if (typeof value !== "string") {
+          fail(`${label}: metadata.${key} must be a string`);
+        }
+      }
+    }
+  }
+
+  requireOptionalString(label, "license", frontmatter.license);
+  requireOptionalString(label, "allowed-tools", frontmatter["allowed-tools"]);
 }
 
 function validateSkills(skillsDirectory) {
@@ -575,7 +594,7 @@ function validateClientMcpParity(label, path, portableServers) {
   }
 
   const servers = config.mcpServers;
-  if (servers == null || typeof servers !== "object" || Array.isArray(servers)) {
+  if (servers === null || typeof servers !== "object" || Array.isArray(servers)) {
     fail(`${label}: mcpServers must be an object`);
     return;
   }
@@ -591,8 +610,11 @@ function validateClientMcpParity(label, path, portableServers) {
     const serverLabel = `${label} mcpServers.${name}`;
     const portable = portableServers[name];
 
-    if (server?.headers?.Authorization != null) {
-      fail(`${serverLabel}: must use OAuth 2.0, not headers.Authorization`);
+    // HTTP header names are case-insensitive, so this file gets the same
+    // credential screening as the portable one rather than a check on one
+    // spelling of `Authorization`.
+    if (server?.headers !== undefined) {
+      validateHeaders(serverLabel, server.headers);
     }
 
     if (portable?.type === "streamable-http" && server?.type !== "http") {

--- a/packages/skills/skills/access-review/SKILL.md
+++ b/packages/skills/skills/access-review/SKILL.md
@@ -20,22 +20,28 @@ Before executing, read these files **relative to this skill directory**:
 
 1. A Probo MCP server must be connected. The plugin ships two hosted servers,
    `probo-us` and `probo-eu`; self-hosted instances are configured in the agent.
-   Use the server for the user's region, and when the region is unknown call
-   `listOrganizations` on each connected server. If the organization identified
-   by the user matches exactly one server/organization pair, use that pair. If
-   no organization was identified and there is exactly one pair across all
-   results, use it. Otherwise show the server names and organizations returned
-   by each, then ask the user which pair to use. Do not infer the region from a
-   merely non-empty result. If tools fail with auth errors, stop and tell the
-   user to complete OAuth sign-in for that server (Claude Code: `/mcp` or
-   `claude mcp login probo-us`; Codex: `codex mcp login probo-us`;
-   OpenCode/Cursor: configure MCP in settings then authenticate).
-2. Resolve the organization, then the campaign from `$ARGUMENTS` (name match or
-   GID). `listAccessReviewCampaigns` requires `organization_id`, so the
-   organization must be known first — reuse the server and organization
-   resolved in step 1. If the campaign is ambiguous, list
-   `listAccessReviewCampaigns` results and ask the user to pick one.
-3. Campaign `status` must be `IN_PROGRESS` or `PENDING_ACTIONS`. Stop with a
+   If tools fail with auth errors, stop and tell the user to complete OAuth
+   sign-in for that server (Claude Code: `/mcp` or `claude mcp login probo-us`;
+   Codex: `codex mcp login probo-us`; OpenCode/Cursor: configure MCP in settings
+   then authenticate).
+2. Resolve **the server**, then **the organization**. These are separate
+   choices: one server can hold several organizations, and the caller can have
+   organizations on more than one server. Settle both before any campaign call,
+   because `listAccessReviewCampaigns` requires `organization_id`.
+   - **Server.** Use the server for the region the user names, or the only
+     connected server when there is one. Otherwise call `listOrganizations` on
+     each connected server and take the server whose organizations uniquely
+     match the one the user named. Never infer the region from a merely
+     non-empty result — when the match is not unique, show each server with the
+     organizations it returned and ask which to use.
+   - **Organization.** Once the server is settled, call `listOrganizations` on
+     it unless an earlier probe already returned its organizations. Take the
+     unique name match, or the only organization when the server returns one.
+     Otherwise list them and ask the user to pick.
+3. Resolve the campaign from `$ARGUMENTS` (name match or GID) within that
+   organization. If the campaign is ambiguous, list `listAccessReviewCampaigns`
+   results and ask the user to pick one.
+4. Campaign `status` must be `IN_PROGRESS` or `PENDING_ACTIONS`. Stop with a
    clear message for `DRAFT`, `COMPLETED`, or `CANCELLED`.
 
 ## Working notes file

--- a/packages/skills/skills/access-review/SKILL.md
+++ b/packages/skills/skills/access-review/SKILL.md
@@ -21,13 +21,17 @@ Before executing, read these files **relative to this skill directory**:
 1. A Probo MCP server must be connected. The plugin ships two hosted servers,
    `probo-us` and `probo-eu`; self-hosted instances are configured in the agent.
    Use the server for the user's region, and when the region is unknown call
-   `listAccessReviewCampaigns` on each connected server and keep the one that
-   returns the campaign. If tools fail with auth errors, stop and tell the user
-   to complete OAuth sign-in for that server (Claude Code: `/mcp` or
+   `listOrganizations` on each connected server and keep the one that returns
+   the user's organization. If tools fail with auth errors, stop and tell the
+   user to complete OAuth sign-in for that server (Claude Code: `/mcp` or
    `claude mcp login probo-us`; Codex: `codex mcp login probo-us`;
    OpenCode/Cursor: configure MCP in settings then authenticate).
-2. Resolve the campaign from `$ARGUMENTS` (name match or GID). If ambiguous,
-   list `listAccessReviewCampaigns` results and ask the user to pick one.
+2. Resolve the organization, then the campaign from `$ARGUMENTS` (name match or
+   GID). `listAccessReviewCampaigns` requires `organization_id`, so the
+   organization must be known first — reuse the one resolved in step 1, or call
+   `listOrganizations` and ask the user to pick when several are available. If
+   the campaign is ambiguous, list `listAccessReviewCampaigns` results and ask
+   the user to pick one.
 3. Campaign `status` must be `IN_PROGRESS` or `PENDING_ACTIONS`. Stop with a
    clear message for `DRAFT`, `COMPLETED`, or `CANCELLED`.
 

--- a/packages/skills/skills/access-review/SKILL.md
+++ b/packages/skills/skills/access-review/SKILL.md
@@ -21,17 +21,20 @@ Before executing, read these files **relative to this skill directory**:
 1. A Probo MCP server must be connected. The plugin ships two hosted servers,
    `probo-us` and `probo-eu`; self-hosted instances are configured in the agent.
    Use the server for the user's region, and when the region is unknown call
-   `listOrganizations` on each connected server and keep the one that returns
-   the user's organization. If tools fail with auth errors, stop and tell the
+   `listOrganizations` on each connected server. If the organization identified
+   by the user matches exactly one server/organization pair, use that pair. If
+   no organization was identified and there is exactly one pair across all
+   results, use it. Otherwise show the server names and organizations returned
+   by each, then ask the user which pair to use. Do not infer the region from a
+   merely non-empty result. If tools fail with auth errors, stop and tell the
    user to complete OAuth sign-in for that server (Claude Code: `/mcp` or
    `claude mcp login probo-us`; Codex: `codex mcp login probo-us`;
    OpenCode/Cursor: configure MCP in settings then authenticate).
 2. Resolve the organization, then the campaign from `$ARGUMENTS` (name match or
    GID). `listAccessReviewCampaigns` requires `organization_id`, so the
-   organization must be known first — reuse the one resolved in step 1, or call
-   `listOrganizations` and ask the user to pick when several are available. If
-   the campaign is ambiguous, list `listAccessReviewCampaigns` results and ask
-   the user to pick one.
+   organization must be known first — reuse the server and organization
+   resolved in step 1. If the campaign is ambiguous, list
+   `listAccessReviewCampaigns` results and ask the user to pick one.
 3. Campaign `status` must be `IN_PROGRESS` or `PENDING_ACTIONS`. Stop with a
    clear message for `DRAFT`, `COMPLETED`, or `CANCELLED`.
 

--- a/packages/skills/skills/access-review/SKILL.md
+++ b/packages/skills/skills/access-review/SKILL.md
@@ -18,10 +18,14 @@ Before executing, read these files **relative to this skill directory**:
 
 ## Preconditions
 
-1. Probo MCP must be connected. If tools fail with auth errors, stop and tell
-   the user to complete OAuth sign-in for the Probo MCP server in their agent
-   (Claude Code: `/mcp` or `claude mcp login probo`; Codex: `codex mcp login
-   probo`; OpenCode/Cursor: configure MCP in settings then authenticate).
+1. A Probo MCP server must be connected. The plugin ships two hosted servers,
+   `probo-us` and `probo-eu`; self-hosted instances are configured in the agent.
+   Use the server for the user's region, and when the region is unknown call
+   `listAccessReviewCampaigns` on each connected server and keep the one that
+   returns the campaign. If tools fail with auth errors, stop and tell the user
+   to complete OAuth sign-in for that server (Claude Code: `/mcp` or
+   `claude mcp login probo-us`; Codex: `codex mcp login probo-us`;
+   OpenCode/Cursor: configure MCP in settings then authenticate).
 2. Resolve the campaign from `$ARGUMENTS` (name match or GID). If ambiguous,
    list `listAccessReviewCampaigns` results and ask the user to pick one.
 3. Campaign `status` must be `IN_PROGRESS` or `PENDING_ACTIONS`. Stop with a

--- a/packages/skills/skills/access-review/references/mcp-tools.md
+++ b/packages/skills/skills/access-review/references/mcp-tools.md
@@ -9,6 +9,11 @@ server configured in the agent). Read each tool schema before calling.
 
 List organizations the caller can access. No required input, so this is also the
 tool to probe each connected server with when the user's region is unknown.
+Each call returns every organization accessible on that server; a non-empty
+result does not uniquely identify the region. Select automatically only when
+the organization identified by the user matches exactly one
+server/organization pair, or when there is exactly one pair across all results.
+Otherwise show the pairs and ask the user to choose.
 
 ## Read
 

--- a/packages/skills/skills/access-review/references/mcp-tools.md
+++ b/packages/skills/skills/access-review/references/mcp-tools.md
@@ -1,7 +1,7 @@
 # Access review MCP tools
 
-All tools are on the Probo MCP server (`probo`). Read each tool schema before
-calling.
+All tools are on a Probo MCP server (`probo-us`, `probo-eu`, or a self-hosted
+server configured in the agent). Read each tool schema before calling.
 
 ## Read
 

--- a/packages/skills/skills/access-review/references/mcp-tools.md
+++ b/packages/skills/skills/access-review/references/mcp-tools.md
@@ -7,13 +7,20 @@ server configured in the agent). Read each tool schema before calling.
 
 ### `listOrganizations`
 
-List organizations the caller can access. No required input, so this is also the
-tool to probe each connected server with when the user's region is unknown.
-Each call returns every organization accessible on that server; a non-empty
-result does not uniquely identify the region. Select automatically only when
-the organization identified by the user matches exactly one
-server/organization pair, or when there is exactly one pair across all results.
-Otherwise show the pairs and ask the user to choose.
+List organizations the caller can access on the server it is called on. No
+required input, so it serves two distinct purposes:
+
+1. **Choosing a server** when the region is unknown — call it on each connected
+   server. A non-empty result does not identify the region, since the caller can
+   have organizations on both. Only a unique match for the organization the user
+   named settles it; otherwise show each server with its organizations and ask.
+2. **Choosing an organization** on a server that is already settled — including
+   a single self-hosted instance serving several organizations. Take the unique
+   name match, or the only organization when the server returns one, and
+   otherwise list them and ask.
+
+Either way the organization must be resolved before `listAccessReviewCampaigns`,
+which requires `organization_id`.
 
 ## Read
 

--- a/packages/skills/skills/access-review/references/mcp-tools.md
+++ b/packages/skills/skills/access-review/references/mcp-tools.md
@@ -3,6 +3,13 @@
 All tools are on a Probo MCP server (`probo-us`, `probo-eu`, or a self-hosted
 server configured in the agent). Read each tool schema before calling.
 
+## Organization scope
+
+### `listOrganizations`
+
+List organizations the caller can access. No required input, so this is also the
+tool to probe each connected server with when the user's region is unknown.
+
 ## Read
 
 ### `listAccessReviewCampaigns`
@@ -10,7 +17,7 @@ server configured in the agent). Read each tool schema before calling.
 List campaigns for an organization. Use to resolve `$ARGUMENTS` to a campaign
 when the user provides a name instead of a GID.
 
-Required: `organization_id`
+Required: `organization_id` — resolve the organization before calling this.
 
 ### `listAccessEntries`
 

--- a/packages/skills/skills/compliance-portal-commitments/SKILL.md
+++ b/packages/skills/skills/compliance-portal-commitments/SKILL.md
@@ -48,9 +48,9 @@ Commitments must trace to controls the company genuinely has. The source of trut
 **published policies** in Probo, not general knowledge about SOC 2 or ISO 27001.
 
 1. **Find the Probo MCP and the organization.** This environment may expose more than one Probo MCP
-   server (for example a US and an EU instance). Call `listOrganizations` on each until you find the one
-   that returns the target company, and use that server for every later call. Match the organization the
-   user named and capture its `id`.
+   server (the plugin ships hosted `probo-us` and `probo-eu`, and self-hosted instances add their own).
+   Call `listOrganizations` on each until you find the one that returns the target company, and use that
+   server for every later call. Match the organization the user named and capture its `id`.
 2. **List the published policies.** Call `listDocuments` with `document_types: ["POLICY"]`. Policies with
    a `current_published_major` are published.
 3. **Read the actual content.** `getDocument` returns metadata only. To get the text, call

--- a/packages/skills/skills/missing-signatures/SKILL.md
+++ b/packages/skills/skills/missing-signatures/SKILL.md
@@ -21,10 +21,14 @@ Before executing, read these files **relative to this skill directory**:
 
 ## Preconditions
 
-1. Probo MCP must be connected. If tools fail with auth errors, stop and tell
-   the user to complete OAuth sign-in for the Probo MCP server in their agent
-   (Claude Code: `/mcp` or `claude mcp login probo`; Codex: `codex mcp login
-   probo`; OpenCode/Cursor: configure MCP in settings then authenticate).
+1. A Probo MCP server must be connected. The plugin ships two hosted servers,
+   `probo-us` and `probo-eu`; self-hosted instances are configured in the agent.
+   Use the server for the user's region, and when the region is unknown call
+   `listOrganizations` on each connected server and keep the one that returns
+   the organization. If tools fail with auth errors, stop and tell the user to
+   complete OAuth sign-in for that server (Claude Code: `/mcp` or
+   `claude mcp login probo-us`; Codex: `codex mcp login probo-us`;
+   OpenCode/Cursor: configure MCP in settings then authenticate).
 2. Resolve the organization from `$ARGUMENTS` (name match or GID). If ambiguous,
    call `listOrganizations` and ask the user to pick one.
 3. This skill is **reporting only**. Do not request signatures, cancel requests,

--- a/packages/skills/skills/missing-signatures/references/mcp-tools.md
+++ b/packages/skills/skills/missing-signatures/references/mcp-tools.md
@@ -1,7 +1,7 @@
 # Missing signatures MCP tools
 
-All tools are on the Probo MCP server (`probo`). Read each tool schema before
-calling.
+All tools are on a Probo MCP server (`probo-us`, `probo-eu`, or a self-hosted
+server configured in the agent). Read each tool schema before calling.
 
 ## Organization scope
 

--- a/packages/skills/skills/open-source-compliance/SKILL.md
+++ b/packages/skills/skills/open-source-compliance/SKILL.md
@@ -11,10 +11,13 @@ first.
 
 ## Before you start
 
-1. Confirm the Probo MCP server is connected. If not, ask the user to run
-   `/mcp` or `claude mcp login probo` to complete the OAuth 2.0 sign-in.
+1. Confirm a Probo MCP server is connected. The plugin ships two hosted
+   servers, `probo-us` and `probo-eu`; self-hosted instances are configured in
+   the agent. If none is connected, ask the user to run `/mcp` or
+   `claude mcp login probo-us` to complete the OAuth 2.0 sign-in.
 2. Identify the target organization. List organizations if the user did not
-   provide one.
+   provide one, and when several servers are connected use the one that returns
+   the target organization.
 3. Prefer MCP tools over manual API calls. The Probo MCP API mirrors the
    platform's GraphQL surface.
 

--- a/packages/skills/skills/open-source-compliance/references/workflows.md
+++ b/packages/skills/skills/open-source-compliance/references/workflows.md
@@ -1,23 +1,28 @@
 # Open-source compliance workflows
 
-This plugin wraps Probo's MCP API for Claude Code. Probo is a self-hostable
-GRC platform; its MCP server exposes tools for third parties, controls,
-obligations, risks, documents, audits, access reviews, and more.
+This plugin wraps Probo's MCP API. Probo is a self-hostable GRC platform; its
+MCP server exposes tools for third parties, controls, obligations, risks,
+documents, audits, access reviews, and more.
+
+## Servers
+
+The plugin ships the two hosted Probo instances. A self-hosted instance is
+added in the agent's own MCP configuration.
+
+| Server | Endpoint |
+| --- | --- |
+| `probo-us` | `https://us.probo.com/api/mcp/v1` |
+| `probo-eu` | `https://eu.probo.com/api/mcp/v1` |
+| self-hosted | `<instance-root>/api/mcp/v1` |
 
 ## Authentication
 
-Probo MCP uses OAuth 2.0. Users sign in once via `/mcp` or
-`claude mcp login probo`; Claude Code stores and refreshes tokens
+Probo MCP uses OAuth 2.0. Users sign in once per server via `/mcp` or
+`claude mcp login probo-us`; the agent stores and refreshes tokens
 automatically. Do not ask the user for API keys or bearer tokens for MCP
 access.
 
-| Variable | Purpose |
-| --- | --- |
-| `PROBO_BASE_URL` | Probo instance root URL (no trailing slash) |
-
-MCP endpoint: `${PROBO_BASE_URL}/mcp/v1`
-
-OAuth discovery:
+OAuth discovery (on the instance root, not the MCP path):
 
 - Protected resource metadata: `/.well-known/oauth-protected-resource`
 - Authorization server metadata: `/.well-known/oauth-authorization-server`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`@probo/skills` shipped portable Agent Skills but was not an [Agent Plugins 1.0.0](https://agent-plugins.org/) package: a conformant client found nothing at the fixed locations the spec defines (`plugin.json` and `mcp.json` at the plugin root), because the manifests lived in `.claude-plugin/` and `.codex-plugin/`, MCP wiring lived in `.mcp.json`, and both used vendor-specific field shapes.

Making it conformant forced a decision about the two hosted Probo instances, since Agent Plugins performs no placeholder expansion in remote MCP URLs (§7.2.1) and `PROBO_BASE_URL` therefore cannot survive the port. Both regions are now declared literally.

## What changed

**Portable package**

- `packages/skills/plugin.json` — the Agent Plugins manifest, declaring `https://agent-plugins.org/schemas/1.0.0/plugin.schema.json`.
- `packages/skills/mcp.json` — `probo-us` (`https://us.probo.com/api/mcp/v1`) and `probo-eu` (`https://eu.probo.com/api/mcp/v1`) as `streamable-http` servers.
- `.mcp.json` mirrors the same two servers using Claude Code's and Codex's `http` keyword, so those clients keep working until they read the portable files.

**Endpoint path fix**

The Probo MCP API is mounted under `/api`, so the previous `${PROBO_BASE_URL}/mcp/v1` resolved to the console SPA and no bundled server could ever connect. The correct path is `<instance-root>/api/mcp/v1`.

**Self-hosted instances**

No longer expressible in the package. Documented as an agent-side step:

```bash
claude mcp add --transport http probo https://probo.example.com/api/mcp/v1
```

**Validation**

`scripts/validate.mjs` enforces the closed manifest and MCP schemas (canonical `$schema` identifiers, plugin name constraints, transport variants, literal HTTPS URLs without userinfo or fragments, no credential headers under any capitalization), Agent Skills frontmatter parsed as YAML, `.mcp.json` parity with `mcp.json`, and manifest versions matching `package.json` — the Claude and Codex manifests had drifted to `0.1.0` while the package moved ahead. `js-yaml` is a devDependency; `scripts/` is not published, so consumers gain no runtime dependency.

**Continuous validation**

The `lint-js` PR job now runs `npm --workspace @probo/skills run validate`, so conformance is checked on every pull request instead of only at release time.

**Release**

Bumped to `0.3.0` (minor, because the change below is breaking) across `package.json`, the Agent Plugins manifest, and both client manifests.

**Skills and docs**

Skills select a region instead of assuming one `probo` server. In `access-review`, server choice and organization choice are separate preconditions — `listOrganizations` (no required input) picks the server when the region is unknown, and picks the organization on whichever server was chosen. Anything short of a unique match asks the user.

## Breaking change

MCP configuration no longer reads `PROBO_BASE_URL`, and the bundled server names changed from `probo` to `probo-us` / `probo-eu`. Self-hosted users add their instance in the agent with the `claude mcp add` command above.

## Review fixes

Four issues were reported on the first revision. All four reproduced, and each was confirmed against the pre-fix validator to be sure the fix addresses a real hole rather than a hypothetical one.

| Issue | Root cause | Fix |
| --- | --- | --- |
| Lowercase `authorization` in `.mcp.json` published a bearer token (P1) | The parity check tested one spelling, `headers.Authorization`, while HTTP header names are case-insensitive | `.mcp.json` now goes through the same case-insensitive credential screening as the portable file |
| `null` optional fields bypassed type validation | Guards used `!= null`, which treats an explicit `null` as an absent property | Guards distinguish `undefined` from `null`; confirmed the published schemas reject every field this accepted |
| Malformed `SKILL.md` frontmatter passed | The helper read fields with string matching and never parsed YAML | Parse with `js-yaml` and check the field types the spec defines |
| `listAccessReviewCampaigns` used for region discovery | That tool requires `organization_id` (`ListAccessReviewCampaignsInput`, specification.yaml:8710) — the very thing discovery establishes — so the step was not executable | Use `listOrganizations` like the three sibling skills, make organization-before-campaign explicit, and document the tool in the skill reference |

Regression evidence, all 16 cases rejected with the intended message and the unmodified package still passing:

```
### Issue 1 — null optional fields must not bypass type validation
rejected: plugin.json "description": null   -> description must be a string
rejected: plugin.json "author": null        -> author must be an object
rejected: plugin.json "keywords": null      -> keywords must be an array of strings
rejected: plugin.json "extensions": null    -> extensions must be an object keyed by reverse-domain namespace
rejected: plugin.json "author.url": null    -> author.url must be a string
rejected: mcp.json "headers": null          -> headers must be an object of strings

### Issue 2 — malformed frontmatter must not pass
rejected: tab in indentation      -> not valid YAML: tab characters must not be used in indentation (3:1)
rejected: duplicate keys          -> not valid YAML: duplicated mapping key (3:1)
rejected: unbalanced quote        -> not valid YAML: unexpected end of the stream within a double quoted scalar (3:1)
rejected: YAML list, not mapping  -> frontmatter must be a YAML mapping
rejected: non-string description  -> frontmatter must declare a non-empty description
rejected: non-string metadata     -> metadata.version must be a string

### Issue 3 — credential headers in .mcp.json, any capitalization
rejected: "authorization" / "AuThOrIzAtIoN" / "x-api-key" / "Authorization"

### Unmodified package must still pass
@probo/skills validation passed
```

Against the pre-fix validator, 10 of these 11 checks were **accepted**, confirming each reported issue was real.

### Later review rounds

| Issue | Root cause | Fix |
| --- | --- | --- |
| Changelog overstated frontmatter validation (P3) | It claimed length limits for `metadata`, but only `description` and `compatibility` have the Agent Skills caps; `metadata` values are type-checked only | Narrowed the wording to match `scripts/validate.mjs` |
| `listOrganizations` could not disambiguate the region (P3) | `ListOrganizationsOutput` returns every accessible organization (specification.yaml:648), so a caller with organizations in both regions gets a non-empty result from both servers and "keep the one that returns the organization" decides nothing | Select automatically only on a unique match, or when one pair exists overall; otherwise show the servers with their organizations and ask. A non-empty result never settles the region |
| Organization unresolved when the region was known (P3) | A regression from the fix above: the organization rules were nested inside the "region is unknown" branch, and the following step's standalone `listOrganizations` fallback had been removed. A single self-hosted server with several organizations, or a user naming a region but not an organization, reached the campaign step with no `organization_id` | Split into a server step and an organization step so each is settled on its own terms; the organization step calls `listOrganizations` on whichever server was chosen |

Server and organization selection were walked through all four combinations of known/unknown, and each now terminates with a resolved organization before any campaign call:

```
server known   + organization known   -> name match on the settled server
server known   + organization unknown -> listOrganizations on the settled server, then unique match / only org / ask
server unknown + organization known   -> probe each server, unique match settles server, organization already in hand
server unknown + organization unknown -> probe each server, ask which server, then listOrganizations on it / ask
```

## Verification

```
=== 1. Package validation ===
@probo/skills validation passed

=== 2. Official Agent Skills validator (skills-ref) ===
Valid skill: access-review / missing-signatures / open-source-compliance / compliance-portal-commitments

=== 3. Official Agent Plugins 1.0.0 JSON Schemas (ajv) ===
ajv: plugin.json conforms to https://agent-plugins.org/schemas/1.0.0/plugin.schema.json
ajv: mcp.json conforms to https://agent-plugins.org/schemas/1.0.0/mcp.schema.json
spec version match (§10.1): plugin.json=1.0.0 mcp.json=1.0.0 -> true

=== 4. Third-party Agent Plugins 1.0.0 client loading the packed tarball ===
manifest: name=probo version=0.3.0
skills:   access-review, compliance-portal-commitments, missing-signatures, open-source-compliance
mcp:      probo-us -> streamable-http https://us.probo.com/api/mcp/v1
mcp:      probo-eu -> streamable-http https://eu.probo.com/api/mcp/v1
errors=0 warnings=0

=== 5. Live endpoints declared in mcp.json ===
https://us.probo.com/api/mcp/v1   HTTP/2 401 | application/json | www-authenticate: Bearer resource_metadata="https://us.probo.com/.well-known/oauth-protected-resource"
https://eu.probo.com/api/mcp/v1   HTTP/2 401 | application/json | www-authenticate: Bearer resource_metadata="https://eu.probo.com/.well-known/oauth-protected-resource"
https://us.probo.com/mcp/v1       HTTP/2 200 | text/html      | no OAuth challenge   <- the old, broken path

=== 6. Prior negative suite ===
12 of 12 cases rejected
```

Step 3 validates the two new documents against the schemas published at `agent-plugins.org`. Step 4 loads the `npm pack` output with an independent third-party implementation of the spec (`pi-agent-plugins`), which reports zero errors and zero warnings and resolves both servers. Step 5 confirms the endpoints are live MCP endpoints returning the RFC 9728 OAuth challenge, and that the path this PR replaces returns HTML. CI confirms the `Validate @probo/skills` step passes after a clean `npm ci`, which is what exercises the new `js-yaml` devDependency.

## Not done here

- End-to-end OAuth sign-in is not exercised (it needs an interactive browser flow against a real account); it is confirmed only as far as the live `401` OAuth challenge on both regional endpoints.
- Moving the client-specific directories under reverse-domain `extensions` namespaces is intentionally out of scope — the spec requires clients to ignore those sibling files, and the package already passes conformance.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16f85fbe-676b-4e8b-ab68-b67327ee02b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16f85fbe-676b-4e8b-ab68-b67327ee02b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships `@probo/skills` as an Agent Plugins 1.0.0 package with root `plugin.json`/`mcp.json`, declares `probo-us`/`probo-eu` at `/api/mcp/v1`, tightens validation, and releases v0.3.0. Skills now choose a server first, then the organization, using `listOrganizations`; only auto-pick a unique server/organization pair, otherwise ask. Drops `PROBO_BASE_URL` (breaking).

### Package: skills **`+740`** **`-134`**
- Add root `plugin.json`/`mcp.json` with canonical 1.0.0 `$schema`; ship both.
- Declare `probo-us`/`probo-eu` as `streamable-http` at `https://{us,eu}.probo.com/api/mcp/v1`; fix path; remove `PROBO_BASE_URL`; rename `probo` → regional names.
- Validation: closed schemas, plugin-name rules, transport variants, literal HTTPS URLs, case-insensitive credential-header block, reject `null` typed fields, parse YAML frontmatter, skill `name` matches its directory, length limits for `description`/`compatibility`, `.mcp.json` parity with `mcp.json`, and manifest versions match `package.json`.
- Skills/docs: discover region with `listOrganizations`; pick server, then organization; only auto-select a unique match; otherwise prompt. Update references and examples.
- Bump to `0.3.0`; align `.claude-plugin/` and `.codex-plugin/` versions; add `js-yaml` dev dep; update README/COMPATIBILITY/CHANGELOG.

### Agents **`+63`** **`-24`**
- Update docs for the portable package, regional servers and `/api/mcp/v1`, OAuth-only auth, version alignment, login commands (`probo-us`), and running `validate`.

### Other **`+7`** **`-2`**
- CI: run `npm --workspace @probo/skills run validate` on PRs; update lockfile.

<sup>Written for commit 57c43f90fafd97c81bb58e1e01ad0870f281bd35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

