### PR TITLE
Show contract end date on people list

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1376,7 +1376,7 @@
   },
   "addPersonDialog": { "title": "Add Person" },
   "peopleList": {
-    "columns": { "name": "Name", "status": "Status", "email": "Email", "role": "Role", "createdOn": "Created on" },
+    "columns": { "name": "Name", "status": "Status", "email": "Email", "role": "Role", "createdOn": "Created on", "contractEndDate": "Contract end date" },
     "empty": "No people",
     "searchPlaceholder": "Search people...",
     "filters": { "allStatuses": "All statuses", "status": "Status", "pending": "Pending", "active": "Active", "deactivated": "Deactivated", "allRoles": "All roles", "allTypes": "All types" }

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -2466,7 +2466,8 @@
       "status": "Statut",
       "email": "E-mail",
       "role": "Rôle",
-      "createdOn": "Créé le"
+      "createdOn": "Créé le",
+      "contractEndDate": "Date de fin de contrat"
     },
     "empty": "Aucune personne",
     "searchPlaceholder": "Rechercher des personnes...",

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -2471,7 +2471,8 @@
       "status": "Status",
       "email": "E-mail",
       "role": "Rol",
-      "createdOn": "Aangemaakt op"
+      "createdOn": "Aangemaakt op",
+      "contractEndDate": "Einddatum contract"
     },
     "empty": "Geen personen",
     "searchPlaceholder": "Personen zoeken...",

--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleList.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleList.tsx
@@ -298,6 +298,7 @@ export function PeopleList(props: {
               <SortableTh field="EMAIL_ADDRESS" onOrderChange={handleOrderChange}>{t("peopleList.columns.email")}</SortableTh>
               {canManageRoles && <Th>{t("peopleList.columns.role")}</Th>}
               <SortableTh field="CREATED_AT" onOrderChange={handleOrderChange}>{t("peopleList.columns.createdOn")}</SortableTh>
+              <Th>{t("peopleList.columns.contractEndDate")}</Th>
               <Th></Th>
             </Tr>
           </Thead>
@@ -305,7 +306,7 @@ export function PeopleList(props: {
             {peoplePagination.data.profiles.totalCount === 0
               ? (
                   <Tr>
-                    <Td colSpan={7} className="text-center text-txt-secondary">
+                    <Td colSpan={canManageRoles ? 7 : 6} className="text-center text-txt-secondary">
                       {t("peopleList.empty")}
                     </Td>
                   </Tr>

--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
@@ -69,6 +69,7 @@ const fragment = graphql`
       }
     }
     createdAt
+    contractEndDate
     canUpdate: permission(action: "iam:membership-profile:update")
     canInvite: permission(action: "iam:invitation:create")
     canDeactivate: permission(action: "iam:membership-profile:deactivate")
@@ -310,6 +311,21 @@ export function PeopleListItem(props: {
       )}
       >
         {dateFormat(i18n.language, profile.createdAt)}
+      </Td>
+      <Td className={clsx(
+        isMutating && "opacity-60 pointer-events-none",
+        isInactive && "opacity-50",
+      )}
+      >
+        {profile.contractEndDate
+          ? (
+              <time dateTime={profile.contractEndDate}>
+                {dateFormat(i18n.language, profile.contractEndDate)}
+              </time>
+            )
+          : (
+              <span className="text-txt-tertiary">—</span>
+            )}
       </Td>
       <Td noLink width={160} className="text-end">
         {(canSendActivationMail || canDeactivate || canRemove) && (

--- a/apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx
@@ -77,15 +77,19 @@ const updatePersonMutation = graphql`
   }
 `;
 
+const emptyToNull = (value: unknown) => (value === "" || value == null ? null : value);
+
 const sharedPersonFields = {
   fullName: z.string().min(1),
-  position: z.string().min(1).optional().nullable(),
+  // SCIM often syncs title/userType as ""; treat blanks as unset so the form
+  // stays valid and contract dates remain savable for SCIM-managed people.
+  position: z.preprocess(emptyToNull, z.string().min(1).nullable().optional()),
   additionalEmailAddresses: z.preprocess(
     // Empty additional emails are skipped
     v => (v as string[]).filter(v => !!v),
     z.array(z.string().email()),
   ),
-  kind: z.string().min(1).optional().nullable(),
+  kind: z.preprocess(emptyToNull, z.string().min(1).nullable().optional()),
   contractStartDate: z.string().optional().nullable(),
   contractEndDate: z.string().optional().nullable(),
 };
@@ -298,11 +302,11 @@ export function PersonFormLoader(props: { fragmentRef: PersonFormFragment$key })
       scimManaged={person.source === "SCIM"}
       defaultValues={
         {
-          kind: person.kind,
+          kind: person.kind || null,
           fullName: person.fullName,
           emailAddress: person.emailAddress,
           role: person.membership.role,
-          position: person.position,
+          position: person.position || null,
           additionalEmailAddresses: [...person.additionalEmailAddresses],
           contractStartDate: person.contractStartDate?.split("T")[0] || "",
           contractEndDate: person.contractEndDate?.split("T")[0] || "",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes ENG-732.

## Summary

Adds a **Contract end date** column to the organization people list so ended contracts are visible without opening each person.

Also fixes SCIM person edit: empty `position` / `kind` from SCIM failed zod `min(1)`, so the form stayed invalid and the Update button never enabled for contract date changes.

## Changes

- Fetch `contractEndDate` in `PeopleListItemFragment`
- Render a new column after “Created on” (formatted date, or `—` when unset)
- Add `peopleList.columns.contractEndDate` in en-US / fr-FR / nl-NL
- Correct empty-state `colSpan` to `7`/`6` (with/without Role), matching the real column count
- Treat blank `position` / `kind` as null in `PersonForm` validation

No backend/schema changes — the field already exists on `Profile`.

## Test plan

- [ ] Open People list and confirm the new column header appears
- [ ] Person with a contract end date shows a localized date
- [ ] Person without a contract end date shows `—`
- [ ] Empty list still spans the full table width with/without role column
- [ ] FR/NL locales show the translated column title
- [ ] SCIM person with empty position: change contract end date and save successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-732](https://linear.app/probo/issue/ENG-732/display-contract-end-date-on-people-list)

<div><a href="https://cursor.com/agents/bc-e28f11b0-e4be-4ba3-bde6-88e2d43cfaa0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e28f11b0-e4be-4ba3-bde6-88e2d43cfaa0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows contract end date in the People list so ended contracts are obvious and explain exclusions from signature workflows. Also fixes SCIM edit so blank `position`/`kind` don’t block saving contract dates (ENG-732).

### **App: console** **`+31`** **`-8`**
- Fetch and display `contractEndDate` in `PeopleListItem`; new column after “Created on”
- Localized date; shows — when unset
- Update `en-US`, `fr-FR`, and `nl-NL` labels
- Fix empty-state `colSpan` to match columns with/without Role
- Treat blank SCIM `position`/`kind` as null in `PersonForm`
- No backend/schema changes

<sup>Written for commit cef1a8658a92db31fa151bbdf7560c8c357b1121. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



