### PR TITLE
Route PDF documents to download tool

### DIFF
--- a/pkg/thirdparty/common_third_party_compliance_docs_agent_test.go
+++ b/pkg/thirdparty/common_third_party_compliance_docs_agent_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package thirdparty
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComplianceDocsPrompt_RoutesPDFsToDownloadTool(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(
+		t,
+		complianceDocsPrompt,
+		"When a document URL points to a PDF, use download_pdf instead of navigate_to_url",
+	)
+}

--- a/pkg/thirdparty/prompts/common_third_party_compliance_docs.txt.tmpl
+++ b/pkg/thirdparty/prompts/common_third_party_compliance_docs.txt.tmpl
@@ -28,11 +28,13 @@ Each field carries a value, a 0.0-1.0 confidence, and the source_url where you f
 
 3. Keep document URLs on the primary <website> host. A vendor may operate several linked domains (for example a product site and a corporate site); when the same document is reachable on more than one of them, choose the one served from the <website> host and verify it loads. Do not mix hosts across fields when one canonical host serves them all.
 
-4. Return the most specific canonical URL. Prefer a direct document/page URL over a generic legal-index page.
+4. When a document URL points to a PDF, use download_pdf instead of navigate_to_url to verify and read it.
 
-5. Never guess or fabricate a URL. If a document is gated, only available on request, or you cannot find it, return an empty string with confidence 0. Several of these (SLA, MSA, BAA) are commonly non-public; leaving them empty is the correct outcome.
+5. Return the most specific canonical URL. Prefer a direct document/page URL over a generic legal-index page.
 
-6. confidence is your own calibrated 0.0-1.0 estimate that the URL is correct and current — it measures how sure you are, not how hard you looked. Aim for it to be well-calibrated: across many vendors, the URLs you tag around 0.9 should turn out correct roughly nine times in ten. Anchor your estimate on the strength of the evidence:
+6. Never guess or fabricate a URL. If a document is gated, only available on request, or you cannot find it, return an empty string with confidence 0. Several of these (SLA, MSA, BAA) are commonly non-public; leaving them empty is the correct outcome.
+
+7. confidence is your own calibrated 0.0-1.0 estimate that the URL is correct and current — it measures how sure you are, not how hard you looked. Aim for it to be well-calibrated: across many vendors, the URLs you tag around 0.9 should turn out correct roughly nine times in ten. Anchor your estimate on the strength of the evidence:
    - 0.9-1.0: a URL you actually reached and that loaded the expected document on the vendor's own domain or hosted trust portal.
    - 0.7-0.9: a URL you found linked from the vendor's own site or trust portal but did not fully open or verify, or one with minor ambiguity about whether it is the current canonical version.
    - 0.4-0.7: a URL from a single third-party source or search result you could not confirm on the vendor's own domain.
@@ -40,7 +42,7 @@ Each field carries a value, a 0.0-1.0 confidence, and the source_url where you f
    - 0: not found, gated, or you cannot verify it at all.
    A downstream step only persists a field when its confidence clears a threshold, so calibrate honestly: do not inflate a value to push it over the bar, and do not deflate a URL you genuinely reached.
 
-7. source_url is the page where you found the link (for certifications, the page you read them from). Leave it empty when nothing was found.
+8. source_url is the page where you found the link (for certifications, the page you read them from). Leave it empty when nothing was found.
 
-8. Do not include commentary; return only the structured fields.
+9. Do not include commentary; return only the structured fields.
 </instructions>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- direct the compliance-document agent to use `download_pdf` for PDF URLs
- preserve browser navigation for HTML pages
- add regression coverage for PDF tool routing

## Testing
- `go test ./pkg/thirdparty ./pkg/agent/tools/browser`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22b757a0-b491-4dd2-99f3-26b74b2b5ac7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22b757a0-b491-4dd2-99f3-26b74b2b5ac7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route PDF URLs to the `download_pdf` tool for the compliance-docs agent, while keeping normal browser navigation for HTML pages. Updates the prompt to make this rule explicit and adds a regression test.

### Tests **`+37`** **`-0`**
- Added a test that asserts the prompt instructs using `download_pdf` instead of `navigate_to_url` for PDF links.

### Service **`+7`** **`-5`**
- Updated the compliance-docs prompt to explicitly route PDFs to `download_pdf`.
- Kept canonical URL guidance and renumbered rules for clarity.

<sup>Written for commit 99568c71c23b696ee3bac279a52e65c8665fc27b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

