### PR TITLE
fix(esign): print signed_at on certificates at seal precision

### DIFF
--- a/pkg/coredata/electronic_signature.go
+++ b/pkg/coredata/electronic_signature.go
@@ -373,6 +373,17 @@ func (es *ElectronicSignature) ComputeSeal(version int) (string, error) {
 	}
 }
 
+// SealSignedAt renders SignedAt exactly as the seal hashes it. Anything
+// displaying the timestamp to a verifier must use this, or the seal cannot be
+// recomputed from what they were shown.
+func (es *ElectronicSignature) SealSignedAt() string {
+	if es.SignedAt == nil {
+		return ""
+	}
+
+	return es.SignedAt.UTC().Truncate(time.Microsecond).Format(time.RFC3339Nano)
+}
+
 func (es *ElectronicSignature) computeSealV1() (string, error) {
 	if es.SignedAt == nil {
 		return "", fmt.Errorf("signed_at must not be nil")
@@ -389,7 +400,7 @@ func (es *ElectronicSignature) computeSealV1() (string, error) {
 		ref.UnrefOrZero(es.SignerIPAddress),
 		ref.UnrefOrZero(es.SignerUserAgent),
 		es.ConsentText,
-		es.SignedAt.UTC().Truncate(time.Microsecond).Format(time.RFC3339Nano),
+		es.SealSignedAt(),
 	}
 
 	for i, f := range fields {

--- a/pkg/coredata/electronic_signature_seal_test.go
+++ b/pkg/coredata/electronic_signature_seal_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+func newSealTestSignature(signedAt time.Time) *coredata.ElectronicSignature {
+	tenantID := gid.NewTenantID()
+
+	fileHash := strings.Repeat("a", 64)
+	signerFullName := "Test Signer"
+	signerIP := "203.0.113.7"
+	signerUA := "Mozilla/5.0 (X11; Linux x86_64)"
+
+	return &coredata.ElectronicSignature{
+		ID:              gid.New(tenantID, coredata.ElectronicSignatureEntityType),
+		OrganizationID:  gid.New(tenantID, coredata.OrganizationEntityType),
+		DocumentType:    coredata.ElectronicSignatureDocumentTypeOther,
+		FileID:          gid.New(tenantID, coredata.FileEntityType),
+		FileHash:        &fileHash,
+		SignerFullName:  &signerFullName,
+		SignerEmail:     "Test.Signer@example.com",
+		SignerIPAddress: &signerIP,
+		SignerUserAgent: &signerUA,
+		ConsentText:     "I consent to sign this document electronically.",
+		SignedAt:        &signedAt,
+	}
+}
+
+// A verifier only ever sees the timestamp the certificate prints. If that
+// rendering drops precision the seal cannot be recomputed from it, so the two
+// must stay byte-identical.
+func TestElectronicSignature_SealSignedAtIsWhatTheSealHashes(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		signedAt time.Time
+		want     string
+	}{
+		{
+			name:     "microseconds",
+			signedAt: time.Date(2026, 8, 11, 9, 36, 49, 961506000, time.UTC),
+			want:     "2026-08-11T09:36:49.961506Z",
+		},
+		{
+			name:     "trailing zeros stripped",
+			signedAt: time.Date(2026, 8, 11, 9, 36, 49, 100000000, time.UTC),
+			want:     "2026-08-11T09:36:49.1Z",
+		},
+		{
+			name:     "whole second carries no fraction",
+			signedAt: time.Date(2026, 8, 11, 9, 36, 49, 0, time.UTC),
+			want:     "2026-08-11T09:36:49Z",
+		},
+		{
+			name:     "nanoseconds truncated to microseconds",
+			signedAt: time.Date(2026, 8, 11, 9, 36, 49, 961506789, time.UTC),
+			want:     "2026-08-11T09:36:49.961506Z",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			signature := newSealTestSignature(tc.signedAt)
+
+			assert.Equal(t, tc.want, signature.SealSignedAt())
+
+			seal, err := signature.ComputeSeal(1)
+			require.NoError(t, err)
+
+			fields := []string{
+				signature.ID.String(),
+				signature.OrganizationID.String(),
+				signature.DocumentType.String(),
+				signature.FileID.String(),
+				*signature.FileHash,
+				*signature.SignerFullName,
+				strings.ToLower(signature.SignerEmail),
+				*signature.SignerIPAddress,
+				*signature.SignerUserAgent,
+				signature.ConsentText,
+				signature.SealSignedAt(),
+			}
+			expected := sha256.Sum256([]byte(strings.Join(fields, "\n")))
+
+			assert.Equal(t, hex.EncodeToString(expected[:]), seal)
+		})
+	}
+}
+
+func TestElectronicSignature_SealSignedAtNilIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	signature := &coredata.ElectronicSignature{}
+
+	assert.Empty(t, signature.SealSignedAt())
+}

--- a/pkg/esign/certgen.go
+++ b/pkg/esign/certgen.go
@@ -103,7 +103,7 @@ func (g *CertificateGenerator) Generate(
 		return nil, fmt.Errorf("cannot generate certificate: signature %s has no signed_at timestamp", signature.ID)
 	}
 
-	data.SignedAt = signature.SignedAt.UTC().Format(time.RFC3339)
+	data.SignedAt = signature.SealSignedAt()
 
 	if len(signature.TSAToken) == 0 {
 		return nil, fmt.Errorf("cannot generate certificate: signature %s has no TSA token", signature.ID)


### PR DESCRIPTION
Fixes #1684.

## Problem

`certgen` rendered the signing timestamp with `time.RFC3339` (second precision) while `computeSealV1` hashes it truncated to microseconds. The certificate's own "Seal Verification (v1)" section instructs the reader to recompute the seal from the fields shown on the certificate, so whenever the fraction was non-zero that procedure could not succeed — the timestamp printed was not the timestamp hashed.

The failure mode is worse than an unhelpful one: a verifier following the printed steps gets a mismatched digest, which reads as evidence of tampering rather than as a formatting difference. Independent verifiability is the property the seal section exists to provide.

## Change

Adds `ElectronicSignature.SealSignedAt()` as the single rendering of that timestamp, used by both `computeSealV1` and `certgen`, so the displayed value and the hashed value cannot drift apart again. I went with a shared accessor rather than duplicating the format expression in `certgen`, since the duplication is what allowed the two to diverge in the first place — happy to reduce it to a one-line change in `certgen` if you'd prefer the smaller diff.

No behaviour change to the seal itself: the hashed bytes are identical before and after.

## Tests

`pkg/coredata/electronic_signature_seal_test.go` asserts that what `SealSignedAt()` returns is exactly what the seal hashes, across the formatting cases that matter — microsecond fractions, trailing-zero stripping (`.1Z`, not `.100000Z`), a whole second carrying no fraction at all, and nanosecond input truncated to microseconds — plus the nil case.

Verified against a real certificate from a self-hosted instance: the seal recomputes and matches once the full-precision timestamp is used.

## Note for existing certificates

Certificates generated before this change stay unverifiable by the printed procedure, because the sub-second component was never written into them. Recovering it means recomputing across the 10^6 candidate microsecond values, which is deterministic and takes about a second. Worth a mention in release notes if any users are relying on that section.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies certificate and seal timestamp rendering by introducing a single `SealSignedAt()` formatter and using it in both the seal and certificate. This fixes seal verification when sub-second fractions exist and avoids false tampering warnings.

### Tests **`+127`** **`-0`**
Adds tests ensuring `SealSignedAt()` is exactly what the seal hashes, covering microseconds, trailing-zero stripping, whole seconds, nanosecond truncation, and nil.

### Coredata **`+12`** **`-1`**
Adds `ElectronicSignature.SealSignedAt()` that returns `SignedAt` in UTC, truncated to microseconds, using `time.RFC3339Nano`. Uses it inside `computeSealV1` so the hashed and displayed timestamps stay in sync.

### Service **`+1`** **`-1`**
Updates `pkg/esign/certgen.go` to print `data.SignedAt = signature.SealSignedAt()` so certificates show the same timestamp that the seal hashes.

<sup>Written for commit ef7b9190a5d83ab5cf48ec6f64348adfdce94bfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

