### PR TITLE
Detach SCIM audit writes from request cancellation

### DIFF
--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -1019,6 +1019,7 @@ func (s *Service) LogEvent(
 	requestBody *string,
 	responseBody *string,
 ) {
+	ctx = context.WithoutCancel(ctx)
 	scope := coredata.NewScopeFromObjectID(config.OrganizationID)
 
 	event := s.createEvent(

--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -49,6 +49,8 @@ import (
 	webhooktypes "go.probo.inc/probo/pkg/webhook/types"
 )
 
+const scimEventLogTimeout = 5 * time.Second
+
 type (
 	Service struct {
 		pg           *pg.Client
@@ -1019,7 +1021,9 @@ func (s *Service) LogEvent(
 	requestBody *string,
 	responseBody *string,
 ) {
-	ctx = context.WithoutCancel(ctx)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), scimEventLogTimeout)
+	defer cancel()
+
 	scope := coredata.NewScopeFromObjectID(config.OrganizationID)
 
 	event := s.createEvent(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- preserve request trace and logging values for SCIM audit events
- detach the audit transaction from client-driven request cancellation
- prevent successful event inserts from failing during commit after the response is sent

## Testing

- `go test ./pkg/iam/scim ./pkg/server/api/connect/v1`
- `make go-fmt`

The targeted `TestSCIMEvent_StoresPayload` end-to-end run could not start `probod` because the local ACME certificate was not trusted (`x509: certificate signed by unknown authority`); no end-to-end test case executed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6180512d-b99b-4c63-9bac-b98fc6fd6539?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6180512d-b99b-4c63-9bac-b98fc6fd6539&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SCIM audit logging reliable by detaching writes from client cancellations and capping them at 5s. Inserts and commits still complete, with trace/log values preserved.

### Service **`+5`** **`-0`**
- Wrap `LogEvent` context with `context.WithoutCancel` and a 5s timeout (`scimEventLogTimeout`).
- Preserve request-scoped values; ignore client aborts while bounding audit write duration.

<sup>Written for commit cfb00a853bcd122c22ebdc75c168c428bcc705b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

