### PR TITLE
Add cookie banner resource reporting switch

### DIFF
--- a/apps/console/src/pages/organizations/cookie-banners/_locales/en-US.json
+++ b/apps/console/src/pages/organizations/cookie-banners/_locales/en-US.json
@@ -128,7 +128,16 @@
     "title": "Settings",
     "messages": { "successTitle": "Success", "updated": "Banner settings updated" },
     "errors": { "title": "Error", "update": "Failed to update" },
-    "fields": { "name": "Name", "origin": "Origin URL", "cookiePolicyUrl": "Cookie policy URL", "privacyPolicyUrl": "Privacy policy URL", "consentExpiryDays": "Consent expiry (days)", "defaultLanguage": "Default language" },
+    "fields": {
+      "name": "Name",
+      "origin": "Origin URL",
+      "cookiePolicyUrl": "Cookie policy URL",
+      "privacyPolicyUrl": "Privacy policy URL",
+      "consentExpiryDays": "Consent expiry (days)",
+      "defaultLanguage": "Default language",
+      "resourceReportingEnabled": "Resource reporting",
+      "resourceReportingEnabledHelp": "When enabled, the banner SDK detects and reports third-party scripts, iframes, and other resources."
+    },
     "languages": { "english": "English", "french": "French", "german": "German", "spanish": "Spanish", "dutch": "Dutch" },
     "actions": { "saving": "Saving...", "save": "Save" }
   },

--- a/apps/console/src/pages/organizations/cookie-banners/_locales/fr-FR.json
+++ b/apps/console/src/pages/organizations/cookie-banners/_locales/fr-FR.json
@@ -128,7 +128,16 @@
     "title": "Paramètres",
     "messages": { "successTitle": "Succès", "updated": "Paramètres de la bannière mis à jour" },
     "errors": { "title": "Erreur", "update": "Échec de la mise à jour" },
-    "fields": { "name": "Nom", "origin": "URL d’origine", "cookiePolicyUrl": "URL de la politique de cookies", "privacyPolicyUrl": "URL de la politique de confidentialité", "consentExpiryDays": "Expiration du consentement (jours)", "defaultLanguage": "Langue par défaut" },
+    "fields": {
+      "name": "Nom",
+      "origin": "URL d’origine",
+      "cookiePolicyUrl": "URL de la politique de cookies",
+      "privacyPolicyUrl": "URL de la politique de confidentialité",
+      "consentExpiryDays": "Expiration du consentement (jours)",
+      "defaultLanguage": "Langue par défaut",
+      "resourceReportingEnabled": "Rapport de ressources",
+      "resourceReportingEnabledHelp": "Lorsqu’il est activé, le SDK de la bannière détecte et signale les scripts tiers, iframes et autres ressources."
+    },
     "languages": { "english": "Anglais", "french": "Français", "german": "Allemand", "spanish": "Espagnol", "dutch": "Néerlandais" },
     "actions": { "saving": "Enregistrement...", "save": "Enregistrer" }
   },

--- a/apps/console/src/pages/organizations/cookie-banners/_locales/nl-NL.json
+++ b/apps/console/src/pages/organizations/cookie-banners/_locales/nl-NL.json
@@ -128,7 +128,16 @@
     "title": "Instellingen",
     "messages": { "successTitle": "Gelukt", "updated": "Bannerinstellingen bijgewerkt" },
     "errors": { "title": "Fout", "update": "Bijwerken mislukt" },
-    "fields": { "name": "Naam", "origin": "Origin-URL", "cookiePolicyUrl": "URL cookiebeleid", "privacyPolicyUrl": "URL privacybeleid", "consentExpiryDays": "Vervaltermijn toestemming (dagen)", "defaultLanguage": "Standaardtaal" },
+    "fields": {
+      "name": "Naam",
+      "origin": "Origin-URL",
+      "cookiePolicyUrl": "URL cookiebeleid",
+      "privacyPolicyUrl": "URL privacybeleid",
+      "consentExpiryDays": "Vervaltermijn toestemming (dagen)",
+      "defaultLanguage": "Standaardtaal",
+      "resourceReportingEnabled": "Resource-rapportage",
+      "resourceReportingEnabledHelp": "Indien ingeschakeld detecteert en rapporteert de banner-SDK scripts van derden, iframes en andere resources."
+    },
     "languages": { "english": "Engels", "french": "Frans", "german": "Duits", "spanish": "Spaans", "dutch": "Nederlands" },
     "actions": { "saving": "Bezig met opslaan...", "save": "Opslaan" }
   },

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/settings/_components/BannerSettingsForm.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/settings/_components/BannerSettingsForm.tsx
@@ -19,7 +19,7 @@
 // SOFTWARE.
 
 import { formatError } from "@probo/helpers";
-import { Button, Card, Field, Input, Label, Option, Select, useToast } from "@probo/ui";
+import { Button, Card, Field, Input, Label, Option, Select, Toggle, useToast } from "@probo/ui";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useFragment, useMutation } from "react-relay";
@@ -37,6 +37,7 @@ const bannerSettingsFormFragment = graphql`
     privacyPolicyUrl
     consentExpiryDays
     defaultLanguage
+    resourceReportingEnabled
   }
 `;
 
@@ -50,6 +51,7 @@ const updateBannerMutation = graphql`
         privacyPolicyUrl
         consentExpiryDays
         defaultLanguage
+        resourceReportingEnabled
         latestVersion {
           id
           version
@@ -66,6 +68,7 @@ interface BannerSettingsFormValues {
   privacyPolicyUrl: string;
   consentExpiryDays: string;
   defaultLanguage: string;
+  resourceReportingEnabled: boolean;
 }
 
 interface BannerSettingsFormProps {
@@ -87,6 +90,7 @@ export function BannerSettingsForm({ cookieBannerKey }: BannerSettingsFormProps)
       privacyPolicyUrl: banner.privacyPolicyUrl ?? "",
       consentExpiryDays: String(banner.consentExpiryDays),
       defaultLanguage: banner.defaultLanguage,
+      resourceReportingEnabled: banner.resourceReportingEnabled,
     },
   });
 
@@ -100,6 +104,7 @@ export function BannerSettingsForm({ cookieBannerKey }: BannerSettingsFormProps)
           privacyPolicyUrl: data.privacyPolicyUrl || undefined,
           consentExpiryDays: parseInt(data.consentExpiryDays, 10),
           defaultLanguage: data.defaultLanguage,
+          resourceReportingEnabled: data.resourceReportingEnabled,
         },
       },
       onCompleted() {
@@ -158,6 +163,26 @@ export function BannerSettingsForm({ cookieBannerKey }: BannerSettingsFormProps)
                 )}
               />
             </div>
+          </div>
+
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <Label>{t("bannerSettingsForm.fields.resourceReportingEnabled")}</Label>
+              <p className="text-sm text-txt-tertiary">
+                {t("bannerSettingsForm.fields.resourceReportingEnabledHelp")}
+              </p>
+            </div>
+            <Controller
+              name="resourceReportingEnabled"
+              control={control}
+              render={({ field }) => (
+                <Toggle
+                  checked={field.value}
+                  onChange={field.onChange}
+                  aria-label={t("bannerSettingsForm.fields.resourceReportingEnabled")}
+                />
+              )}
+            />
           </div>
 
           <Button type="submit" disabled={isUpdating}>

--- a/e2e/console/cookie_banner_test.go
+++ b/e2e/console/cookie_banner_test.go
@@ -48,6 +48,7 @@ func TestCookieBanner_Create(t *testing.T) {
 							cookiePolicyUrl
 							consentExpiryDays
 							showBranding
+							resourceReportingEnabled
 							defaultLanguage
 							createdAt
 							updatedAt
@@ -64,16 +65,17 @@ func TestCookieBanner_Create(t *testing.T) {
 			CreateCookieBanner struct {
 				CookieBannerEdge struct {
 					Node struct {
-						ID                string `json:"id"`
-						Name              string `json:"name"`
-						Origin            string `json:"origin"`
-						State             string `json:"state"`
-						CookiePolicyUrl   string `json:"cookiePolicyUrl"`
-						ConsentExpiryDays int    `json:"consentExpiryDays"`
-						ShowBranding      bool   `json:"showBranding"`
-						DefaultLanguage   string `json:"defaultLanguage"`
-						CreatedAt         string `json:"createdAt"`
-						UpdatedAt         string `json:"updatedAt"`
+						ID                       string `json:"id"`
+						Name                     string `json:"name"`
+						Origin                   string `json:"origin"`
+						State                    string `json:"state"`
+						CookiePolicyUrl          string `json:"cookiePolicyUrl"`
+						ConsentExpiryDays        int    `json:"consentExpiryDays"`
+						ShowBranding             bool   `json:"showBranding"`
+						ResourceReportingEnabled bool   `json:"resourceReportingEnabled"`
+						DefaultLanguage          string `json:"defaultLanguage"`
+						CreatedAt                string `json:"createdAt"`
+						UpdatedAt                string `json:"updatedAt"`
 					} `json:"node"`
 				} `json:"cookieBannerEdge"`
 			} `json:"createCookieBanner"`
@@ -97,6 +99,7 @@ func TestCookieBanner_Create(t *testing.T) {
 		assert.Equal(t, "ACTIVE", node.State)
 		assert.Equal(t, "https://example.com/cookies", node.CookiePolicyUrl)
 		assert.Equal(t, 365, node.ConsentExpiryDays)
+		assert.True(t, node.ResourceReportingEnabled)
 		assert.Equal(t, "en", node.DefaultLanguage)
 		assert.NotEmpty(t, node.CreatedAt)
 		assert.NotEmpty(t, node.UpdatedAt)

--- a/e2e/console/cookie_banner_test.go
+++ b/e2e/console/cookie_banner_test.go
@@ -336,6 +336,44 @@ func TestCookieBanner_Update(t *testing.T) {
 		assert.Equal(t, 90, result.UpdateCookieBanner.CookieBanner.ConsentExpiryDays)
 		assert.Equal(t, "fr", result.UpdateCookieBanner.CookieBanner.DefaultLanguage)
 	})
+
+	t.Run("disable resource reporting", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const query = `
+			mutation UpdateCookieBanner($input: UpdateCookieBannerInput!) {
+				updateCookieBanner(input: $input) {
+					cookieBanner {
+						id
+						resourceReportingEnabled
+					}
+				}
+			}
+		`
+
+		var result struct {
+			UpdateCookieBanner struct {
+				CookieBanner struct {
+					ID                       string `json:"id"`
+					ResourceReportingEnabled bool   `json:"resourceReportingEnabled"`
+				} `json:"cookieBanner"`
+			} `json:"updateCookieBanner"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookieBannerId":           bannerID,
+				"resourceReportingEnabled": false,
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, bannerID, result.UpdateCookieBanner.CookieBanner.ID)
+		assert.False(t, result.UpdateCookieBanner.CookieBanner.ResourceReportingEnabled)
+	})
 }
 
 func TestCookieBanner_Delete(t *testing.T) {

--- a/e2e/console/cookie_consent_test.go
+++ b/e2e/console/cookie_consent_test.go
@@ -59,16 +59,17 @@ func TestCookieConsent_PublicAPIAndConsole(t *testing.T) {
 	assert.Contains(t, configResp.Header.Get("Vary"), "Origin")
 
 	var config struct {
-		BannerID          string `json:"banner_id"`
-		Version           int    `json:"version"`
-		Language          string `json:"language"`
-		DefaultLanguage   string `json:"default_language"`
-		CookiePolicyURL   string `json:"cookie_policy_url"`
-		ConsentExpiryDays int    `json:"consent_expiry_days"`
-		ConsentMode       string `json:"consent_mode"`
-		Regulation        string `json:"regulation"`
-		ShowBranding      bool   `json:"show_branding"`
-		Layout            struct {
+		BannerID                 string `json:"banner_id"`
+		Version                  int    `json:"version"`
+		Language                 string `json:"language"`
+		DefaultLanguage          string `json:"default_language"`
+		CookiePolicyURL          string `json:"cookie_policy_url"`
+		ConsentExpiryDays        int    `json:"consent_expiry_days"`
+		ConsentMode              string `json:"consent_mode"`
+		Regulation               string `json:"regulation"`
+		ShowBranding             bool   `json:"show_branding"`
+		ResourceReportingEnabled bool   `json:"resource_reporting_enabled"`
+		Layout                   struct {
 			Presentation string `json:"presentation"`
 			InitialState string `json:"initial_state"`
 		} `json:"layout"`
@@ -88,6 +89,7 @@ func TestCookieConsent_PublicAPIAndConsole(t *testing.T) {
 	assert.Equal(t, 365, config.ConsentExpiryDays)
 	assert.NotEmpty(t, config.ConsentMode)
 	assert.NotEmpty(t, config.Regulation)
+	assert.True(t, config.ResourceReportingEnabled)
 	assert.NotEmpty(t, config.Layout.Presentation)
 	assert.NotEmpty(t, config.Layout.InitialState)
 	assert.NotEmpty(t, config.Categories)

--- a/package-lock.json
+++ b/package-lock.json
@@ -22695,7 +22695,8 @@
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.28.1",
-        "typescript": "~7.0.2"
+        "typescript": "~7.0.2",
+        "vitest": "^4.1.10"
       }
     },
     "packages/cookie-banner/node_modules/typescript": {

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -25,7 +25,9 @@
   },
   "scripts": {
     "build": "node build.mjs && tsc --emitDeclarationOnly",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "author": {
     "name": "Probo Inc",
@@ -56,6 +58,7 @@
   },
   "devDependencies": {
     "esbuild": "^0.28.1",
-    "typescript": "~7.0.2"
+    "typescript": "~7.0.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -25,13 +25,19 @@ import {
 import { getConsent } from "./consent";
 import { COOKIE_NAME, getConsentCookie, setConsentCookie } from "./cookie";
 import type { Detector } from "./detectors";
-import { CookieDetector, ReportQueue, ResourceDetector, StorageDetector } from "./detectors";
+import {
+  CookieDetector,
+  ReportQueue,
+  ResourceDetector,
+  resolveResourceReportingEnabled,
+  StorageDetector,
+} from "./detectors";
 import { NotFoundError } from "./errors";
 import { fetchJSON } from "./http";
 import { detectLanguage } from "./i18n";
-import { resolveLayout } from "./layout";
 import type { ConsentIntegration } from "./integrations";
 import { createDefaultIntegrations } from "./integrations";
+import { resolveLayout } from "./layout";
 import { enqueue, flush } from "./queue";
 import type {
   BannerConfig,
@@ -53,6 +59,16 @@ export type {
   Regulation,
   VisitorConsent,
 } from "./types";
+
+// Normalize fields that older self-hosted backends may omit so the rest of the
+// client can read `layout` and `resource_reporting_enabled` without re-checking.
+function resolveConfig(config: BannerConfig): BannerConfig {
+  return {
+    ...config,
+    layout: resolveLayout(config),
+    resource_reporting_enabled: resolveResourceReportingEnabled(config),
+  };
+}
 
 export class CookieBannerClient {
   private readonly baseUrl: URL;
@@ -97,7 +113,7 @@ export class CookieBannerClient {
 
     let config: BannerConfig;
     try {
-      config = await fetchJSON<BannerConfig>(configUrl);
+      config = resolveConfig(await fetchJSON<BannerConfig>(configUrl));
     } catch {
       // Discovery mode: no published banner config, but detectors still run
       // so admins can inventory trackers. Grant GCM so GTM-managed tags can
@@ -325,7 +341,7 @@ export class CookieBannerClient {
 
   private buildDefaultConsentData(): Record<string, boolean> {
     const cfg = this.config;
-    const defaultGranted = resolveLayout(cfg).default_non_necessary_granted;
+    const defaultGranted = cfg.layout.default_non_necessary_granted;
     const consentData: Record<string, boolean> = {};
     for (const cat of cfg.categories) {
       consentData[cat.slug] = defaultGranted || cat.kind === "NECESSARY";
@@ -373,8 +389,11 @@ export class CookieBannerClient {
     this.detectors = [
       new CookieDetector(this.reportQueue, apiOrigin, knownNames),
       new StorageDetector(this.reportQueue, apiOrigin),
-      new ResourceDetector(this.reportQueue, apiOrigin),
     ];
+
+    if (!config || config.resource_reporting_enabled) {
+      this.detectors.push(new ResourceDetector(this.reportQueue, apiOrigin));
+    }
 
     for (const d of this.detectors) {
       d.start();

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -30,6 +30,7 @@ import {
   ReportQueue,
   ResourceDetector,
   resolveResourceReportingEnabled,
+  shouldStartResourceDetector,
   StorageDetector,
 } from "./detectors";
 import { NotFoundError } from "./errors";
@@ -391,7 +392,7 @@ export class CookieBannerClient {
       new StorageDetector(this.reportQueue, apiOrigin),
     ];
 
-    if (!config || config.resource_reporting_enabled) {
+    if (shouldStartResourceDetector(config)) {
       this.detectors.push(new ResourceDetector(this.reportQueue, apiOrigin));
     }
 

--- a/packages/cookie-banner/src/detectors/index.ts
+++ b/packages/cookie-banner/src/detectors/index.ts
@@ -21,7 +21,7 @@
 export type { Detector } from "./detector";
 export { CookieDetector } from "./cookie-detector";
 export { StorageDetector } from "./storage-detector";
-export { ResourceDetector } from "./resource-detector";
+export { ResourceDetector, resolveResourceReportingEnabled } from "./resource-detector";
 export { ReportQueue } from "./report-queue";
 export type {
   CookieSource,

--- a/packages/cookie-banner/src/detectors/resource-detector.test.ts
+++ b/packages/cookie-banner/src/detectors/resource-detector.test.ts
@@ -18,20 +18,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-export type { Detector } from "./detector";
-export { CookieDetector } from "./cookie-detector";
-export { StorageDetector } from "./storage-detector";
-export {
-  ResourceDetector,
-  resolveResourceReportingEnabled,
-  shouldStartResourceDetector,
-} from "./resource-detector";
-export { ReportQueue } from "./report-queue";
-export type {
-  CookieSource,
-  DetectedCookieEntry,
-  DetectedResourceEntry,
-  DetectedStorageEntry,
-  ResourceType,
-  StorageType,
-} from "./types";
+import { describe, expect, it } from "vitest";
+
+import { shouldStartResourceDetector } from "./resource-detector";
+
+describe("shouldStartResourceDetector", () => {
+  it("starts in discovery mode when config is absent", () => {
+    expect(shouldStartResourceDetector()).toBe(true);
+    expect(shouldStartResourceDetector(undefined)).toBe(true);
+  });
+
+  it("starts when resource reporting is enabled", () => {
+    expect(shouldStartResourceDetector({ resource_reporting_enabled: true })).toBe(true);
+  });
+
+  it("skips when resource reporting is disabled", () => {
+    expect(shouldStartResourceDetector({ resource_reporting_enabled: false })).toBe(false);
+  });
+});

--- a/packages/cookie-banner/src/detectors/resource-detector.ts
+++ b/packages/cookie-banner/src/detectors/resource-detector.ts
@@ -18,11 +18,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import type { BannerConfig } from "../types";
 import type { Detector } from "./detector";
 import { isExtensionContext } from "./extension-context";
 import type { ReportQueue } from "./report-queue";
 import { getSelfResourceUrls } from "./self-origin";
 import type { ResourceType } from "./types";
+
+let warnedResourceReporting = false;
+
+// resolveResourceReportingEnabled returns whether the SDK should run the
+// resource detector. The SDK and backend are released together, so
+// `resource_reporting_enabled` is always present in practice; the only way it
+// can be missing is a self-hosted Probo backend older than the first release
+// that sends it.
+export function resolveResourceReportingEnabled(config: BannerConfig): boolean {
+  if (typeof config.resource_reporting_enabled === "boolean") {
+    return config.resource_reporting_enabled;
+  }
+
+  if (!warnedResourceReporting) {
+    warnedResourceReporting = true;
+    console.error(
+      "[probo] banner config has no `resource_reporting_enabled`: your self-hosted Probo backend (probod) is older than this SDK. Update probod to match this SDK. Falling back to resource reporting enabled.",
+    );
+  }
+
+  return true;
+}
 
 // Map browser-reported PerformanceResourceTiming.initiatorType to the
 // server-side tracker_resource_type. Anything we cannot classify is

--- a/packages/cookie-banner/src/detectors/resource-detector.ts
+++ b/packages/cookie-banner/src/detectors/resource-detector.ts
@@ -47,6 +47,14 @@ export function resolveResourceReportingEnabled(config: BannerConfig): boolean {
   return true;
 }
 
+// shouldStartResourceDetector is true in discovery mode (no config) and when
+// the resolved banner config enables resource reporting.
+export function shouldStartResourceDetector(
+  config?: Pick<BannerConfig, "resource_reporting_enabled">,
+): boolean {
+  return config == null || config.resource_reporting_enabled;
+}
+
 // Map browser-reported PerformanceResourceTiming.initiatorType to the
 // server-side tracker_resource_type. Anything we cannot classify is
 // dropped rather than reported as "other" to keep the table tidy.

--- a/packages/cookie-banner/src/layout.ts
+++ b/packages/cookie-banner/src/layout.ts
@@ -33,7 +33,7 @@ const STRICT_LAYOUT: BannerLayout = {
   settings_link: "default",
 };
 
-let warned = false;
+let warnedLayout = false;
 
 // resolveLayout returns the presentation policy the server sends. The SDK and
 // backend are released together, so `layout` is always present in practice; the
@@ -44,8 +44,8 @@ export function resolveLayout(config: BannerConfig): BannerLayout {
     return config.layout;
   }
 
-  if (!warned) {
-    warned = true;
+  if (!warnedLayout) {
+    warnedLayout = true;
     console.error(
       "[probo] banner config has no `layout`: your self-hosted Probo backend (probod) is older than this SDK. Update probod to v0.246.0 or later. Falling back to strict opt-in.",
     );

--- a/packages/cookie-banner/src/types.ts
+++ b/packages/cookie-banner/src/types.ts
@@ -90,6 +90,7 @@ export interface BannerConfig {
   regulation: Regulation | null;
   layout: BannerLayout;
   show_branding: boolean;
+  resource_reporting_enabled: boolean;
   categories: Category[];
   texts: BannerTexts;
 }

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/activate.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/activate.operation.ts
@@ -56,6 +56,7 @@ export async function execute(
 					cookiePolicyUrl
 					consentExpiryDays
 					showBranding
+					resourceReportingEnabled
 					defaultLanguage
 					createdAt
 					updatedAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/create.operation.ts
@@ -134,6 +134,7 @@ export async function execute(
 						cookiePolicyUrl
 						consentExpiryDays
 						showBranding
+						resourceReportingEnabled
 						defaultLanguage
 						createdAt
 						updatedAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/deactivate.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/deactivate.operation.ts
@@ -56,6 +56,7 @@ export async function execute(
 					cookiePolicyUrl
 					consentExpiryDays
 					showBranding
+					resourceReportingEnabled
 					defaultLanguage
 					createdAt
 					updatedAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/get.operation.ts
@@ -56,6 +56,7 @@ export async function execute(
 					cookiePolicyUrl
 					consentExpiryDays
 					showBranding
+					resourceReportingEnabled
 					defaultLanguage
 					createdAt
 					updatedAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/getAll.operation.ts
@@ -91,6 +91,7 @@ export async function execute(
 								cookiePolicyUrl
 								consentExpiryDays
 								showBranding
+								resourceReportingEnabled
 								defaultLanguage
 								createdAt
 								updatedAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
@@ -113,7 +113,8 @@ export const description: INodeProperties[] = [
 				name: 'resourceReportingEnabled',
 				type: 'boolean',
 				default: true,
-				description: 'Whether the SDK reports detected resources',
+				description:
+					'Whether the SDK reports detected resources. Only add this field when you intend to change the value; omit it to keep the banner\'s current setting.',
 			},
 		],
 	},

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
@@ -108,6 +108,13 @@ export const description: INodeProperties[] = [
 				default: '',
 				description: 'The URL to the privacy policy. Leave empty to clear the existing value.',
 			},
+			{
+				displayName: 'Resource Reporting Enabled',
+				name: 'resourceReportingEnabled',
+				type: 'boolean',
+				default: true,
+				description: 'Whether the SDK reports detected resources',
+			},
 		],
 	},
 ];
@@ -123,6 +130,7 @@ export async function execute(
 	const defaultLanguage = this.getNodeParameter('defaultLanguage', itemIndex, '') as string;
 	const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as {
 		privacyPolicyUrl?: string;
+		resourceReportingEnabled?: boolean;
 	};
 
 	const query = `
@@ -137,6 +145,7 @@ export async function execute(
 					cookiePolicyUrl
 					consentExpiryDays
 					showBranding
+					resourceReportingEnabled
 					defaultLanguage
 					createdAt
 					updatedAt
@@ -152,6 +161,9 @@ export async function execute(
 	if (defaultLanguage) input.defaultLanguage = defaultLanguage;
 	if (additionalFields.privacyPolicyUrl !== undefined) {
 		input.privacyPolicyUrl = additionalFields.privacyPolicyUrl === '' ? null : additionalFields.privacyPolicyUrl;
+	}
+	if (additionalFields.resourceReportingEnabled !== undefined) {
+		input.resourceReportingEnabled = additionalFields.resourceReportingEnabled;
 	}
 
 	const responseData = await proboApiRequest.call(this, query, { input });

--- a/pkg/cmd/cookie-banner/update/update.go
+++ b/pkg/cmd/cookie-banner/update/update.go
@@ -51,11 +51,12 @@ type updateResponse struct {
 
 func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	var (
-		flagName             string
-		flagCookiePolicyUrl  string
-		flagPrivacyPolicyUrl string
-		flagConsentExpiry    int
-		flagDefaultLanguage  string
+		flagName                     string
+		flagCookiePolicyUrl          string
+		flagPrivacyPolicyUrl         string
+		flagConsentExpiry            int
+		flagDefaultLanguage          string
+		flagResourceReportingEnabled bool
 	)
 
 	cmd := &cobra.Command{
@@ -103,6 +104,10 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				input["defaultLanguage"] = flagDefaultLanguage
 			}
 
+			if cmd.Flags().Changed("resource-reporting-enabled") {
+				input["resourceReportingEnabled"] = flagResourceReportingEnabled
+			}
+
 			if len(input) == 1 {
 				return fmt.Errorf("at least one field must be specified for update")
 			}
@@ -129,6 +134,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagPrivacyPolicyUrl, "privacy-policy-url", "", "Privacy policy URL")
 	cmd.Flags().IntVar(&flagConsentExpiry, "consent-expiry-days", 0, "Days until consent expires")
 	cmd.Flags().StringVar(&flagDefaultLanguage, "default-language", "", "Default language code")
+	cmd.Flags().BoolVar(&flagResourceReportingEnabled, "resource-reporting-enabled", true, "Whether the SDK reports detected resources")
 
 	return cmd
 }

--- a/pkg/cmd/cookie-banner/view/view.go
+++ b/pkg/cmd/cookie-banner/view/view.go
@@ -43,6 +43,7 @@ query($id: ID!) {
       privacyPolicyUrl
       consentExpiryDays
       showBranding
+      resourceReportingEnabled
       defaultLanguage
       createdAt
       updatedAt
@@ -53,18 +54,19 @@ query($id: ID!) {
 
 type viewResponse struct {
 	Node *struct {
-		Typename          string  `json:"__typename"`
-		ID                string  `json:"id"`
-		Name              string  `json:"name"`
-		Origin            string  `json:"origin"`
-		State             string  `json:"state"`
-		CookiePolicyUrl   string  `json:"cookiePolicyUrl"`
-		PrivacyPolicyUrl  *string `json:"privacyPolicyUrl"`
-		ConsentExpiryDays int     `json:"consentExpiryDays"`
-		ShowBranding      bool    `json:"showBranding"`
-		DefaultLanguage   string  `json:"defaultLanguage"`
-		CreatedAt         string  `json:"createdAt"`
-		UpdatedAt         string  `json:"updatedAt"`
+		Typename                 string  `json:"__typename"`
+		ID                       string  `json:"id"`
+		Name                     string  `json:"name"`
+		Origin                   string  `json:"origin"`
+		State                    string  `json:"state"`
+		CookiePolicyUrl          string  `json:"cookiePolicyUrl"`
+		PrivacyPolicyUrl         *string `json:"privacyPolicyUrl"`
+		ConsentExpiryDays        int     `json:"consentExpiryDays"`
+		ShowBranding             bool    `json:"showBranding"`
+		ResourceReportingEnabled bool    `json:"resourceReportingEnabled"`
+		DefaultLanguage          string  `json:"defaultLanguage"`
+		CreatedAt                string  `json:"createdAt"`
+		UpdatedAt                string  `json:"updatedAt"`
 	} `json:"node"`
 }
 
@@ -128,6 +130,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("State:"), v.State)
 			_, _ = fmt.Fprintf(out, "%s%d days\n", label.Render("Consent Expiry:"), v.ConsentExpiryDays)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Default Language:"), v.DefaultLanguage)
+			_, _ = fmt.Fprintf(out, "%s%t\n", label.Render("Resource Reporting:"), v.ResourceReportingEnabled)
 
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Cookie Policy:"), v.CookiePolicyUrl)
 			if v.PrivacyPolicyUrl != nil && *v.PrivacyPolicyUrl != "" {

--- a/pkg/cookiebanner/pattern_analysis_worker_process_test.go
+++ b/pkg/cookiebanner/pattern_analysis_worker_process_test.go
@@ -61,17 +61,18 @@ func seedWorkerFixture(t *testing.T, ctx context.Context, client *pg.Client) wor
 	now := time.Now().UTC().Truncate(time.Microsecond)
 
 	banner := coredata.CookieBanner{
-		ID:                bannerID,
-		OrganizationID:    organizationID,
-		Name:              "Worker Test Banner",
-		Origin:            "https://worker-test-" + bannerID.String() + ".example.com",
-		State:             coredata.CookieBannerStateActive,
-		CookiePolicyURL:   "https://worker-test.example.com/cookies",
-		ConsentExpiryDays: 180,
-		ShowBranding:      false,
-		DefaultLanguage:   "en",
-		CreatedAt:         now,
-		UpdatedAt:         now,
+		ID:                       bannerID,
+		OrganizationID:           organizationID,
+		Name:                     "Worker Test Banner",
+		Origin:                   "https://worker-test-" + bannerID.String() + ".example.com",
+		State:                    coredata.CookieBannerStateActive,
+		CookiePolicyURL:          "https://worker-test.example.com/cookies",
+		ConsentExpiryDays:        180,
+		ShowBranding:             false,
+		ResourceReportingEnabled: true,
+		DefaultLanguage:          "en",
+		CreatedAt:                now,
+		UpdatedAt:                now,
 	}
 
 	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {

--- a/pkg/cookiebanner/report_detected_trackers_test.go
+++ b/pkg/cookiebanner/report_detected_trackers_test.go
@@ -31,6 +31,7 @@ import (
 	"go.probo.inc/probo/internal/test"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/page"
+	"go.probo.inc/probo/pkg/uri"
 )
 
 // TestReportDetectedTrackers_SkipsOversizedIdentifier asserts that a
@@ -198,4 +199,131 @@ func TestReportDetectedTrackers_AcceptsMaxLengthIdentifier(t *testing.T) {
 		),
 	)
 	assert.Equal(t, maxLenKey, pattern.Pattern)
+}
+
+func TestReportDetectedTrackers_ResourceReportingDisabled(t *testing.T) {
+	t.Parallel()
+
+	client := test.PGClient(t)
+	ctx := context.Background()
+	fx := seedWorkerFixture(t, ctx, client)
+	svc := NewService(client, false)
+
+	_, err := svc.UpdateCookieBanner(
+		ctx,
+		fx.scope,
+		UpdateCookieBannerRequest{
+			CookieBannerID:           fx.banner.ID,
+			ResourceReportingEnabled: new(false),
+		},
+	)
+	require.NoError(t, err)
+
+	require.NoError(
+		t,
+		svc.ReportDetectedTrackers(
+			ctx,
+			fx.banner.ID,
+			ReportDetectedTrackersRequest{
+				Cookies: []DetectedCookie{
+					{
+						Name:   "_ga",
+						Source: coredata.CookieSourceScript,
+					},
+				},
+				Resources: []DetectedResourceItem{
+					{
+						URL:          uri.URI("https://cdn.example.com/tracker.js"),
+						ResourceType: coredata.TrackerResourceTypeScript,
+					},
+				},
+			},
+		),
+	)
+
+	var resource coredata.TrackerResource
+
+	err = client.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			return resource.LoadByBannerTypeOriginPath(
+				ctx,
+				conn,
+				fx.scope,
+				fx.banner.ID,
+				coredata.TrackerResourceTypeScript,
+				"https://cdn.example.com",
+				"/tracker.js",
+			)
+		},
+	)
+	require.ErrorIs(t, err, coredata.ErrResourceNotFound)
+
+	var cookiePattern coredata.TrackerPattern
+
+	require.NoError(
+		t,
+		client.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				return cookiePattern.LoadByBannerIDTypeAndPattern(
+					ctx,
+					conn,
+					fx.scope,
+					fx.banner.ID,
+					coredata.TrackerTypeCookie,
+					"_ga",
+					nil,
+				)
+			},
+		),
+	)
+	assert.Equal(t, "_ga", cookiePattern.Pattern)
+}
+
+func TestReportDetectedTrackers_ResourceReportingEnabled(t *testing.T) {
+	t.Parallel()
+
+	client := test.PGClient(t)
+	ctx := context.Background()
+	fx := seedWorkerFixture(t, ctx, client)
+	svc := NewService(client, false)
+
+	require.NoError(
+		t,
+		svc.ReportDetectedTrackers(
+			ctx,
+			fx.banner.ID,
+			ReportDetectedTrackersRequest{
+				Resources: []DetectedResourceItem{
+					{
+						URL:          uri.URI("https://cdn.example.com/pixel.js"),
+						ResourceType: coredata.TrackerResourceTypeScript,
+					},
+				},
+			},
+		),
+	)
+
+	var resource coredata.TrackerResource
+
+	require.NoError(
+		t,
+		client.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				return resource.LoadByBannerTypeOriginPath(
+					ctx,
+					conn,
+					fx.scope,
+					fx.banner.ID,
+					coredata.TrackerResourceTypeScript,
+					"https://cdn.example.com",
+					"/pixel.js",
+				)
+			},
+		),
+	)
+	assert.Equal(t, "https://cdn.example.com", resource.Origin)
+	assert.Equal(t, "/pixel.js", resource.Path)
 }

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -69,12 +69,13 @@ type (
 	}
 
 	UpdateCookieBannerRequest struct {
-		CookieBannerID    gid.GID
-		Name              *string
-		PrivacyPolicyURL  *string
-		CookiePolicyURL   *string
-		ConsentExpiryDays *int
-		DefaultLanguage   *string
+		CookieBannerID           gid.GID
+		Name                     *string
+		PrivacyPolicyURL         *string
+		CookiePolicyURL          *string
+		ConsentExpiryDays        *int
+		DefaultLanguage          *string
+		ResourceReportingEnabled *bool
 	}
 
 	UpdateCookieCategoryRequest struct {
@@ -202,19 +203,20 @@ type (
 	}
 
 	BannerConfig struct {
-		BannerID          gid.GID                                        `json:"banner_id"`
-		Version           int                                            `json:"version"`
-		Language          string                                         `json:"language"`
-		DefaultLanguage   string                                         `json:"default_language"`
-		PrivacyPolicyURL  string                                         `json:"privacy_policy_url,omitempty"`
-		CookiePolicyURL   string                                         `json:"cookie_policy_url"`
-		ConsentExpiryDays int                                            `json:"consent_expiry_days"`
-		ConsentMode       string                                         `json:"consent_mode"`
-		Regulation        Regulation                                     `json:"regulation"`
-		Layout            Layout                                         `json:"layout"`
-		ShowBranding      bool                                           `json:"show_branding"`
-		Categories        []coredata.CookieBannerVersionSnapshotCategory `json:"categories"`
-		Texts             map[string]string                              `json:"texts"`
+		BannerID                 gid.GID                                        `json:"banner_id"`
+		Version                  int                                            `json:"version"`
+		Language                 string                                         `json:"language"`
+		DefaultLanguage          string                                         `json:"default_language"`
+		PrivacyPolicyURL         string                                         `json:"privacy_policy_url,omitempty"`
+		CookiePolicyURL          string                                         `json:"cookie_policy_url"`
+		ConsentExpiryDays        int                                            `json:"consent_expiry_days"`
+		ConsentMode              string                                         `json:"consent_mode"`
+		Regulation               Regulation                                     `json:"regulation"`
+		Layout                   Layout                                         `json:"layout"`
+		ShowBranding             bool                                           `json:"show_branding"`
+		ResourceReportingEnabled bool                                           `json:"resource_reporting_enabled"`
+		Categories               []coredata.CookieBannerVersionSnapshotCategory `json:"categories"`
+		Texts                    map[string]string                              `json:"texts"`
 	}
 
 	UpsertCookieBannerTranslationRequest struct {
@@ -620,18 +622,19 @@ func (s *Service) CreateCookieBanner(
 			now := time.Now()
 
 			banner = &coredata.CookieBanner{
-				ID:                gid.New(scope.GetTenantID(), coredata.CookieBannerEntityType),
-				OrganizationID:    req.OrganizationID,
-				Name:              req.Name,
-				Origin:            CanonicalizeOrigin(req.Origin),
-				State:             coredata.CookieBannerStateActive,
-				PrivacyPolicyURL:  req.PrivacyPolicyURL,
-				CookiePolicyURL:   req.CookiePolicyURL,
-				ConsentExpiryDays: req.ConsentExpiryDays,
-				ShowBranding:      s.showBranding,
-				DefaultLanguage:   "en",
-				CreatedAt:         now,
-				UpdatedAt:         now,
+				ID:                       gid.New(scope.GetTenantID(), coredata.CookieBannerEntityType),
+				OrganizationID:           req.OrganizationID,
+				Name:                     req.Name,
+				Origin:                   CanonicalizeOrigin(req.Origin),
+				State:                    coredata.CookieBannerStateActive,
+				PrivacyPolicyURL:         req.PrivacyPolicyURL,
+				CookiePolicyURL:          req.CookiePolicyURL,
+				ConsentExpiryDays:        req.ConsentExpiryDays,
+				ShowBranding:             s.showBranding,
+				ResourceReportingEnabled: true,
+				DefaultLanguage:          "en",
+				CreatedAt:                now,
+				UpdatedAt:                now,
 			}
 
 			if err := banner.Insert(ctx, tx, scope); err != nil {
@@ -913,10 +916,12 @@ func (s *Service) UpdateCookieBanner(
 			cookiePolicyChanged := req.CookiePolicyURL != nil && *req.CookiePolicyURL != banner.CookiePolicyURL
 			expiryChanged := req.ConsentExpiryDays != nil && *req.ConsentExpiryDays != banner.ConsentExpiryDays
 			defaultLangChanged := req.DefaultLanguage != nil && *req.DefaultLanguage != banner.DefaultLanguage
+			resourceReportingChanged := req.ResourceReportingEnabled != nil &&
+				*req.ResourceReportingEnabled != banner.ResourceReportingEnabled
 
 			snapshotChanged := privacyChanged || cookiePolicyChanged || expiryChanged || defaultLangChanged
 
-			if !nameChanged && !snapshotChanged {
+			if !nameChanged && !snapshotChanged && !resourceReportingChanged {
 				return nil
 			}
 
@@ -938,6 +943,10 @@ func (s *Service) UpdateCookieBanner(
 
 			if req.DefaultLanguage != nil {
 				banner.DefaultLanguage = *req.DefaultLanguage
+			}
+
+			if req.ResourceReportingEnabled != nil {
+				banner.ResourceReportingEnabled = *req.ResourceReportingEnabled
 			}
 
 			banner.UpdatedAt = time.Now()
@@ -1850,16 +1859,17 @@ func buildBannerConfig(
 	}
 
 	return &BannerConfig{
-		BannerID:          banner.ID,
-		Version:           version.Version,
-		Language:          resolvedLang,
-		DefaultLanguage:   defaultLang,
-		PrivacyPolicyURL:  privacyPolicyURL,
-		CookiePolicyURL:   snapshot.CookiePolicyURL,
-		ConsentExpiryDays: snapshot.ConsentExpiryDays,
-		ShowBranding:      banner.ShowBranding,
-		Categories:        categories,
-		Texts:             texts,
+		BannerID:                 banner.ID,
+		Version:                  version.Version,
+		Language:                 resolvedLang,
+		DefaultLanguage:          defaultLang,
+		PrivacyPolicyURL:         privacyPolicyURL,
+		CookiePolicyURL:          snapshot.CookiePolicyURL,
+		ConsentExpiryDays:        snapshot.ConsentExpiryDays,
+		ShowBranding:             banner.ShowBranding,
+		ResourceReportingEnabled: banner.ResourceReportingEnabled,
+		Categories:               categories,
+		Texts:                    texts,
 	}
 }
 
@@ -2163,6 +2173,10 @@ func (s *Service) ReportDetectedTrackers(
 				}
 
 				return fmt.Errorf("cannot load cookie banner: %w", err)
+			}
+
+			if !banner.ResourceReportingEnabled {
+				req.Resources = nil
 			}
 
 			var uncategorised coredata.CookieCategory

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -945,18 +945,31 @@ func (s *Service) UpdateCookieBanner(
 				banner.DefaultLanguage = *req.DefaultLanguage
 			}
 
-			if req.ResourceReportingEnabled != nil {
-				banner.ResourceReportingEnabled = *req.ResourceReportingEnabled
-			}
-
 			banner.UpdatedAt = time.Now()
 
-			if err := banner.Update(ctx, tx, scope); err != nil {
-				if errors.Is(err, coredata.ErrResourceAlreadyExists) {
-					return ErrOriginAlreadyInUse
-				}
+			if nameChanged || snapshotChanged {
+				if err := banner.Update(ctx, tx, scope); err != nil {
+					if errors.Is(err, coredata.ErrResourceAlreadyExists) {
+						return ErrOriginAlreadyInUse
+					}
 
-				return fmt.Errorf("cannot update cookie banner: %w", err)
+					return fmt.Errorf("cannot update cookie banner: %w", err)
+				}
+			}
+
+			if resourceReportingChanged {
+				if err := banner.UpdateResourceReportingEnabled(
+					ctx,
+					tx,
+					scope,
+					*req.ResourceReportingEnabled,
+				); err != nil {
+					if errors.Is(err, coredata.ErrResourceNotFound) {
+						return ErrBannerNotFound
+					}
+
+					return fmt.Errorf("cannot update resource reporting: %w", err)
+				}
 			}
 
 			if snapshotChanged {

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -945,31 +945,18 @@ func (s *Service) UpdateCookieBanner(
 				banner.DefaultLanguage = *req.DefaultLanguage
 			}
 
-			banner.UpdatedAt = time.Now()
-
-			if nameChanged || snapshotChanged {
-				if err := banner.Update(ctx, tx, scope); err != nil {
-					if errors.Is(err, coredata.ErrResourceAlreadyExists) {
-						return ErrOriginAlreadyInUse
-					}
-
-					return fmt.Errorf("cannot update cookie banner: %w", err)
-				}
+			if req.ResourceReportingEnabled != nil {
+				banner.ResourceReportingEnabled = *req.ResourceReportingEnabled
 			}
 
-			if resourceReportingChanged {
-				if err := banner.UpdateResourceReportingEnabled(
-					ctx,
-					tx,
-					scope,
-					*req.ResourceReportingEnabled,
-				); err != nil {
-					if errors.Is(err, coredata.ErrResourceNotFound) {
-						return ErrBannerNotFound
-					}
+			banner.UpdatedAt = time.Now()
 
-					return fmt.Errorf("cannot update resource reporting: %w", err)
+			if err := banner.Update(ctx, tx, scope); err != nil {
+				if errors.Is(err, coredata.ErrResourceAlreadyExists) {
+					return ErrOriginAlreadyInUse
 				}
+
+				return fmt.Errorf("cannot update cookie banner: %w", err)
 			}
 
 			if snapshotChanged {

--- a/pkg/coredata/cookie_banner.go
+++ b/pkg/coredata/cookie_banner.go
@@ -516,7 +516,6 @@ SET
 	cookie_policy_url = @cookie_policy_url,
 	consent_expiry_days = @consent_expiry_days,
 	show_branding = @show_branding,
-	resource_reporting_enabled = @resource_reporting_enabled,
 	default_language = @default_language,
 	policy_document_id = @policy_document_id,
 	updated_at = @updated_at
@@ -528,17 +527,16 @@ WHERE
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
-		"id":                         b.ID,
-		"name":                       b.Name,
-		"state":                      b.State,
-		"privacy_policy_url":         b.PrivacyPolicyURL,
-		"cookie_policy_url":          b.CookiePolicyURL,
-		"consent_expiry_days":        b.ConsentExpiryDays,
-		"show_branding":              b.ShowBranding,
-		"resource_reporting_enabled": b.ResourceReportingEnabled,
-		"default_language":           b.DefaultLanguage,
-		"policy_document_id":         b.PolicyDocumentID,
-		"updated_at":                 b.UpdatedAt,
+		"id":                  b.ID,
+		"name":                b.Name,
+		"state":               b.State,
+		"privacy_policy_url":  b.PrivacyPolicyURL,
+		"cookie_policy_url":   b.CookiePolicyURL,
+		"consent_expiry_days": b.ConsentExpiryDays,
+		"show_branding":       b.ShowBranding,
+		"default_language":    b.DefaultLanguage,
+		"policy_document_id":  b.PolicyDocumentID,
+		"updated_at":          b.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())
 
@@ -595,6 +593,45 @@ WHERE
 	}
 
 	b.ShowBranding = show
+
+	return nil
+}
+
+func (b *CookieBanner) UpdateResourceReportingEnabled(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+	enabled bool,
+) error {
+	q := `
+UPDATE cookie_banners
+SET
+	resource_reporting_enabled = @resource_reporting_enabled,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":                         b.ID,
+		"resource_reporting_enabled": enabled,
+		"updated_at":                 time.Now(),
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	result, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update cookie banner resource_reporting_enabled: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return ErrResourceNotFound
+	}
+
+	b.ResourceReportingEnabled = enabled
 
 	return nil
 }

--- a/pkg/coredata/cookie_banner.go
+++ b/pkg/coredata/cookie_banner.go
@@ -46,6 +46,7 @@ type (
 		CookiePolicyURL             string            `db:"cookie_policy_url"`
 		ConsentExpiryDays           int               `db:"consent_expiry_days"`
 		ShowBranding                bool              `db:"show_branding"`
+		ResourceReportingEnabled    bool              `db:"resource_reporting_enabled"`
 		DefaultLanguage             string            `db:"default_language"`
 		PatternAnalysisRequestedAt  *time.Time        `db:"pattern_analysis_requested_at"`
 		PolicyDocumentID            *gid.GID          `db:"policy_document_id"`
@@ -122,6 +123,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
+	resource_reporting_enabled,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -176,6 +178,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
+	resource_reporting_enabled,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -231,6 +234,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
+	resource_reporting_enabled,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -290,6 +294,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
+	resource_reporting_enabled,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -346,6 +351,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
+	resource_reporting_enabled,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -434,6 +440,7 @@ INSERT INTO cookie_banners (
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
+	resource_reporting_enabled,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -451,6 +458,7 @@ INSERT INTO cookie_banners (
 	@cookie_policy_url,
 	@consent_expiry_days,
 	@show_branding,
+	@resource_reporting_enabled,
 	@default_language,
 	@pattern_analysis_requested_at,
 	@policy_document_id,
@@ -471,6 +479,7 @@ INSERT INTO cookie_banners (
 		"cookie_policy_url":              b.CookiePolicyURL,
 		"consent_expiry_days":            b.ConsentExpiryDays,
 		"show_branding":                  b.ShowBranding,
+		"resource_reporting_enabled":     b.ResourceReportingEnabled,
 		"default_language":               b.DefaultLanguage,
 		"pattern_analysis_requested_at":  b.PatternAnalysisRequestedAt,
 		"policy_document_id":             b.PolicyDocumentID,
@@ -507,6 +516,7 @@ SET
 	cookie_policy_url = @cookie_policy_url,
 	consent_expiry_days = @consent_expiry_days,
 	show_branding = @show_branding,
+	resource_reporting_enabled = @resource_reporting_enabled,
 	default_language = @default_language,
 	policy_document_id = @policy_document_id,
 	updated_at = @updated_at
@@ -518,16 +528,17 @@ WHERE
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
-		"id":                  b.ID,
-		"name":                b.Name,
-		"state":               b.State,
-		"privacy_policy_url":  b.PrivacyPolicyURL,
-		"cookie_policy_url":   b.CookiePolicyURL,
-		"consent_expiry_days": b.ConsentExpiryDays,
-		"show_branding":       b.ShowBranding,
-		"default_language":    b.DefaultLanguage,
-		"policy_document_id":  b.PolicyDocumentID,
-		"updated_at":          b.UpdatedAt,
+		"id":                         b.ID,
+		"name":                       b.Name,
+		"state":                      b.State,
+		"privacy_policy_url":         b.PrivacyPolicyURL,
+		"cookie_policy_url":          b.CookiePolicyURL,
+		"consent_expiry_days":        b.ConsentExpiryDays,
+		"show_branding":              b.ShowBranding,
+		"resource_reporting_enabled": b.ResourceReportingEnabled,
+		"default_language":           b.DefaultLanguage,
+		"policy_document_id":         b.PolicyDocumentID,
+		"updated_at":                 b.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())
 
@@ -628,6 +639,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
+	resource_reporting_enabled,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -721,6 +733,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
+	resource_reporting_enabled,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,

--- a/pkg/coredata/cookie_banner.go
+++ b/pkg/coredata/cookie_banner.go
@@ -516,6 +516,7 @@ SET
 	cookie_policy_url = @cookie_policy_url,
 	consent_expiry_days = @consent_expiry_days,
 	show_branding = @show_branding,
+	resource_reporting_enabled = @resource_reporting_enabled,
 	default_language = @default_language,
 	policy_document_id = @policy_document_id,
 	updated_at = @updated_at
@@ -527,16 +528,17 @@ WHERE
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
-		"id":                  b.ID,
-		"name":                b.Name,
-		"state":               b.State,
-		"privacy_policy_url":  b.PrivacyPolicyURL,
-		"cookie_policy_url":   b.CookiePolicyURL,
-		"consent_expiry_days": b.ConsentExpiryDays,
-		"show_branding":       b.ShowBranding,
-		"default_language":    b.DefaultLanguage,
-		"policy_document_id":  b.PolicyDocumentID,
-		"updated_at":          b.UpdatedAt,
+		"id":                         b.ID,
+		"name":                       b.Name,
+		"state":                      b.State,
+		"privacy_policy_url":         b.PrivacyPolicyURL,
+		"cookie_policy_url":          b.CookiePolicyURL,
+		"consent_expiry_days":        b.ConsentExpiryDays,
+		"show_branding":              b.ShowBranding,
+		"resource_reporting_enabled": b.ResourceReportingEnabled,
+		"default_language":           b.DefaultLanguage,
+		"policy_document_id":         b.PolicyDocumentID,
+		"updated_at":                 b.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())
 
@@ -593,45 +595,6 @@ WHERE
 	}
 
 	b.ShowBranding = show
-
-	return nil
-}
-
-func (b *CookieBanner) UpdateResourceReportingEnabled(
-	ctx context.Context,
-	tx pg.Tx,
-	scope Scoper,
-	enabled bool,
-) error {
-	q := `
-UPDATE cookie_banners
-SET
-	resource_reporting_enabled = @resource_reporting_enabled,
-	updated_at = @updated_at
-WHERE
-	%s
-	AND id = @id
-`
-
-	q = fmt.Sprintf(q, scope.SQLFragment())
-
-	args := pgx.StrictNamedArgs{
-		"id":                         b.ID,
-		"resource_reporting_enabled": enabled,
-		"updated_at":                 time.Now(),
-	}
-	maps.Copy(args, scope.SQLArguments())
-
-	result, err := tx.Exec(ctx, q, args)
-	if err != nil {
-		return fmt.Errorf("cannot update cookie banner resource_reporting_enabled: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return ErrResourceNotFound
-	}
-
-	b.ResourceReportingEnabled = enabled
 
 	return nil
 }

--- a/pkg/coredata/migrations/20260811T074045Z.sql
+++ b/pkg/coredata/migrations/20260811T074045Z.sql
@@ -1,0 +1,22 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TABLE cookie_banners ADD COLUMN resource_reporting_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE cookie_banners ALTER COLUMN resource_reporting_enabled DROP DEFAULT;

--- a/pkg/coredata/tracker_pattern_test.go
+++ b/pkg/coredata/tracker_pattern_test.go
@@ -66,17 +66,18 @@ func seedTrackerPatternFixture(t *testing.T, ctx context.Context, client *pg.Cli
 		}
 
 		banner := &coredata.CookieBanner{
-			ID:                cookieBannerID,
-			OrganizationID:    organizationID,
-			Name:              "TrackerPattern Test Banner",
-			Origin:            "https://tracker-pattern-test.example.com",
-			State:             coredata.CookieBannerStateActive,
-			CookiePolicyURL:   "https://tracker-pattern-test.example.com/cookies",
-			ConsentExpiryDays: 180,
-			ShowBranding:      false,
-			DefaultLanguage:   "en",
-			CreatedAt:         now,
-			UpdatedAt:         now,
+			ID:                       cookieBannerID,
+			OrganizationID:           organizationID,
+			Name:                     "TrackerPattern Test Banner",
+			Origin:                   "https://tracker-pattern-test.example.com",
+			State:                    coredata.CookieBannerStateActive,
+			CookiePolicyURL:          "https://tracker-pattern-test.example.com/cookies",
+			ConsentExpiryDays:        180,
+			ShowBranding:             false,
+			ResourceReportingEnabled: true,
+			DefaultLanguage:          "en",
+			CreatedAt:                now,
+			UpdatedAt:                now,
 		}
 		if err := banner.Insert(ctx, tx, scope); err != nil {
 			return err

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -634,12 +634,13 @@ func (r *mutationResolver) UpdateCookieBanner(ctx context.Context, input types.U
 		ctx,
 		scope,
 		cookiebanner.UpdateCookieBannerRequest{
-			CookieBannerID:    input.CookieBannerID,
-			Name:              input.Name,
-			PrivacyPolicyURL:  input.PrivacyPolicyURL,
-			CookiePolicyURL:   input.CookiePolicyURL,
-			ConsentExpiryDays: input.ConsentExpiryDays,
-			DefaultLanguage:   input.DefaultLanguage,
+			CookieBannerID:           input.CookieBannerID,
+			Name:                     input.Name,
+			PrivacyPolicyURL:         input.PrivacyPolicyURL,
+			CookiePolicyURL:          input.CookiePolicyURL,
+			ConsentExpiryDays:        input.ConsentExpiryDays,
+			DefaultLanguage:          input.DefaultLanguage,
+			ResourceReportingEnabled: input.ResourceReportingEnabled,
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -136,6 +136,7 @@ type CookieBanner implements Node {
     cookiePolicyUrl: String!
     consentExpiryDays: Int!
     showBranding: Boolean!
+    resourceReportingEnabled: Boolean!
     defaultLanguage: String!
 
     organization: Organization @goField(forceResolver: true)
@@ -667,6 +668,7 @@ input UpdateCookieBannerInput {
     cookiePolicyUrl: String
     consentExpiryDays: Int
     defaultLanguage: String
+    resourceReportingEnabled: Boolean
 }
 
 input DeleteCookieBannerInput {

--- a/pkg/server/api/console/v1/types/cookie_banner.go
+++ b/pkg/server/api/console/v1/types/cookie_banner.go
@@ -72,16 +72,17 @@ func NewCookieBanner(b *coredata.CookieBanner) *CookieBanner {
 		Organization: &Organization{
 			ID: b.OrganizationID,
 		},
-		Name:              b.Name,
-		Origin:            b.Origin,
-		State:             b.State,
-		PrivacyPolicyURL:  b.PrivacyPolicyURL,
-		CookiePolicyURL:   b.CookiePolicyURL,
-		ConsentExpiryDays: b.ConsentExpiryDays,
-		ShowBranding:      b.ShowBranding,
-		DefaultLanguage:   b.DefaultLanguage,
-		CreatedAt:         b.CreatedAt,
-		UpdatedAt:         b.UpdatedAt,
+		Name:                     b.Name,
+		Origin:                   b.Origin,
+		State:                    b.State,
+		PrivacyPolicyURL:         b.PrivacyPolicyURL,
+		CookiePolicyURL:          b.CookiePolicyURL,
+		ConsentExpiryDays:        b.ConsentExpiryDays,
+		ShowBranding:             b.ShowBranding,
+		ResourceReportingEnabled: b.ResourceReportingEnabled,
+		DefaultLanguage:          b.DefaultLanguage,
+		CreatedAt:                b.CreatedAt,
+		UpdatedAt:                b.UpdatedAt,
 	}
 
 	if b.PolicyDocumentID != nil {

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5663,6 +5663,10 @@ func (r *Resolver) UpdateCookieBannerTool(ctx context.Context, req *mcp.CallTool
 		updateReq.DefaultLanguage = *v
 	}
 
+	if v := UnwrapOmittable(input.ResourceReportingEnabled); v != nil && *v != nil {
+		updateReq.ResourceReportingEnabled = *v
+	}
+
 	banner, err := r.cookieBanner.UpdateCookieBanner(ctx, scope, updateReq)
 	if err != nil {
 		return nil, types.UpdateCookieBannerOutput{}, fmt.Errorf("cannot update cookie banner: %w", err)

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -11151,6 +11151,7 @@ components:
         - cookie_policy_url
         - consent_expiry_days
         - show_branding
+        - resource_reporting_enabled
         - default_language
         - created_at
         - updated_at
@@ -11185,6 +11186,9 @@ components:
         show_branding:
           type: boolean
           description: Whether to show Probo branding
+        resource_reporting_enabled:
+          type: boolean
+          description: Whether the SDK reports detected resources
         default_language:
           type: string
           description: Default language code
@@ -11633,6 +11637,11 @@ components:
         default_language:
           type:
             - string
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+        resource_reporting_enabled:
+          type:
+            - boolean
             - "null"
           go.probo.inc/mcpgen/omittable: true
 

--- a/pkg/server/api/mcp/v1/types/cookie_banner.go
+++ b/pkg/server/api/mcp/v1/types/cookie_banner.go
@@ -27,18 +27,19 @@ import (
 
 func NewCookieBanner(b *coredata.CookieBanner) *CookieBanner {
 	return &CookieBanner{
-		ID:                b.ID,
-		OrganizationID:    b.OrganizationID,
-		Name:              b.Name,
-		Origin:            b.Origin,
-		State:             CookieBannerState(b.State),
-		PrivacyPolicyURL:  b.PrivacyPolicyURL,
-		CookiePolicyURL:   b.CookiePolicyURL,
-		ConsentExpiryDays: b.ConsentExpiryDays,
-		ShowBranding:      b.ShowBranding,
-		DefaultLanguage:   b.DefaultLanguage,
-		CreatedAt:         b.CreatedAt,
-		UpdatedAt:         b.UpdatedAt,
+		ID:                       b.ID,
+		OrganizationID:           b.OrganizationID,
+		Name:                     b.Name,
+		Origin:                   b.Origin,
+		State:                    CookieBannerState(b.State),
+		PrivacyPolicyURL:         b.PrivacyPolicyURL,
+		CookiePolicyURL:          b.CookiePolicyURL,
+		ConsentExpiryDays:        b.ConsentExpiryDays,
+		ShowBranding:             b.ShowBranding,
+		ResourceReportingEnabled: b.ResourceReportingEnabled,
+		DefaultLanguage:          b.DefaultLanguage,
+		CreatedAt:                b.CreatedAt,
+		UpdatedAt:                b.UpdatedAt,
 	}
 }
 


### PR DESCRIPTION
Closes [ENG-731](https://linear.app/probo/issue/ENG-731/cb-switch-to-not-report-resources-on-a-cookie-banner)

Operators can disable resource detection per banner so the SDK skips ResourceDetector and the server ignores resources on the shared report endpoint. Cookies and storage still report normally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-banner “Resource reporting” switch in the SDK and backend. When disabled, the SDK skips resource detection and the server ignores resource reports; cookies and storage still report.

### Tests **`+253`** **`-42`**
- Added SDK unit tests for `shouldStartResourceDetector` and service tests for enabled/disabled paths.
- Expanded e2e to cover disabling via GraphQL and public config assertions.

### Coredata **`+45`** **`-10`**
- Added `resource_reporting_enabled` (migration) and wired it across model/queries.

### GraphQL API **`+20`** **`-16`**
- Exposed `resourceReportingEnabled` on `CookieBanner` and `UpdateCookieBannerInput`; updated resolvers.

### MCP **`+26`** **`-12`**
- Added `resource_reporting_enabled` to spec/types and made update tool field omittable.

### prb (CLI) **`+26`** **`-17`**
- `update`: `--resource-reporting-enabled` (only sent when specified).
- `view`: shows “Resource Reporting”.

### Service **`+56`** **`-42`**
- New banners default `ResourceReportingEnabled` to true; included in built config.
- Update treats the flag like other fields; report handler drops resources when disabled.

### App: console **`+56`** **`-4`**
- Settings toggle with help text and locales; included in fragment and mutation.

### Package: `cookie-banner` **`+70`** **`-11`**
- Normalized config with `resolveLayout` and `resolveResourceReportingEnabled`; start `ResourceDetector` only when enabled or in discovery mode; one-time warning if missing.
- Added `vitest` and a unit test for `shouldStartResourceDetector`.

### Package: `n8n-node` **`+18`** **`-0`**
- Queries include `resourceReportingEnabled`.
- `update` accepts optional flag; docs clarify omitting keeps current value.

### Other **`+2`** **`-1`**
- Updated lockfile for `vitest`.

<sup>Written for commit f6f7f07694534f37151f643d88d8bd070dc01d2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



