### PR TITLE
feat: add UniFi connector support

### DIFF
--- a/apps/console/src/pages/organizations/access-reviews/dialogs/_lib/connectorSettings.ts
+++ b/apps/console/src/pages/organizations/access-reviews/dialogs/_lib/connectorSettings.ts
@@ -92,6 +92,9 @@ export function mapAPIKeyExtraSettingToField(
     case "CRISP":
       if (settingKey === "websiteId") return "crispWebsiteId";
       break;
+    case "UNIFI":
+      if (settingKey === "consoleId") return "unifiConsoleId";
+      break;
   }
   return null;
 }

--- a/packages/ui/src/Atoms/ThirdParties/ThirdPartyLogo.tsx
+++ b/packages/ui/src/Atoms/ThirdParties/ThirdPartyLogo.tsx
@@ -77,6 +77,7 @@ import { Square } from "./Square";
 import { Supabase } from "./Supabase";
 import { Tailscale } from "./Tailscale";
 import { Tally } from "./Tally";
+import { UniFi } from "./UniFi";
 import { UpCloud } from "./UpCloud";
 import { Vercel } from "./Vercel";
 import { Yousign } from "./Yousign";
@@ -143,6 +144,7 @@ const thirdParties: Record<string, FC<ComponentProps<"svg">>> = {
   SUPABASE: Supabase,
   TAILSCALE: Tailscale,
   TALLY: Tally,
+  UNIFI: UniFi,
   UPCLOUD: UpCloud,
   VERCEL: Vercel,
   YOUSIGN: Yousign,

--- a/packages/ui/src/Atoms/ThirdParties/UniFi.tsx
+++ b/packages/ui/src/Atoms/ThirdParties/UniFi.tsx
@@ -1,0 +1,12 @@
+import type { ComponentProps } from "react";
+
+export function UniFi(props: ComponentProps<"svg">) {
+  return (
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path
+        fill="#0559C9"
+        d="M3.6 2.4h3.6v3.6H3.6zM3.6 8.4h3.6v4.8a4.8 4.8 0 009.6 0V8.4h3.6v4.8a8.4 8.4 0 01-16.8 0z"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/Atoms/ThirdParties/index.ts
+++ b/packages/ui/src/Atoms/ThirdParties/index.ts
@@ -56,6 +56,7 @@ export { Supabase } from "./Supabase";
 export { Tally } from "./Tally";
 export { Tailscale } from "./Tailscale";
 export { ThirdPartyLogo } from "./ThirdPartyLogo";
+export { UniFi } from "./UniFi";
 export { UpCloud } from "./UpCloud";
 export { Vercel } from "./Vercel";
 export { Yousign } from "./Yousign";

--- a/pkg/accessreview/drivers/testdata/unifi.yaml
+++ b/pkg/accessreview/drivers/testdata/unifi.yaml
@@ -1,0 +1,284 @@
+---
+# Hand-authored cassette for one UniFi console, reached through the Site Manager
+# console proxy on api.ui.com (X-API-KEY stripped by the recorder). It covers
+# BOTH APIs the driver reads, walked in driver order: the documented Integration
+# API collections under /proxy/network/integration, then each WiFi broadcast's
+# detail representation, then the LEGACY application API RADIUS user list under
+# /proxy/network/api/s/default/list/account.
+#
+# The driver emits a record only for an identifiable holder of access, so the
+# SSIDs, the RADIUS profile and the VPN servers in this fixture are here as
+# CONTEXT for the rows it does emit, not as rows themselves. Expect 8 records:
+# three filtered MACs, three RADIUS users, two vouchers.
+#
+#   - Office: WPA2/WPA3-Enterprise on RADIUS profile P1, plus an ALLOW filter
+#     with a colon- and a dash-separated MAC, so ExternalID normalization is
+#     exercised alongside the RADIUS linkage. Two records.
+#   - Corp-WiFi: a second Enterprise SSID on the SAME profile and with no
+#     filter of its own. It contributes no record; its purpose is to make the
+#     profile resolve to two (sorted) WiFi roles on every RADIUS user.
+#   - Guest: open SSID, no client filtering (clientFilteringPolicy null), and so
+#     no record at all — nothing in the API says who joins it.
+#   - IoT Legacy: DISABLED SSID with a BLOCK filter. Its one MAC must report
+#     Active=false on both counts, which is what pins that the SSID's on-air
+#     state still reaches the device rows now that the SSID has no row.
+#   - One RADIUS profile, so the sole-profile attribution on user records fires.
+#   - Four RADIUS users: vlan as a string, vlan as a NUMBER (older firmware
+#     spelled it either way), no vlan, and a blank entry that must be skipped.
+#     Each carries an x_password placeholder the driver must never decode.
+#   - Two Hotspot vouchers: live and expired, the latter never activated.
+#
+# There is no /vpn/servers interaction because the driver no longer requests
+# one: the API exposes no VPN membership, so it would answer nobody.
+#
+# Integration shapes mirror the documented schemas (Site overview, Wifi
+# broadcast overview/details, Radius Profile Overview, Hotspot voucher
+# details). The legacy envelope is {meta:{rc},data:[...]} and is UNVERIFIED
+# against a live console — re-record with UNIFI_API_KEY to confirm.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.ui.com
+        form:
+            limit:
+                - "200"
+            offset:
+                - "0"
+        headers:
+            Accept:
+                - application/json
+        url: https://api.ui.com/v1/connector/consoles/ABCDEF0123456789:1234567890/proxy/network/integration/v1/sites?limit=200&offset=0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"count":1,"data":[{"id":"11111111-1111-4111-8111-111111111111","internalReference":"default","name":"HQ"}],"limit":200,"offset":0,"totalCount":1}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.ui.com
+        form:
+            limit:
+                - "200"
+            offset:
+                - "0"
+        headers:
+            Accept:
+                - application/json
+        url: https://api.ui.com/v1/connector/consoles/ABCDEF0123456789:1234567890/proxy/network/integration/v1/sites/11111111-1111-4111-8111-111111111111/wifi/broadcasts?limit=200&offset=0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"count":4,"data":[{"id":"22222222-2222-4222-8222-222222222001","name":"Office","type":"STANDARD","enabled":true,"metadata":{"origin":"USER_DEFINED"},"securityConfiguration":{"type":"WPA2_WPA3_ENTERPRISE"}},{"id":"22222222-2222-4222-8222-222222222002","name":"Guest","type":"STANDARD","enabled":true,"metadata":{"origin":"USER_DEFINED"},"securityConfiguration":{"type":"OPEN"},"hotspotConfiguration":{"type":"CAPTIVE_PORTAL"}},{"id":"22222222-2222-4222-8222-222222222003","name":"IoT Legacy","type":"IOT_OPTIMIZED","enabled":false,"metadata":{"origin":"USER_DEFINED"},"securityConfiguration":{"type":"WPA2_PERSONAL"}},{"id":"22222222-2222-4222-8222-222222222004","name":"Corp-WiFi","type":"STANDARD","enabled":true,"metadata":{"origin":"USER_DEFINED"},"securityConfiguration":{"type":"WPA3_ENTERPRISE"}}],"limit":200,"offset":0,"totalCount":4}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.ui.com
+        form:
+            limit:
+                - "200"
+            offset:
+                - "0"
+        headers:
+            Accept:
+                - application/json
+        url: https://api.ui.com/v1/connector/consoles/ABCDEF0123456789:1234567890/proxy/network/integration/v1/sites/11111111-1111-4111-8111-111111111111/radius/profiles?limit=200&offset=0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"count":1,"data":[{"id":"77777777-7777-4777-8777-777777777001","name":"Built-in RADIUS","metadata":{"origin":"SYSTEM_DEFINED"}}],"limit":200,"offset":0,"totalCount":1}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.ui.com
+        form:
+            limit:
+                - "1000"
+            offset:
+                - "0"
+        headers:
+            Accept:
+                - application/json
+        url: https://api.ui.com/v1/connector/consoles/ABCDEF0123456789:1234567890/proxy/network/integration/v1/sites/11111111-1111-4111-8111-111111111111/hotspot/vouchers?limit=1000&offset=0
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"count":2,"data":[{"id":"44444444-4444-4444-8444-444444444001","name":"hotel-guest","code":"4861409510","createdAt":"2026-07-01T09:00:00Z","activatedAt":"2026-07-02T14:20:00Z","expiresAt":"2026-07-03T14:20:00Z","expired":false,"authorizedGuestCount":1,"authorizedGuestLimit":1,"timeLimitMinutes":1440},{"id":"44444444-4444-4444-8444-444444444002","name":"conference","code":"1029384756","createdAt":"2026-05-14T08:00:00Z","expired":true,"authorizedGuestCount":0,"timeLimitMinutes":480}],"limit":1000,"offset":0,"totalCount":2}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.ui.com
+        headers:
+            Accept:
+                - application/json
+        url: https://api.ui.com/v1/connector/consoles/ABCDEF0123456789:1234567890/proxy/network/integration/v1/sites/11111111-1111-4111-8111-111111111111/wifi/broadcasts/22222222-2222-4222-8222-222222222001
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"22222222-2222-4222-8222-222222222001","name":"Office","type":"STANDARD","enabled":true,"metadata":{"origin":"USER_DEFINED"},"securityConfiguration":{"type":"WPA2_WPA3_ENTERPRISE","coaEnabled":false,"wpa3FastRoamingEnabled":false,"pmfMode":"OPTIONAL","radiusConfiguration":{"profileId":"77777777-7777-4777-8777-777777777001","nasId":{"type":"DERIVED","source":"DEVICE_NAME"}}},"clientFilteringPolicy":{"action":"ALLOW","macAddressFilter":["94:2a:6f:26:c6:ca","AA-BB-CC-DD-EE-FF"]}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.ui.com
+        headers:
+            Accept:
+                - application/json
+        url: https://api.ui.com/v1/connector/consoles/ABCDEF0123456789:1234567890/proxy/network/integration/v1/sites/11111111-1111-4111-8111-111111111111/wifi/broadcasts/22222222-2222-4222-8222-222222222002
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"22222222-2222-4222-8222-222222222002","name":"Guest","type":"STANDARD","enabled":true,"metadata":{"origin":"USER_DEFINED"},"securityConfiguration":{"type":"OPEN"},"clientFilteringPolicy":null}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.ui.com
+        headers:
+            Accept:
+                - application/json
+        url: https://api.ui.com/v1/connector/consoles/ABCDEF0123456789:1234567890/proxy/network/integration/v1/sites/11111111-1111-4111-8111-111111111111/wifi/broadcasts/22222222-2222-4222-8222-222222222003
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"22222222-2222-4222-8222-222222222003","name":"IoT Legacy","type":"IOT_OPTIMIZED","enabled":false,"metadata":{"origin":"USER_DEFINED"},"securityConfiguration":{"type":"WPA2_PERSONAL","passphrase":"REDACTED"},"clientFilteringPolicy":{"action":"BLOCK","macAddressFilter":["00:11:22:33:44:55"]}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.ui.com
+        headers:
+            Accept:
+                - application/json
+        url: https://api.ui.com/v1/connector/consoles/ABCDEF0123456789:1234567890/proxy/network/integration/v1/sites/11111111-1111-4111-8111-111111111111/wifi/broadcasts/22222222-2222-4222-8222-222222222004
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"id":"22222222-2222-4222-8222-222222222004","name":"Corp-WiFi","type":"STANDARD","enabled":true,"metadata":{"origin":"USER_DEFINED"},"securityConfiguration":{"type":"WPA3_ENTERPRISE","coaEnabled":true,"securityMode":"DEFAULT","radiusConfiguration":{"profileId":"77777777-7777-4777-8777-777777777001","nasId":{"type":"USER_DEFINED","value":"corp"}}}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.ui.com
+        headers:
+            Accept:
+                - application/json
+        url: https://api.ui.com/v1/connector/consoles/ABCDEF0123456789:1234567890/proxy/network/api/s/default/list/account
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"meta":{"rc":"ok"},"data":[{"_id":"ra1","name":"alice","x_password":"REDACTED","vlan":"20","site_id":"5f0c1b2a3d4e5f60718293a4"},{"_id":"ra2","name":"bob","x_password":"REDACTED","vlan":30,"tunnel_type":13,"tunnel_medium_type":6,"site_id":"5f0c1b2a3d4e5f60718293a4"},{"_id":"ra3","name":"carol","x_password":"REDACTED","site_id":"5f0c1b2a3d4e5f60718293a4"},{"_id":"","name":"  "}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 100ms

--- a/pkg/accessreview/drivers/unifi.go
+++ b/pkg/accessreview/drivers/unifi.go
@@ -1,0 +1,981 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+const (
+	// Path elements below a console's UniFi Network application root. The
+	// modern Integration API hangs off `integration`; the legacy application
+	// API, which still owns the RADIUS user list, hangs off `api/s/<site>`.
+	unifiIntegrationSegment = "integration"
+	unifiVersionSegment     = "v1"
+	unifiSitesSegment       = "sites"
+	unifiWifiSegment        = "wifi"
+	unifiBroadcastSegment   = "broadcasts"
+	unifiHotspotSegment     = "hotspot"
+	unifiVouchersSegment    = "vouchers"
+	unifiRadiusSegment      = "radius"
+	unifiProfilesSegment    = "profiles"
+	unifiProxySegment       = "proxy"
+	unifiNetworkSegment     = "network"
+
+	// Legacy application API path elements for the RADIUS user list.
+	unifiLegacyAPISegment     = "api"
+	unifiLegacySiteSegment    = "s"
+	unifiLegacyListSegment    = "list"
+	unifiLegacyAccountSegment = "account"
+
+	// unifiPageLimit is the documented maximum `limit` for every collection
+	// except vouchers, which allows a larger page.
+	unifiPageLimit = 200
+	// unifiVoucherPageLimit is the documented maximum for
+	// /hotspot/vouchers. Voucher counts dwarf every other collection (a
+	// campaign can mint 1000 at a time), so the larger page keeps the run
+	// inside the per-source deadline.
+	unifiVoucherPageLimit = 1000
+)
+
+// UniFiConsoleBaseURL builds a console's UniFi Network application root under
+// apiBase, the Site Manager console-proxy origin (e.g.
+// https://api.ui.com/v1/connector/consoles). Both APIs the driver reads hang off
+// this root: the Integration API under `integration`, and the legacy
+// application API — still the only source of the RADIUS user list — under
+// `api/s/<site>`.
+//
+// The console ID contains a colon (`<hardware id>:<numeric id>`), which is a
+// legal path character, but it is escaped anyway so a malformed value cannot add
+// a path segment.
+//
+// It lives here rather than in the provider registration so the driver, the
+// name resolver and the connection probe all derive the same root from the same
+// apiBase: an APIBase override must move all three together.
+func UniFiConsoleBaseURL(apiBase, consoleID string) (string, error) {
+	consoleID = strings.TrimSpace(consoleID)
+	if consoleID == "" {
+		return "", fmt.Errorf("cannot build unifi console URL: console_id is required")
+	}
+
+	baseURL, err := url.JoinPath(
+		apiBase,
+		url.PathEscape(consoleID),
+		unifiProxySegment,
+		unifiNetworkSegment,
+	)
+	if err != nil {
+		return "", fmt.Errorf("cannot build unifi console URL: %w", err)
+	}
+
+	return baseURL, nil
+}
+
+// UniFiSitesURL builds the Integration API site-listing URL under baseURL, a
+// console's Network application root produced by UniFiConsoleBaseURL. The
+// connection probe uses it: listing sites is the cheapest call that proves both
+// that the API key is valid and that it reaches the configured console.
+func UniFiSitesURL(baseURL string) (string, error) {
+	endpoint, err := url.JoinPath(baseURL, unifiIntegrationSegment, unifiVersionSegment, unifiSitesSegment)
+	if err != nil {
+		return "", fmt.Errorf("cannot build unifi sites URL: %w", err)
+	}
+
+	return endpoint, nil
+}
+
+// UniFiDriver reports who can reach a UniFi console's network resources, using
+// a pre-authenticated HTTP client (the API key rides in X-API-KEY, attached by
+// the connection transport). It walks every site the key can see and emits one
+// record per access grant it finds.
+//
+// Every record is a USER: an identifiable holder of access. There are three
+// kinds — RADIUS directory users, MAC addresses on an SSID's client-filtering
+// list, and Hotspot vouchers. A RADIUS user's row names the SSIDs its directory
+// unlocks, so one entry carries both the person and what they can reach.
+//
+// # What is deliberately NOT reported
+//
+// The driver emits no row for a resource — no SSID, no VPN server, no RADIUS
+// profile. Those are the things being accessed, not parties holding access, and
+// a campaign asks its reviewer to approve or revoke each entry, which is not a
+// question an SSID can answer. Their useful signal is folded into the rows for
+// the people instead: an SSID's security mode and on-air state qualify the
+// device grants on it, and a RADIUS profile's SSID list appears on its users.
+//
+// This has a cost worth stating plainly. Access granted by a credential that
+// UniFi shares among everyone who holds it — a WPA-Personal passphrase, an L2TP
+// or PPTP VPN secret — has no identifiable holder anywhere in the API, so it
+// produces no records at all. A site whose networks are all PSK-based, or whose
+// only remote access is a shared-secret VPN, will therefore yield an empty
+// review rather than a row per shared credential.
+//
+// # Where the data comes from
+//
+// Everything except the RADIUS user list comes from the documented Network
+// Integration API. That API has exactly one RADIUS path,
+// /v1/sites/{siteId}/radius/profiles, and it returns only a profile's id, name
+// and origin — never its users. The user list is therefore read from the LEGACY
+// application API (GET api/s/{site}/list/account), which is what the Network
+// application's own Settings > Profiles > RADIUS > Users screen reads.
+//
+// That endpoint is undocumented, so it is treated as best-effort: an auth or
+// not-found answer skips the RADIUS users with a warning rather than failing
+// the whole review (see fetchRadiusUsers). A review that silently omits
+// accounts is a real hazard, so the warning names what was dropped — but
+// failing every other grant because one undocumented endpoint moved would be
+// worse.
+//
+// # What this API cannot answer
+//
+//   - Console administrators — the people who can sign in to the UniFi
+//     configuration portal — are exposed by neither API path the driver reads.
+//     A review of portal access has to come from the Ubiquiti SSO account
+//     inventory instead.
+//   - VPN membership. `VPN server overview` carries only {id, name, type,
+//     enabled} with no link to a RADIUS profile, and the "VPN client access"
+//     schemas describe live sessions rather than a roster. Nothing in the API
+//     joins a person to a VPN, so no record claims to.
+//   - An externally-hosted RADIUS profile keeps its users in that directory,
+//     not on the console, so only profiles backed by the console's built-in
+//     RADIUS server contribute user records.
+//
+// Data quality: UniFi models none of these grants with an email address or an
+// MFA signal, so Email is always empty (records key on ExternalID alone) and
+// MFAStatus is always Unknown.
+type UniFiDriver struct {
+	httpClient *http.Client
+	logger     *log.Logger
+	baseURL    string
+}
+
+var _ Driver = (*UniFiDriver)(nil)
+
+// NewUniFiDriver builds a driver against baseURL, a console's Network
+// application root as returned by UniFiConsoleBaseURL.
+//
+// Retries are layered on by COPYING the caller's client and swapping only its
+// transport, rather than wrapping the transport in a fresh &http.Client. The
+// connection's client carries SSRF protection in two places — the dial check on
+// the transport and a CheckRedirect that refuses a redirect to another
+// host/scheme/port — and a fresh client would keep the first while silently
+// dropping the second, so a 302 off api.ui.com would carry the API key with it.
+func NewUniFiDriver(httpClient *http.Client, logger *log.Logger, baseURL string) *UniFiDriver {
+	retryClient := *httpClient
+	retryClient.Transport = &retryRoundTripper{
+		next:       httpClient.Transport,
+		maxRetries: 3,
+	}
+
+	return &UniFiDriver{
+		httpClient: &retryClient,
+		logger:     logger,
+		baseURL:    baseURL,
+	}
+}
+
+// unifiPage is the envelope every Integration API collection returns.
+// TotalCount is the full result size and drives pagination; Count is the size
+// of this page.
+type unifiPage[T any] struct {
+	Count      int   `json:"count"`
+	Data       []T   `json:"data"`
+	Limit      int   `json:"limit"`
+	Offset     int64 `json:"offset"`
+	TotalCount int64 `json:"totalCount"`
+}
+
+// unifiLegacyEnvelope is the envelope the legacy application API returns. Its
+// `meta.rc` carries the application-level verdict, which can be "error" on a
+// 200 response, so it is checked rather than assumed.
+type unifiLegacyEnvelope[T any] struct {
+	Meta struct {
+		RC  string `json:"rc"`
+		Msg string `json:"msg"`
+	} `json:"meta"`
+	Data []T `json:"data"`
+}
+
+type unifiSite struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// InternalReference is the site's legacy short name (e.g. "default"). The
+	// Integration API documents it as "internal unique name of the site used in
+	// older APIs", and it is exactly what the legacy RADIUS path needs as its
+	// {site} segment — the UUID does not work there.
+	InternalReference string `json:"internalReference"`
+}
+
+type unifiWifiBroadcast struct {
+	ID                    string `json:"id"`
+	Name                  string `json:"name"`
+	Enabled               bool   `json:"enabled"`
+	SecurityConfiguration struct {
+		Type string `json:"type"`
+		// RadiusConfiguration is present on the Enterprise variants (and on
+		// non-Enterprise SSIDs using RADIUS MAC authentication). Its profile ID
+		// is what links an SSID to the directory that authenticates its users.
+		RadiusConfiguration *struct {
+			ProfileID string `json:"profileId"`
+		} `json:"radiusConfiguration"`
+	} `json:"securityConfiguration"`
+	// ClientFilteringPolicy is present only on the detail representation. A
+	// nil pointer means the SSID admits any client that satisfies its
+	// security configuration.
+	ClientFilteringPolicy *struct {
+		Action           string   `json:"action"`
+		MACAddressFilter []string `json:"macAddressFilter"`
+	} `json:"clientFilteringPolicy"`
+}
+
+type unifiRadiusProfile struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// unifiRadiusUser is one entry of the console's built-in RADIUS directory, as
+// the legacy api/s/{site}/list/account endpoint returns it.
+//
+// It deliberately does NOT decode the response's `x_password` field. That is
+// the user's live RADIUS credential, and a review record is not the place for
+// one — leaving it undecoded means it cannot reach an entry, a log line or an
+// error message by accident.
+type unifiRadiusUser struct {
+	ID   string `json:"_id"`
+	Name string `json:"name"`
+	// VLAN is the VLAN the directory assigns on successful authentication.
+	// Legacy responses have spelled it as both a string and a number across
+	// versions, so it is decoded leniently.
+	VLAN unifiLenientString `json:"vlan"`
+}
+
+// unifiLenientString decodes a JSON value that a legacy endpoint may send as
+// either a string or a number into its string form. An absent, null or
+// otherwise unusable value decodes to "".
+type unifiLenientString string
+
+func (s *unifiLenientString) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		*s = ""
+
+		return nil
+	}
+
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		*s = unifiLenientString(str)
+
+		return nil
+	}
+
+	var number json.Number
+	if err := json.Unmarshal(data, &number); err == nil {
+		*s = unifiLenientString(number.String())
+
+		return nil
+	}
+
+	// An unexpected shape (object, array, bool) is not worth failing a whole
+	// review over: the field is descriptive, not identifying.
+	*s = ""
+
+	return nil
+}
+
+type unifiVoucher struct {
+	ID                   string `json:"id"`
+	Name                 string `json:"name"`
+	CreatedAt            string `json:"createdAt"`
+	ActivatedAt          string `json:"activatedAt"`
+	Expired              bool   `json:"expired"`
+	AuthorizedGuestCount int64  `json:"authorizedGuestCount"`
+}
+
+func (d *UniFiDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
+	sites, err := d.fetchSites(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var records []AccountRecord
+
+	for _, site := range sites {
+		// The ID is the only identifier every site is guaranteed to carry and
+		// the path segment for every Integration API call below. Dropping a
+		// blank row would hide a whole site's grants and mark them removed on
+		// the next review.
+		siteID := strings.TrimSpace(site.ID)
+		if siteID == "" {
+			return nil, fmt.Errorf("cannot list unifi accounts: site with an empty id")
+		}
+
+		siteRecords, err := d.listSiteAccounts(ctx, site, siteID)
+		if err != nil {
+			return nil, err
+		}
+
+		records = append(records, siteRecords...)
+	}
+
+	return records, nil
+}
+
+// listSiteAccounts collects every access grant one site exposes.
+//
+// Every ExternalID it produces is scoped to the site. Resource IDs look
+// console-global today, but a review keys entries on ExternalID: were any of
+// them ever site-scoped instead, two sites' grants would collapse into one
+// entry and a reviewer would approve one while seeing the other. Scoping costs
+// nothing and makes that unrepresentable.
+func (d *UniFiDriver) listSiteAccounts(ctx context.Context, site unifiSite, siteID string) ([]AccountRecord, error) {
+	siteRole := "Site: " + unifiSiteLabel(site)
+	sitePrefix := "site/" + siteID + "/"
+
+	overviews, err := d.fetchWifiBroadcasts(ctx, siteID)
+	if err != nil {
+		return nil, err
+	}
+
+	profiles, err := d.fetchRadiusProfiles(ctx, siteID)
+	if err != nil {
+		return nil, err
+	}
+
+	vouchers, err := d.fetchVouchers(ctx, siteID)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		records []AccountRecord
+		// ssidsByProfile is what lets a RADIUS user's row name the WiFi
+		// networks its directory unlocks.
+		ssidsByProfile = make(map[string][]string, len(profiles))
+	)
+
+	for _, overview := range overviews {
+		broadcastID := strings.TrimSpace(overview.ID)
+		if broadcastID == "" {
+			return nil, fmt.Errorf("cannot list unifi accounts: wifi broadcast with an empty id")
+		}
+
+		// Both the client-filtering policy — the API's only per-SSID list of
+		// who may join — and the RADIUS profile link exist on the detail
+		// representation alone, so the overview is never enough.
+		broadcast, err := d.fetchWifiBroadcast(ctx, siteID, broadcastID)
+		if err != nil {
+			return nil, err
+		}
+
+		if broadcast == nil {
+			// Deleted between the list and this fetch: it is genuinely gone,
+			// not a failure, and re-listing would race the same way.
+			d.logger.WarnCtx(
+				ctx,
+				"unifi wifi broadcast vanished between list and detail fetch",
+				log.String("site_id", siteID),
+			)
+
+			continue
+		}
+
+		ssid := unifiBroadcastLabel(*broadcast)
+
+		if radius := broadcast.SecurityConfiguration.RadiusConfiguration; radius != nil {
+			if id := strings.TrimSpace(radius.ProfileID); id != "" {
+				ssidsByProfile[id] = append(ssidsByProfile[id], ssid)
+			}
+		}
+
+		records = append(records, unifiWifiRecords(*broadcast, ssid, sitePrefix, siteRole)...)
+	}
+
+	// The directory is per-site and reached through the legacy API, which the
+	// Integration API's UUID does not address — it needs the site's legacy
+	// short name.
+	radiusUsers, err := d.fetchRadiusUsers(ctx, site)
+	if err != nil {
+		return nil, err
+	}
+
+	// A user authenticates against the directory, not against one profile, so
+	// the profile — and the SSIDs delegating to it — are named only when the
+	// site leaves exactly one candidate. With two directories in play, nothing
+	// in either API says which one holds a given username, and a guess would
+	// read as fact on the reviewer's screen.
+	var (
+		soleProfile string
+		soleSSIDs   []string
+	)
+
+	if len(profiles) == 1 {
+		soleProfile = unifiProfileLabel(profiles[0])
+		soleSSIDs = ssidsByProfile[profiles[0].ID]
+	}
+
+	for _, user := range radiusUsers {
+		record, ok := unifiRadiusUserRecord(user, soleProfile, soleSSIDs, sitePrefix, siteRole)
+		if !ok {
+			continue
+		}
+
+		records = append(records, record)
+	}
+
+	for _, voucher := range vouchers {
+		if strings.TrimSpace(voucher.ID) == "" {
+			return nil, fmt.Errorf("cannot list unifi accounts: hotspot voucher with an empty id")
+		}
+
+		records = append(records, unifiVoucherRecord(voucher, sitePrefix, siteRole))
+	}
+
+	return records, nil
+}
+
+// unifiWifiRecords turns one WiFi broadcast into one USER record per MAC
+// address on its client-filtering list — the API's only per-SSID statement of
+// who may join.
+//
+// The broadcast itself gets no record. An SSID is a network, not somebody who
+// holds access, and a row named after it asks a reviewer a question they cannot
+// answer in approve/revoke terms. What that row did carry — the security mode,
+// and whether the SSID is even on air — is folded into the device rows below
+// instead, where it qualifies an actual grant.
+func unifiWifiRecords(broadcast unifiWifiBroadcast, ssid, sitePrefix, siteRole string) []AccountRecord {
+	if broadcast.ClientFilteringPolicy == nil {
+		return nil
+	}
+
+	roles := []string{"WiFi: " + ssid, siteRole}
+	if security := strings.TrimSpace(broadcast.SecurityConfiguration.Type); security != "" {
+		roles = append(roles, "Security: "+security)
+	}
+
+	// ALLOW makes the list exhaustive — only these MACs may join. BLOCK
+	// inverts it: the SSID admits everyone else, and the listed MACs are
+	// explicitly denied, which is exactly what a false Active means.
+	//
+	// A disabled SSID grants nothing either way, so it settles Active for every
+	// device on the list: the broadcast's own row used to be what reported that,
+	// and dropping the signal with the row would have left a listed MAC reading
+	// as live access to a network that is off the air.
+	allowed := broadcast.Enabled &&
+		strings.EqualFold(strings.TrimSpace(broadcast.ClientFilteringPolicy.Action), "ALLOW")
+
+	// The same device listed twice — plainly, or once per format — normalizes
+	// to one key. Emitting it twice would inflate the fetched-account count and
+	// hand the campaign two rows that collapse into one entry on upsert.
+	var (
+		records []AccountRecord
+		seen    = make(map[string]struct{}, len(broadcast.ClientFilteringPolicy.MACAddressFilter))
+	)
+
+	for _, mac := range broadcast.ClientFilteringPolicy.MACAddressFilter {
+		mac = strings.TrimSpace(mac)
+		if mac == "" {
+			continue
+		}
+
+		key := unifiMACKey(mac)
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+
+		seen[key] = struct{}{}
+
+		permitted := allowed
+
+		records = append(records, AccountRecord{
+			FullName: mac,
+			// Cloned rather than shared: a slice handed to several records
+			// with spare capacity turns any later append into a write the
+			// siblings can see.
+			Roles:     append([]string(nil), roles...),
+			Active:    &permitted,
+			MFAStatus: coredata.MFAStatusUnknown,
+			// A MAC filter authenticates a device by its hardware address,
+			// which is not a credential the holder proves.
+			AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
+			AccountType: coredata.AccessReviewEntryAccountTypeUser,
+			ExternalID:  unifiWifiExternalID(sitePrefix, broadcast.ID) + "/mac/" + key,
+		})
+	}
+
+	return records
+}
+
+// unifiRadiusUserRecord turns one entry of the console's built-in RADIUS
+// directory into a USER record. These are the accounts that authenticate to
+// WPA-Enterprise SSIDs and to RADIUS-backed VPN servers, so they are the
+// closest thing UniFi has to a person.
+//
+// ssids are the SSIDs that delegate authentication to the user's directory, and
+// they carry the whole answer to "which WiFi networks can this person reach".
+// They are named on the person's own row rather than on a row for the directory,
+// so a reviewer reads the grant without cross-referencing a second entry.
+//
+// It reports false when the entry carries neither a username nor an ID, which
+// would leave nothing stable to key on.
+func unifiRadiusUserRecord(
+	user unifiRadiusUser,
+	soleProfile string,
+	ssids []string,
+	sitePrefix, siteRole string,
+) (AccountRecord, bool) {
+	name := strings.TrimSpace(user.Name)
+	id := strings.TrimSpace(user.ID)
+
+	if name == "" && id == "" {
+		return AccountRecord{}, false
+	}
+
+	// The username is the directory's own key and is what an administrator
+	// recognises; the opaque _id is the fallback.
+	external := id
+	if external == "" {
+		external = unifiMACKey(name)
+	}
+
+	if name == "" {
+		name = id
+	}
+
+	roles := []string{"RADIUS user", siteRole}
+	if soleProfile != "" {
+		roles = append(roles, "RADIUS profile: "+soleProfile)
+	}
+
+	// Sorted so the role list does not reshuffle between campaigns purely
+	// because the API returned the broadcasts in a different order.
+	networks := append([]string(nil), ssids...)
+	sort.Strings(networks)
+
+	for _, ssid := range networks {
+		roles = append(roles, "WiFi: "+ssid)
+	}
+
+	if vlan := strings.TrimSpace(string(user.VLAN)); vlan != "" {
+		roles = append(roles, "VLAN: "+vlan)
+	}
+
+	return AccountRecord{
+		FullName:  name,
+		Roles:     roles,
+		MFAStatus: coredata.MFAStatusUnknown,
+		// A RADIUS account authenticates with a password held by the console's
+		// built-in directory. Active is left nil: the legacy entry carries no
+		// enabled/disabled state — an account exists or it does not.
+		AuthMethod:  coredata.AccessReviewEntryAuthMethodPassword,
+		AccountType: coredata.AccessReviewEntryAccountTypeUser,
+		ExternalID:  sitePrefix + "radius-user/" + external,
+	}, true
+}
+
+// unifiVoucherRecord turns one Hotspot voucher into a USER record. A voucher
+// is a named, time-boxed grant of guest network access, and its note is the
+// only identity UniFi records for the guest who holds it.
+func unifiVoucherRecord(voucher unifiVoucher, sitePrefix, siteRole string) AccountRecord {
+	name := strings.TrimSpace(voucher.Name)
+	if name == "" {
+		name = voucher.ID
+	}
+
+	roles := []string{"Hotspot voucher", siteRole}
+	if voucher.AuthorizedGuestCount > 0 {
+		roles = append(roles, "Guests authorized: "+strconv.FormatInt(voucher.AuthorizedGuestCount, 10))
+	}
+
+	// `expired` is the API's own verdict on whether the voucher still grants
+	// access, which is precisely the Active signal.
+	usable := !voucher.Expired
+
+	return AccountRecord{
+		FullName:  name,
+		Roles:     roles,
+		Active:    &usable,
+		MFAStatus: coredata.MFAStatusUnknown,
+		// The guest types the voucher code to get on the network; it is a
+		// shared secret, not a delegated identity.
+		AuthMethod:  coredata.AccessReviewEntryAuthMethodPassword,
+		AccountType: coredata.AccessReviewEntryAccountTypeUser,
+		CreatedAt:   parseRFC3339Ptr(voucher.CreatedAt),
+		// activatedAt is when the first guest redeemed the voucher — the only
+		// use timestamp UniFi keeps, so it stands in for a last login.
+		LastLogin:  parseRFC3339Ptr(voucher.ActivatedAt),
+		ExternalID: sitePrefix + "voucher/" + voucher.ID,
+	}
+}
+
+// unifiWifiExternalID is the identity prefix a WiFi broadcast and its
+// filtered MAC addresses share, under the site they belong to.
+func unifiWifiExternalID(sitePrefix, broadcastID string) string {
+	return sitePrefix + "wifi/" + broadcastID
+}
+
+// unifiMACKey normalizes a MAC address for use inside an ExternalID: lower
+// case with separators removed, so the same device keys identically across
+// campaigns even if UniFi changes how it formats the address. The record's
+// FullName keeps the address as the API returned it.
+func unifiMACKey(mac string) string {
+	var b strings.Builder
+
+	for _, r := range strings.ToLower(mac) {
+		if r == ':' || r == '-' || r == '.' || r == ' ' {
+			continue
+		}
+
+		b.WriteRune(r)
+	}
+
+	return b.String()
+}
+
+// unifiSiteLabel is the human name for a site, falling back to the internal
+// reference older UniFi APIs use and finally to the ID, so a role always names
+// something.
+func unifiSiteLabel(site unifiSite) string {
+	if name := strings.TrimSpace(site.Name); name != "" {
+		return name
+	}
+
+	if ref := strings.TrimSpace(site.InternalReference); ref != "" {
+		return ref
+	}
+
+	return strings.TrimSpace(site.ID)
+}
+
+// unifiBroadcastLabel is the SSID name, falling back to the ID.
+func unifiBroadcastLabel(broadcast unifiWifiBroadcast) string {
+	if name := strings.TrimSpace(broadcast.Name); name != "" {
+		return name
+	}
+
+	return broadcast.ID
+}
+
+// unifiProfileLabel is the RADIUS profile name, falling back to the ID.
+func unifiProfileLabel(profile unifiRadiusProfile) string {
+	if name := strings.TrimSpace(profile.Name); name != "" {
+		return name
+	}
+
+	return profile.ID
+}
+
+func (d *UniFiDriver) fetchSites(ctx context.Context) ([]unifiSite, error) {
+	return fetchUniFiCollection[unifiSite](
+		ctx, d, "sites", unifiPageLimit,
+		unifiVersionSegment, unifiSitesSegment,
+	)
+}
+
+func (d *UniFiDriver) fetchWifiBroadcasts(ctx context.Context, siteID string) ([]unifiWifiBroadcast, error) {
+	return fetchUniFiCollection[unifiWifiBroadcast](
+		ctx, d, "wifi broadcasts", unifiPageLimit,
+		unifiVersionSegment, unifiSitesSegment, url.PathEscape(siteID), unifiWifiSegment, unifiBroadcastSegment,
+	)
+}
+
+func (d *UniFiDriver) fetchRadiusProfiles(ctx context.Context, siteID string) ([]unifiRadiusProfile, error) {
+	return fetchUniFiCollection[unifiRadiusProfile](
+		ctx, d, "radius profiles", unifiPageLimit,
+		unifiVersionSegment, unifiSitesSegment, url.PathEscape(siteID), unifiRadiusSegment, unifiProfilesSegment,
+	)
+}
+
+func (d *UniFiDriver) fetchVouchers(ctx context.Context, siteID string) ([]unifiVoucher, error) {
+	return fetchUniFiCollection[unifiVoucher](
+		ctx, d, "hotspot vouchers", unifiVoucherPageLimit,
+		unifiVersionSegment, unifiSitesSegment, url.PathEscape(siteID), unifiHotspotSegment, unifiVouchersSegment,
+	)
+}
+
+// fetchWifiBroadcast reads one broadcast's detail representation, the only one
+// carrying the client-filtering policy and the RADIUS profile link. A 404
+// yields (nil, nil): the broadcast was deleted between the list and this call,
+// which is a stable answer rather than a failure.
+func (d *UniFiDriver) fetchWifiBroadcast(ctx context.Context, siteID, broadcastID string) (*unifiWifiBroadcast, error) {
+	endpoint, err := url.JoinPath(
+		d.baseURL,
+		unifiIntegrationSegment,
+		unifiVersionSegment, unifiSitesSegment, url.PathEscape(siteID),
+		unifiWifiSegment, unifiBroadcastSegment, url.PathEscape(broadcastID),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build unifi wifi broadcast URL: %w", err)
+	}
+
+	body, status, err := d.get(ctx, endpoint, "wifi broadcast")
+	if err != nil {
+		return nil, err
+	}
+
+	if status == http.StatusNotFound {
+		return nil, nil
+	}
+
+	var broadcast unifiWifiBroadcast
+	if err := json.Unmarshal(body, &broadcast); err != nil {
+		return nil, fmt.Errorf("cannot decode unifi wifi broadcast response: %w", err)
+	}
+
+	return &broadcast, nil
+}
+
+// fetchRadiusUsers reads the console's built-in RADIUS directory for one site
+// through the LEGACY application API, the only place UniFi exposes it — the
+// Integration API's /radius/profiles returns a profile's id and name and
+// nothing about its members.
+//
+// The legacy path is addressed by the site's legacy short name, not its UUID,
+// so a site with no internalReference is skipped rather than requested with an
+// identifier the endpoint would reject.
+//
+// Being undocumented, the endpoint is treated as best-effort: 401/403 (the API
+// key does not reach the legacy API), 404 (the route moved or the console
+// predates it) and an application-level `meta.rc` error all yield no users plus
+// a warning naming what was dropped. Everything else — a 5xx, a decode failure
+// — is still an error, because those are transient and a silently short answer
+// would mark real accounts removed on the next campaign.
+func (d *UniFiDriver) fetchRadiusUsers(ctx context.Context, site unifiSite) ([]unifiRadiusUser, error) {
+	siteRef := strings.TrimSpace(site.InternalReference)
+	if siteRef == "" {
+		d.logger.WarnCtx(
+			ctx,
+			"skipping unifi radius users: site has no legacy short name to address the legacy API with",
+			log.String("site_id", site.ID),
+		)
+
+		return nil, nil
+	}
+
+	endpoint, err := url.JoinPath(
+		d.baseURL,
+		unifiLegacyAPISegment, unifiLegacySiteSegment, url.PathEscape(siteRef),
+		unifiLegacyListSegment, unifiLegacyAccountSegment,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build unifi radius users URL: %w", err)
+	}
+
+	body, status, err := d.get(ctx, endpoint, "radius users")
+
+	switch {
+	case status == http.StatusUnauthorized,
+		status == http.StatusForbidden,
+		status == http.StatusNotFound:
+		d.logger.WarnCtx(
+			ctx,
+			"unifi radius users unavailable, review will omit them",
+			log.String("site", siteRef),
+			log.Int("status", status),
+		)
+
+		return nil, nil
+	case err != nil:
+		return nil, err
+	}
+
+	var resp unifiLegacyEnvelope[unifiRadiusUser]
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("cannot decode unifi radius users response: %w", err)
+	}
+
+	// The legacy API reports application errors in the body with a 200 status.
+	if rc := strings.TrimSpace(resp.Meta.RC); rc != "" && !strings.EqualFold(rc, "ok") {
+		d.logger.WarnCtx(
+			ctx,
+			"unifi radius users refused by the legacy API, review will omit them",
+			log.String("site", siteRef),
+			log.String("rc", rc),
+		)
+
+		return nil, nil
+	}
+
+	return resp.Data, nil
+}
+
+// fetchUniFiCollection walks one offset/limit paginated Integration API
+// collection to completion. UniFi returns the full result size in totalCount,
+// so the walk stops on reaching it rather than trusting a page to come back
+// short.
+//
+// A 404 on the collection means the site does not expose that feature (a
+// console with no gateway serves no VPN servers, one with no Hotspot serves no
+// vouchers). It answers the same way on every run, so an empty result is
+// stable and cannot make one campaign's grants look removed in the next; any
+// other non-2xx aborts, because a partial fetch WOULD.
+func fetchUniFiCollection[T any](
+	ctx context.Context,
+	d *UniFiDriver,
+	what string,
+	pageLimit int,
+	segments ...string,
+) ([]T, error) {
+	base, err := url.JoinPath(d.baseURL, append([]string{unifiIntegrationSegment}, segments...)...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build unifi %s URL: %w", what, err)
+	}
+
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse unifi %s URL: %w", what, err)
+	}
+
+	var (
+		items  []T
+		offset int64
+	)
+
+	for range maxPaginationPages {
+		q := url.Values{}
+		q.Set("limit", strconv.Itoa(pageLimit))
+		q.Set("offset", strconv.FormatInt(offset, 10))
+
+		endpoint := *parsed
+		endpoint.RawQuery = q.Encode()
+
+		body, status, err := d.get(ctx, endpoint.String(), what)
+		if err != nil {
+			return nil, err
+		}
+
+		if status == http.StatusNotFound {
+			d.logger.WarnCtx(
+				ctx,
+				"unifi collection not available on this console",
+				log.String("collection", what),
+			)
+
+			return nil, nil
+		}
+
+		var page unifiPage[T]
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("cannot decode unifi %s response: %w", what, err)
+		}
+
+		items = append(items, page.Data...)
+
+		// An empty page terminates regardless of what totalCount claims: a
+		// count that never comes into reach would otherwise spin until the
+		// pagination guard trips.
+		if len(page.Data) == 0 || int64(len(items)) >= page.TotalCount {
+			return items, nil
+		}
+
+		offset += int64(len(page.Data))
+	}
+
+	return nil, fmt.Errorf("cannot list all unifi %s: %w", what, ErrPaginationLimitReached)
+}
+
+// get performs an authenticated GET and returns the body together with the
+// status code. The status is returned rather than swallowed so callers can
+// treat some statuses as answers; every other non-2xx becomes an error here,
+// wrapping ErrTerminalNameResolution on a permanent client error so the name
+// resolver (which shares these calls) stops re-claiming a source it can never
+// read.
+//
+// The status is returned on the error path too, so a caller that tolerates a
+// particular status can inspect it without having to unwrap the error.
+func (d *UniFiDriver) get(ctx context.Context, endpoint, what string) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("cannot create unifi %s request: %w", what, err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	httpResp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("cannot execute unifi %s request: %w", what, err)
+	}
+
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode == http.StatusNotFound {
+		return nil, httpResp.StatusCode, nil
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, httpResp.StatusCode, nameStatusError("unifi "+what, httpResp.StatusCode)
+	}
+
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, httpResp.StatusCode, fmt.Errorf("cannot read unifi %s response: %w", what, err)
+	}
+
+	return body, httpResp.StatusCode, nil
+}
+
+// unifiNameResolver names the source after the console's site. A UniFi console
+// exposes no name of its own through the Integration API — only its sites — so
+// a single-site console (the overwhelmingly common shape) is named after that
+// site. A multi-site console has no one right label, and an empty name leaves
+// the source with the generic provider name rather than an arbitrary pick.
+type unifiNameResolver struct {
+	httpClient *http.Client
+	logger     *log.Logger
+	baseURL    string
+}
+
+var _ NameResolver = (*unifiNameResolver)(nil)
+
+// NewUniFiNameResolver resolves the console's name against baseURL, a console's
+// Network application root as returned by UniFiConsoleBaseURL.
+func NewUniFiNameResolver(httpClient *http.Client, logger *log.Logger, baseURL string) NameResolver {
+	return &unifiNameResolver{httpClient: httpClient, logger: logger, baseURL: baseURL}
+}
+
+func (r *unifiNameResolver) ResolveInstanceName(ctx context.Context) (string, error) {
+	// Constructed rather than composite-literalled so the driver always
+	// carries the resolver's base URL.
+	driver := NewUniFiDriver(r.httpClient, r.logger, r.baseURL)
+
+	sites, err := driver.fetchSites(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if len(sites) != 1 {
+		return "", nil
+	}
+
+	return unifiSiteLabel(sites[0]), nil
+}

--- a/pkg/accessreview/drivers/unifi_test.go
+++ b/pkg/accessreview/drivers/unifi_test.go
@@ -1,0 +1,934 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+// unifiTestConsoleID is the synthetic console the cassette was authored
+// against. Its colon is the real shape Site Manager uses.
+const unifiTestConsoleID = "ABCDEF0123456789:1234567890"
+
+// unifiTestAPIBase mirrors the provider registration's Endpoints.APIBase.
+const unifiTestAPIBase = "https://api.ui.com/v1/connector/consoles"
+
+func unifiTestLogger() *log.Logger {
+	return log.NewLogger(log.WithName("test"))
+}
+
+func TestUniFiDriver(t *testing.T) {
+	t.Parallel()
+
+	rec := newRecorder(t, "testdata/unifi", "UNIFI_API_KEY")
+	// UniFi authenticates with the key in X-API-KEY. The matcher ignores it
+	// and the BeforeSave hook strips it, so replay needs no credential.
+	client := newVCRClientWithHeader(rec, "X-API-KEY", os.Getenv("UNIFI_API_KEY"))
+
+	baseURL, err := UniFiConsoleBaseURL(unifiTestAPIBase, unifiTestConsoleID)
+	require.NoError(t, err)
+
+	records, err := NewUniFiDriver(client, unifiTestLogger(), baseURL).ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 8)
+
+	// UniFi models none of these grants with an email or an MFA signal, so
+	// every record keys on its ExternalID alone.
+	for _, record := range records {
+		assert.Emptyf(t, record.Email, "record %q must carry no email", record.ExternalID)
+		assert.Equalf(t, coredata.MFAStatusUnknown, record.MFAStatus, "record %q", record.ExternalID)
+		assert.NotEmpty(t, record.ExternalID)
+		assert.NotEmpty(t, record.FullName)
+		assert.False(t, record.IsAdmin, "neither API exposes an administrative grant")
+		// Every record names somebody who holds access. A resource — an SSID, a
+		// VPN server, a RADIUS directory — is the thing being accessed, and a
+		// campaign cannot ask a reviewer to approve or revoke one.
+		assert.Equalf(
+			t,
+			coredata.AccessReviewEntryAccountTypeUser,
+			record.AccountType,
+			"record %q must not be a resource row", record.ExternalID,
+		)
+	}
+
+	byID := make(map[string]AccountRecord, len(records))
+	for _, record := range records {
+		_, duplicate := byID[record.ExternalID]
+		require.Falsef(t, duplicate, "duplicate external id %q", record.ExternalID)
+		byID[record.ExternalID] = record
+	}
+
+	// Every ExternalID is scoped to its site, so two sites' grants can never
+	// collapse into one entry.
+	const (
+		site   = "site/11111111-1111-4111-8111-111111111111/"
+		office = site + "wifi/22222222-2222-4222-8222-222222222001"
+		guest  = site + "wifi/22222222-2222-4222-8222-222222222002"
+		iot    = site + "wifi/22222222-2222-4222-8222-222222222003"
+		corp   = site + "wifi/22222222-2222-4222-8222-222222222004"
+	)
+
+	// ---- RADIUS users: the accounts that authenticate to Enterprise SSIDs and
+	// RADIUS-backed VPNs, and the closest thing UniFi models to a person.
+	//
+	// Both Enterprise SSIDs delegate to this site's sole directory, so each user
+	// row names both networks — sorted, so the role list does not reshuffle when
+	// the API reorders its broadcast pages. That join is the whole answer to
+	// "who can access which WiFi network", and it lives on the person's row
+	// rather than on a separate row for the directory.
+
+	alice := byID[site+"radius-user/ra1"]
+	assert.Equal(t, "alice", alice.FullName)
+	assert.Equal(t, []string{
+		"RADIUS user", "Site: HQ", "RADIUS profile: Built-in RADIUS",
+		"WiFi: Corp-WiFi", "WiFi: Office", "VLAN: 20",
+	}, alice.Roles)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodPassword, alice.AuthMethod)
+	// The legacy entry carries no enabled/disabled state — an account exists or
+	// it does not — so fabricating one would be worse than reporting none.
+	assert.Nil(t, alice.Active)
+
+	// Older firmware spells vlan as a number rather than a string; both must
+	// decode, or a review would silently lose the VLAN on some consoles.
+	bob := byID[site+"radius-user/ra2"]
+	assert.Equal(t, "bob", bob.FullName)
+	assert.Equal(t, []string{
+		"RADIUS user", "Site: HQ", "RADIUS profile: Built-in RADIUS",
+		"WiFi: Corp-WiFi", "WiFi: Office", "VLAN: 30",
+	}, bob.Roles)
+
+	carol := byID[site+"radius-user/ra3"]
+	assert.Equal(t, []string{
+		"RADIUS user", "Site: HQ", "RADIUS profile: Built-in RADIUS",
+		"WiFi: Corp-WiFi", "WiFi: Office",
+	}, carol.Roles)
+
+	// The blank fourth entry has nothing stable to key on and is dropped.
+	assert.Len(t, unifiRecordsWithPrefix(records, site+"radius-user/"), 3)
+
+	// No record may carry a RADIUS password: the driver does not decode the
+	// field at all, and this pins that it stays that way.
+	for _, record := range records {
+		assert.NotContains(t, record.FullName, "REDACTED")
+		assert.NotContains(t, strings.Join(record.Roles, " "), "REDACTED")
+	}
+
+	// ---- Devices on an SSID's client-filtering list, the API's only per-SSID
+	// statement of who may join.
+
+	// An ALLOW filter is exhaustive: these MACs, and only these, may join. Both
+	// are keyed with separators stripped so the same device keys identically
+	// however UniFi formats the address, while the displayed name keeps the
+	// API's formatting. The SSID's security mode rides along on the role list —
+	// it used to live on the SSID's own row.
+	allowedColon := byID[office+"/mac/942a6f26c6ca"]
+	assert.Equal(t, "94:2a:6f:26:c6:ca", allowedColon.FullName)
+	assert.Equal(t, []string{"WiFi: Office", "Site: HQ", "Security: WPA2_WPA3_ENTERPRISE"}, allowedColon.Roles)
+	require.NotNil(t, allowedColon.Active)
+	assert.True(t, *allowedColon.Active)
+
+	allowedDash := byID[office+"/mac/aabbccddeeff"]
+	assert.Equal(t, "AA-BB-CC-DD-EE-FF", allowedDash.FullName)
+	require.NotNil(t, allowedDash.Active)
+	assert.True(t, *allowedDash.Active)
+
+	// A BLOCK filter lists denials, and the SSID is disabled besides — both
+	// settle Active false. That the SSID's on-air state still reaches this row
+	// is what stops a listed device reading as live access to a network that is
+	// off the air, now that the SSID has no row of its own to report it.
+	blocked := byID[iot+"/mac/001122334455"]
+	assert.Equal(t, "00:11:22:33:44:55", blocked.FullName)
+	assert.Equal(t, []string{"WiFi: IoT Legacy", "Site: HQ", "Security: WPA2_PERSONAL"}, blocked.Roles)
+	require.NotNil(t, blocked.Active)
+	assert.False(t, *blocked.Active)
+
+	// ---- SSIDs and the directory contribute no rows of their own.
+
+	// Neither the open Guest SSID nor either Enterprise SSID is an account, and
+	// with no filtering policy Guest and Corp-WiFi name nobody at all. The MAC
+	// records live UNDER these IDs, so absence has to be checked on the exact
+	// key rather than the prefix.
+	for _, ssid := range []string{office, guest, iot, corp} {
+		_, present := byID[ssid]
+		assert.Falsef(t, present, "the SSID at %q must not have a record of its own", ssid)
+	}
+
+	assert.Empty(t, unifiRecordsWithPrefix(records, guest+"/mac/"))
+	assert.Empty(t, unifiRecordsWithPrefix(records, corp+"/mac/"))
+	assert.Empty(t, unifiRecordsWithPrefix(records, site+"radius-profile/"))
+
+	// The API exposes no VPN membership at all — no link from a server to a
+	// RADIUS profile, and "VPN client access" describes live sessions rather
+	// than a roster — so the driver does not request VPN servers and claims
+	// nothing about them.
+	assert.Empty(t, unifiRecordsWithPrefix(records, site+"vpn/"))
+
+	// ---- Hotspot vouchers.
+
+	liveVoucher := byID[site+"voucher/44444444-4444-4444-8444-444444444001"]
+	assert.Equal(t, "hotel-guest", liveVoucher.FullName)
+	assert.Equal(t, []string{"Hotspot voucher", "Site: HQ", "Guests authorized: 1"}, liveVoucher.Roles)
+	require.NotNil(t, liveVoucher.Active)
+	assert.True(t, *liveVoucher.Active)
+	require.NotNil(t, liveVoucher.LastLogin)
+	assert.Equal(t, "2026-07-02T14:20:00Z", liveVoucher.LastLogin.Format("2006-01-02T15:04:05Z"))
+
+	expiredVoucher := byID[site+"voucher/44444444-4444-4444-8444-444444444002"]
+	assert.Nil(t, expiredVoucher.LastLogin)
+	require.NotNil(t, expiredVoucher.Active)
+	assert.False(t, *expiredVoucher.Active)
+
+	// Connected clients are deliberately NOT a record shape: they are a
+	// point-in-time snapshot, so a device that happened to be offline during a
+	// campaign would read as access removed.
+	assert.Empty(t, unifiRecordsWithPrefix(records, site+"client/"))
+}
+
+// TestUniFiRadiusUsersBestEffort pins the containment around the LEGACY RADIUS
+// endpoint. It is undocumented, so an auth or not-found answer must cost only
+// the RADIUS users — not the whole review — while a transient failure must still
+// abort, since a silently short answer would mark real accounts removed on the
+// next campaign.
+func TestUniFiRadiusUsersBestEffort(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		status    int
+		body      string
+		wantUsers int
+		wantError bool
+	}{
+		{
+			name:      "key does not reach the legacy api",
+			status:    http.StatusUnauthorized,
+			body:      `{"meta":{"rc":"error"}}`,
+			wantUsers: 0,
+		},
+		{
+			name:      "legacy route absent on this console",
+			status:    http.StatusNotFound,
+			body:      `{"meta":{"rc":"error","msg":"api.err.NoSiteContext"}}`,
+			wantUsers: 0,
+		},
+		{
+			// The legacy API reports application errors in the body with a 200.
+			name:      "application level error on a 200",
+			status:    http.StatusOK,
+			body:      `{"meta":{"rc":"error","msg":"api.err.NoSiteContext"},"data":[]}`,
+			wantUsers: 0,
+		},
+		{
+			name:      "transient failure aborts",
+			status:    http.StatusInternalServerError,
+			body:      `{"meta":{"rc":"error"}}`,
+			wantError: true,
+		},
+		{
+			name:      "throttled aborts",
+			status:    http.StatusTooManyRequests,
+			body:      `{"meta":{"rc":"error"}}`,
+			wantError: true,
+		},
+		{
+			name:      "users returned",
+			status:    http.StatusOK,
+			body:      `{"meta":{"rc":"ok"},"data":[{"_id":"ra1","name":"alice"}]}`,
+			wantUsers: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := unifiStubClient(t, func(req *http.Request) (int, string) {
+				if strings.HasSuffix(req.URL.Path, "/list/account") {
+					return tc.status, tc.body
+				}
+
+				if strings.HasSuffix(req.URL.Path, "/v1/sites") {
+					return http.StatusOK, `{"count":1,"limit":200,"offset":0,"totalCount":1,` +
+						`"data":[{"id":"site-a","name":"HQ","internalReference":"default"}]}`
+				}
+
+				return http.StatusOK, `{"count":0,"limit":200,"offset":0,"totalCount":0,"data":[]}`
+			})
+
+			records, err := NewUniFiDriver(client, unifiTestLogger(), "https://api.ui.com/x").
+				ListAccounts(context.Background())
+
+			if tc.wantError {
+				require.Error(t, err)
+				assert.Nil(t, records)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, unifiRecordsWithPrefix(records, "site/site-a/radius-user/"), tc.wantUsers)
+		})
+	}
+}
+
+// TestUniFiRadiusUsersNeedLegacySiteName pins that the legacy path is addressed
+// by the site's legacy short name, never its UUID. A site without one is skipped
+// rather than requested with an identifier the endpoint would reject.
+func TestUniFiRadiusUsersNeedLegacySiteName(t *testing.T) {
+	t.Parallel()
+
+	var legacyPaths []string
+
+	client := unifiStubClient(t, func(req *http.Request) (int, string) {
+		if strings.Contains(req.URL.Path, "/list/account") {
+			legacyPaths = append(legacyPaths, req.URL.Path)
+
+			return http.StatusOK, `{"meta":{"rc":"ok"},"data":[{"_id":"ra1","name":"alice"}]}`
+		}
+
+		if strings.HasSuffix(req.URL.Path, "/v1/sites") {
+			return http.StatusOK, `{"count":2,"limit":200,"offset":0,"totalCount":2,"data":[` +
+				`{"id":"site-a","name":"HQ","internalReference":"default"},` +
+				`{"id":"site-b","name":"Branch"}]}`
+		}
+
+		return http.StatusOK, `{"count":0,"limit":200,"offset":0,"totalCount":0,"data":[]}`
+	})
+
+	records, err := NewUniFiDriver(client, unifiTestLogger(), "https://api.ui.com/x").
+		ListAccounts(context.Background())
+	require.NoError(t, err)
+
+	// Only the site carrying a legacy short name was asked, and it was asked
+	// with that name rather than its UUID.
+	require.Len(t, legacyPaths, 1)
+	assert.Contains(t, legacyPaths[0], "/api/s/default/list/account")
+	assert.NotContains(t, legacyPaths[0], "site-a")
+
+	require.Len(t, records, 1)
+	assert.Equal(t, "site/site-a/radius-user/ra1", records[0].ExternalID)
+}
+
+// TestUniFiRadiusUserRecord pins identity and labelling for one directory entry.
+func TestUniFiRadiusUserRecord(t *testing.T) {
+	t.Parallel()
+
+	t.Run("keys on the opaque id, displays the username", func(t *testing.T) {
+		t.Parallel()
+
+		record, ok := unifiRadiusUserRecord(
+			unifiRadiusUser{ID: "ra1", Name: " alice ", VLAN: "20"},
+			"Built-in RADIUS", []string{"Office", "Corp-WiFi", "Lab"},
+			"site/s/", "Site: HQ",
+		)
+		require.True(t, ok)
+		assert.Equal(t, "site/s/radius-user/ra1", record.ExternalID)
+		assert.Equal(t, "alice", record.FullName)
+		// The SSID names are sorted so the role list does not reshuffle between
+		// campaigns purely because the API paged its broadcasts differently.
+		assert.Equal(t, []string{
+			"RADIUS user", "Site: HQ", "RADIUS profile: Built-in RADIUS",
+			"WiFi: Corp-WiFi", "WiFi: Lab", "WiFi: Office", "VLAN: 20",
+		}, record.Roles)
+	})
+
+	// Several profiles means a user cannot be attributed to one, so neither the
+	// directory nor the networks it unlocks are named — a guess would read as
+	// fact on the reviewer's screen.
+	t.Run("omits the profile when the site has several", func(t *testing.T) {
+		t.Parallel()
+
+		record, ok := unifiRadiusUserRecord(
+			unifiRadiusUser{ID: "ra1", Name: "alice"}, "", nil, "site/s/", "Site: HQ",
+		)
+		require.True(t, ok)
+		assert.Equal(t, []string{"RADIUS user", "Site: HQ"}, record.Roles)
+	})
+
+	// A directory no SSID delegates to still holds accounts; they simply reach
+	// no WiFi network through it.
+	t.Run("names the profile with no networks behind it", func(t *testing.T) {
+		t.Parallel()
+
+		record, ok := unifiRadiusUserRecord(
+			unifiRadiusUser{ID: "ra1", Name: "alice"}, "Built-in RADIUS", nil, "site/s/", "Site: HQ",
+		)
+		require.True(t, ok)
+		assert.Equal(t, []string{"RADIUS user", "Site: HQ", "RADIUS profile: Built-in RADIUS"}, record.Roles)
+	})
+
+	// An entry with no _id still keys stably off its username, which is the
+	// directory's own key.
+	t.Run("falls back to the username as the key", func(t *testing.T) {
+		t.Parallel()
+
+		record, ok := unifiRadiusUserRecord(
+			unifiRadiusUser{Name: "alice"}, "", nil, "site/s/", "Site: HQ",
+		)
+		require.True(t, ok)
+		assert.Equal(t, "site/s/radius-user/alice", record.ExternalID)
+		assert.Equal(t, "alice", record.FullName)
+	})
+
+	// Nothing stable to key on: emitting it would produce a record that lands
+	// under a different key on every run.
+	t.Run("drops an entry with neither id nor username", func(t *testing.T) {
+		t.Parallel()
+
+		_, ok := unifiRadiusUserRecord(unifiRadiusUser{Name: "  "}, "", nil, "site/s/", "Site: HQ")
+		assert.False(t, ok)
+	})
+}
+
+// TestUniFiLenientString pins the tolerance the legacy shape needs: the same
+// field has shipped as a string and as a number, and an unexpected shape must
+// not fail a whole review over a descriptive field.
+func TestUniFiLenientString(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		`"20"`:     "20",
+		`30`:       "30",
+		`null`:     "",
+		`""`:       "",
+		`{"a":1}`:  "",
+		`[1,2]`:    "",
+		`true`:     "",
+		`"  40  "`: "  40  ",
+	}
+
+	for raw, want := range cases {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+
+			var got unifiLenientString
+			require.NoError(t, got.UnmarshalJSON([]byte(raw)))
+			assert.Equal(t, want, string(got))
+		})
+	}
+}
+
+// TestUniFiProfileLabel pins that a role always names something: a profile with
+// no display name falls back to its ID rather than producing "RADIUS profile: ".
+func TestUniFiProfileLabel(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "Built-in RADIUS", unifiProfileLabel(unifiRadiusProfile{ID: "p1", Name: " Built-in RADIUS "}))
+	assert.Equal(t, "p2", unifiProfileLabel(unifiRadiusProfile{ID: "p2"}))
+}
+
+// TestUniFiConsoleBaseURL pins the composition every caller shares. The console
+// ID is a path segment on api.ui.com, so a value that could add segments must
+// not survive into a request URL.
+func TestUniFiConsoleBaseURL(t *testing.T) {
+	t.Parallel()
+
+	baseURL, err := UniFiConsoleBaseURL(unifiTestAPIBase, unifiTestConsoleID)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"https://api.ui.com/v1/connector/consoles/ABCDEF0123456789:1234567890/proxy/network",
+		baseURL,
+	)
+
+	// The probe URL must stay byte-identical to the one verified against the
+	// live API, even though the driver now also reaches the legacy sibling path.
+	sitesURL, err := UniFiSitesURL(baseURL)
+	require.NoError(t, err)
+	assert.Equal(t, baseURL+"/integration/v1/sites", sitesURL)
+
+	// A blank console ID would resolve to the console collection itself,
+	// silently reviewing something other than a console.
+	_, err = UniFiConsoleBaseURL(unifiTestAPIBase, "   ")
+	require.Error(t, err)
+
+	// A traversal attempt escapes into an encoded segment rather than
+	// climbing out of the console.
+	escaped, err := UniFiConsoleBaseURL(unifiTestAPIBase, "../../../v1/hosts")
+	require.NoError(t, err)
+	assert.NotContains(t, escaped, "/../")
+	assert.Contains(t, escaped, "%2F")
+}
+
+// TestUniFiDriverPagination pins that the driver walks a collection to
+// completion off totalCount rather than stopping at the first page.
+func TestUniFiDriverPagination(t *testing.T) {
+	t.Parallel()
+
+	client := unifiStubClient(t, func(req *http.Request) (int, string) {
+		path := req.URL.Path
+
+		switch {
+		case strings.HasSuffix(path, "/v1/sites"):
+			switch req.URL.Query().Get("offset") {
+			case "0":
+				return http.StatusOK, `{"count":1,"limit":200,"offset":0,"totalCount":2,` +
+					`"data":[{"id":"site-a","name":"HQ"}]}`
+			default:
+				return http.StatusOK, `{"count":1,"limit":200,"offset":1,"totalCount":2,` +
+					`"data":[{"id":"site-b","name":"Branch"}]}`
+			}
+		case strings.HasSuffix(path, "/hotspot/vouchers"):
+			return http.StatusOK, `{"count":1,"limit":1000,"offset":0,"totalCount":1,` +
+				`"data":[{"id":"v-1","name":"lobby","expired":false}]}`
+		default:
+			return http.StatusOK, `{"count":0,"limit":200,"offset":0,"totalCount":0,"data":[]}`
+		}
+	})
+
+	records, err := NewUniFiDriver(client, unifiTestLogger(), "https://api.ui.com/x").
+		ListAccounts(context.Background())
+	require.NoError(t, err)
+
+	// Both pages of sites were walked, so both sites contributed their voucher;
+	// the site role distinguishes them.
+	require.Len(t, records, 2)
+	assert.Equal(t, []string{"Hotspot voucher", "Site: HQ"}, records[0].Roles)
+	assert.Equal(t, []string{"Hotspot voucher", "Site: Branch"}, records[1].Roles)
+
+	// The two sites deliberately answer with the SAME resource ID. Scoping each
+	// ExternalID to its site is what stops them collapsing into one entry that
+	// a reviewer would decide once for both.
+	assert.Equal(t, "site/site-a/voucher/v-1", records[0].ExternalID)
+	assert.Equal(t, "site/site-b/voucher/v-1", records[1].ExternalID)
+}
+
+// TestUniFiDriverAbortsOnFailure pins the identity guarantee: entries key on
+// ExternalID, so a run that silently dropped a collection would mark every
+// grant in it removed on the next campaign. Only a 404 — a stable "this console
+// does not have that feature" — is allowed to yield nothing.
+func TestUniFiDriverAbortsOnFailure(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		suffix    string
+		status    int
+		wantError bool
+	}{
+		{name: "wifi broadcasts unreadable", suffix: "/wifi/broadcasts", status: http.StatusInternalServerError, wantError: true},
+		{name: "radius profiles throttled", suffix: "/radius/profiles", status: http.StatusTooManyRequests, wantError: true},
+		{name: "vouchers forbidden", suffix: "/hotspot/vouchers", status: http.StatusForbidden, wantError: true},
+		{name: "wifi absent on this console", suffix: "/wifi/broadcasts", status: http.StatusNotFound},
+		{name: "radius absent on this console", suffix: "/radius/profiles", status: http.StatusNotFound},
+		{name: "hotspot absent on this console", suffix: "/hotspot/vouchers", status: http.StatusNotFound},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := unifiStubClient(t, func(req *http.Request) (int, string) {
+				if strings.HasSuffix(req.URL.Path, tc.suffix) {
+					return tc.status, `{"statusCode":0}`
+				}
+
+				if strings.HasSuffix(req.URL.Path, "/v1/sites") {
+					return http.StatusOK, `{"count":1,"limit":200,"offset":0,"totalCount":1,` +
+						`"data":[{"id":"site-a","name":"HQ"}]}`
+				}
+
+				if strings.HasSuffix(req.URL.Path, "/list/account") {
+					return http.StatusOK, `{"meta":{"rc":"ok"},"data":[]}`
+				}
+
+				return http.StatusOK, `{"count":0,"limit":200,"offset":0,"totalCount":0,"data":[]}`
+			})
+
+			records, err := NewUniFiDriver(client, unifiTestLogger(), "https://api.ui.com/x").
+				ListAccounts(context.Background())
+
+			if tc.wantError {
+				require.Error(t, err)
+				assert.Nil(t, records)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Empty(t, records)
+		})
+	}
+}
+
+// TestUniFiDriverBlankSiteIDAborts pins the malformed-list guarantee: the site
+// ID is the path segment every grant below it is fetched with, so a blank row
+// would silently hide a whole site rather than fail.
+func TestUniFiDriverBlankSiteIDAborts(t *testing.T) {
+	t.Parallel()
+
+	client := unifiStubClient(t, func(req *http.Request) (int, string) {
+		if !strings.HasSuffix(req.URL.Path, "/v1/sites") {
+			t.Errorf("driver must not fetch a site's grants after a malformed list row")
+		}
+
+		return http.StatusOK, `{"count":1,"limit":200,"offset":0,"totalCount":1,` +
+			`"data":[{"id":"  ","name":"HQ"}]}`
+	})
+
+	records, err := NewUniFiDriver(client, unifiTestLogger(), "https://api.ui.com/x").
+		ListAccounts(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, records)
+}
+
+// TestUniFiDriverSkipsVanishedBroadcast pins that a broadcast deleted between
+// the list and its detail fetch is dropped rather than failing the run: the
+// 404 is a stable answer, and re-listing would race the same way.
+func TestUniFiDriverSkipsVanishedBroadcast(t *testing.T) {
+	t.Parallel()
+
+	client := unifiStubClient(t, func(req *http.Request) (int, string) {
+		path := req.URL.Path
+
+		switch {
+		case strings.HasSuffix(path, "/v1/sites"):
+			return http.StatusOK, `{"count":1,"limit":200,"offset":0,"totalCount":1,` +
+				`"data":[{"id":"site-a","name":"HQ"}]}`
+		case strings.HasSuffix(path, "/wifi/broadcasts"):
+			return http.StatusOK, `{"count":2,"limit":200,"offset":0,"totalCount":2,"data":[` +
+				`{"id":"w-gone","name":"Old","enabled":true,"securityConfiguration":{"type":"OPEN"}},` +
+				`{"id":"w-live","name":"Office","enabled":true,"securityConfiguration":{"type":"OPEN"}}]}`
+		case strings.HasSuffix(path, "/wifi/broadcasts/w-gone"):
+			return http.StatusNotFound, `{"statusCode":404}`
+		case strings.HasSuffix(path, "/wifi/broadcasts/w-live"):
+			// Carries a filtered device, so the surviving broadcast has
+			// something to contribute and the run is not vacuously empty.
+			return http.StatusOK, `{"id":"w-live","name":"Office","enabled":true,` +
+				`"securityConfiguration":{"type":"OPEN"},` +
+				`"clientFilteringPolicy":{"action":"ALLOW",` +
+				`"macAddressFilter":["de:ad:be:ef:00:01"]}}`
+		default:
+			return http.StatusOK, `{"count":0,"limit":200,"offset":0,"totalCount":0,"data":[]}`
+		}
+	})
+
+	records, err := NewUniFiDriver(client, unifiTestLogger(), "https://api.ui.com/x").
+		ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "site/site-a/wifi/w-live/mac/deadbeef0001", records[0].ExternalID)
+}
+
+// TestUniFiWifiRecordsDedupesMACs pins that one device listed twice — plainly
+// or once per format — yields one record. Two would inflate the fetched-account
+// count and collapse into a single entry on upsert anyway.
+func TestUniFiWifiRecordsDedupesMACs(t *testing.T) {
+	t.Parallel()
+
+	broadcast := unifiWifiBroadcast{ID: "w-1", Name: "Office", Enabled: true}
+	broadcast.SecurityConfiguration.Type = "WPA2_PERSONAL"
+	broadcast.ClientFilteringPolicy = &struct {
+		Action           string   `json:"action"`
+		MACAddressFilter []string `json:"macAddressFilter"`
+	}{
+		Action: "ALLOW",
+		MACAddressFilter: []string{
+			"94:2a:6f:26:c6:ca",
+			"94-2A-6F-26-C6-CA",
+			"  ",
+			"de:ad:be:ef:00:01",
+		},
+	}
+
+	records := unifiWifiRecords(broadcast, "Office", "site/s/", "Site: HQ")
+
+	// Two distinct devices, and no row for the SSID itself.
+	require.Len(t, records, 2)
+	assert.Equal(t, "site/s/wifi/w-1/mac/942a6f26c6ca", records[0].ExternalID)
+	assert.Equal(t, "site/s/wifi/w-1/mac/deadbeef0001", records[1].ExternalID)
+	// The first spelling wins the display name; the key is format-independent.
+	assert.Equal(t, "94:2a:6f:26:c6:ca", records[0].FullName)
+}
+
+// TestUniFiWifiRecordsNoFilterNoRecords pins that an SSID whose membership the
+// API does not state contributes nothing. A WPA-Personal or open SSID with no
+// filter is reached with a credential UniFi shares among everyone holding it,
+// and there is no identifiable holder to review.
+func TestUniFiWifiRecordsNoFilterNoRecords(t *testing.T) {
+	t.Parallel()
+
+	broadcast := unifiWifiBroadcast{ID: "w-1", Name: "Guest", Enabled: true}
+	broadcast.SecurityConfiguration.Type = "OPEN"
+
+	assert.Empty(t, unifiWifiRecords(broadcast, "Guest", "site/s/", "Site: HQ"))
+}
+
+// TestUniFiWifiRecordsDisabledSSID pins that an SSID's on-air state still
+// reaches its device rows. The broadcast used to carry a row of its own to
+// report it; without one, a MAC on a disabled SSID would otherwise read as live
+// access to a network nobody can join.
+func TestUniFiWifiRecordsDisabledSSID(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		enabled    bool
+		action     string
+		wantActive bool
+	}{
+		{name: "allowed on a live ssid", enabled: true, action: "ALLOW", wantActive: true},
+		{name: "allowed on a disabled ssid", enabled: false, action: "ALLOW"},
+		{name: "blocked on a live ssid", enabled: true, action: "BLOCK"},
+		{name: "blocked on a disabled ssid", enabled: false, action: "BLOCK"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			broadcast := unifiWifiBroadcast{ID: "w-1", Name: "Office", Enabled: tc.enabled}
+			broadcast.SecurityConfiguration.Type = "WPA2_PERSONAL"
+			broadcast.ClientFilteringPolicy = &struct {
+				Action           string   `json:"action"`
+				MACAddressFilter []string `json:"macAddressFilter"`
+			}{Action: tc.action, MACAddressFilter: []string{"de:ad:be:ef:00:01"}}
+
+			records := unifiWifiRecords(broadcast, "Office", "site/s/", "Site: HQ")
+			require.Len(t, records, 1)
+			require.NotNil(t, records[0].Active)
+			assert.Equal(t, tc.wantActive, *records[0].Active)
+		})
+	}
+}
+
+// TestUniFiSoleProfileAttribution pins the ambiguity rule at the driver level:
+// a user is attributed to a RADIUS profile only when the site has exactly one.
+func TestUniFiSoleProfileAttribution(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		profiles  string
+		wantRoles []string
+	}{
+		{
+			name: "one profile is unambiguous",
+			profiles: `{"count":1,"limit":200,"offset":0,"totalCount":1,` +
+				`"data":[{"id":"p1","name":"Built-in"}]}`,
+			wantRoles: []string{"RADIUS user", "Site: HQ", "RADIUS profile: Built-in"},
+		},
+		{
+			name: "two profiles leave it unattributed",
+			profiles: `{"count":2,"limit":200,"offset":0,"totalCount":2,"data":[` +
+				`{"id":"p1","name":"Built-in"},{"id":"p2","name":"Corporate AD"}]}`,
+			wantRoles: []string{"RADIUS user", "Site: HQ"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := unifiStubClient(t, func(req *http.Request) (int, string) {
+				switch {
+				case strings.HasSuffix(req.URL.Path, "/v1/sites"):
+					return http.StatusOK, `{"count":1,"limit":200,"offset":0,"totalCount":1,` +
+						`"data":[{"id":"site-a","name":"HQ","internalReference":"default"}]}`
+				case strings.HasSuffix(req.URL.Path, "/radius/profiles"):
+					return http.StatusOK, tc.profiles
+				case strings.HasSuffix(req.URL.Path, "/list/account"):
+					return http.StatusOK, `{"meta":{"rc":"ok"},"data":[{"_id":"ra1","name":"alice"}]}`
+				default:
+					return http.StatusOK, `{"count":0,"limit":200,"offset":0,"totalCount":0,"data":[]}`
+				}
+			})
+
+			records, err := NewUniFiDriver(client, unifiTestLogger(), "https://api.ui.com/x").
+				ListAccounts(context.Background())
+			require.NoError(t, err)
+
+			users := unifiRecordsWithPrefix(records, "site/site-a/radius-user/")
+			require.Len(t, users, 1)
+			assert.Equal(t, tc.wantRoles, users[0].Roles)
+		})
+	}
+}
+
+// TestUniFiMACKey pins that the same device keys identically however UniFi
+// formats its address, so a formatting change cannot read as one account
+// removed and another added.
+func TestUniFiMACKey(t *testing.T) {
+	t.Parallel()
+
+	for _, mac := range []string{
+		"94:2a:6f:26:c6:ca",
+		"94-2A-6F-26-C6-CA",
+		"942A6F26C6CA",
+		"94 2a 6f 26 c6 ca",
+		"942a.6f26.c6ca",
+	} {
+		t.Run(mac, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, "942a6f26c6ca", unifiMACKey(mac))
+		})
+	}
+}
+
+// TestUniFiSiteLabel pins that a role always names something: the display name
+// first, then the internal reference older UniFi APIs use, then the ID.
+func TestUniFiSiteLabel(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "HQ", unifiSiteLabel(unifiSite{ID: "x", Name: " HQ ", InternalReference: "default"}))
+	assert.Equal(t, "default", unifiSiteLabel(unifiSite{ID: "x", InternalReference: "default"}))
+	assert.Equal(t, "x", unifiSiteLabel(unifiSite{ID: "x"}))
+}
+
+// TestUniFiNameResolver pins the single-site rule: a console exposes no name of
+// its own, so it is named after its site when it has exactly one.
+func TestUniFiNameResolver(t *testing.T) {
+	t.Parallel()
+
+	rec := newRecorder(t, "testdata/unifi", "UNIFI_API_KEY")
+	client := newVCRClientWithHeader(rec, "X-API-KEY", os.Getenv("UNIFI_API_KEY"))
+
+	baseURL, err := UniFiConsoleBaseURL(unifiTestAPIBase, unifiTestConsoleID)
+	require.NoError(t, err)
+
+	name, err := NewUniFiNameResolver(client, unifiTestLogger(), baseURL).ResolveInstanceName(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "HQ", name)
+}
+
+// TestUniFiNameResolverMultiSite pins the other half of the rule: a multi-site
+// console has no single right label, and an empty name leaves the source with
+// the generic provider name rather than an arbitrary pick.
+func TestUniFiNameResolverMultiSite(t *testing.T) {
+	t.Parallel()
+
+	body := `{"count":2,"limit":200,"offset":0,"totalCount":2,"data":[` +
+		`{"id":"aaaa","name":"HQ","internalReference":"default"},` +
+		`{"id":"bbbb","name":"Branch","internalReference":"site2"}]}`
+
+	client := unifiStubClient(t, func(*http.Request) (int, string) {
+		return http.StatusOK, body
+	})
+
+	name, err := NewUniFiNameResolver(client, unifiTestLogger(), "https://api.ui.com/x").
+		ResolveInstanceName(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, name)
+}
+
+// TestUniFiNameResolverTerminalStatus pins that a revoked key or a console the
+// key cannot reach is classified terminal, so the source-name worker keeps the
+// generic name instead of re-claiming the source on every poll.
+func TestUniFiNameResolverTerminalStatus(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		status   int
+		terminal bool
+	}{
+		{status: http.StatusUnauthorized, terminal: true},
+		{status: http.StatusForbidden, terminal: true},
+		{status: http.StatusBadRequest, terminal: true},
+		{status: http.StatusInternalServerError, terminal: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			t.Parallel()
+
+			client := unifiStubClient(t, func(*http.Request) (int, string) {
+				return tc.status, `{"statusCode":0}`
+			})
+
+			_, err := NewUniFiNameResolver(client, unifiTestLogger(), "https://api.ui.com/x").
+				ResolveInstanceName(context.Background())
+			require.Error(t, err)
+			assert.Equal(t, tc.terminal, errors.Is(err, ErrTerminalNameResolution))
+		})
+	}
+}
+
+// TestUniFiDriverContextCancellation verifies that a context canceled mid-run
+// aborts with the cancellation error rather than being mistaken for a complete,
+// smaller sync.
+func TestUniFiDriverContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasSuffix(req.URL.Path, "/v1/sites") {
+				cancel()
+
+				return nil, ctx.Err()
+			}
+
+			body := `{"count":1,"limit":200,"offset":0,"totalCount":1,` +
+				`"data":[{"id":"site-a","name":"HQ"}]}`
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}),
+	}
+
+	records, err := NewUniFiDriver(client, unifiTestLogger(), "https://api.ui.com/x").ListAccounts(ctx)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+	assert.Nil(t, records)
+}
+
+// unifiRecordsWithPrefix returns the records whose ExternalID starts with prefix.
+func unifiRecordsWithPrefix(records []AccountRecord, prefix string) []AccountRecord {
+	var out []AccountRecord
+
+	for _, record := range records {
+		if strings.HasPrefix(record.ExternalID, prefix) {
+			out = append(out, record)
+		}
+	}
+
+	return out
+}
+
+// unifiStubClient returns an *http.Client answering every request from respond,
+// which maps a request to a status code and a JSON body.
+func unifiStubClient(t *testing.T, respond func(*http.Request) (int, string)) *http.Client {
+	t.Helper()
+
+	return &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		status, body := respond(req)
+
+		return &http.Response{
+			StatusCode: status,
+			Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	})}
+}

--- a/pkg/connector/provider/builtin.go
+++ b/pkg/connector/provider/builtin.go
@@ -112,6 +112,7 @@ func NewBuiltinRegistryWith(opts ...Option) (*Registry, error) {
 		supabaseRegistration(),
 		tailscaleRegistration(),
 		tallyRegistration(),
+		unifiRegistration(),
 		upcloudRegistration(),
 		vercelRegistration(),
 		yousignRegistration(),

--- a/pkg/connector/provider/probe.go
+++ b/pkg/connector/provider/probe.go
@@ -392,6 +392,19 @@ func buildSigNozProbeURL(conn *coredata.Connector, _ Endpoints) (string, error) 
 	return u.JoinPath("api", "v1", "user").String(), nil
 }
 
+// buildUniFiProbeURL points the connection check at the configured console's
+// site listing — the same call the driver opens with, so a check that passes
+// proves the key reaches the console the review will read, not merely that
+// api.ui.com accepted it.
+func buildUniFiProbeURL(conn *coredata.Connector, ep Endpoints) (string, error) {
+	baseURL, err := unifiConsoleBaseURL(conn, ep)
+	if err != nil {
+		return "", err
+	}
+
+	return drivers.UniFiSitesURL(baseURL)
+}
+
 func buildPostHogProbeURL(conn *coredata.Connector) (string, error) {
 	s, err := coredata.ConnectorSettings[coredata.PostHogConnectorSettings](conn)
 	if err != nil {

--- a/pkg/connector/provider/probe_test.go
+++ b/pkg/connector/provider/probe_test.go
@@ -452,6 +452,16 @@ func TestBuildProbeURLFromAPIBase(t *testing.T) {
 			settings: &coredata.QoveryConnectorSettings{OrganizationID: "c4f2de4d-3e50-4f98-bf00-065778f7f5b5"},
 			wantURL:  "https://api.qovery.com/organization/c4f2de4d-3e50-4f98-bf00-065778f7f5b5/member",
 		},
+		{
+			// The probe lands on the console's own site listing — the call the
+			// driver opens with — so a passing check proves the key reaches the
+			// configured console, not merely that api.ui.com accepted it.
+			name:     "unifi",
+			reg:      unifiRegistration(),
+			settings: &coredata.UniFiConnectorSettings{ConsoleID: "ABCDEF0123456789:1234567890"},
+			wantURL: "https://api.ui.com/v1/connector/consoles/ABCDEF0123456789:1234567890" +
+				"/proxy/network/integration/v1/sites",
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/connector/provider/unifi.go
+++ b/pkg/connector/provider/unifi.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/accessreview/drivers"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+// unifiRegistration wires UniFi Network as an API-key access-review connector.
+//
+// Ubiquiti runs no partner OAuth program for the Network API, so the customer
+// supplies a console API key (UniFi Site Manager > API) plus the ID of the
+// console to review. The key authenticates in X-API-KEY rather than as a Bearer
+// token, hence APIKeyHeader.
+//
+// APIBase is the Site Manager console-proxy root: its host is a compile-time
+// constant and only the {consoleId} segment varies per connector, so the
+// driver, the name resolver and the probe all compose from ep.APIBase (via
+// drivers.UniFiConsoleBaseURL) and an override moves all three together.
+//
+// Reaching a console directly on its LAN address is deliberately not offered:
+// that host resolves to a private IP, which the SSRF-protected connector client
+// refuses to dial. The cloud proxy is the only route a hosted deployment can
+// take.
+func unifiRegistration() *Registration {
+	return &Registration{
+		Provider:    coredata.ConnectorProviderUniFi,
+		DisplayName: "UniFi",
+		// DocumentationURL is left empty until the probo.com docs page exists;
+		// the console renders it as a link, so a slug that 404s is worse than
+		// no link.
+		SupportsAPIKey: true,
+		APIKeyHeader:   "X-API-KEY",
+		BuildProbeURL:  buildUniFiProbeURL,
+		Endpoints: Endpoints{
+			APIBase: "https://api.ui.com/v1/connector/consoles",
+		},
+		APIKeyExtraSettings: []ExtraSetting{
+			{Key: "consoleId", Label: "Console ID", Required: true},
+		},
+		NewDriver: func(_ context.Context, c *http.Client, conn *coredata.Connector, logger *log.Logger, ep Endpoints) (drivers.Driver, error) {
+			baseURL, err := unifiConsoleBaseURL(conn, ep)
+			if err != nil {
+				return nil, fmt.Errorf("cannot create unifi driver: %w", err)
+			}
+
+			return drivers.NewUniFiDriver(c, logger.Named("unifi"), baseURL), nil
+		},
+		// A single-site console is named after its site; a multi-site console
+		// keeps the generic name (see drivers.NewUniFiNameResolver).
+		NewNameResolver: func(ctx context.Context, c *http.Client, conn *coredata.Connector, logger *log.Logger, ep Endpoints) drivers.NameResolver {
+			baseURL, err := unifiConsoleBaseURL(conn, ep)
+			if err != nil {
+				logger.ErrorCtx(ctx, "cannot resolve unifi console base url", log.Error(err))
+
+				return nil
+			}
+
+			return drivers.NewUniFiNameResolver(c, logger.Named("unifi"), baseURL)
+		},
+	}
+}
+
+// unifiConsoleBaseURL reads the connector's console ID and composes the
+// console's Network Integration API root under ep.APIBase.
+func unifiConsoleBaseURL(conn *coredata.Connector, ep Endpoints) (string, error) {
+	settings, err := coredata.ConnectorSettings[coredata.UniFiConnectorSettings](conn)
+	if err != nil {
+		return "", fmt.Errorf("cannot read unifi connector settings: %w", err)
+	}
+
+	return drivers.UniFiConsoleBaseURL(ep.APIBase, settings.ConsoleID)
+}

--- a/pkg/connector/provider/unifi_test.go
+++ b/pkg/connector/provider/unifi_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/httpclient"
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/accessreview/drivers"
+	"go.probo.inc/probo/pkg/connector/provider"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func unifiTestRegistration(t *testing.T) *provider.Registration {
+	t.Helper()
+
+	reg, ok := provider.NewBuiltinRegistry().Get(coredata.ConnectorProviderUniFi)
+	require.True(t, ok, "unifi provider must be registered")
+
+	return reg
+}
+
+func TestUniFiRegistrationMetadata(t *testing.T) {
+	t.Parallel()
+
+	reg := unifiTestRegistration(t)
+
+	assert.Equal(t, "UniFi", reg.DisplayName)
+	assert.True(t, reg.SupportsAPIKey)
+	// UniFi rejects a Bearer token; the console API key rides in X-API-KEY.
+	assert.Equal(t, "X-API-KEY", reg.APIKeyHeader)
+	// There is no OAuth2 program for the Network API.
+	assert.Empty(t, reg.OAuth2Scopes)
+	assert.Empty(t, reg.Endpoints.Auth)
+	assert.Empty(t, reg.Endpoints.Token)
+	// The probe is per-connector (it embeds the console ID), so there is no
+	// static Probe URL to pin.
+	assert.Empty(t, reg.Endpoints.Probe)
+	require.NotNil(t, reg.BuildProbeURL)
+	assert.Equal(t, "https://api.ui.com/v1/connector/consoles", reg.Endpoints.APIBase)
+
+	require.Len(t, reg.APIKeyExtraSettings, 1)
+	assert.Equal(t, "consoleId", reg.APIKeyExtraSettings[0].Key)
+	assert.Equal(t, "Console ID", reg.APIKeyExtraSettings[0].Label)
+	assert.True(t, reg.APIKeyExtraSettings[0].Required)
+
+	require.NotNil(t, reg.NewDriver)
+	require.NotNil(t, reg.NewNameResolver)
+}
+
+func TestUniFiNewDriver(t *testing.T) {
+	t.Parallel()
+
+	reg := unifiTestRegistration(t)
+
+	t.Run("creates driver with a console id", func(t *testing.T) {
+		t.Parallel()
+
+		drv, err := reg.NewDriver(
+			context.Background(),
+			httpclient.DefaultClient(httpclient.WithSSRFProtection()),
+			unifiTestConnector(t, "ABCDEF0123456789:1234567890"),
+			log.NewLogger(log.WithName("test")),
+			reg.Endpoints,
+		)
+		require.NoError(t, err)
+		assert.IsType(t, &drivers.UniFiDriver{}, drv)
+	})
+
+	// Without a console ID the URL would resolve to the console collection
+	// itself, so the review would silently read something other than a
+	// console. Refuse instead.
+	t.Run("errors when the console id is missing", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := reg.NewDriver(
+			context.Background(),
+			httpclient.DefaultClient(httpclient.WithSSRFProtection()),
+			&coredata.Connector{
+				Provider:    coredata.ConnectorProviderUniFi,
+				RawSettings: []byte(`{}`),
+			},
+			log.NewLogger(log.WithName("test")),
+			reg.Endpoints,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "console_id is required")
+	})
+}
+
+func TestUniFiNewNameResolver(t *testing.T) {
+	t.Parallel()
+
+	reg := unifiTestRegistration(t)
+
+	resolver := reg.NewNameResolver(
+		context.Background(),
+		httpclient.DefaultClient(httpclient.WithSSRFProtection()),
+		unifiTestConnector(t, "ABCDEF0123456789:1234567890"),
+		log.NewLogger(log.WithName("test")),
+		reg.Endpoints,
+	)
+	require.NotNil(t, resolver)
+
+	// A connector with no console ID has nothing to resolve against; the
+	// worker treats a nil resolver as "keep the generic name".
+	assert.Nil(t, reg.NewNameResolver(
+		context.Background(),
+		httpclient.DefaultClient(httpclient.WithSSRFProtection()),
+		&coredata.Connector{
+			Provider:    coredata.ConnectorProviderUniFi,
+			RawSettings: []byte(`{}`),
+		},
+		log.NewLogger(log.WithName("test")),
+		reg.Endpoints,
+	))
+}
+
+func unifiTestConnector(t *testing.T, consoleID string) *coredata.Connector {
+	t.Helper()
+
+	raw, err := json.Marshal(&coredata.UniFiConnectorSettings{ConsoleID: consoleID})
+	require.NoError(t, err)
+
+	return &coredata.Connector{
+		Provider:    coredata.ConnectorProviderUniFi,
+		RawSettings: raw,
+	}
+}

--- a/pkg/coredata/connector_provider.go
+++ b/pkg/coredata/connector_provider.go
@@ -91,6 +91,7 @@ const (
 	ConnectorProviderSquare          ConnectorProvider = "SQUARE"
 	ConnectorProviderGoogleAnalytics ConnectorProvider = "GOOGLE_ANALYTICS"
 	ConnectorProviderUpCloud         ConnectorProvider = "UPCLOUD"
+	ConnectorProviderUniFi           ConnectorProvider = "UNIFI"
 )
 
 var (
@@ -160,6 +161,7 @@ func ConnectorProviders() []ConnectorProvider {
 		ConnectorProviderSquare,
 		ConnectorProviderGoogleAnalytics,
 		ConnectorProviderUpCloud,
+		ConnectorProviderUniFi,
 	}
 }
 
@@ -225,7 +227,8 @@ func (v ConnectorProvider) IsValid() bool {
 		ConnectorProviderSegment,
 		ConnectorProviderSquare,
 		ConnectorProviderGoogleAnalytics,
-		ConnectorProviderUpCloud:
+		ConnectorProviderUpCloud,
+		ConnectorProviderUniFi:
 		return true
 	}
 

--- a/pkg/coredata/connector_settings.go
+++ b/pkg/coredata/connector_settings.go
@@ -213,6 +213,20 @@ type (
 	GoogleAnalyticsConnectorSettings struct {
 		AccountID string `json:"account_id"`
 	}
+
+	// UniFiConnectorSettings stores the UniFi console the access source
+	// reviews. ConsoleID is the identifier Ubiquiti's Site Manager uses as the
+	// {consoleId} path segment when proxying to a console's Network
+	// Integration API (e.g. "942A6FF6…873F:9999999999"); a Ubiquiti account can
+	// hold several consoles, and the API key names none of them, so the
+	// reviewed console is captured up front.
+	//
+	// The console proxy on api.ui.com is the only supported route. A console's
+	// own LAN address is not: it resolves to a private IP, which the
+	// SSRF-protected connector client refuses to dial by design.
+	UniFiConnectorSettings struct {
+		ConsoleID string `json:"console_id"`
+	}
 )
 
 // GrantType returns the OAuth2 grant type recorded on the connector's

--- a/pkg/coredata/migrations/20260811T094500Z.sql
+++ b/pkg/coredata/migrations/20260811T094500Z.sql
@@ -1,0 +1,21 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TYPE connector_provider ADD VALUE IF NOT EXISTS 'UNIFI';

--- a/pkg/server/api/console/v1/connector_settings.go
+++ b/pkg/server/api/console/v1/connector_settings.go
@@ -364,6 +364,26 @@ func apiKeyConnectorSettings(input types.CreateAPIKeyConnectorInput) (json.RawMe
 		// verified, and displayed website are identical (a padded value would
 		// verify then break the driver's URL).
 		return json.Marshal(&coredata.CrispConnectorSettings{WebsiteID: websiteID})
+	case coredata.ConnectorProviderUniFi:
+		consoleID := ""
+		if input.UnifiConsoleID != nil {
+			consoleID = strings.TrimSpace(*input.UnifiConsoleID)
+		}
+
+		if consoleID == "" {
+			return nil, fmt.Errorf("cannot create unifi connector: unifiConsoleId is required")
+		}
+
+		// The console ID becomes a path segment on api.ui.com, so a value
+		// carrying its own separators or query would silently retarget every
+		// request. Reject rather than sanitize: the ID is copied out of the
+		// Site Manager UI, so anything decorated is a paste error the operator
+		// should see. The message names only the field — never the value.
+		if strings.ContainsAny(consoleID, "/\\?#% \t") {
+			return nil, fmt.Errorf("cannot create unifi connector: unifiConsoleId must be a bare console identifier")
+		}
+
+		return json.Marshal(&coredata.UniFiConnectorSettings{ConsoleID: consoleID})
 	}
 
 	return nil, nil

--- a/pkg/server/api/console/v1/connector_settings_test.go
+++ b/pkg/server/api/console/v1/connector_settings_test.go
@@ -22,6 +22,7 @@ package console_v1
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,6 +62,75 @@ func TestApiKeyConnectorSettings_LangfuseBaseURL(t *testing.T) {
 
 	_, err = apiKeyConnectorSettings(types.CreateAPIKeyConnectorInput{
 		Provider: coredata.ConnectorProviderLangfuse,
+	})
+	require.Error(t, err)
+}
+
+// TestApiKeyConnectorSettings_UniFiConsoleID walks the same chain for UniFi and
+// pins the extra rule its setting carries: the console ID becomes a path
+// segment on api.ui.com, so a value bringing its own separators would retarget
+// every request the driver makes and must be refused rather than sanitized.
+func TestApiKeyConnectorSettings_UniFiConsoleID(t *testing.T) {
+	t.Parallel()
+
+	reg, ok := provider.NewBuiltinRegistry().Get(coredata.ConnectorProviderUniFi)
+	require.True(t, ok)
+	require.Len(t, reg.APIKeyExtraSettings, 1)
+	require.Equal(t, "consoleId", reg.APIKeyExtraSettings[0].Key)
+
+	consoleID := "ABCDEF0123456789:1234567890"
+
+	raw, err := apiKeyConnectorSettings(types.CreateAPIKeyConnectorInput{
+		Provider:       coredata.ConnectorProviderUniFi,
+		UnifiConsoleID: &consoleID,
+	})
+	require.NoError(t, err)
+
+	var settings coredata.UniFiConnectorSettings
+	require.NoError(t, json.Unmarshal(raw, &settings))
+	assert.Equal(t, consoleID, settings.ConsoleID)
+
+	// Padding is a paste artifact, not a different console.
+	padded := "  " + consoleID + "  "
+
+	raw, err = apiKeyConnectorSettings(types.CreateAPIKeyConnectorInput{
+		Provider:       coredata.ConnectorProviderUniFi,
+		UnifiConsoleID: &padded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(raw, &settings))
+	assert.Equal(t, consoleID, settings.ConsoleID)
+
+	for _, invalid := range []string{
+		"",
+		"   ",
+		// A pasted URL rather than the bare identifier.
+		"https://api.ui.com/v1/connector/consoles/ABCDEF:1",
+		"ABCDEF:1/proxy/network/integration",
+		"../../v1/hosts",
+		"ABCDEF:1?x=1",
+		"ABCDEF:1#frag",
+		"ABC DEF:1",
+	} {
+		t.Run("rejects "+invalid, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := apiKeyConnectorSettings(types.CreateAPIKeyConnectorInput{
+				Provider:       coredata.ConnectorProviderUniFi,
+				UnifiConsoleID: &invalid,
+			})
+			require.Error(t, err)
+
+			// The message is surfaced verbatim to the client, so it must name
+			// the field and never echo the value.
+			if strings.TrimSpace(invalid) != "" {
+				assert.NotContains(t, err.Error(), invalid)
+			}
+		})
+	}
+
+	_, err = apiKeyConnectorSettings(types.CreateAPIKeyConnectorInput{
+		Provider: coredata.ConnectorProviderUniFi,
 	})
 	require.Error(t, err)
 }

--- a/pkg/server/api/console/v1/graphql/connector.graphql
+++ b/pkg/server/api/console/v1/graphql/connector.graphql
@@ -110,6 +110,7 @@ enum ConnectorProvider
         )
     UPCLOUD
         @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderUpCloud")
+    UNIFI @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderUniFi")
 }
 
 type ConnectorProviderInfo {
@@ -227,6 +228,7 @@ input CreateAPIKeyConnectorInput {
     scalewayOrganizationId: String
     crispWebsiteId: String
     segmentRegion: String
+    unifiConsoleId: String
 }
 
 type CreateAPIKeyConnectorPayload {


### PR DESCRIPTION
Access review driver for Unifi, a network platform.
The access review will cover the radius server. There is no email or mfa available for the radius service, only username.
Unifi has no oAuth posibility, which is the reason that this drive will use an API Key instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add UniFi connector with API key auth and a new access review driver for UniFi RADIUS users, MAC filters, and vouchers. Updates API, DB, console app, and UI to support the `UNIFI` provider with a console ID setting, connection probe, and logo.

### Service **`+1376`** **`-0`**
- Added UniFi access review driver reading Integration API and legacy RADIUS endpoints; emits records for RADIUS users, MAC filters, and vouchers.
- Registered `UNIFI` provider (API key auth) and implemented console base URL helpers and a probe that hits the console’s site listing.
- Included fixture cassette for end-to-end driver tests.

### GraphQL API **`+22`** **`-0`**
- Exposed `UNIFI` in the schema and added `unifiConsoleId` to `CreateAPIKeyConnectorInput`.
- Created settings builder that trims `unifiConsoleId` and rejects values with path/query separators to prevent retargeting.

### Coredata **`+39`** **`-1`**
- Added `UNIFI` provider enum and `UniFiConnectorSettings` with `console_id`.
- New migration to persist the provider and settings.

### App: console **`+3`** **`-0`**
- Mapped UniFi extra setting `consoleId` to `unifiConsoleId` in connector settings UI.

### Package: ui **`+15`** **`-0`**
- Added UniFi logo component and wired it into `ThirdPartyLogo`.

### Tests **`+1166`** **`-0`**
- Added unit tests for UniFi driver, provider registration, probe URL building, and API settings validation, plus a full cassette for driver behavior.

<sup>Written for commit 933d6c106d491c1e86d5165bda10305ee6019032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

