### PR TITLE
Add period start and end to risk analyses

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -2228,16 +2228,16 @@
     "messages": { "error": "Error" },
     "errors": { "delete": "Failed to delete risk assessment" },
     "deleteConfirmation": "This will permanently delete this risk assessment and all its diagrams, nodes, processes, and threats. This action cannot be undone.",
-    "actions": { "delete": "Delete" },
+    "actions": { "edit": "Edit", "delete": "Delete" },
     "details": "Details",
-    "fields": { "createdAt": "Created at", "updatedAt": "Updated at" },
+    "fields": { "period": "Period", "createdAt": "Created at", "updatedAt": "Updated at" },
     "diagrams": "Diagrams",
     "emptyDiagrams": "No diagrams yet. Create a diagram to start defining nodes, processes, and threats."
   },
   "riskAnalysesPage": {
     "title": "Risk Analyses",
     "description": "Manage risk analyses with diagrams, nodes, processes, threats, and scenarios.",
-    "columns": { "name": "Name", "description": "Description", "created": "Created" }
+    "columns": { "name": "Name", "description": "Description", "period": "Period", "created": "Created" }
   },
   "riskAnalysisBoundaryActions": {
     "breadcrumb": { "boundaries": "Boundaries" },
@@ -2272,10 +2272,26 @@
   "createRiskAnalysisDialog": {
     "title": "New Risk Analysis",
     "breadcrumb": { "riskAnalyses": "Risk Analyses" },
-    "fields": { "name": "Name", "description": "Description" },
-    "validation": { "nameRequired": "This field is required" },
+    "fields": { "name": "Name", "description": "Description", "periodStart": "Period start", "periodEnd": "Period end" },
+    "validation": {
+      "nameRequired": "This field is required",
+      "periodStartRequired": "This field is required",
+      "periodEndRequired": "This field is required",
+      "periodEndBeforeStart": "Period end must be on or after period start"
+    },
     "placeholders": { "name": "e.g. Platform Threat Model 2026", "description": "Describe the scope and purpose of this assessment..." },
     "actions": { "create": "Create" }
+  },
+  "updateRiskAnalysisDialog": {
+    "title": "Edit Risk Analysis",
+    "breadcrumb": { "riskAnalyses": "Risk Analyses" },
+    "fields": { "name": "Name", "description": "Description", "periodStart": "Period start", "periodEnd": "Period end" },
+    "validation": {
+      "nameRequired": "This field is required",
+      "periodEndBeforeStart": "Period end must be on or after period start"
+    },
+    "placeholders": { "name": "e.g. Platform Threat Model 2026", "description": "Describe the scope and purpose of this assessment..." },
+    "actions": { "save": "Save" }
   },
   "createScenarioInDiagramDialog": {
     "breadcrumb": { "scenarios": "Scenarios", "addScenario": "Add Scenario" },

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -4735,10 +4735,12 @@
     },
     "deleteConfirmation": "Cette action supprimera définitivement cette analyse des risques ainsi que tous ses diagrammes, nœuds, processus et menaces. Cette action est irréversible.",
     "actions": {
+      "edit": "Modifier",
       "delete": "Supprimer"
     },
     "details": "Détails",
     "fields": {
+      "period": "Période",
       "createdAt": "Créé le",
       "updatedAt": "Mis à jour le"
     },
@@ -4751,6 +4753,7 @@
     "columns": {
       "name": "Nom",
       "description": "Description",
+      "period": "Période",
       "created": "Créé le"
     }
   },
@@ -4842,10 +4845,15 @@
     },
     "fields": {
       "name": "Nom",
-      "description": "Description"
+      "description": "Description",
+      "periodStart": "Début de période",
+      "periodEnd": "Fin de période"
     },
     "validation": {
-      "nameRequired": "Ce champ est requis"
+      "nameRequired": "Ce champ est requis",
+      "periodStartRequired": "Ce champ est requis",
+      "periodEndRequired": "Ce champ est requis",
+      "periodEndBeforeStart": "La fin de période doit être égale ou postérieure au début"
     },
     "placeholders": {
       "name": "ex. Modèle de menace de la plateforme 2026",
@@ -4853,6 +4861,29 @@
     },
     "actions": {
       "create": "Créer"
+    }
+  },
+  "updateRiskAnalysisDialog": {
+    "title": "Modifier l’analyse des risques",
+    "breadcrumb": {
+      "riskAnalyses": "Analyses des risques"
+    },
+    "fields": {
+      "name": "Nom",
+      "description": "Description",
+      "periodStart": "Début de période",
+      "periodEnd": "Fin de période"
+    },
+    "validation": {
+      "nameRequired": "Ce champ est requis",
+      "periodEndBeforeStart": "La fin de période doit être égale ou postérieure au début"
+    },
+    "placeholders": {
+      "name": "ex. Modèle de menace de la plateforme 2026",
+      "description": "Décrivez la portée et l’objectif de cette analyse..."
+    },
+    "actions": {
+      "save": "Enregistrer"
     }
   },
   "createScenarioInDiagramDialog": {

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -4731,10 +4731,12 @@
     },
     "deleteConfirmation": "Hiermee worden deze risicobeoordeling en alle bijbehorende diagrammen, nodes, processen en dreigingen permanent verwijderd. Deze actie kan niet ongedaan worden gemaakt.",
     "actions": {
+      "edit": "Bewerken",
       "delete": "Verwijderen"
     },
     "details": "Details",
     "fields": {
+      "period": "Periode",
       "createdAt": "Aangemaakt op",
       "updatedAt": "Bijgewerkt op"
     },
@@ -4747,6 +4749,7 @@
     "columns": {
       "name": "Naam",
       "description": "Beschrijving",
+      "period": "Periode",
       "created": "Aangemaakt"
     }
   },
@@ -4838,10 +4841,15 @@
     },
     "fields": {
       "name": "Naam",
-      "description": "Beschrijving"
+      "description": "Beschrijving",
+      "periodStart": "Periode start",
+      "periodEnd": "Periode eind"
     },
     "validation": {
-      "nameRequired": "Dit veld is verplicht"
+      "nameRequired": "Dit veld is verplicht",
+      "periodStartRequired": "Dit veld is verplicht",
+      "periodEndRequired": "Dit veld is verplicht",
+      "periodEndBeforeStart": "Periode eind moet op of na periode start liggen"
     },
     "placeholders": {
       "name": "bijv. Platform Dreigingsmodel 2026",
@@ -4849,6 +4857,29 @@
     },
     "actions": {
       "create": "Aanmaken"
+    }
+  },
+  "updateRiskAnalysisDialog": {
+    "title": "Risicobeoordeling bewerken",
+    "breadcrumb": {
+      "riskAnalyses": "Risicobeoordelingen"
+    },
+    "fields": {
+      "name": "Naam",
+      "description": "Beschrijving",
+      "periodStart": "Periode start",
+      "periodEnd": "Periode eind"
+    },
+    "validation": {
+      "nameRequired": "Dit veld is verplicht",
+      "periodEndBeforeStart": "Periode eind moet op of na periode start liggen"
+    },
+    "placeholders": {
+      "name": "bijv. Platform Dreigingsmodel 2026",
+      "description": "Beschrijf de reikwijdte en het doel van deze beoordeling..."
+    },
+    "actions": {
+      "save": "Opslaan"
     }
   },
   "createScenarioInDiagramDialog": {

--- a/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysesPage.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysesPage.tsx
@@ -86,6 +86,10 @@ const riskAnalysesFragment = graphql`
           id
           name
           description
+          period {
+            start
+            end
+          }
           createdAt
         }
       }
@@ -148,6 +152,7 @@ export default function RiskAnalysesPage({ queryRef }: RiskAnalysesPageProps) {
           <Tr>
             <SortableTh field="NAME">{t("riskAnalysesPage.columns.name")}</SortableTh>
             <Th>{t("riskAnalysesPage.columns.description")}</Th>
+            <Th>{t("riskAnalysesPage.columns.period")}</Th>
             <SortableTh field="CREATED_AT">{t("riskAnalysesPage.columns.created")}</SortableTh>
           </Tr>
         </Thead>
@@ -160,6 +165,11 @@ export default function RiskAnalysesPage({ queryRef }: RiskAnalysesPageProps) {
               <Td className="font-medium">{ra.name}</Td>
               <Td className="text-txt-secondary truncate max-w-xs">
                 {ra.description || "—"}
+              </Td>
+              <Td className="text-txt-secondary">
+                {ra.period
+                  ? `${ra.period.start ? dateFormat(i18n.language, ra.period.start) : "—"} – ${ra.period.end ? dateFormat(i18n.language, ra.period.end) : "—"}`
+                  : "—"}
               </Td>
               <Td className="text-txt-secondary">
                 {dateFormat(i18n.language, ra.createdAt)}

--- a/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysisDetailPage.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysisDetailPage.tsx
@@ -47,6 +47,7 @@ import { useOrganizationId } from "#/hooks/useOrganizationId";
 
 import { CreateDiagramDialog } from "./_components/CreateDiagramDialog";
 import { DiagramCard } from "./_components/DiagramCard";
+import { UpdateRiskAnalysisDialog } from "./_components/UpdateRiskAnalysisDialog";
 
 export const riskAnalysisDetailPageQuery = graphql`
   query RiskAnalysisDetailPageQuery($riskAnalysisId: ID!) {
@@ -55,8 +56,13 @@ export const riskAnalysisDetailPageQuery = graphql`
         id
         name
         description
+        period {
+          start
+          end
+        }
         createdAt
         updatedAt
+        canUpdate: permission(action: "core:risk-analysis:update")
         canDelete: permission(action: "core:risk-analysis:delete")
         diagrams(first: 50)
           @connection(key: "RiskAnalysisDetailPage_diagrams", filters: []) {
@@ -114,6 +120,9 @@ export default function RiskAnalysisDetailPage({ queryRef }: RiskAnalysisDetailP
     RiskAnalysesConnectionKey,
   );
   const listUrl = `/organizations/${organizationId}/risk-analyses`;
+  const periodLabel = ra.period
+    ? `${ra.period.start ? dateFormat(i18n.language, ra.period.start) : "—"} – ${ra.period.end ? dateFormat(i18n.language, ra.period.end) : "—"}`
+    : "—";
 
   const handleDelete = () => {
     confirm(
@@ -163,17 +172,32 @@ export default function RiskAnalysisDetailPage({ queryRef }: RiskAnalysisDetailP
       <PageHeader
         title={ra.name}
       >
-        {ra.canDelete && (
-          <ActionDropdown variant="secondary">
-            <DropdownItem
-              variant="danger"
-              icon={IconTrashCan}
-              onClick={handleDelete}
-            >
-              {t("riskAnalysisDetailPage.actions.delete")}
-            </DropdownItem>
-          </ActionDropdown>
-        )}
+        {ra.canUpdate
+          ? (
+              <UpdateRiskAnalysisDialog
+                riskAnalysis={{
+                  id: raId,
+                  name: ra.name ?? "",
+                  description: ra.description,
+                  period: ra.period,
+                }}
+                canDelete={ra.canDelete}
+                onDelete={handleDelete}
+              />
+            )
+          : ra.canDelete
+            ? (
+                <ActionDropdown variant="secondary">
+                  <DropdownItem
+                    variant="danger"
+                    icon={IconTrashCan}
+                    onClick={handleDelete}
+                  >
+                    {t("riskAnalysisDetailPage.actions.delete")}
+                  </DropdownItem>
+                </ActionDropdown>
+              )
+            : null}
       </PageHeader>
 
       <div className="space-y-4">
@@ -183,6 +207,14 @@ export default function RiskAnalysisDetailPage({ queryRef }: RiskAnalysisDetailP
             <div className="text-sm text-txt-secondary">{ra.description}</div>
           )}
           <div className="grid grid-cols-3 gap-4">
+            <div>
+              <div className="text-xs text-txt-tertiary font-semibold mb-1">
+                {t("riskAnalysisDetailPage.fields.period")}
+              </div>
+              <div className="text-sm text-txt-primary">
+                {periodLabel}
+              </div>
+            </div>
             <div>
               <div className="text-xs text-txt-tertiary font-semibold mb-1">
                 {t("riskAnalysisDetailPage.fields.createdAt")}

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_components/CreateRiskAnalysisDialog.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_components/CreateRiskAnalysisDialog.tsx
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import { formatDatetime } from "@probo/helpers";
 import {
   Breadcrumb,
   Button,
@@ -26,6 +27,7 @@ import {
   DialogFooter,
   Field,
   IconPlusLarge,
+  Input,
   useDialogRef,
 } from "@probo/ui";
 import { useForm } from "react-hook-form";
@@ -46,12 +48,23 @@ const createMutation = graphql`
           id
           name
           description
+          period {
+            start
+            end
+          }
           createdAt
         }
       }
     }
   }
 `;
+
+type FormData = {
+  name: string;
+  description: string;
+  periodStart: string;
+  periodEnd: string;
+};
 
 export function CreateRiskAnalysisDialog(props: {
   connectionId: string;
@@ -60,17 +73,32 @@ export function CreateRiskAnalysisDialog(props: {
   const organizationId = useOrganizationId();
   const dialogRef = useDialogRef();
   const [createRiskAnalysis, isCreating] = useMutation<CreateRiskAnalysisDialogCreateMutation>(createMutation);
-  const { register, handleSubmit, reset, formState } = useForm({
-    defaultValues: { name: "", description: "" },
+  const { register, handleSubmit, reset, formState } = useForm<FormData>({
+    defaultValues: {
+      name: "",
+      description: "",
+      periodStart: "",
+      periodEnd: "",
+    },
   });
 
-  const onSubmit = (data: { name: string; description: string }) => {
+  const onSubmit = (data: FormData) => {
+    const periodStart = formatDatetime(data.periodStart);
+    const periodEnd = formatDatetime(data.periodEnd);
+    const period = periodStart || periodEnd
+      ? {
+          start: periodStart ?? null,
+          end: periodEnd ?? null,
+        }
+      : null;
+
     createRiskAnalysis({
       variables: {
         input: {
           organizationId,
           name: data.name,
           description: data.description || null,
+          period,
         },
         connections: [props.connectionId],
       },
@@ -112,6 +140,27 @@ export function CreateRiskAnalysisDialog(props: {
             rows={3}
             placeholder={t("createRiskAnalysisDialog.placeholders.description")}
           />
+          <Field
+            label={t("createRiskAnalysisDialog.fields.periodStart")}
+            error={formState.errors.periodStart?.message}
+          >
+            <Input {...register("periodStart")} type="date" />
+          </Field>
+          <Field
+            label={t("createRiskAnalysisDialog.fields.periodEnd")}
+            error={formState.errors.periodEnd?.message}
+          >
+            <Input
+              {...register("periodEnd", {
+                validate: (value, formValues) =>
+                  !value
+                  || !formValues.periodStart
+                  || value >= formValues.periodStart
+                  || t("createRiskAnalysisDialog.validation.periodEndBeforeStart"),
+              })}
+              type="date"
+            />
+          </Field>
         </DialogContent>
         <DialogFooter>
           <Button type="submit" disabled={isCreating}>

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_components/UpdateRiskAnalysisDialog.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_components/UpdateRiskAnalysisDialog.tsx
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { formatDatetime, toDateInput } from "@probo/helpers";
+import {
+  ActionDropdown,
+  Breadcrumb,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DropdownItem,
+  Field,
+  IconPencil,
+  IconTrashCan,
+  Input,
+  useDialogRef,
+} from "@probo/ui";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { graphql, useMutation } from "react-relay";
+
+import type { UpdateRiskAnalysisDialogMutation } from "#/__generated__/core/UpdateRiskAnalysisDialogMutation.graphql";
+
+const updateMutation = graphql`
+  mutation UpdateRiskAnalysisDialogMutation(
+    $input: UpdateRiskAnalysisInput!
+  ) {
+    updateRiskAnalysis(input: $input) {
+      riskAnalysis {
+        id
+        name
+        description
+        period {
+          start
+          end
+        }
+        updatedAt
+      }
+    }
+  }
+`;
+
+type FormData = {
+  name: string;
+  description: string;
+  periodStart: string;
+  periodEnd: string;
+};
+
+export function UpdateRiskAnalysisDialog(props: {
+  riskAnalysis: {
+    id: string;
+    name: string;
+    description: string | null | undefined;
+    period: {
+      start: string | null | undefined;
+      end: string | null | undefined;
+    } | null | undefined;
+  };
+  canDelete?: boolean;
+  onDelete?: () => void;
+}) {
+  const { t } = useTranslation();
+  const dialogRef = useDialogRef();
+  const [updateRiskAnalysis, isUpdating] = useMutation<UpdateRiskAnalysisDialogMutation>(updateMutation);
+  const { register, handleSubmit, formState } = useForm<FormData>({
+    values: {
+      name: props.riskAnalysis.name,
+      description: props.riskAnalysis.description ?? "",
+      periodStart: toDateInput(props.riskAnalysis.period?.start),
+      periodEnd: toDateInput(props.riskAnalysis.period?.end),
+    },
+  });
+
+  const onSubmit = (data: FormData) => {
+    updateRiskAnalysis({
+      variables: {
+        input: {
+          id: props.riskAnalysis.id,
+          name: data.name,
+          description: data.description || null,
+          period: {
+            start: formatDatetime(data.periodStart) ?? null,
+            end: formatDatetime(data.periodEnd) ?? null,
+          },
+        },
+      },
+      onCompleted: () => {
+        dialogRef.current?.close();
+      },
+    });
+  };
+
+  return (
+    <>
+      <ActionDropdown variant="secondary">
+        <DropdownItem
+          icon={IconPencil}
+          onSelect={() => dialogRef.current?.open()}
+        >
+          {t("riskAnalysisDetailPage.actions.edit")}
+        </DropdownItem>
+        {props.canDelete && props.onDelete && (
+          <DropdownItem
+            variant="danger"
+            icon={IconTrashCan}
+            onClick={props.onDelete}
+          >
+            {t("riskAnalysisDetailPage.actions.delete")}
+          </DropdownItem>
+        )}
+      </ActionDropdown>
+      <Dialog
+        className="max-w-lg"
+        ref={dialogRef}
+        title={(
+          <Breadcrumb
+            items={[
+              t("updateRiskAnalysisDialog.breadcrumb.riskAnalyses"),
+              t("updateRiskAnalysisDialog.title"),
+            ]}
+          />
+        )}
+      >
+        <form onSubmit={e => void handleSubmit(onSubmit)(e)}>
+          <DialogContent padded className="space-y-4">
+            <Field
+              label={t("updateRiskAnalysisDialog.fields.name")}
+              {...register("name", { required: t("updateRiskAnalysisDialog.validation.nameRequired") })}
+              type="text"
+              error={formState.errors.name?.message}
+              placeholder={t("updateRiskAnalysisDialog.placeholders.name")}
+            />
+            <Field
+              label={t("updateRiskAnalysisDialog.fields.description")}
+              {...register("description")}
+              type="textarea"
+              rows={3}
+              placeholder={t("updateRiskAnalysisDialog.placeholders.description")}
+            />
+            <Field
+              label={t("updateRiskAnalysisDialog.fields.periodStart")}
+              error={formState.errors.periodStart?.message}
+            >
+              <Input {...register("periodStart")} type="date" />
+            </Field>
+            <Field
+              label={t("updateRiskAnalysisDialog.fields.periodEnd")}
+              error={formState.errors.periodEnd?.message}
+            >
+              <Input
+                {...register("periodEnd", {
+                  validate: (value, formValues) =>
+                    !value
+                    || !formValues.periodStart
+                    || value >= formValues.periodStart
+                    || t("updateRiskAnalysisDialog.validation.periodEndBeforeStart"),
+                })}
+                type="date"
+              />
+            </Field>
+          </DialogContent>
+          <DialogFooter>
+            <Button type="submit" disabled={isUpdating}>
+              {t("updateRiskAnalysisDialog.actions.save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/n8n-node/nodes/Probo/actions/riskAnalysis/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/riskAnalysis/create.operation.ts
@@ -70,6 +70,20 @@ export const description: INodeProperties[] = [
 				default: '',
 				description: 'The description of the risk analysis',
 			},
+			{
+				displayName: 'Period Start',
+				name: 'periodStart',
+				type: 'dateTime',
+				default: '',
+				description: 'Start of the analysis period',
+			},
+			{
+				displayName: 'Period End',
+				name: 'periodEnd',
+				type: 'dateTime',
+				default: '',
+				description: 'End of the analysis period',
+			},
 		],
 	},
 ];
@@ -82,6 +96,8 @@ export async function execute(
 	const name = this.getNodeParameter('name', itemIndex) as string;
 	const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as {
 		description?: string;
+		periodStart?: string;
+		periodEnd?: string;
 	};
 
 	const query = `
@@ -92,6 +108,10 @@ export async function execute(
 						id
 						name
 						description
+						period {
+							start
+							end
+						}
 						createdAt
 						updatedAt
 					}
@@ -105,6 +125,12 @@ export async function execute(
 		name,
 	};
 	if (additionalFields.description) input.description = additionalFields.description;
+	if (additionalFields.periodStart || additionalFields.periodEnd) {
+		input.period = {
+			...(additionalFields.periodStart ? { start: additionalFields.periodStart } : {}),
+			...(additionalFields.periodEnd ? { end: additionalFields.periodEnd } : {}),
+		};
+	}
 
 	const responseData = await proboApiRequest.call(this, query, { input });
 

--- a/packages/n8n-node/nodes/Probo/actions/riskAnalysis/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/riskAnalysis/getAll.operation.ts
@@ -86,6 +86,10 @@ export async function execute(
 								id
 								name
 								description
+								period {
+									start
+									end
+								}
 								createdAt
 								updatedAt
 							}

--- a/packages/n8n-node/nodes/Probo/actions/riskAnalysis/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/riskAnalysis/update.operation.ts
@@ -63,6 +63,20 @@ export const description: INodeProperties[] = [
 				default: '',
 				description: 'The name of the risk analysis',
 			},
+			{
+				displayName: 'Period Start',
+				name: 'periodStart',
+				type: 'dateTime',
+				default: '',
+				description: 'Start of the analysis period',
+			},
+			{
+				displayName: 'Period End',
+				name: 'periodEnd',
+				type: 'dateTime',
+				default: '',
+				description: 'End of the analysis period',
+			},
 		],
 	},
 ];
@@ -75,6 +89,8 @@ export async function execute(
 	const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as {
 		name?: string;
 		description?: string;
+		periodStart?: string;
+		periodEnd?: string;
 	};
 
 	const query = `
@@ -84,6 +100,10 @@ export async function execute(
 					id
 					name
 					description
+					period {
+						start
+						end
+					}
 					createdAt
 					updatedAt
 				}
@@ -94,6 +114,12 @@ export async function execute(
 	const input: Record<string, unknown> = { id: riskAnalysisId };
 	if (additionalFields.name) input.name = additionalFields.name;
 	if (additionalFields.description !== undefined) input.description = additionalFields.description === '' ? null : additionalFields.description;
+	if (additionalFields.periodStart || additionalFields.periodEnd) {
+		input.period = {
+			...(additionalFields.periodStart ? { start: additionalFields.periodStart } : {}),
+			...(additionalFields.periodEnd ? { end: additionalFields.periodEnd } : {}),
+		};
+	}
 
 	if (Object.keys(input).length === 1) {
 		throw new Error('At least one field must be provided to update');

--- a/pkg/cmd/risk-analysis/create/create.go
+++ b/pkg/cmd/risk-analysis/create/create.go
@@ -38,6 +38,10 @@ mutation($input: CreateRiskAnalysisInput!) {
         id
         name
         description
+        period {
+          start
+          end
+        }
         createdAt
         updatedAt
       }
@@ -53,8 +57,12 @@ type createResponse struct {
 				ID          string  `json:"id"`
 				Name        string  `json:"name"`
 				Description *string `json:"description"`
-				CreatedAt   string  `json:"createdAt"`
-				UpdatedAt   string  `json:"updatedAt"`
+				Period      *struct {
+					Start *string `json:"start"`
+					End   *string `json:"end"`
+				} `json:"period"`
+				CreatedAt string `json:"createdAt"`
+				UpdatedAt string `json:"updatedAt"`
 			} `json:"node"`
 		} `json:"riskAnalysisEdge"`
 	} `json:"createRiskAnalysis"`
@@ -65,6 +73,8 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 		flagOrg         string
 		flagName        string
 		flagDescription string
+		flagPeriodStart string
+		flagPeriodEnd   string
 	)
 
 	cmd := &cobra.Command{
@@ -74,7 +84,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
   prb risk-analysis create
 
   # Create a risk analysis non-interactively
-  prb risk-analysis create --name "Annual Risk Analysis" --description "2026 annual review"`,
+  prb risk-analysis create --name "Annual Risk Analysis" --period-start 2026-01-01 --period-end 2026-12-31`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := f.Config()
 			if err != nil {
@@ -127,6 +137,19 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				input["description"] = flagDescription
 			}
 
+			if flagPeriodStart != "" || flagPeriodEnd != "" {
+				period := map[string]any{}
+				if flagPeriodStart != "" {
+					period["start"] = flagPeriodStart
+				}
+
+				if flagPeriodEnd != "" {
+					period["end"] = flagPeriodEnd
+				}
+
+				input["period"] = period
+			}
+
 			data, err := client.Do(
 				createMutation,
 				map[string]any{"input": input},
@@ -155,6 +178,8 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
 	cmd.Flags().StringVar(&flagName, "name", "", "Risk analysis name (required)")
 	cmd.Flags().StringVar(&flagDescription, "description", "", "Risk analysis description")
+	cmd.Flags().StringVar(&flagPeriodStart, "period-start", "", "Period start date (e.g. 2026-01-01)")
+	cmd.Flags().StringVar(&flagPeriodEnd, "period-end", "", "Period end date (e.g. 2026-12-31)")
 
 	return cmd
 }

--- a/pkg/cmd/risk-analysis/list/list.go
+++ b/pkg/cmd/risk-analysis/list/list.go
@@ -41,6 +41,10 @@ query($id: ID!, $first: Int, $after: CursorKey, $orderBy: RiskAnalysisOrder) {
             id
             name
             description
+            period {
+              start
+              end
+            }
             createdAt
             updatedAt
           }
@@ -59,8 +63,12 @@ type riskAnalysis struct {
 	ID          string  `json:"id"`
 	Name        string  `json:"name"`
 	Description *string `json:"description"`
-	CreatedAt   string  `json:"createdAt"`
-	UpdatedAt   string  `json:"updatedAt"`
+	Period      *struct {
+		Start *string `json:"start"`
+		End   *string `json:"end"`
+	} `json:"period"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
 }
 
 func NewCmdList(f *cmdutil.Factory) *cobra.Command {
@@ -175,15 +183,30 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 					desc = *r.Description
 				}
 
+				periodStart := ""
+				periodEnd := ""
+
+				if r.Period != nil {
+					if r.Period.Start != nil {
+						periodStart = cmdutil.FormatTime(*r.Period.Start)
+					}
+
+					if r.Period.End != nil {
+						periodEnd = cmdutil.FormatTime(*r.Period.End)
+					}
+				}
+
 				rows = append(rows, []string{
 					r.ID,
 					r.Name,
 					desc,
+					periodStart,
+					periodEnd,
 					cmdutil.FormatTime(r.CreatedAt),
 				})
 			}
 
-			t := cmdutil.NewTable("ID", "NAME", "DESCRIPTION", "CREATED AT").Rows(rows...)
+			t := cmdutil.NewTable("ID", "NAME", "DESCRIPTION", "PERIOD START", "PERIOD END", "CREATED AT").Rows(rows...)
 
 			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
 

--- a/pkg/cmd/risk-analysis/update/update.go
+++ b/pkg/cmd/risk-analysis/update/update.go
@@ -36,6 +36,10 @@ mutation($input: UpdateRiskAnalysisInput!) {
       id
       name
       description
+      period {
+        start
+        end
+      }
       createdAt
       updatedAt
     }
@@ -49,8 +53,12 @@ type updateResponse struct {
 			ID          string  `json:"id"`
 			Name        string  `json:"name"`
 			Description *string `json:"description"`
-			CreatedAt   string  `json:"createdAt"`
-			UpdatedAt   string  `json:"updatedAt"`
+			Period      *struct {
+				Start *string `json:"start"`
+				End   *string `json:"end"`
+			} `json:"period"`
+			CreatedAt string `json:"createdAt"`
+			UpdatedAt string `json:"updatedAt"`
 		} `json:"riskAnalysis"`
 	} `json:"updateRiskAnalysis"`
 }
@@ -59,6 +67,8 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	var (
 		flagName        string
 		flagDescription string
+		flagPeriodStart string
+		flagPeriodEnd   string
 	)
 
 	cmd := &cobra.Command{
@@ -96,6 +106,19 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				input["description"] = flagDescription
 			}
 
+			if cmd.Flags().Changed("period-start") || cmd.Flags().Changed("period-end") {
+				period := map[string]any{}
+				if cmd.Flags().Changed("period-start") {
+					period["start"] = flagPeriodStart
+				}
+
+				if cmd.Flags().Changed("period-end") {
+					period["end"] = flagPeriodEnd
+				}
+
+				input["period"] = period
+			}
+
 			if len(input) == 1 {
 				return fmt.Errorf("at least one field must be specified for update")
 			}
@@ -127,6 +150,8 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVar(&flagName, "name", "", "Risk analysis name")
 	cmd.Flags().StringVar(&flagDescription, "description", "", "Risk analysis description")
+	cmd.Flags().StringVar(&flagPeriodStart, "period-start", "", "Period start date (e.g. 2026-01-01)")
+	cmd.Flags().StringVar(&flagPeriodEnd, "period-end", "", "Period end date (e.g. 2026-12-31)")
 
 	return cmd
 }

--- a/pkg/cmd/risk-analysis/view/view.go
+++ b/pkg/cmd/risk-analysis/view/view.go
@@ -38,6 +38,10 @@ query($id: ID!) {
       id
       name
       description
+      period {
+        start
+        end
+      }
       createdAt
       updatedAt
     }
@@ -51,8 +55,12 @@ type viewResponse struct {
 		ID          string  `json:"id"`
 		Name        string  `json:"name"`
 		Description *string `json:"description"`
-		CreatedAt   string  `json:"createdAt"`
-		UpdatedAt   string  `json:"updatedAt"`
+		Period      *struct {
+			Start *string `json:"start"`
+			End   *string `json:"end"`
+		} `json:"period"`
+		CreatedAt string `json:"createdAt"`
+		UpdatedAt string `json:"updatedAt"`
 	} `json:"node"`
 }
 
@@ -123,6 +131,16 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 
 			if r.Description != nil && *r.Description != "" {
 				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Description:"), *r.Description)
+			}
+
+			if r.Period != nil {
+				if r.Period.Start != nil {
+					_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Period start:"), cmdutil.FormatTime(*r.Period.Start))
+				}
+
+				if r.Period.End != nil {
+					_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Period end:"), cmdutil.FormatTime(*r.Period.End))
+				}
 			}
 
 			_, _ = fmt.Fprintln(out)

--- a/pkg/coredata/migrations/20260810T125506Z.sql
+++ b/pkg/coredata/migrations/20260810T125506Z.sql
@@ -1,0 +1,23 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TABLE risk_analyses
+    ADD COLUMN period_start DATE,
+    ADD COLUMN period_end DATE;

--- a/pkg/coredata/risk_analysis.go
+++ b/pkg/coredata/risk_analysis.go
@@ -36,12 +36,14 @@ import (
 
 type (
 	RiskAnalysis struct {
-		ID             gid.GID   `db:"id"`
-		OrganizationID gid.GID   `db:"organization_id"`
-		Name           string    `db:"name"`
-		Description    *string   `db:"description"`
-		CreatedAt      time.Time `db:"created_at"`
-		UpdatedAt      time.Time `db:"updated_at"`
+		ID             gid.GID    `db:"id"`
+		OrganizationID gid.GID    `db:"organization_id"`
+		Name           string     `db:"name"`
+		Description    *string    `db:"description"`
+		PeriodStart    *time.Time `db:"period_start"`
+		PeriodEnd      *time.Time `db:"period_end"`
+		CreatedAt      time.Time  `db:"created_at"`
+		UpdatedAt      time.Time  `db:"updated_at"`
 	}
 
 	RiskAnalyses []*RiskAnalysis
@@ -130,7 +132,15 @@ func (ra *RiskAnalyses) LoadByOrganizationID(
 	cursor *page.Cursor[RiskAnalysisOrderField],
 ) error {
 	q := `
-SELECT id, organization_id, name, description, created_at, updated_at
+SELECT
+	id,
+	organization_id,
+	name,
+	description,
+	period_start,
+	period_end,
+	created_at,
+	updated_at
 FROM risk_analyses
 WHERE %s
 	AND organization_id = @organization_id
@@ -169,6 +179,8 @@ SELECT
 	organization_id,
 	name,
 	description,
+	period_start,
+	period_end,
 	created_at,
 	updated_at
 FROM risk_analyses
@@ -206,8 +218,28 @@ func (ra *RiskAnalysis) Insert(
 	scope Scoper,
 ) error {
 	q := `
-INSERT INTO risk_analyses (id, tenant_id, organization_id, name, description, created_at, updated_at)
-VALUES (@id, @tenant_id, @organization_id, @name, @description, @created_at, @updated_at)
+INSERT INTO risk_analyses (
+	id,
+	tenant_id,
+	organization_id,
+	name,
+	description,
+	period_start,
+	period_end,
+	created_at,
+	updated_at
+)
+VALUES (
+	@id,
+	@tenant_id,
+	@organization_id,
+	@name,
+	@description,
+	@period_start,
+	@period_end,
+	@created_at,
+	@updated_at
+)
 `
 
 	args := pgx.StrictNamedArgs{
@@ -216,6 +248,8 @@ VALUES (@id, @tenant_id, @organization_id, @name, @description, @created_at, @up
 		"organization_id": ra.OrganizationID,
 		"name":            ra.Name,
 		"description":     ra.Description,
+		"period_start":    ra.PeriodStart,
+		"period_end":      ra.PeriodEnd,
 		"created_at":      ra.CreatedAt,
 		"updated_at":      ra.UpdatedAt,
 	}
@@ -238,6 +272,8 @@ UPDATE risk_analyses
 SET
 	name = @name,
 	description = @description,
+	period_start = @period_start,
+	period_end = @period_end,
 	updated_at = @updated_at
 WHERE %s
 	AND id = @id
@@ -245,10 +281,12 @@ WHERE %s
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
-		"id":          ra.ID,
-		"name":        ra.Name,
-		"description": ra.Description,
-		"updated_at":  ra.UpdatedAt,
+		"id":           ra.ID,
+		"name":         ra.Name,
+		"description":  ra.Description,
+		"period_start": ra.PeriodStart,
+		"period_end":   ra.PeriodEnd,
+		"updated_at":   ra.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())
 

--- a/pkg/riskmanagement/service.go
+++ b/pkg/riskmanagement/service.go
@@ -46,16 +46,23 @@ func NewService(pgClient *pg.Client) *Service {
 }
 
 type (
+	Period struct {
+		Start *time.Time
+		End   *time.Time
+	}
+
 	CreateRiskAnalysisRequest struct {
 		OrganizationID gid.GID
 		Name           string
 		Description    *string
+		Period         *Period
 	}
 
 	UpdateRiskAnalysisRequest struct {
 		ID          gid.GID
 		Name        *string
 		Description **string
+		Period      *Period
 	}
 
 	CreateRiskAnalysisDiagramRequest struct {
@@ -161,6 +168,10 @@ func (r *CreateRiskAnalysisRequest) Validate() error {
 	v.Check(r.Name, "name", validator.Required(), validator.SafeTextNoNewLine(TitleMaxLength))
 	v.Check(r.Description, "description", validator.SafeText(ContentMaxLength))
 
+	if r.Period != nil {
+		validatePeriodRange(v, r.Period.Start, r.Period.End)
+	}
+
 	return v.Error()
 }
 
@@ -170,7 +181,30 @@ func (r *UpdateRiskAnalysisRequest) Validate() error {
 	v.Check(r.Name, "name", validator.SafeTextNoNewLine(TitleMaxLength))
 	v.Check(r.Description, "description", validator.SafeText(ContentMaxLength))
 
+	if r.Period != nil {
+		validatePeriodRange(v, r.Period.Start, r.Period.End)
+	}
+
 	return v.Error()
+}
+
+func validatePeriodRange(v *validator.Validator, periodStart, periodEnd *time.Time) {
+	if periodStart == nil || periodEnd == nil {
+		return
+	}
+
+	if periodEnd.Before(*periodStart) {
+		v.Check(
+			periodEnd,
+			"period_end",
+			func(any) *validator.ValidationError {
+				return &validator.ValidationError{
+					Code:    validator.ErrorCodeOutOfRange,
+					Message: fmt.Sprintf("must be on or after %s", periodStart.Format(time.DateOnly)),
+				}
+			},
+		)
+	}
 }
 
 func (r *CreateRiskAnalysisDiagramRequest) Validate() error {
@@ -344,6 +378,11 @@ func (s *Service) Create(ctx context.Context, scope coredata.Scoper, req CreateR
 		UpdatedAt:      now,
 	}
 
+	if req.Period != nil {
+		ra.PeriodStart = req.Period.Start
+		ra.PeriodEnd = req.Period.End
+	}
+
 	err := s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
@@ -401,6 +440,18 @@ func (s *Service) Update(ctx context.Context, scope coredata.Scoper, req UpdateR
 
 			if req.Description != nil {
 				ra.Description = *req.Description
+			}
+
+			if req.Period != nil {
+				ra.PeriodStart = req.Period.Start
+				ra.PeriodEnd = req.Period.End
+			}
+
+			v := validator.New()
+			validatePeriodRange(v, ra.PeriodStart, ra.PeriodEnd)
+
+			if err := v.Error(); err != nil {
+				return fmt.Errorf("invalid request: %w", err)
 			}
 
 			ra.UpdatedAt = time.Now()

--- a/pkg/server/api/console/v1/graphql/base.graphql
+++ b/pkg/server/api/console/v1/graphql/base.graphql
@@ -18,6 +18,16 @@ scalar Duration
 scalar BigInt
 scalar EmailAddr
 
+type Period {
+    start: Datetime
+    end: Datetime
+}
+
+input PeriodInput {
+    start: Datetime
+    end: Datetime
+}
+
 interface Node {
     id: ID!
 }

--- a/pkg/server/api/console/v1/graphql/risk_analysis.graphql
+++ b/pkg/server/api/console/v1/graphql/risk_analysis.graphql
@@ -200,6 +200,7 @@ type RiskAnalysis implements Node {
     id: ID!
     name: String!
     description: String
+    period: Period
     organization: Organization @goField(forceResolver: true)
 
     diagrams(
@@ -526,12 +527,14 @@ input CreateRiskAnalysisInput {
     organizationId: ID!
     name: String!
     description: String
+    period: PeriodInput
 }
 
 input UpdateRiskAnalysisInput {
     id: ID!
     name: String
     description: String @goField(omittable: true)
+    period: PeriodInput
 }
 
 input DeleteRiskAnalysisInput {

--- a/pkg/server/api/console/v1/risk_analysis_resolvers.go
+++ b/pkg/server/api/console/v1/risk_analysis_resolvers.go
@@ -29,6 +29,14 @@ func (r *mutationResolver) CreateRiskAnalysis(ctx context.Context, input types.C
 		return nil, err
 	}
 
+	var period *riskmanagement.Period
+	if input.Period != nil {
+		period = &riskmanagement.Period{
+			Start: input.Period.Start,
+			End:   input.Period.End,
+		}
+	}
+
 	ra, err := r.riskManagement.Create(
 		ctx,
 		scope,
@@ -36,6 +44,7 @@ func (r *mutationResolver) CreateRiskAnalysis(ctx context.Context, input types.C
 			OrganizationID: input.OrganizationID,
 			Name:           input.Name,
 			Description:    input.Description,
+			Period:         period,
 		},
 	)
 	if err != nil {
@@ -64,6 +73,14 @@ func (r *mutationResolver) UpdateRiskAnalysis(ctx context.Context, input types.U
 		return nil, err
 	}
 
+	var period *riskmanagement.Period
+	if input.Period != nil {
+		period = &riskmanagement.Period{
+			Start: input.Period.Start,
+			End:   input.Period.End,
+		}
+	}
+
 	ra, err := r.riskManagement.Update(
 		ctx,
 		scope,
@@ -71,6 +88,7 @@ func (r *mutationResolver) UpdateRiskAnalysis(ctx context.Context, input types.U
 			ID:          input.ID,
 			Name:        input.Name,
 			Description: gqlutils.UnwrapOmittable(input.Description),
+			Period:      period,
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/console/v1/types/period.go
+++ b/pkg/server/api/console/v1/types/period.go
@@ -18,58 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
-import { proboApiRequest } from '../../GenericFunctions';
+package types
 
-export const description: INodeProperties[] = [
-	{
-		displayName: 'Risk Analysis ID',
-		name: 'riskAnalysisId',
-		type: 'string',
-		displayOptions: {
-			show: {
-				resource: ['riskAnalysis'],
-				operation: ['get'],
-			},
-		},
-		default: '',
-		description: 'The ID of the risk analysis',
-		required: true,
-	},
-];
+import "time"
 
-export async function execute(
-	this: IExecuteFunctions,
-	itemIndex: number,
-): Promise<INodeExecutionData> {
-	const riskAnalysisId = this.getNodeParameter('riskAnalysisId', itemIndex) as string;
+func NewPeriod(start, end *time.Time) *Period {
+	if start == nil && end == nil {
+		return nil
+	}
 
-	const query = `
-		query GetRiskAnalysis($id: ID!) {
-			node(id: $id) {
-				... on RiskAnalysis {
-					id
-					name
-					description
-					period {
-						start
-						end
-					}
-					createdAt
-					updatedAt
-				}
-			}
-		}
-	`;
-
-	const variables = {
-		id: riskAnalysisId,
-	};
-
-	const responseData = await proboApiRequest.call(this, query, variables);
-
-	return {
-		json: responseData,
-		pairedItem: { item: itemIndex },
-	};
+	return &Period{
+		Start: start,
+		End:   end,
+	}
 }

--- a/pkg/server/api/console/v1/types/risk_analysis.go
+++ b/pkg/server/api/console/v1/types/risk_analysis.go
@@ -71,6 +71,7 @@ func NewRiskAnalysis(ra *coredata.RiskAnalysis) *RiskAnalysis {
 		ID:          ra.ID,
 		Name:        ra.Name,
 		Description: ra.Description,
+		Period:      NewPeriod(ra.PeriodStart, ra.PeriodEnd),
 		Organization: &Organization{
 			ID: ra.OrganizationID,
 		},

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -6437,10 +6437,19 @@ func (r *Resolver) AddRiskAnalysisTool(ctx context.Context, req *mcp.CallToolReq
 		return nil, types.AddRiskAnalysisOutput{}, err
 	}
 
+	var period *riskmanagement.Period
+	if input.Period != nil {
+		period = &riskmanagement.Period{
+			Start: input.Period.Start,
+			End:   input.Period.End,
+		}
+	}
+
 	ra, err := r.riskManagement.Create(ctx, scope, riskmanagement.CreateRiskAnalysisRequest{
 		OrganizationID: input.OrganizationID,
 		Name:           input.Name,
 		Description:    input.Description,
+		Period:         period,
 	})
 	if err != nil {
 		return nil, types.AddRiskAnalysisOutput{}, fmt.Errorf("failed to create risk analysis: %w", err)
@@ -6457,10 +6466,19 @@ func (r *Resolver) UpdateRiskAnalysisTool(ctx context.Context, req *mcp.CallTool
 		return nil, types.UpdateRiskAnalysisOutput{}, err
 	}
 
+	var period *riskmanagement.Period
+	if input.Period != nil {
+		period = &riskmanagement.Period{
+			Start: input.Period.Start,
+			End:   input.Period.End,
+		}
+	}
+
 	ra, err := r.riskManagement.Update(ctx, scope, riskmanagement.UpdateRiskAnalysisRequest{
 		ID:          input.ID,
 		Name:        input.Name,
 		Description: UnwrapOmittable(input.Description),
+		Period:      period,
 	})
 	if err != nil {
 		return nil, types.UpdateRiskAnalysisOutput{}, fmt.Errorf("failed to update risk analysis: %w", err)

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -638,6 +638,22 @@ components:
       format: string
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/page.CursorKey
 
+    Period:
+      type: object
+      properties:
+        start:
+          type:
+            - string
+            - "null"
+          format: date-time
+          description: Start of the period
+        end:
+          type:
+            - string
+            - "null"
+          format: date-time
+          description: End of the period
+
     ListOrganizationsInput:
       type: object
       properties:
@@ -13183,6 +13199,9 @@ components:
           type:
             - string
             - "null"
+        period:
+          $ref: "#/components/schemas/Period"
+          description: Analysis period
         created_at:
           type: string
           format: date-time
@@ -13428,6 +13447,9 @@ components:
         description:
           type: string
           description: Risk analysis description
+        period:
+          $ref: "#/components/schemas/Period"
+          description: Analysis period
 
     AddRiskAnalysisOutput:
       type: object
@@ -13452,6 +13474,9 @@ components:
           type: ["string", "null"]
           description: Risk analysis description
           go.probo.inc/mcpgen/omittable: true
+        period:
+          $ref: "#/components/schemas/Period"
+          description: Analysis period
 
     UpdateRiskAnalysisOutput:
       type: object

--- a/pkg/server/api/mcp/v1/types/period.go
+++ b/pkg/server/api/mcp/v1/types/period.go
@@ -18,58 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
-import { proboApiRequest } from '../../GenericFunctions';
+package types
 
-export const description: INodeProperties[] = [
-	{
-		displayName: 'Risk Analysis ID',
-		name: 'riskAnalysisId',
-		type: 'string',
-		displayOptions: {
-			show: {
-				resource: ['riskAnalysis'],
-				operation: ['get'],
-			},
-		},
-		default: '',
-		description: 'The ID of the risk analysis',
-		required: true,
-	},
-];
+import "time"
 
-export async function execute(
-	this: IExecuteFunctions,
-	itemIndex: number,
-): Promise<INodeExecutionData> {
-	const riskAnalysisId = this.getNodeParameter('riskAnalysisId', itemIndex) as string;
+func NewPeriod(start, end *time.Time) *Period {
+	if start == nil && end == nil {
+		return nil
+	}
 
-	const query = `
-		query GetRiskAnalysis($id: ID!) {
-			node(id: $id) {
-				... on RiskAnalysis {
-					id
-					name
-					description
-					period {
-						start
-						end
-					}
-					createdAt
-					updatedAt
-				}
-			}
-		}
-	`;
-
-	const variables = {
-		id: riskAnalysisId,
-	};
-
-	const responseData = await proboApiRequest.call(this, query, variables);
-
-	return {
-		json: responseData,
-		pairedItem: { item: itemIndex },
-	};
+	return &Period{
+		Start: start,
+		End:   end,
+	}
 }

--- a/pkg/server/api/mcp/v1/types/risk_analysis.go
+++ b/pkg/server/api/mcp/v1/types/risk_analysis.go
@@ -31,6 +31,7 @@ func NewRiskAnalysis(ra *coredata.RiskAnalysis) *RiskAnalysis {
 		OrganizationID: ra.OrganizationID,
 		Name:           ra.Name,
 		Description:    ra.Description,
+		Period:         NewPeriod(ra.PeriodStart, ra.PeriodEnd),
 		CreatedAt:      ra.CreatedAt,
 		UpdatedAt:      ra.UpdatedAt,
 	}


### PR DESCRIPTION
Track the analysis time window so periods can be filtered and continued across yearly cycles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional periodStart/periodEnd to risk analyses across DB, API, UI, CLI, and automations. Validates end >= start and shows the period in lists and detail pages, with a new edit dialog in the console.

### Coredata **`+74`** **`-13`**
- Migration adds nullable period_start/period_end columns.
- Model/queries include the fields in SELECT/INSERT/UPDATE.

### Service **`+51`** **`-0`**
- Requests accept optional Period; validate end >= start and persist on create/update.

### GraphQL API **`+66`** **`-0`**
- Added Period/PeriodInput; RiskAnalysis exposes `period`; Create/Update accept optional `period`; resolvers map to service.

### MCP **`+78`** **`-0`**
- Spec/types add `period`; tools support create/update with period and return it.

### prb (CLI) **`+101`** **`-10`**
- Create/Update: `--period-start`/`--period-end` flags.
- List/View: show period start/end columns.

### Package: `n8n-node` **`+60`** **`-0`**
- Create/Update accept `periodStart`/`periodEnd`; get/getAll return `period`; map to GraphQL.

### App: console **`+382`** **`-23`**
- Table: new Period column with start–end formatting.
- Detail page: shows Period; adds Edit action and Update dialog with date fields and validation (permission-gated).
- Create dialog: optional date fields; validation; send `period` in mutation; i18n updates for en-US, fr-FR, nl-NL.

<sup>Written for commit 2bb153fb62242af35db4b2c9c7ecc2351ff309cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

