### PR TITLE
Reject signatures without signer names

### DIFF
--- a/pkg/esign/service.go
+++ b/pkg/esign/service.go
@@ -37,6 +37,7 @@ import (
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/html2pdf"
 	"go.probo.inc/probo/pkg/mail"
+	"go.probo.inc/probo/pkg/validator"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -91,6 +92,22 @@ type (
 		ActorUA     string
 	}
 )
+
+func (req AcceptSignatureRequest) Validate() error {
+	v := validator.New()
+
+	v.Check(req.SignerFullName, "signer_full_name", validator.NotEmpty())
+
+	return v.Error()
+}
+
+func (req CreateAndAcceptSignatureRequest) Validate() error {
+	v := validator.New()
+
+	v.Check(req.SignerFullName, "signer_full_name", validator.NotEmpty())
+
+	return v.Error()
+}
 
 func NewService(
 	pgClient *pg.Client,
@@ -209,6 +226,10 @@ func (s *Service) CreateAndAcceptSignature(
 	conn pg.Tx,
 	req *CreateAndAcceptSignatureRequest,
 ) (*coredata.ElectronicSignature, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
 	sig, err := s.CreateSignature(
 		ctx,
 		conn,
@@ -318,6 +339,10 @@ func (s *Service) createStampedDocument(
 }
 
 func (s *Service) AcceptSignature(ctx context.Context, scope coredata.Scoper, req *AcceptSignatureRequest) (*coredata.ElectronicSignature, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
 	var (
 		now       = time.Now()
 		signature = coredata.ElectronicSignature{}

--- a/pkg/esign/service_test.go
+++ b/pkg/esign/service_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package esign
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/validator"
+)
+
+func TestAcceptSignature_EmptySignerFullName(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{}
+	_, err := s.AcceptSignature(
+		context.Background(),
+		nil,
+		&AcceptSignatureRequest{SignerFullName: " \t "},
+	)
+
+	require.Error(t, err)
+	validationErrors, ok := errors.AsType[validator.ValidationErrors](err)
+	require.True(t, ok)
+	assert.NotEmpty(t, validationErrors.ByField("signer_full_name"))
+}
+
+func TestCreateAndAcceptSignature_EmptySignerFullName(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{}
+	_, err := s.CreateAndAcceptSignature(
+		context.Background(),
+		nil,
+		&CreateAndAcceptSignatureRequest{},
+	)
+
+	require.Error(t, err)
+	validationErrors, ok := errors.AsType[validator.ValidationErrors](err)
+	require.True(t, ok)
+	assert.NotEmpty(t, validationErrors.ByField("signer_full_name"))
+}
+
+func TestSignatureRequestsValidate_SignerFullName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		validate func() error
+	}{
+		{
+			name: "accept signature",
+			validate: func() error {
+				return (AcceptSignatureRequest{SignerFullName: "Ada Lovelace"}).Validate()
+			},
+		},
+		{
+			name: "create and accept signature",
+			validate: func() error {
+				return (CreateAndAcceptSignatureRequest{SignerFullName: "Ada Lovelace"}).Validate()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				assert.NoError(t, tt.validate())
+			},
+		)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- validate signer full names before accepting signatures
- reject empty and whitespace-only names before database or file operations
- cover both acceptance paths with regression tests

## Testing
- Pending targeted Go tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d7ff5ca-31a9-4f3a-922e-6d961063b0bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d7ff5ca-31a9-4f3a-922e-6d961063b0bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject signatures when `signer_full_name` is empty or whitespace. Validate requests early and return `invalid request` instead of proceeding.

### Service **`+25`** **`-0`**
- Add `Validate()` to `AcceptSignatureRequest` and `CreateAndAcceptSignatureRequest` using `validator.NotEmpty()`.
- Enforce validation in `AcceptSignature` and `CreateAndAcceptSignature`; wrap errors with `invalid request`.
- Import `go.probo.inc/probo/pkg/validator`.

### Tests **`+96`** **`-0`**
- Add tests rejecting empty/whitespace names for both acceptance paths; assert `validator.ValidationErrors` on `signer_full_name`.
- Add positive tests for valid names (e.g., "Ada Lovelace").

<sup>Written for commit 0fc98f2e1e5701c6ea638e47c88e20d408ac2c43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

