### PR TITLE
Preserve certificate seal timestamp precision

### DIFF
--- a/pkg/esign/certgen.go
+++ b/pkg/esign/certgen.go
@@ -103,7 +103,7 @@ func (g *CertificateGenerator) Generate(
 		return nil, fmt.Errorf("cannot generate certificate: signature %s has no signed_at timestamp", signature.ID)
 	}
 
-	data.SignedAt = signature.SignedAt.UTC().Format(time.RFC3339)
+	data.SignedAt = formatSealSignedAt(*signature.SignedAt)
 
 	if len(signature.TSAToken) == 0 {
 		return nil, fmt.Errorf("cannot generate certificate: signature %s has no TSA token", signature.ID)
@@ -154,6 +154,10 @@ func (g *CertificateGenerator) Generate(
 	}
 
 	return pdfReader, nil
+}
+
+func formatSealSignedAt(signedAt time.Time) string {
+	return signedAt.UTC().Truncate(time.Microsecond).Format(time.RFC3339Nano)
 }
 
 func tsaAuthorityName(ts *timestamp.Timestamp) string {

--- a/pkg/esign/certgen_test.go
+++ b/pkg/esign/certgen_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package esign
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatSealSignedAt(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		signedAt time.Time
+		expected string
+	}{
+		"microsecond precision": {
+			signedAt: time.Date(2026, time.January, 2, 3, 4, 5, 961506789, time.UTC),
+			expected: "2026-01-02T03:04:05.961506Z",
+		},
+		"UTC conversion": {
+			signedAt: time.Date(
+				2026,
+				time.January,
+				2,
+				3,
+				4,
+				5,
+				123456789,
+				time.FixedZone("UTC+2", 2*60*60),
+			),
+			expected: "2026-01-02T01:04:05.123456Z",
+		},
+		"whole second": {
+			signedAt: time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC),
+			expected: "2026-01-02T03:04:05Z",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(
+			name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				assert.Equal(t, tt.expected, formatSealSignedAt(tt.signedAt))
+			},
+		)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- render certificate `Signed At` values with the same UTC, microsecond-truncated RFC 3339 representation used by seal v1
- add regression coverage for fractional precision, timezone conversion, and whole-second timestamps

Fixes #1684

## Testing

- `go test ./pkg/esign`
- `go test ./pkg/coredata`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c179b8d9-5849-44a7-8e79-280050e2e154?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c179b8d9-5849-44a7-8e79-280050e2e154&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves certificate “Signed At” timestamps by formatting in UTC RFC 3339 with microsecond precision (truncated), matching seal v1. Adds regression tests for precision and timezone handling. Fixes #1684.

### Service **`+5`** **`-1`**
Uses `formatSealSignedAt` in `pkg/esign/certgen.go` to emit UTC RFC 3339Nano truncated to microseconds, replacing previous whole-second `RFC3339` formatting and keeping seals/certificates consistent with v1.

### Tests **`+70`** **`-0`**
Adds unit tests for `formatSealSignedAt` covering microsecond truncation, UTC conversion from offset timezones, and whole-second formatting to prevent regressions.

<sup>Written for commit 7bd56afddd9ec45610c64cec942bd61e66945cfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

