### PR TITLE
Fix people contract end date clear and list date layout

### DIFF
--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
@@ -327,7 +327,7 @@ export function PeopleListItem(props: {
               <span className="text-txt-tertiary">—</span>
             )}
       </Td>
-      <Td noLink width={160} className="text-end">
+      <Td noLink width={50} className="text-end">
         {(canSendActivationMail || canDeactivate || canRemove) && (
           <ActionDropdown>
             {canSendActivationMail && (

--- a/apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx
@@ -72,6 +72,8 @@ const updatePersonMutation = graphql`
     updateUser(input: $input) {
       profile {
         id
+        ...PersonFormFragment
+        ...PeopleListItemFragment
       }
     }
   }


### PR DESCRIPTION
The actions column reserved 160px for a right-aligned menu, which starved the date columns and made dates wrap even though the row looked like it had room. Match other tables with a 50px actions column so dates stay on one line until space is actually tight.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wrapped dates in the people list by shrinking the actions column to 50px. Also ensures clearing a contract end date updates the UI by returning the needed fragments in the `updateUser` mutation.

### App: console **`+3`** **`-1`**
- `PeopleListItem.tsx`: change actions `<Td>` width from `160` to `50` to keep date columns on one line.
- `PersonForm.tsx`: return `...PersonFormFragment` and `...PeopleListItemFragment` from `updateUser` so a cleared `contractEndDate` updates the list and form.

<sup>Written for commit 2aca0898d7137331a6af0fc9aea3319102c58612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

