### PR TITLE
Require full name before portal NDA signing

### DIFF
--- a/apps/compliance-portal/src/pages/nda/NDAPage.tsx
+++ b/apps/compliance-portal/src/pages/nda/NDAPage.tsx
@@ -62,6 +62,7 @@ export const ndaPageQuery = graphql`
   query NDAPageQuery {
     viewer {
       id
+      fullName
     }
     currentCompliancePortal @required(action: THROW) {
       entityName
@@ -115,7 +116,8 @@ interface NDAPageProps {
 // the electronic signature, polls until it is sealed, then returns to the
 // continue URL. A Documents back link dismisses without signing (avoids bouncing
 // into the continue URL that re-triggers the gate). Reached from the route
-// boundary / mutation layer on NDA_SIGNATURE_REQUIRED.
+// boundary / mutation layer on NDA_SIGNATURE_REQUIRED. Visitors without a full
+// name are sent to /full-name before the sign UI (mutations still enforce it).
 export function NDAPage({ queryRef }: NDAPageProps) {
   const { t } = useTranslation("nda");
   const localizedPath = useLocalizedPath();
@@ -135,6 +137,7 @@ export function NDAPage({ queryRef }: NDAPageProps) {
 
   const nda = compliancePortal.nonDisclosureAgreement;
   const signature = fragment.nonDisclosureAgreement.viewerSignature;
+  const hasFullName = Boolean(data.viewer?.fullName.trim());
 
   const safeContinueUrl = getSafeContinueUrl(searchParams.get("continue"));
 
@@ -172,14 +175,17 @@ export function NDAPage({ queryRef }: NDAPageProps) {
   }, [isProcessing, refetch]);
 
   // Record that the document was viewed once, on first render of a pending gate.
+  // Skip when the full-name gate will redirect — signing mutations reject empty
+  // names, and we must not flash a DOCUMENT_VIEWED error redirect race.
   useEffect(() => {
-    if (signature?.status === "PENDING" && !documentViewedRef.current) {
-      documentViewedRef.current = true;
-      void recordSigningEvent({
-        variables: { input: { signatureId: signature.id, eventType: "DOCUMENT_VIEWED" } },
-      }).catch(() => {});
+    if (!hasFullName || signature?.status !== "PENDING" || documentViewedRef.current) {
+      return;
     }
-  }, [signature, recordSigningEvent]);
+    documentViewedRef.current = true;
+    void recordSigningEvent({
+      variables: { input: { signatureId: signature.id, eventType: "DOCUMENT_VIEWED" } },
+    }).catch(() => {});
+  }, [hasFullName, signature, recordSigningEvent]);
 
   const handleAccept = () => {
     if (!signature) {
@@ -218,6 +224,17 @@ export function NDAPage({ queryRef }: NDAPageProps) {
 
   if (!data.viewer) {
     return <Navigate to={localizedPath("/")} replace />;
+  }
+
+  // Soft entry to /nda (banner / locked CTA) never hits requireCompletedNDA.
+  // Send nameless visitors to the full-name gate first; continue returns here.
+  if (!hasFullName) {
+    return (
+      <Navigate
+        to={`${localizedPath("/full-name")}?continue=${encodeURIComponent(window.location.href)}`}
+        replace
+      />
+    );
   }
 
   if (!nda || !signature) {

--- a/apps/compliance-portal/src/pages/nda/NDAPage.tsx
+++ b/apps/compliance-portal/src/pages/nda/NDAPage.tsx
@@ -137,7 +137,7 @@ export function NDAPage({ queryRef }: NDAPageProps) {
 
   const nda = compliancePortal.nonDisclosureAgreement;
   const signature = fragment.nonDisclosureAgreement.viewerSignature;
-  const hasFullName = Boolean(data.viewer?.fullName.trim());
+  const hasFullName = data.viewer != null && data.viewer.fullName !== "";
 
   const safeContinueUrl = getSafeContinueUrl(searchParams.get("continue"));
 

--- a/e2e/trust/compliance_portal_nda_signature_test.go
+++ b/e2e/trust/compliance_portal_nda_signature_test.go
@@ -126,8 +126,8 @@ func TestCompliancePortal_AcceptElectronicSignature_RejectsForeignSignature(t *t
 
 // TestCompliancePortal_NDASigning_RequiresFullName ensures visitors with an
 // empty identity name cannot accept or record NDA signing events. Soft paths
-// to /nda no longer hit requireCompletedNDA, so the signing mutations must
-// enforce FULL_NAME_REQUIRED themselves.
+// to /nda no longer hit requireCompletedNDA; both mutations map esign full-name
+// validation to FULL_NAME_REQUIRED.
 func TestCompliancePortal_NDASigning_RequiresFullName(t *testing.T) {
 	t.Parallel()
 

--- a/e2e/trust/compliance_portal_nda_signature_test.go
+++ b/e2e/trust/compliance_portal_nda_signature_test.go
@@ -49,6 +49,22 @@ const minimalPDFBase64 = "JVBERi0xLjcKJeLjz9MKMSAwIG9iago8PC9QYWdlcyAyIDAgUi9UeX
 	"ES//AhpppZNeBhllklmyLLLKJrsclh/4AgAA//9tzQSTZW5kc3RyZWFtCmVuZG9iagoKc3RhcnR4" +
 	"cmVmCjUxMgolJUVPRg=="
 
+const acceptElectronicSignatureMutation = `
+	mutation($input: AcceptElectronicSignatureInput!) {
+		acceptElectronicSignature(input: $input) {
+			signature { id status }
+		}
+	}
+`
+
+const recordSigningEventMutation = `
+	mutation($input: RecordSigningEventInput!) {
+		recordSigningEvent(input: $input) {
+			success
+		}
+	}
+`
+
 // TestCompliancePortal_AcceptElectronicSignature_RejectsForeignSignature is a
 // regression test for GHSA-22xj-f767-ppw6: any self-provisioned trust
 // center visitor could accept another visitor's NDA signature, or inject
@@ -74,29 +90,13 @@ func TestCompliancePortal_AcceptElectronicSignature_RejectsForeignSignature(t *t
 	require.NotEmpty(t, victimSignatureID)
 	require.Equal(t, "PENDING", victimSignatureStatus)
 
-	const acceptMutation = `
-		mutation($input: AcceptElectronicSignatureInput!) {
-			acceptElectronicSignature(input: $input) {
-				signature { id status }
-			}
-		}
-	`
-
-	err := attacker.ExecuteTrust(trustHost, acceptMutation, map[string]any{
+	err := attacker.ExecuteTrust(trustHost, acceptElectronicSignatureMutation, map[string]any{
 		"input": map[string]any{"signatureId": victimSignatureID},
 	}, nil)
 	require.Error(t, err, "attacker must not be able to accept another visitor's signature")
 	assertForbidden(t, err)
 
-	const recordEventMutation = `
-		mutation($input: RecordSigningEventInput!) {
-			recordSigningEvent(input: $input) {
-				success
-			}
-		}
-	`
-
-	err = attacker.ExecuteTrust(trustHost, recordEventMutation, map[string]any{
+	err = attacker.ExecuteTrust(trustHost, recordSigningEventMutation, map[string]any{
 		"input": map[string]any{
 			"signatureId": victimSignatureID,
 			"eventType":   "DOCUMENT_VIEWED",
@@ -117,7 +117,7 @@ func TestCompliancePortal_AcceptElectronicSignature_RejectsForeignSignature(t *t
 		} `json:"acceptElectronicSignature"`
 	}
 
-	err = victim.ExecuteTrust(trustHost, acceptMutation, map[string]any{
+	err = victim.ExecuteTrust(trustHost, acceptElectronicSignatureMutation, map[string]any{
 		"input": map[string]any{"signatureId": victimSignatureID},
 	}, &acceptResult)
 	require.NoError(t, err, "the legitimate signer must still be able to accept their own signature")
@@ -143,29 +143,13 @@ func TestCompliancePortal_NDASigning_RequiresFullName(t *testing.T) {
 	require.NotEmpty(t, signatureID)
 	require.Equal(t, "PENDING", signatureStatus)
 
-	const acceptMutation = `
-		mutation($input: AcceptElectronicSignatureInput!) {
-			acceptElectronicSignature(input: $input) {
-				signature { id status }
-			}
-		}
-	`
-
-	err := visitor.ExecuteTrust(trustHost, acceptMutation, map[string]any{
+	err := visitor.ExecuteTrust(trustHost, acceptElectronicSignatureMutation, map[string]any{
 		"input": map[string]any{"signatureId": signatureID},
 	}, nil)
 	require.Error(t, err, "accept must require a full name")
 	assertFullNameRequired(t, err)
 
-	const recordEventMutation = `
-		mutation($input: RecordSigningEventInput!) {
-			recordSigningEvent(input: $input) {
-				success
-			}
-		}
-	`
-
-	err = visitor.ExecuteTrust(trustHost, recordEventMutation, map[string]any{
+	err = visitor.ExecuteTrust(trustHost, recordSigningEventMutation, map[string]any{
 		"input": map[string]any{
 			"signatureId": signatureID,
 			"eventType":   "DOCUMENT_VIEWED",

--- a/e2e/trust/compliance_portal_nda_signature_test.go
+++ b/e2e/trust/compliance_portal_nda_signature_test.go
@@ -65,6 +65,11 @@ func TestCompliancePortal_AcceptElectronicSignature_RejectsForeignSignature(t *t
 	victim := testutil.SelfProvisionCompliancePortalVisitor(t, trustHost)
 	attacker := testutil.SelfProvisionCompliancePortalVisitor(t, trustHost)
 
+	// Signing mutations require a full name before the ownership check; set
+	// names so this test observes FORBIDDEN rather than FULL_NAME_REQUIRED.
+	updateVisitorFullName(t, victim, trustHost, "Victim Visitor")
+	updateVisitorFullName(t, attacker, trustHost, "Attacker Visitor")
+
 	victimSignatureID, victimSignatureStatus := viewerSignature(t, victim, trustHost)
 	require.NotEmpty(t, victimSignatureID)
 	require.Equal(t, "PENDING", victimSignatureStatus)
@@ -117,6 +122,60 @@ func TestCompliancePortal_AcceptElectronicSignature_RejectsForeignSignature(t *t
 	}, &acceptResult)
 	require.NoError(t, err, "the legitimate signer must still be able to accept their own signature")
 	assert.Equal(t, "ACCEPTED", acceptResult.AcceptElectronicSignature.Signature.Status)
+}
+
+// TestCompliancePortal_NDASigning_RequiresFullName ensures visitors with an
+// empty identity name cannot accept or record NDA signing events. Soft paths
+// to /nda no longer hit requireCompletedNDA, so the signing mutations must
+// enforce FULL_NAME_REQUIRED themselves.
+func TestCompliancePortal_NDASigning_RequiresFullName(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	compliancePortalID := lookupCompliancePortalID(t, owner)
+
+	uploadCompliancePortalNDA(t, owner, compliancePortalID)
+	trustHost := lookupTrustHost(t, owner, compliancePortalID)
+
+	visitor := testutil.SelfProvisionCompliancePortalVisitor(t, trustHost)
+
+	signatureID, signatureStatus := viewerSignature(t, visitor, trustHost)
+	require.NotEmpty(t, signatureID)
+	require.Equal(t, "PENDING", signatureStatus)
+
+	const acceptMutation = `
+		mutation($input: AcceptElectronicSignatureInput!) {
+			acceptElectronicSignature(input: $input) {
+				signature { id status }
+			}
+		}
+	`
+
+	err := visitor.ExecuteTrust(trustHost, acceptMutation, map[string]any{
+		"input": map[string]any{"signatureId": signatureID},
+	}, nil)
+	require.Error(t, err, "accept must require a full name")
+	assertFullNameRequired(t, err)
+
+	const recordEventMutation = `
+		mutation($input: RecordSigningEventInput!) {
+			recordSigningEvent(input: $input) {
+				success
+			}
+		}
+	`
+
+	err = visitor.ExecuteTrust(trustHost, recordEventMutation, map[string]any{
+		"input": map[string]any{
+			"signatureId": signatureID,
+			"eventType":   "DOCUMENT_VIEWED",
+		},
+	}, nil)
+	require.Error(t, err, "recordSigningEvent must require a full name")
+	assertFullNameRequired(t, err)
+
+	_, statusAfter := viewerSignature(t, visitor, trustHost)
+	assert.Equal(t, "PENDING", statusAfter, "failed gate attempts must not complete the signature")
 }
 
 func uploadCompliancePortalNDA(t *testing.T, owner *testutil.Client, compliancePortalID string) {
@@ -179,6 +238,30 @@ func viewerSignature(t *testing.T, visitor *testutil.Client, trustHost string) (
 	return sig.ID, sig.Status
 }
 
+func updateVisitorFullName(t *testing.T, visitor *testutil.Client, trustHost, fullName string) {
+	t.Helper()
+
+	const mutation = `
+		mutation($input: UpdateFullNameInput!) {
+			updateFullName(input: $input) {
+				success
+			}
+		}
+	`
+
+	var result struct {
+		UpdateFullName struct {
+			Success bool `json:"success"`
+		} `json:"updateFullName"`
+	}
+
+	err := visitor.ExecuteTrust(trustHost, mutation, map[string]any{
+		"input": map[string]any{"fullName": fullName},
+	}, &result)
+	require.NoError(t, err)
+	require.True(t, result.UpdateFullName.Success)
+}
+
 func assertForbidden(t *testing.T, err error) {
 	t.Helper()
 
@@ -186,4 +269,13 @@ func assertForbidden(t *testing.T, err error) {
 	require.True(t, ok, "expected a GraphQL error, got %T: %v", err, err)
 	require.NotEmpty(t, gqlErrs)
 	assert.Equal(t, "FORBIDDEN", gqlErrs[0].Code())
+}
+
+func assertFullNameRequired(t *testing.T, err error) {
+	t.Helper()
+
+	gqlErrs, ok := err.(testutil.GraphQLErrors)
+	require.True(t, ok, "expected a GraphQL error, got %T: %v", err, err)
+	require.NotEmpty(t, gqlErrs)
+	assert.Equal(t, "FULL_NAME_REQUIRED", gqlErrs[0].Code())
 }

--- a/pkg/esign/service.go
+++ b/pkg/esign/service.go
@@ -84,12 +84,13 @@ type (
 	}
 
 	RecordEventRequest struct {
-		SignatureID gid.GID
-		EventType   coredata.ElectronicSignatureEventType
-		EventSource coredata.ElectronicSignatureEventSource
-		ActorEmail  mail.Addr
-		ActorIPAddr string
-		ActorUA     string
+		SignatureID   gid.GID
+		EventType     coredata.ElectronicSignatureEventType
+		EventSource   coredata.ElectronicSignatureEventSource
+		ActorFullName string
+		ActorEmail    mail.Addr
+		ActorIPAddr   string
+		ActorUA       string
 	}
 )
 
@@ -105,6 +106,14 @@ func (req CreateAndAcceptSignatureRequest) Validate() error {
 	v := validator.New()
 
 	v.Check(req.SignerFullName, "signer_full_name", validator.NotEmpty())
+
+	return v.Error()
+}
+
+func (req RecordEventRequest) Validate() error {
+	v := validator.New()
+
+	v.Check(req.ActorFullName, "actor_full_name", validator.NotEmpty())
 
 	return v.Error()
 }
@@ -266,12 +275,13 @@ func (s *Service) CreateAndAcceptSignature(
 		conn,
 		scope,
 		&RecordEventRequest{
-			SignatureID: sig.ID,
-			EventType:   coredata.ElectronicSignatureEventTypeSignatureAccepted,
-			EventSource: coredata.ElectronicSignatureEventSourceServer,
-			ActorEmail:  req.SignerEmail,
-			ActorIPAddr: req.SignerIPAddr,
-			ActorUA:     req.SignerUA,
+			SignatureID:   sig.ID,
+			EventType:     coredata.ElectronicSignatureEventTypeSignatureAccepted,
+			EventSource:   coredata.ElectronicSignatureEventSourceServer,
+			ActorFullName: req.SignerFullName,
+			ActorEmail:    req.SignerEmail,
+			ActorIPAddr:   req.SignerIPAddr,
+			ActorUA:       req.SignerUA,
 		},
 	); err != nil {
 		return nil, fmt.Errorf("cannot record signature event: %w", err)
@@ -389,12 +399,13 @@ func (s *Service) AcceptSignature(ctx context.Context, scope coredata.Scoper, re
 				tx,
 				scope,
 				&RecordEventRequest{
-					SignatureID: signature.ID,
-					EventType:   coredata.ElectronicSignatureEventTypeSignatureAccepted,
-					EventSource: coredata.ElectronicSignatureEventSourceServer,
-					ActorEmail:  req.SignerEmail,
-					ActorIPAddr: req.SignerIPAddr,
-					ActorUA:     req.SignerUA,
+					SignatureID:   signature.ID,
+					EventType:     coredata.ElectronicSignatureEventTypeSignatureAccepted,
+					EventSource:   coredata.ElectronicSignatureEventSourceServer,
+					ActorFullName: req.SignerFullName,
+					ActorEmail:    req.SignerEmail,
+					ActorIPAddr:   req.SignerIPAddr,
+					ActorUA:       req.SignerUA,
 				},
 			); err != nil {
 				return fmt.Errorf("cannot record event: %w", err)
@@ -411,6 +422,10 @@ func (s *Service) AcceptSignature(ctx context.Context, scope coredata.Scoper, re
 }
 
 func (s *Service) RecordEvent(ctx context.Context, scope coredata.Scoper, req *RecordEventRequest) error {
+	if err := req.Validate(); err != nil {
+		return fmt.Errorf("invalid request: %w", err)
+	}
+
 	return s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {

--- a/pkg/esign/service_test.go
+++ b/pkg/esign/service_test.go
@@ -62,6 +62,22 @@ func TestCreateAndAcceptSignature_EmptySignerFullName(t *testing.T) {
 	assert.NotEmpty(t, validationErrors.ByField("signer_full_name"))
 }
 
+func TestRecordEvent_EmptyActorFullName(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{}
+	err := s.RecordEvent(
+		context.Background(),
+		nil,
+		&RecordEventRequest{ActorFullName: " \t "},
+	)
+
+	require.Error(t, err)
+	validationErrors, ok := errors.AsType[validator.ValidationErrors](err)
+	require.True(t, ok)
+	assert.NotEmpty(t, validationErrors.ByField("actor_full_name"))
+}
+
 func TestSignatureRequestsValidate_SignerFullName(t *testing.T) {
 	t.Parallel()
 
@@ -79,6 +95,12 @@ func TestSignatureRequestsValidate_SignerFullName(t *testing.T) {
 			name: "create and accept signature",
 			validate: func() error {
 				return (CreateAndAcceptSignatureRequest{SignerFullName: "Ada Lovelace"}).Validate()
+			},
+		},
+		{
+			name: "record event",
+			validate: func() error {
+				return (RecordEventRequest{ActorFullName: "Ada Lovelace"}).Validate()
 			},
 		},
 	}

--- a/pkg/iam/account_service.go
+++ b/pkg/iam/account_service.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.gearno.de/kit/pg"
@@ -90,7 +91,9 @@ func (req ChangeEmailRequest) Validate() error {
 	return v.Error()
 }
 
-func (req UpdateIdentityRequest) Validate() error {
+func (req *UpdateIdentityRequest) Validate() error {
+	req.FullName = strings.TrimSpace(req.FullName)
+
 	v := validator.New()
 
 	v.Check(req.FullName, "full_name", validator.NotEmpty(), validator.MinLen(2), validator.MaxLen(255))

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.gearno.de/kit/pg"
@@ -120,7 +121,9 @@ func (req ChangePasswordRequest) Validate() error {
 	return v.Error()
 }
 
-func (req CreateIdentityWithPasswordRequest) Validate() error {
+func (req *CreateIdentityWithPasswordRequest) Validate() error {
+	req.FullName = strings.TrimSpace(req.FullName)
+
 	v := validator.New()
 
 	v.Check(req.FullName, "fullName", validator.NotEmpty(), validator.MinLen(1), validator.MaxLen(255))

--- a/pkg/iam/full_name_validate_test.go
+++ b/pkg/iam/full_name_validate_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package iam
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/validator"
+)
+
+func TestUpdateIdentityRequest_Validate_TrimsAndRejectsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		req := &UpdateIdentityRequest{FullName: "  Ada Lovelace  "}
+		require.NoError(t, req.Validate())
+		assert.Equal(t, "Ada Lovelace", req.FullName)
+	})
+
+	t.Run("rejects whitespace-only", func(t *testing.T) {
+		t.Parallel()
+
+		req := &UpdateIdentityRequest{FullName: " \t "}
+		err := req.Validate()
+		require.Error(t, err)
+
+		validationErrors, ok := errors.AsType[validator.ValidationErrors](err)
+		require.True(t, ok)
+		assert.NotEmpty(t, validationErrors.ByField("full_name"))
+		assert.Equal(t, "", req.FullName)
+	})
+}
+
+func TestCreateIdentityWithPasswordRequest_Validate_TrimsAndRejectsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		req := &CreateIdentityWithPasswordRequest{
+			FullName: "  Ada Lovelace  ",
+			Password: "a-strong-password-123",
+		}
+		require.NoError(t, req.Validate())
+		assert.Equal(t, "Ada Lovelace", req.FullName)
+	})
+
+	t.Run("rejects whitespace-only", func(t *testing.T) {
+		t.Parallel()
+
+		req := &CreateIdentityWithPasswordRequest{
+			FullName: "   ",
+			Password: "a-strong-password-123",
+		}
+		err := req.Validate()
+		require.Error(t, err)
+
+		validationErrors, ok := errors.AsType[validator.ValidationErrors](err)
+		require.True(t, ok)
+		assert.NotEmpty(t, validationErrors.ByField("fullName"))
+		assert.Equal(t, "", req.FullName)
+	})
+}
+
+func TestCreateUserRequest_Validate_TrimsAndRejectsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	orgID := gid.New(gid.NewTenantID(), coredata.OrganizationEntityType)
+
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		req := &CreateUserRequest{
+			OrganizationID: orgID,
+			FullName:       "  Ada Lovelace  ",
+		}
+		require.NoError(t, req.Validate())
+		assert.Equal(t, "Ada Lovelace", req.FullName)
+	})
+
+	t.Run("rejects whitespace-only", func(t *testing.T) {
+		t.Parallel()
+
+		req := &CreateUserRequest{
+			OrganizationID: orgID,
+			FullName:       " \n ",
+		}
+		err := req.Validate()
+		require.Error(t, err)
+
+		validationErrors, ok := errors.AsType[validator.ValidationErrors](err)
+		require.True(t, ok)
+		assert.NotEmpty(t, validationErrors.ByField("full_name"))
+		assert.Equal(t, "", req.FullName)
+	})
+}
+
+func TestUpdateUserRequest_Validate_TrimsAndRejectsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	profileID := gid.New(gid.NewTenantID(), coredata.MembershipProfileEntityType)
+
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		req := &UpdateUserRequest{
+			ID:       profileID,
+			FullName: "  Ada Lovelace  ",
+		}
+		require.NoError(t, req.Validate())
+		assert.Equal(t, "Ada Lovelace", req.FullName)
+	})
+
+	t.Run("rejects whitespace-only", func(t *testing.T) {
+		t.Parallel()
+
+		req := &UpdateUserRequest{
+			ID:       profileID,
+			FullName: "\t  ",
+		}
+		err := req.Validate()
+		require.Error(t, err)
+
+		validationErrors, ok := errors.AsType[validator.ValidationErrors](err)
+		require.True(t, ok)
+		assert.NotEmpty(t, validationErrors.ByField("full_name"))
+		assert.Equal(t, "", req.FullName)
+	})
+}

--- a/pkg/iam/oidc/service.go
+++ b/pkg/iam/oidc/service.go
@@ -517,7 +517,7 @@ func (s *Service) HandleCallback(
 				identity = &coredata.Identity{
 					ID:                   gid.New(gid.NilTenant, coredata.IdentityEntityType),
 					EmailAddress:         email,
-					FullName:             claims.Name,
+					FullName:             strings.TrimSpace(claims.Name),
 					EmailAddressVerified: true,
 					CreatedAt:            now,
 					UpdatedAt:            now,

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"go.gearno.de/crypto/uuid"
@@ -207,6 +208,8 @@ func (req UpdateOrganizationRequest) Validate() error {
 }
 
 func (cur *CreateUserRequest) Validate() error {
+	cur.FullName = strings.TrimSpace(cur.FullName)
+
 	v := validator.New()
 
 	v.Check(cur.OrganizationID, "id", validator.Required(), validator.GID(coredata.OrganizationEntityType))
@@ -223,6 +226,8 @@ func (cur *CreateUserRequest) Validate() error {
 }
 
 func (upr *UpdateUserRequest) Validate() error {
+	upr.FullName = strings.TrimSpace(upr.FullName)
+
 	v := validator.New()
 
 	v.Check(upr.ID, "id", validator.Required(), validator.GID(coredata.MembershipProfileEntityType))

--- a/pkg/iam/saml/attributes.go
+++ b/pkg/iam/saml/attributes.go
@@ -76,8 +76,11 @@ func extractUserAttributes(assertion *saml.Assertion, config *coredata.SAMLConfi
 		lastname = ""
 	}
 
+	firstname = strings.TrimSpace(firstname)
+	lastname = strings.TrimSpace(lastname)
+
 	if firstname != "" && lastname != "" {
-		fullname = strings.TrimSpace(firstname + " " + lastname)
+		fullname = firstname + " " + lastname
 	} else if firstname != "" {
 		fullname = firstname
 	} else if lastname != "" {
@@ -95,7 +98,7 @@ func extractUserAttributes(assertion *saml.Assertion, config *coredata.SAMLConfi
 		role = mapSAMLRoleToSystemRole(roleString)
 	}
 
-	return email, fullname, role, nil
+	return email, strings.TrimSpace(fullname), role, nil
 }
 
 func extractAttributeValue(assertion *saml.Assertion, attributeName string) (string, error) {

--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -1162,13 +1162,13 @@ func ParseUserFromAttributes(attributes scim.ResourceAttributes) scimUserAttribu
 		}
 	}
 
-	attrs.FullName = displayName
+	attrs.FullName = strings.TrimSpace(displayName)
 	if attrs.FullName == "" {
 		attrs.FullName = strings.TrimSpace(givenName + " " + familyName)
 	}
 
 	if attrs.FullName == "" {
-		attrs.FullName = attrs.UserName
+		attrs.FullName = strings.TrimSpace(attrs.UserName)
 	}
 
 	attrs.Title, _ = attributes["title"].(string)
@@ -1250,7 +1250,7 @@ func ParseUserFromReplaceAttributes(attributes scim.ResourceAttributes) scimRepl
 	attrs.GivenName = &givenName
 	attrs.FamilyName = &familyName
 
-	attrs.FullName = displayName
+	attrs.FullName = strings.TrimSpace(displayName)
 	if attrs.FullName == "" {
 		attrs.FullName = strings.TrimSpace(givenName + " " + familyName)
 	}
@@ -1417,7 +1417,7 @@ func ParseUserFromPatchOperations(operations []scim.PatchOperation) scimReplaceA
 					}
 
 					if name, ok := valueMap["displayName"].(string); ok {
-						attrs.FullName = name
+						attrs.FullName = strings.TrimSpace(name)
 					}
 
 					if nameMap, ok := valueMap["name"].(map[string]any); ok {
@@ -1576,7 +1576,7 @@ func ParseUserFromPatchOperations(operations []scim.PatchOperation) scimReplaceA
 				}
 			case "displayname":
 				if name, ok := op.Value.(string); ok {
-					attrs.FullName = name
+					attrs.FullName = strings.TrimSpace(name)
 				}
 			case "name":
 				if nameMap, ok := op.Value.(map[string]any); ok {
@@ -1735,6 +1735,8 @@ func ParseUserFromPatchOperations(operations []scim.PatchOperation) scimReplaceA
 	if attrs.FullName == "" && (givenName != "" || familyName != "") {
 		attrs.FullName = strings.TrimSpace(givenName + " " + familyName)
 	}
+
+	attrs.FullName = strings.TrimSpace(attrs.FullName)
 
 	if givenName != "" && attrs.GivenName == nil {
 		attrs.GivenName = &givenName

--- a/pkg/server/api/complianceportal/v1/nda.go
+++ b/pkg/server/api/complianceportal/v1/nda.go
@@ -30,6 +30,17 @@ import (
 	"go.probo.inc/probo/pkg/server/gqlutils"
 )
 
+// requireFullName returns FULL_NAME_REQUIRED when the signed-in identity has no
+// name. Call after authentication on NDA signing mutations, and from
+// requireCompletedNDA before NDA_SIGNATURE_REQUIRED so the full-name gate wins.
+func requireFullName(ctx context.Context, identity *coredata.Identity) error {
+	if identity.FullName == "" {
+		return gqlutils.FullNameRequiredf(ctx, "full name is required")
+	}
+
+	return nil
+}
+
 // requireCompletedNDA enforces portal NDA completion for the signed-in identity.
 // No-ops when there is no viewer or the portal membership has no NDA signature.
 // Call from protected (non-PUBLIC) export resolvers after authentication.
@@ -64,8 +75,8 @@ func (r *Resolver) requireCompletedNDA(ctx context.Context) error {
 		return gqlutils.Internal(ctx)
 	}
 
-	if identity.FullName == "" {
-		return gqlutils.FullNameRequiredf(ctx, "full name is required")
+	if err := requireFullName(ctx, identity); err != nil {
+		return err
 	}
 
 	if sig.Status != coredata.ElectronicSignatureStatusCompleted {

--- a/pkg/server/api/complianceportal/v1/nda.go
+++ b/pkg/server/api/complianceportal/v1/nda.go
@@ -22,23 +22,32 @@ package complianceportal_v1
 
 import (
 	"context"
+	"errors"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/server/api/authn"
 	"go.probo.inc/probo/pkg/server/api/complianceportal"
 	"go.probo.inc/probo/pkg/server/gqlutils"
+	"go.probo.inc/probo/pkg/validator"
 )
 
-// requireFullName returns FULL_NAME_REQUIRED when the signed-in identity has no
-// name. Call after authentication on NDA signing mutations, and from
-// requireCompletedNDA before NDA_SIGNATURE_REQUIRED so the full-name gate wins.
-func requireFullName(ctx context.Context, identity *coredata.Identity) error {
-	if identity.FullName == "" {
+// mapNDASigningValidationError maps esign full-name validation failures to
+// FULL_NAME_REQUIRED so the portal gate redirect keeps working. Other
+// validation errors become InvalidValidationErrors. Returns nil when err is
+// not a ValidationErrors value.
+func mapNDASigningValidationError(ctx context.Context, err error) error {
+	validationErrors, ok := errors.AsType[validator.ValidationErrors](err)
+	if !ok {
+		return nil
+	}
+
+	if len(validationErrors.ByField("signer_full_name")) > 0 ||
+		len(validationErrors.ByField("actor_full_name")) > 0 {
 		return gqlutils.FullNameRequiredf(ctx, "full name is required")
 	}
 
-	return nil
+	return gqlutils.InvalidValidationErrors(ctx, validationErrors)
 }
 
 // requireCompletedNDA enforces portal NDA completion for the signed-in identity.
@@ -75,8 +84,10 @@ func (r *Resolver) requireCompletedNDA(ctx context.Context) error {
 		return gqlutils.Internal(ctx)
 	}
 
-	if err := requireFullName(ctx, identity); err != nil {
-		return err
+	// Full name before NDA so export paths send users to /full-name first.
+	// Accept maps esign signer_full_name validation to the same gate code.
+	if identity.FullName == "" {
+		return gqlutils.FullNameRequiredf(ctx, "full name is required")
 	}
 
 	if sig.Status != coredata.ElectronicSignatureStatusCompleted {

--- a/pkg/server/api/complianceportal/v1/nda_resolvers.go
+++ b/pkg/server/api/complianceportal/v1/nda_resolvers.go
@@ -32,6 +32,10 @@ func (r *mutationResolver) AcceptElectronicSignature(ctx context.Context, input 
 		return nil, gqlutils.Unauthenticated(ctx, errors.New("unauthenticated"))
 	}
 
+	if err := requireFullName(ctx, identity); err != nil {
+		return nil, err
+	}
+
 	signerIP := clientip.Extract(httpReq)
 
 	scope := coredata.NewScopeFromObjectID(compliancePortal.ID)
@@ -73,6 +77,10 @@ func (r *mutationResolver) RecordSigningEvent(ctx context.Context, input types.R
 	)
 	if identity == nil {
 		return nil, gqlutils.Unauthenticated(ctx, errors.New("unauthenticated"))
+	}
+
+	if err := requireFullName(ctx, identity); err != nil {
+		return nil, err
 	}
 
 	actorIP := clientip.Extract(httpReq)

--- a/pkg/server/api/complianceportal/v1/nda_resolvers.go
+++ b/pkg/server/api/complianceportal/v1/nda_resolvers.go
@@ -32,10 +32,6 @@ func (r *mutationResolver) AcceptElectronicSignature(ctx context.Context, input 
 		return nil, gqlutils.Unauthenticated(ctx, errors.New("unauthenticated"))
 	}
 
-	if err := requireFullName(ctx, identity); err != nil {
-		return nil, err
-	}
-
 	signerIP := clientip.Extract(httpReq)
 
 	scope := coredata.NewScopeFromObjectID(compliancePortal.ID)
@@ -56,6 +52,10 @@ func (r *mutationResolver) AcceptElectronicSignature(ctx context.Context, input 
 	if err != nil {
 		if errors.Is(err, esign.ErrSignatureAccessDenied) {
 			return nil, gqlutils.Forbidden(ctx, err)
+		}
+
+		if mapped := mapNDASigningValidationError(ctx, err); mapped != nil {
+			return nil, mapped
 		}
 
 		r.logger.ErrorCtx(ctx, "cannot accept electronic signature", log.Error(err))
@@ -79,10 +79,6 @@ func (r *mutationResolver) RecordSigningEvent(ctx context.Context, input types.R
 		return nil, gqlutils.Unauthenticated(ctx, errors.New("unauthenticated"))
 	}
 
-	if err := requireFullName(ctx, identity); err != nil {
-		return nil, err
-	}
-
 	actorIP := clientip.Extract(httpReq)
 
 	scope := coredata.NewScopeFromObjectID(compliancePortal.ID)
@@ -93,16 +89,21 @@ func (r *mutationResolver) RecordSigningEvent(ctx context.Context, input types.R
 		compliancePortal.ID,
 		identity.ID,
 		&esign.RecordEventRequest{
-			SignatureID: input.SignatureID,
-			EventType:   input.EventType,
-			EventSource: coredata.ElectronicSignatureEventSourceClient,
-			ActorEmail:  identity.EmailAddress,
-			ActorIPAddr: actorIP,
-			ActorUA:     httpReq.UserAgent(),
+			SignatureID:   input.SignatureID,
+			EventType:     input.EventType,
+			EventSource:   coredata.ElectronicSignatureEventSourceClient,
+			ActorFullName: identity.FullName,
+			ActorEmail:    identity.EmailAddress,
+			ActorIPAddr:   actorIP,
+			ActorUA:       httpReq.UserAgent(),
 		},
 	); err != nil {
 		if errors.Is(err, esign.ErrSignatureAccessDenied) {
 			return nil, gqlutils.Forbidden(ctx, err)
+		}
+
+		if mapped := mapNDASigningValidationError(ctx, err); mapped != nil {
+			return nil, mapped
 		}
 
 		r.logger.ErrorCtx(ctx, "cannot record signing event", log.Error(err))


### PR DESCRIPTION
Closes [ENG-734](https://linear.app/probo/issue/ENG-734/cp-issue-with-full-name-required-error-not-triggering-before-nda)

Soft paths to /nda no longer hit requireCompletedNDA, so empty-name visitors could accept with a blank SignerFullName. Gate signing mutations and redirect /nda to the full-name page up front.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a visitor full name before NDA signing in the compliance portal. Redirect nameless visitors to the full-name page, surface `pkg/esign` full-name validation as `FULL_NAME_REQUIRED`, and normalize names at write time so whitespace-only values never persist (ENG-734).

### GraphQL API **`+37`** **`-6`**
- Map `pkg/esign` full-name validation (signer_full_name and actor_full_name) to `FULL_NAME_REQUIRED` in AcceptElectronicSignature and RecordSigningEvent.
- Run the full-name gate before NDA checks; pass the viewer’s full name to RecordSigningEvent.

### Service **`+59`** **`-28`**
- Add `ActorFullName` to `RecordEventRequest`, validate non-empty, and enforce in `RecordEvent`.
- Normalize `pkg/iam` full names on create/update and SSO ingest (OIDC, SAML, SCIM): trim and reject whitespace-only values.

### App: compliance-portal **`+24`** **`-7`**
- NDAPage reads `viewer.fullName` and redirects to `/full-name?continue=<url>` when empty.
- Skip initial DOCUMENT_VIEWED when the name is missing; use an exact empty-string gate.

### Tests **`+271`** **`-19`**
- New e2e asserts `FULL_NAME_REQUIRED` for accept and record-event; signature stays PENDING.
- Update foreign-signature test to set full names so it fails with `FORBIDDEN`; share GraphQL mutation defs.
- Add IAM/service tests for trimming and rejecting blank full names.

<sup>Written for commit 1261654c7c8086cd68482ac80880bdff1e1be491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

