### PR TITLE
Allow gstatic favicons and Zod without eval

### DIFF
--- a/apps/compliance-portal/content-security-policy.txt.tmpl
+++ b/apps/compliance-portal/content-security-policy.txt.tmpl
@@ -1,7 +1,7 @@
 default-src 'self';
 script-src 'self';
 style-src 'self' 'unsafe-inline';
-img-src 'self' data: {{.AppOrigin}} {{.FileStorageOrigin}} https://www.google.com;
+img-src 'self' data: {{.AppOrigin}} {{.FileStorageOrigin}} https://www.google.com https://*.gstatic.com;
 font-src 'self';
 connect-src 'self' {{.AppOrigin}} {{.FileStorageOrigin}};
 worker-src 'self' blob:;

--- a/apps/compliance-portal/csp_test.go
+++ b/apps/compliance-portal/csp_test.go
@@ -47,7 +47,7 @@ func TestContentSecurityPolicy_SubstitutesOrigins(t *testing.T) {
 	assert.Contains(
 		t,
 		policy,
-		"img-src 'self' data: https://app.example.com https://probod.s3.eu-west-1.amazonaws.com https://www.google.com",
+		"img-src 'self' data: https://app.example.com https://probod.s3.eu-west-1.amazonaws.com https://www.google.com https://*.gstatic.com",
 	)
 	assert.Contains(
 		t,

--- a/apps/console/content-security-policy.txt.tmpl
+++ b/apps/console/content-security-policy.txt.tmpl
@@ -1,7 +1,7 @@
 default-src 'self';
 script-src 'self';
 style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
-img-src 'self' data: {{.AppOrigin}} {{.FileStorageOrigin}} https://www.google.com;
+img-src 'self' data: {{.AppOrigin}} {{.FileStorageOrigin}} https://www.google.com https://*.gstatic.com;
 font-src 'self' https://fonts.gstatic.com;
 connect-src 'self' {{.AppOrigin}} {{.FileStorageOrigin}};
 worker-src 'self' blob:;

--- a/apps/console/csp_test.go
+++ b/apps/console/csp_test.go
@@ -49,7 +49,7 @@ func TestContentSecurityPolicy_SubstitutesOrigins(t *testing.T) {
 	assert.Contains(
 		t,
 		policy,
-		"img-src 'self' data: https://app.example.com https://probod.s3.eu-west-1.amazonaws.com https://www.google.com",
+		"img-src 'self' data: https://app.example.com https://probod.s3.eu-west-1.amazonaws.com https://www.google.com https://*.gstatic.com",
 	)
 	assert.Contains(
 		t,

--- a/apps/console/src/components/assets/AssetsTable.tsx
+++ b/apps/console/src/components/assets/AssetsTable.tsx
@@ -37,7 +37,6 @@ import { useMutation } from "react-relay";
 import type { usePaginationFragmentHookType } from "react-relay/relay-hooks/usePaginationFragment";
 import { Link } from "react-router";
 import type { OperationType } from "relay-runtime";
-import { z } from "zod";
 
 import type { AssetGraphDeleteMutation } from "#/__generated__/core/AssetGraphDeleteMutation.graphql";
 import type {
@@ -50,6 +49,7 @@ import {
   updateAssetMutation,
 } from "#/hooks/graph/AssetGraph";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 import { EditableTable } from "../table/EditableTable";
 import { PeopleCell } from "../table/PeopleCell";

--- a/apps/console/src/components/compliancePortal/CompliancePortalReferenceDialog.tsx
+++ b/apps/console/src/components/compliancePortal/CompliancePortalReferenceDialog.tsx
@@ -32,10 +32,10 @@ import {
 } from "@probo/ui";
 import { forwardRef, type ReactNode, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { z } from "zod";
 
 import type { CompliancePortalReferenceListItemFragment$data } from "#/__generated__/core/CompliancePortalReferenceListItemFragment.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 import {
   useCreateCompliancePortalReferenceMutation,
   useUpdateCompliancePortalReferenceMutation,

--- a/apps/console/src/components/dialogs/PublishListDialog.tsx
+++ b/apps/console/src/components/dialogs/PublishListDialog.tsx
@@ -31,10 +31,10 @@ import {
 } from "@probo/ui";
 import type { ReactNode } from "react";
 import { useMemo, useRef } from "react";
-import { z } from "zod";
 
 import { PeopleMultiSelectField } from "#/components/form/PeopleMultiSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 export type PublishListDialogLabels = {
   title: string;

--- a/apps/console/src/components/documents/watermark.ts
+++ b/apps/console/src/components/documents/watermark.ts
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { z } from "zod";
+import { z } from "#/lib/zod";
 
 const goWhitespacePattern = /^\p{White_Space}*$/u;
 

--- a/apps/console/src/components/table/EditableTable.tsx
+++ b/apps/console/src/components/table/EditableTable.tsx
@@ -34,7 +34,6 @@ import { type ReactNode } from "react";
 import type { KeyType, KeyTypeData } from "react-relay/ReactRelayTypes";
 import type { usePaginationFragmentHookType } from "react-relay/relay-hooks/usePaginationFragment";
 import type { GraphQLTaggedNode, OperationType } from "relay-runtime";
-import { z } from "zod";
 
 import { defaultPageSize,
   SortableCellHead,
@@ -43,6 +42,7 @@ import { defaultPageSize,
 import { useMutateField } from "#/hooks/useMutateField";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
 import { useStateWithSchema } from "#/hooks/useStateWithSchema";
+import { z } from "#/lib/zod";
 
 type ColumnDefinition = { label: string; field: string } | string;
 

--- a/apps/console/src/components/tasks/TaskFormDialog.tsx
+++ b/apps/console/src/components/tasks/TaskFormDialog.tsx
@@ -42,7 +42,6 @@ import { Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useFragment, useRelayEnvironment } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { TaskFormDialogFragment$key } from "#/__generated__/core/TaskFormDialogFragment.graphql";
 import { MeasureSelectField } from "#/components/form/MeasureSelectField";
@@ -51,6 +50,7 @@ import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { updateStoreCounter } from "#/hooks/useMutationWithIncrement";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 const taskFragment = graphql`
   fragment TaskFormDialogFragment on Task {

--- a/apps/console/src/hooks/forms/useRiskForm.tsx
+++ b/apps/console/src/hooks/forms/useRiskForm.tsx
@@ -18,9 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { z } from "zod";
-
 import type { FormRiskDialog_risk$data } from "#/__generated__/core/FormRiskDialog_risk.graphql";
+import { z } from "#/lib/zod";
 
 import { useFormWithSchema } from "../useFormWithSchema";
 

--- a/apps/console/src/hooks/forms/useThirdPartyForm.tsx
+++ b/apps/console/src/hooks/forms/useThirdPartyForm.tsx
@@ -22,9 +22,9 @@ import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { useThirdPartyFormFragment$key } from "#/__generated__/core/useThirdPartyFormFragment.graphql";
+import { z } from "#/lib/zod";
 
 import { useFormWithSchema } from "../useFormWithSchema";
 import { useMutationWithToasts } from "../useMutationWithToasts";

--- a/apps/console/src/hooks/useFormWithSchema.ts
+++ b/apps/console/src/hooks/useFormWithSchema.ts
@@ -20,7 +20,8 @@
 
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { type FieldValues, useForm, type UseFormReturn } from "react-hook-form";
-import type { z } from "zod";
+
+import type { z } from "#/lib/zod";
 
 export function useFormWithSchema<T extends z.ZodType<FieldValues, FieldValues>>(
   schema: T,

--- a/apps/console/src/lib/zod.ts
+++ b/apps/console/src/lib/zod.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,43 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { useCallback, useMemo, useState } from "react";
+import { z } from "zod";
 
-import { z, ZodError } from "#/lib/zod";
+// Zod's default JIT schema compilation uses eval/new Function, which CSP
+// blocks (script-src 'self'). Disable it for the console bundle.
+z.config({ jitless: true });
 
-export function useStateWithSchema<T extends z.ZodType<Record<string, unknown>>>(
-  schema: T,
-  initialValue: z.infer<T>,
-) {
-  const [state, setState] = useState(initialValue);
-  const [value, errors] = useMemo((): [z.infer<T>, Record<string, string>] => {
-    try {
-      return [schema.parse(state), {}];
-    } catch (error) {
-      if (error instanceof ZodError) {
-        return [
-          state,
-          Object.fromEntries(
-            error.issues.map(issue => [
-              issue.path.join("."),
-              issue.message,
-            ]) ?? [],
-          ),
-        ];
-      }
-      return [state, {}];
-    }
-  }, [state, schema]);
-
-  return {
-    rawValue: state,
-    value,
-    errors,
-    update: useCallback(
-      <TKey extends keyof z.infer<T>>(key: TKey, value: z.infer<T>[TKey]) => {
-        setState(prevState => ({ ...prevState, [key]: value }));
-      },
-      [],
-    ),
-  };
-}
+export * from "zod";

--- a/apps/console/src/pages/iam/apiKeys/_components/PersonalAPIKeyList.tsx
+++ b/apps/console/src/pages/iam/apiKeys/_components/PersonalAPIKeyList.tsx
@@ -43,11 +43,11 @@ import {
   useFragment,
   useMutation,
 } from "react-relay";
-import { z } from "zod";
 
 import type { PersonalAPIKeyListCreateMutation } from "#/__generated__/iam/PersonalAPIKeyListCreateMutation.graphql";
 import type { PersonalAPIKeyListFragment$key } from "#/__generated__/iam/PersonalAPIKeyListFragment.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 import { PersonalAPIKeysTable } from "./PersonalAPIKeysTable";
 import { PersonalAPIKeyTokenDialog } from "./PersonalAPIKeyTokenDialog";

--- a/apps/console/src/pages/iam/auth/CreatePasswordPage.tsx
+++ b/apps/console/src/pages/iam/auth/CreatePasswordPage.tsx
@@ -25,10 +25,10 @@ import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { Link, useNavigate, useSearchParams } from "react-router";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { CreatePasswordPageMutation } from "#/__generated__/iam/CreatePasswordPageMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const createPasswordMutation = graphql`
   mutation CreatePasswordPageMutation($input: ResetPasswordInput!) {

--- a/apps/console/src/pages/iam/auth/ForgotPasswordPage.tsx
+++ b/apps/console/src/pages/iam/auth/ForgotPasswordPage.tsx
@@ -26,10 +26,10 @@ import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { Link } from "react-router";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { ForgotPasswordPageMutation } from "#/__generated__/iam/ForgotPasswordPageMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const sendInstructionsMutation = graphql`
   mutation ForgotPasswordPageMutation($input: ForgotPasswordInput!) {

--- a/apps/console/src/pages/iam/auth/ResendVerificationEmailPage.tsx
+++ b/apps/console/src/pages/iam/auth/ResendVerificationEmailPage.tsx
@@ -26,10 +26,10 @@ import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { Link, useSearchParams } from "react-router";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { ResendVerificationEmailPageMutation } from "#/__generated__/iam/ResendVerificationEmailPageMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const resendVerificationEmailMutation = graphql`
   mutation ResendVerificationEmailPageMutation($input: ResendVerificationEmailInput!) {

--- a/apps/console/src/pages/iam/auth/ResetPasswordPage.tsx
+++ b/apps/console/src/pages/iam/auth/ResetPasswordPage.tsx
@@ -25,10 +25,10 @@ import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { Link, useNavigate, useSearchParams } from "react-router";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { ResetPasswordPageMutation } from "#/__generated__/iam/ResetPasswordPageMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const resetPasswordMutation = graphql`
   mutation ResetPasswordPageMutation($input: ResetPasswordInput!) {

--- a/apps/console/src/pages/iam/auth/SignUpPage.tsx
+++ b/apps/console/src/pages/iam/auth/SignUpPage.tsx
@@ -26,11 +26,11 @@ import { useTranslation } from "react-i18next";
 import { useMutation, usePreloadedQuery, useQueryLoader } from "react-relay";
 import { Link, useNavigate } from "react-router";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { SignUpPageMutation } from "#/__generated__/iam/SignUpPageMutation.graphql";
 import type { SignUpPageQuery } from "#/__generated__/iam/SignUpPageQuery.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const signUpPageQuery = graphql`
   query SignUpPageQuery {

--- a/apps/console/src/pages/iam/auth/VerifyEmailPage.tsx
+++ b/apps/console/src/pages/iam/auth/VerifyEmailPage.tsx
@@ -26,10 +26,10 @@ import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { Link, useSearchParams } from "react-router";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { VerifyEmailPageMutation } from "#/__generated__/iam/VerifyEmailPageMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const verifyEmailMutation = graphql`
   mutation VerifyEmailPageMutation($input: VerifyEmailInput!) {

--- a/apps/console/src/pages/iam/auth/sign-in/_components/MagicLinkForm.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/_components/MagicLinkForm.tsx
@@ -21,10 +21,10 @@
 import { Button, Field, useToast } from "@probo/ui";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { z } from "zod";
 
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { usePostAuthRedirectUrl } from "#/hooks/usePostAuthRedirectUrl";
+import { z } from "#/lib/zod";
 
 const schema = z.object({
   email: z.string().email(),

--- a/apps/console/src/pages/iam/oauthTokens/NewOAuthTokenPage.tsx
+++ b/apps/console/src/pages/iam/oauthTokens/NewOAuthTokenPage.tsx
@@ -38,12 +38,12 @@ import { useTranslation } from "react-i18next";
 import { ConnectionHandler, useLazyLoadQuery } from "react-relay";
 import { Link, useNavigate } from "react-router";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { NewOAuthTokenPageCreateMutation } from "#/__generated__/iam/NewOAuthTokenPageCreateMutation.graphql";
 import type { NewOAuthTokenPageQuery } from "#/__generated__/iam/NewOAuthTokenPageQuery.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
+import { z } from "#/lib/zod";
 
 import { OAuthTokenCredentialsDialog } from "./_components/OAuthTokenCredentialsDialog";
 import { formatApiScopeLabel } from "./_components/scopeLabels";

--- a/apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx
@@ -25,7 +25,6 @@ import { useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useFragment } from "react-relay";
 import { type DataID, graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { PersonForm_createMutation } from "#/__generated__/iam/PersonForm_createMutation.graphql";
 import type { PersonForm_updateMutation } from "#/__generated__/iam/PersonForm_updateMutation.graphql";
@@ -35,6 +34,7 @@ import { EmailsField } from "#/components/form/EmailsField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 import { CurrentUser } from "#/providers/CurrentUser";
 
 const fragment = graphql`

--- a/apps/console/src/pages/iam/organizations/settings/_components/OrganizationForm.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/OrganizationForm.tsx
@@ -36,11 +36,11 @@ import { type ChangeEventHandler, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { OrganizationFormFragment$key } from "#/__generated__/iam/OrganizationFormFragment.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
+import { z } from "#/lib/zod";
 
 const fragment = graphql`
   fragment OrganizationFormFragment on Organization {

--- a/apps/console/src/pages/iam/organizations/settings/_components/SAMLConfigurationForm.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/SAMLConfigurationForm.tsx
@@ -31,9 +31,9 @@ import {
 } from "@probo/ui";
 import { Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { z } from "zod";
 
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const defaultValues: SAMLConfigurationFormData = {
   emailDomain: "",

--- a/apps/console/src/pages/organizations/access-reviews/CreateCsvAccessReviewSourcePage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/CreateCsvAccessReviewSourcePage.tsx
@@ -31,12 +31,12 @@ import { useTranslation } from "react-i18next";
 import { type PreloadedQuery, useMutation, usePreloadedQuery } from "react-relay";
 import { Link, useNavigate } from "react-router";
 import { ConnectionHandler, graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { accessReviewSourceMutationsCreateMutation } from "#/__generated__/core/accessReviewSourceMutationsCreateMutation.graphql";
 import type { CreateCsvAccessReviewSourcePageQuery } from "#/__generated__/core/CreateCsvAccessReviewSourcePageQuery.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 import { createAccessReviewSourceMutation } from "./dialogs/accessReviewSourceMutations";
 

--- a/apps/console/src/pages/organizations/access-reviews/dialogs/CreateAccessReviewCampaignDialog.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/dialogs/CreateAccessReviewCampaignDialog.tsx
@@ -33,11 +33,11 @@ import {
 import { type ReactNode, Suspense, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useLazyLoadQuery, useMutation } from "react-relay";
-import { z } from "zod";
 
 import type { CreateAccessReviewCampaignDialogMutation } from "#/__generated__/core/CreateAccessReviewCampaignDialogMutation.graphql";
 import type { CreateAccessReviewCampaignDialogSourcesQuery } from "#/__generated__/core/CreateAccessReviewCampaignDialogSourcesQuery.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const createCampaignMutation = graphql`
   mutation CreateAccessReviewCampaignDialogMutation(

--- a/apps/console/src/pages/organizations/assets/AssetDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/assets/AssetDetailsPage.tsx
@@ -35,7 +35,6 @@ import {
   type PreloadedQuery,
   usePreloadedQuery,
 } from "react-relay";
-import { z } from "zod";
 
 import type { AssetGraphNodeQuery } from "#/__generated__/core/AssetGraphNodeQuery.graphql";
 import { ControlledField } from "#/components/form/ControlledField";
@@ -43,6 +42,7 @@ import { PeopleSelectField } from "#/components/form/PeopleSelectField";
 import { ThirdPartiesMultiSelectField } from "#/components/form/ThirdPartiesMultiSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 import {
   assetNodeQuery,

--- a/apps/console/src/pages/organizations/assets/dialogs/CreateAssetDialog.tsx
+++ b/apps/console/src/pages/organizations/assets/dialogs/CreateAssetDialog.tsx
@@ -29,13 +29,13 @@ import {
   useDialogRef,
 } from "@probo/ui";
 import { useTranslation } from "react-i18next";
-import { z } from "zod";
 
 import { ControlledField } from "#/components/form/ControlledField";
 import { PeopleSelectField } from "#/components/form/PeopleSelectField";
 import { ThirdPartiesMultiSelectField } from "#/components/form/ThirdPartiesMultiSelectField";
 import { useCreateAsset } from "#/hooks/graph/AssetGraph";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 type Props = {
   children: React.ReactNode;

--- a/apps/console/src/pages/organizations/audits/AuditDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/audits/AuditDetailsPage.tsx
@@ -50,12 +50,12 @@ import {
   usePreloadedQuery,
 } from "react-relay";
 import { useNavigate } from "react-router";
-import { z } from "zod";
 
 import type { AuditGraphNodeQuery } from "#/__generated__/core/AuditGraphNodeQuery.graphql";
 import { ControlledField } from "#/components/form/ControlledField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 import {
   auditNodeQuery,

--- a/apps/console/src/pages/organizations/audits/dialogs/CreateAuditDialog.tsx
+++ b/apps/console/src/pages/organizations/audits/dialogs/CreateAuditDialog.tsx
@@ -44,12 +44,12 @@ import { type Control, Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useLazyLoadQuery } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { CreateAuditDialogFrameworksQuery } from "#/__generated__/core/CreateAuditDialogFrameworksQuery.graphql";
 import { ControlledField } from "#/components/form/ControlledField";
 import { useCreateAudit } from "#/hooks/graph/AuditGraph";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const frameworksQuery = graphql`
   query CreateAuditDialogFrameworksQuery($organizationId: ID!) {

--- a/apps/console/src/pages/organizations/businessFunctions/BusinessFunctionDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/businessFunctions/BusinessFunctionDetailsPage.tsx
@@ -43,7 +43,6 @@ import {
   usePreloadedQuery,
 } from "react-relay";
 import { useNavigate } from "react-router";
-import { z } from "zod";
 
 import type { BusinessFunctionDetailsPageDeleteMutation } from "#/__generated__/core/BusinessFunctionDetailsPageDeleteMutation.graphql";
 import type { BusinessFunctionDetailsPageQuery } from "#/__generated__/core/BusinessFunctionDetailsPageQuery.graphql";
@@ -55,6 +54,7 @@ import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 import { NotFoundError } from "#/lib/relay/errors";
 import { useMutation } from "#/lib/relay/useMutation";
+import { z } from "#/lib/zod";
 
 import {
   businessFunctionClassificationOptions,

--- a/apps/console/src/pages/organizations/businessFunctions/_components/CreateBusinessFunctionDialog.tsx
+++ b/apps/console/src/pages/organizations/businessFunctions/_components/CreateBusinessFunctionDialog.tsx
@@ -37,7 +37,6 @@ import { type ReactNode } from "react";
 import { Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { graphql } from "react-relay";
-import { z } from "zod";
 
 import type { CreateBusinessFunctionDialogMutation } from "#/__generated__/core/CreateBusinessFunctionDialogMutation.graphql";
 import { AssetsMultiSelectField } from "#/components/form/AssetsMultiSelectField";
@@ -46,6 +45,7 @@ import { ThirdPartiesMultiSelectField } from "#/components/form/ThirdPartiesMult
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 import { useMutation } from "#/lib/relay/useMutation";
+import { z } from "#/lib/zod";
 
 import {
   businessFunctionClassificationOptions,

--- a/apps/console/src/pages/organizations/compliance-portals/configuration/brand/_components/CompliancePortalCustomLinkDialog.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/configuration/brand/_components/CompliancePortalCustomLinkDialog.tsx
@@ -25,13 +25,13 @@ import {
 import { forwardRef, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ConnectionHandler, graphql, readInlineData } from "relay-runtime";
-import { z } from "zod";
 
 import type { CompliancePortalCustomLinkDialog_createMutation } from "#/__generated__/core/CompliancePortalCustomLinkDialog_createMutation.graphql";
 import type { CompliancePortalCustomLinkDialog_customLink$key } from "#/__generated__/core/CompliancePortalCustomLinkDialog_customLink.graphql";
 import type { CompliancePortalCustomLinkDialog_updateMutation } from "#/__generated__/core/CompliancePortalCustomLinkDialog_updateMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutation } from "#/lib/relay/useMutation";
+import { z } from "#/lib/zod";
 
 const customLinkFragment = graphql`
   fragment CompliancePortalCustomLinkDialog_customLink on ComplianceCustomLink @inline {

--- a/apps/console/src/pages/organizations/compliance-portals/configuration/brand/_components/CompliancePortalProfileSection.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/configuration/brand/_components/CompliancePortalProfileSection.tsx
@@ -16,11 +16,11 @@ import { Button, Card, Field, Label, Spinner, Textarea } from "@probo/ui";
 import { useTranslation } from "react-i18next";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { CompliancePortalProfileSection_compliancePortalFragment$key } from "#/__generated__/core/CompliancePortalProfileSection_compliancePortalFragment.graphql";
 import { useUpdateCompliancePortalMutation } from "#/hooks/graph/CompliancePortalGraph";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const compliancePortalFragment = graphql`
   fragment CompliancePortalProfileSection_compliancePortalFragment on CompliancePortal {

--- a/apps/console/src/pages/organizations/compliance-portals/configuration/commitments/_components/CompliancePortalCommitmentDialog.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/configuration/commitments/_components/CompliancePortalCommitmentDialog.tsx
@@ -22,7 +22,6 @@ import { Button, Dialog, DialogContent, DialogFooter, Field, Label, Option, Spin
 import { forwardRef, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { CompliancePortalCommitmentDialogCreateMutation, CompliancePortalCommitmentIcon } from "#/__generated__/core/CompliancePortalCommitmentDialogCreateMutation.graphql";
 import type { CompliancePortalCommitmentDialogUpdateMutation } from "#/__generated__/core/CompliancePortalCommitmentDialogUpdateMutation.graphql";
@@ -30,6 +29,7 @@ import type { CompliancePortalCommitmentListItemFragment$data } from "#/__genera
 import { ControlledSelect } from "#/components/form/ControlledField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
+import { z } from "#/lib/zod";
 
 import { COMMITMENT_ICON_VALUES } from "../_lib/commitmentIcons";
 

--- a/apps/console/src/pages/organizations/compliance-portals/configuration/commitments/_components/CompliancePortalCommitmentGroupDialog.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/configuration/commitments/_components/CompliancePortalCommitmentGroupDialog.tsx
@@ -22,13 +22,13 @@ import { Button, Dialog, DialogContent, DialogFooter, Field, Spinner, Textarea, 
 import { forwardRef, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { CompliancePortalCommitmentGroupDialogCreateMutation } from "#/__generated__/core/CompliancePortalCommitmentGroupDialogCreateMutation.graphql";
 import type { CompliancePortalCommitmentGroupDialogUpdateMutation } from "#/__generated__/core/CompliancePortalCommitmentGroupDialogUpdateMutation.graphql";
 import type { CompliancePortalCommitmentGroupListItemFragment$data } from "#/__generated__/core/CompliancePortalCommitmentGroupListItemFragment.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
+import { z } from "#/lib/zod";
 
 const createGroupMutation = graphql`
   mutation CompliancePortalCommitmentGroupDialogCreateMutation(

--- a/apps/console/src/pages/organizations/compliance-portals/configuration/domain/_components/NewCompliancePortalDomainDialog.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/configuration/domain/_components/NewCompliancePortalDomainDialog.tsx
@@ -30,11 +30,11 @@ import {
 import type { PropsWithChildren } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { NewCompliancePortalDomainDialogMutation } from "#/__generated__/core/NewCompliancePortalDomainDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutation } from "#/lib/relay/useMutation";
+import { z } from "#/lib/zod";
 
 const createCustomDomainMutation = graphql`
   mutation NewCompliancePortalDomainDialogMutation($input: CreateCustomDomainInput!) {

--- a/apps/console/src/pages/organizations/compliance-portals/configuration/files/_components/EditCompliancePortalFileDialog.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/configuration/files/_components/EditCompliancePortalFileDialog.tsx
@@ -21,12 +21,12 @@
 import { Button, Dialog, DialogContent, DialogFooter, Field, Spinner } from "@probo/ui";
 import { useTranslation } from "react-i18next";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { CompliancePortalFileListItem_fileFragment$data } from "#/__generated__/core/CompliancePortalFileListItem_fileFragment.graphql";
 import type { EditCompliancePortalFileDialogMutation } from "#/__generated__/core/EditCompliancePortalFileDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutation } from "#/lib/relay/useMutation";
+import { z } from "#/lib/zod";
 
 const updateCompliancePortalFileMutation = graphql`
   mutation EditCompliancePortalFileDialogMutation($input: UpdateCompliancePortalFileInput!) {

--- a/apps/console/src/pages/organizations/compliance-portals/configuration/files/_components/NewCompliancePortalFileDialog.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/configuration/files/_components/NewCompliancePortalFileDialog.tsx
@@ -31,11 +31,11 @@ import { Badge, Button, Dialog, DialogContent, DialogFooter, type DialogRef, Dro
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { type DataID, graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { NewCompliancePortalFileDialog_createMutation } from "#/__generated__/core/NewCompliancePortalFileDialog_createMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutation } from "#/lib/relay/useMutation";
+import { z } from "#/lib/zod";
 
 const acceptedFileTypes = {
   ...acceptDocument,

--- a/apps/console/src/pages/organizations/compliance-portals/configuration/mailing-list/_components/ComplianceUpdateFormDialog.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/configuration/mailing-list/_components/ComplianceUpdateFormDialog.tsx
@@ -22,12 +22,12 @@ import { Button, Dialog, DialogContent, DialogFooter, type DialogRef, Field, Ico
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { ComplianceUpdateFormDialogCreateMutation } from "#/__generated__/core/ComplianceUpdateFormDialogCreateMutation.graphql";
 import type { ComplianceUpdateFormDialogUpdateMutation } from "#/__generated__/core/ComplianceUpdateFormDialogUpdateMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutation } from "#/lib/relay/useMutation";
+import { z } from "#/lib/zod";
 
 import type { UpdateNode } from "./CompliancePortalUpdatesList";
 

--- a/apps/console/src/pages/organizations/compliance-portals/configuration/mailing-list/_components/NewCompliancePortalSubscriberDialog.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/configuration/mailing-list/_components/NewCompliancePortalSubscriberDialog.tsx
@@ -21,11 +21,11 @@
 import { Button, Checkbox, Dialog, DialogContent, DialogFooter, type DialogRef, Field, Spinner } from "@probo/ui";
 import { useTranslation } from "react-i18next";
 import { type DataID, graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { NewCompliancePortalSubscriberDialogMutation } from "#/__generated__/core/NewCompliancePortalSubscriberDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutation } from "#/lib/relay/useMutation";
+import { z } from "#/lib/zod";
 
 const createSubscriberMutation = graphql`
   mutation NewCompliancePortalSubscriberDialogMutation(

--- a/apps/console/src/pages/organizations/data/DatumDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/data/DatumDetailsPage.tsx
@@ -34,7 +34,6 @@ import {
   type PreloadedQuery,
   usePreloadedQuery,
 } from "react-relay";
-import { z } from "zod";
 
 import type { DatumGraphNodeQuery } from "#/__generated__/core/DatumGraphNodeQuery.graphql";
 import { ControlledField } from "#/components/form/ControlledField";
@@ -47,6 +46,7 @@ import {
 } from "#/hooks/graph/DatumGraph";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 type Props = {
   queryRef: PreloadedQuery<DatumGraphNodeQuery>;

--- a/apps/console/src/pages/organizations/data/dialogs/CreateDatumDialog.tsx
+++ b/apps/console/src/pages/organizations/data/dialogs/CreateDatumDialog.tsx
@@ -29,12 +29,12 @@ import {
   useDialogRef,
 } from "@probo/ui";
 import { useTranslation } from "react-i18next";
-import { z } from "zod";
 
 import { ControlledField } from "#/components/form/ControlledField";
 import { PeopleSelectField } from "#/components/form/PeopleSelectField";
 import { ThirdPartiesMultiSelectField } from "#/components/form/ThirdPartiesMultiSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 import { useCreateDatum } from "../../../../hooks/graph/DatumGraph";
 

--- a/apps/console/src/pages/organizations/devices/dialogs/CreateDeviceDialog.tsx
+++ b/apps/console/src/pages/organizations/devices/dialogs/CreateDeviceDialog.tsx
@@ -32,11 +32,11 @@ import { type ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { CreateDeviceDialogMutation } from "#/__generated__/core/CreateDeviceDialogMutation.graphql";
 import { PeopleSelectField } from "#/components/form/PeopleSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 import { EnrollmentInstructions } from "../../employee/_components/EnrollmentInstructions";
 

--- a/apps/console/src/pages/organizations/devices/dialogs/ReassignDeviceDialog.tsx
+++ b/apps/console/src/pages/organizations/devices/dialogs/ReassignDeviceDialog.tsx
@@ -32,12 +32,12 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFragment, useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { ReassignDeviceDialog_device$key } from "#/__generated__/core/ReassignDeviceDialog_device.graphql";
 import type { ReassignDeviceDialogMutation } from "#/__generated__/core/ReassignDeviceDialogMutation.graphql";
 import { PeopleSelectField } from "#/components/form/PeopleSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const reassignDeviceDialogFragment = graphql`
   fragment ReassignDeviceDialog_device on Device {

--- a/apps/console/src/pages/organizations/documents/_components/CreateDocumentDialog.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/CreateDocumentDialog.tsx
@@ -36,7 +36,6 @@ import { type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { CreateDocumentDialogMutation } from "#/__generated__/core/CreateDocumentDialogMutation.graphql";
 import { ControlledField } from "#/components/form/ControlledField";
@@ -45,6 +44,7 @@ import { DocumentTypeOptions } from "#/components/form/DocumentTypeOptions";
 import { PeopleMultiSelectField } from "#/components/form/PeopleMultiSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 type CreateDocumentDialogProps = {
   trigger?: ReactNode;

--- a/apps/console/src/pages/organizations/documents/_components/DocumentDetailsCard.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/DocumentDetailsCard.tsx
@@ -25,7 +25,6 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFragment, useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { DocumentDetailsCard_documentFragment$key } from "#/__generated__/core/DocumentDetailsCard_documentFragment.graphql";
 import type { DocumentDetailsCard_updateApproversMutation } from "#/__generated__/core/DocumentDetailsCard_updateApproversMutation.graphql";
@@ -38,6 +37,7 @@ import { DocumentTypeOptions } from "#/components/form/DocumentTypeOptions";
 import { PeopleMultiSelectField } from "#/components/form/PeopleMultiSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 const documentFragment = graphql`
   fragment DocumentDetailsCard_documentFragment on Document {

--- a/apps/console/src/pages/organizations/documents/_components/DocumentTitleForm.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/DocumentTitleForm.tsx
@@ -24,11 +24,11 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFragment, useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { DocumentTitleFormFragment$key } from "#/__generated__/core/DocumentTitleFormFragment.graphql";
 import type { DocumentTitleFormMutation } from "#/__generated__/core/DocumentTitleFormMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const updateDocumentTitleMutation = graphql`
   mutation DocumentTitleFormMutation($input: UpdateDocumentInput!) {

--- a/apps/console/src/pages/organizations/documents/_components/PublishDialog.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/PublishDialog.tsx
@@ -34,13 +34,13 @@ import { type Ref, useImperativeHandle, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useFragment, useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { PublishDialog_documentFragment$key } from "#/__generated__/core/PublishDialog_documentFragment.graphql";
 import type { PublishDialog_publishMutation } from "#/__generated__/core/PublishDialog_publishMutation.graphql";
 import { PeopleMultiSelectField } from "#/components/form/PeopleMultiSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 export type PublishDialogRef = {
   open: () => void;

--- a/apps/console/src/pages/organizations/documents/_components/PublishDocumentsDialog.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/PublishDocumentsDialog.tsx
@@ -34,10 +34,10 @@ import { type ReactNode, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { PublishDocumentsDialog_bulkPublishMutation } from "#/__generated__/core/PublishDocumentsDialog_bulkPublishMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 type Props = {
   documentIds: string[];

--- a/apps/console/src/pages/organizations/documents/_components/SignatureDocumentsDialog.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/SignatureDocumentsDialog.tsx
@@ -39,7 +39,6 @@ import { type ReactNode, Suspense } from "react";
 import { useTranslation } from "react-i18next";
 import { useLazyLoadQuery, usePaginationFragment } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { SignatureDocumentsDialogMutation } from "#/__generated__/core/SignatureDocumentsDialogMutation.graphql";
 import type { SignatureDocumentsDialogPeopleFragment$key } from "#/__generated__/core/SignatureDocumentsDialogPeopleFragment.graphql";
@@ -48,6 +47,7 @@ import type { SignatureDocumentsDialogPeopleRefetchQuery } from "#/__generated__
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 type Props = {
   documentIds: string[];

--- a/apps/console/src/pages/organizations/findings/FindingDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/findings/FindingDetailsPage.tsx
@@ -50,7 +50,6 @@ import {
   useMutation,
   usePreloadedQuery,
 } from "react-relay";
-import { z } from "zod";
 
 import type { FindingDetailsPageDeleteMutation } from "#/__generated__/core/FindingDetailsPageDeleteMutation.graphql";
 import type { FindingDetailsPageQuery } from "#/__generated__/core/FindingDetailsPageQuery.graphql";
@@ -60,6 +59,7 @@ import { PeopleSelectField } from "#/components/form/PeopleSelectField";
 import { RiskSelectField } from "#/components/form/RiskSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 import { FindingsConnectionKey } from "./FindingsPage";
 

--- a/apps/console/src/pages/organizations/findings/dialogs/CreateFindingDialog.tsx
+++ b/apps/console/src/pages/organizations/findings/dialogs/CreateFindingDialog.tsx
@@ -41,12 +41,12 @@ import { type ReactNode, useEffect } from "react";
 import { Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { graphql, useMutation } from "react-relay";
-import { z } from "zod";
 
 import type { CreateFindingDialogMutation } from "#/__generated__/core/CreateFindingDialogMutation.graphql";
 import { PeopleSelectField } from "#/components/form/PeopleSelectField";
 import { RiskSelectField } from "#/components/form/RiskSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const createFindingMutation = graphql`
   mutation CreateFindingDialogMutation(

--- a/apps/console/src/pages/organizations/frameworks/dialogs/FrameworkControlDialog.tsx
+++ b/apps/console/src/pages/organizations/frameworks/dialogs/FrameworkControlDialog.tsx
@@ -35,12 +35,12 @@ import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { FrameworkControlDialogFragment$key } from "#/__generated__/core/FrameworkControlDialogFragment.graphql";
 import { ControlMaturityLevelOptions } from "#/components/form/ControlMaturityLevelOptions";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
+import { z } from "#/lib/zod";
 
 type Props = {
   children: ReactNode;

--- a/apps/console/src/pages/organizations/frameworks/dialogs/FrameworkFormDialog.tsx
+++ b/apps/console/src/pages/organizations/frameworks/dialogs/FrameworkFormDialog.tsx
@@ -31,10 +31,10 @@ import {
 } from "@probo/ui";
 import { useTranslation } from "react-i18next";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
+import { z } from "#/lib/zod";
 
 const createFrameworkMutation = graphql`
   mutation FrameworkFormDialogMutation(

--- a/apps/console/src/pages/organizations/measures/dialog/CreateEvidenceDialog.tsx
+++ b/apps/console/src/pages/organizations/measures/dialog/CreateEvidenceDialog.tsx
@@ -42,11 +42,11 @@ import {
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useRelayEnvironment } from "react-relay";
-import { z } from "zod";
 
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { updateStoreCounter } from "#/hooks/useMutationWithIncrement";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
+import { z } from "#/lib/zod";
 
 const uploadEvidenceMutation = graphql`
   mutation CreateEvidenceDialogUploadMutation(

--- a/apps/console/src/pages/organizations/measures/dialog/MeasureFormDialog.tsx
+++ b/apps/console/src/pages/organizations/measures/dialog/MeasureFormDialog.tsx
@@ -37,7 +37,6 @@ import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { MeasureFormDialogMeasureFragment$key } from "#/__generated__/core/MeasureFormDialogMeasureFragment.graphql";
 import { ControlledSelect } from "#/components/form/ControlledField";
@@ -45,6 +44,7 @@ import { useUpdateMeasure } from "#/hooks/graph/MeasureGraph";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 const measureFragment = graphql`
   fragment MeasureFormDialogMeasureFragment on Measure {

--- a/apps/console/src/pages/organizations/obligations/ObligationDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/obligations/ObligationDetailsPage.tsx
@@ -45,12 +45,12 @@ import {
   type PreloadedQuery,
   usePreloadedQuery,
 } from "react-relay";
-import { z } from "zod";
 
 import type { ObligationGraphNodeQuery } from "#/__generated__/core/ObligationGraphNodeQuery.graphql";
 import { PeopleSelectField } from "#/components/form/PeopleSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 import {
   obligationNodeQuery,

--- a/apps/console/src/pages/organizations/obligations/dialogs/CreateObligationDialog.tsx
+++ b/apps/console/src/pages/organizations/obligations/dialogs/CreateObligationDialog.tsx
@@ -38,10 +38,10 @@ import {
 import { type ReactNode } from "react";
 import { Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { z } from "zod";
 
 import { PeopleSelectField } from "#/components/form/PeopleSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 import { useCreateObligation } from "../../../../hooks/graph/ObligationGraph";
 

--- a/apps/console/src/pages/organizations/processingActivities/ProcessingActivityDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/processingActivities/ProcessingActivityDetailsPage.tsx
@@ -48,13 +48,13 @@ import {
   type PreloadedQuery,
   usePreloadedQuery,
 } from "react-relay";
-import { z } from "zod";
 
 import type { ProcessingActivityGraphNodeQuery } from "#/__generated__/core/ProcessingActivityGraphNodeQuery.graphql";
 import { PeopleSelectField } from "#/components/form/PeopleSelectField";
 import { ThirdPartiesMultiSelectField } from "#/components/form/ThirdPartiesMultiSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 import {
   DataProtectionImpactAssessmentOptions,

--- a/apps/console/src/pages/organizations/processingActivities/dialogs/CreateProcessingActivityDialog.tsx
+++ b/apps/console/src/pages/organizations/processingActivities/dialogs/CreateProcessingActivityDialog.tsx
@@ -37,11 +37,11 @@ import {
 import { type ReactNode } from "react";
 import { Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { z } from "zod";
 
 import { PeopleSelectField } from "#/components/form/PeopleSelectField";
 import { ThirdPartiesMultiSelectField } from "#/components/form/ThirdPartiesMultiSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 import {
   DataProtectionImpactAssessmentOptions,

--- a/apps/console/src/pages/organizations/rightsRequests/RightsRequestDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/rightsRequests/RightsRequestDetailsPage.tsx
@@ -47,11 +47,11 @@ import {
   type PreloadedQuery,
   usePreloadedQuery,
 } from "react-relay";
-import { z } from "zod";
 
 import type { RightsRequestGraphNodeQuery } from "#/__generated__/core/RightsRequestGraphNodeQuery.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 import {
   rightsRequestNodeQuery,

--- a/apps/console/src/pages/organizations/rightsRequests/dialogs/CreateRightsRequestDialog.tsx
+++ b/apps/console/src/pages/organizations/rightsRequests/dialogs/CreateRightsRequestDialog.tsx
@@ -41,9 +41,9 @@ import {
 import { type ReactNode } from "react";
 import { Controller } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { z } from "zod";
 
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 import { useCreateRightsRequest } from "../../../../hooks/graph/RightsRequestGraph";
 

--- a/apps/console/src/pages/organizations/settings/WebhooksSettingsPage.tsx
+++ b/apps/console/src/pages/organizations/settings/WebhooksSettingsPage.tsx
@@ -43,7 +43,6 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { type PreloadedQuery, usePreloadedQuery, useRelayEnvironment } from "react-relay";
 import { ConnectionHandler, fetchQuery, graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { WebhooksSettingsPage_createMutation } from "#/__generated__/core/WebhooksSettingsPage_createMutation.graphql";
 import type { WebhooksSettingsPage_deleteMutation } from "#/__generated__/core/WebhooksSettingsPage_deleteMutation.graphql";
@@ -53,6 +52,7 @@ import type { WebhooksSettingsPage_updateMutation } from "#/__generated__/core/W
 import type { WebhooksSettingsPageQuery } from "#/__generated__/core/WebhooksSettingsPageQuery.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
+import { z } from "#/lib/zod";
 
 export const webhooksSettingsPageQuery = graphql`
   query WebhooksSettingsPageQuery($organizationId: ID!) {

--- a/apps/console/src/pages/organizations/statements-of-applicability/StatementOfApplicabilityDetailPage.tsx
+++ b/apps/console/src/pages/organizations/statements-of-applicability/StatementOfApplicabilityDetailPage.tsx
@@ -48,7 +48,6 @@ import {
   usePreloadedQuery,
 } from "react-relay";
 import { Link, useNavigate, useParams } from "react-router";
-import { z } from "zod";
 
 import type { StatementOfApplicabilityDetailPageDeleteMutation } from "#/__generated__/core/StatementOfApplicabilityDetailPageDeleteMutation.graphql";
 import type { StatementOfApplicabilityDetailPageQuery } from "#/__generated__/core/StatementOfApplicabilityDetailPageQuery.graphql";
@@ -57,6 +56,7 @@ import type { StatementOfApplicabilityDetailPageUpdateMutation } from "#/__gener
 import { PeopleMultiSelectField } from "#/components/form/PeopleMultiSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 import { PublishStatementOfApplicabilityDialog } from "./dialogs/PublishStatementOfApplicabilityDialog";
 import StatementOfApplicabilityControlsTab from "./tabs/StatementOfApplicabilityControlsTab";

--- a/apps/console/src/pages/organizations/statements-of-applicability/dialogs/CreateStatementOfApplicabilityDialog.tsx
+++ b/apps/console/src/pages/organizations/statements-of-applicability/dialogs/CreateStatementOfApplicabilityDialog.tsx
@@ -34,11 +34,11 @@ import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { useNavigate } from "react-router";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { CreateStatementOfApplicabilityDialogMutation } from "#/__generated__/core/CreateStatementOfApplicabilityDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 const createMutation = graphql`
     mutation CreateStatementOfApplicabilityDialogMutation(

--- a/apps/console/src/pages/organizations/statements-of-applicability/dialogs/EditControlDialog.tsx
+++ b/apps/console/src/pages/organizations/statements-of-applicability/dialogs/EditControlDialog.tsx
@@ -34,10 +34,10 @@ import {
 import { forwardRef, useImperativeHandle, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql } from "react-relay";
-import { z } from "zod";
 
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
+import { z } from "#/lib/zod";
 
 const updateApplicabilityStatementMutation = graphql`
     mutation EditControlDialogUpdateMutation($input: UpdateApplicabilityStatementInput!) {

--- a/apps/console/src/pages/organizations/statements-of-applicability/dialogs/PublishStatementOfApplicabilityDialog.tsx
+++ b/apps/console/src/pages/organizations/statements-of-applicability/dialogs/PublishStatementOfApplicabilityDialog.tsx
@@ -34,12 +34,12 @@ import { useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { PublishStatementOfApplicabilityDialogMutation } from "#/__generated__/core/PublishStatementOfApplicabilityDialogMutation.graphql";
 import { PeopleMultiSelectField } from "#/components/form/PeopleMultiSelectField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { z } from "#/lib/zod";
 
 const publishMutation = graphql`
   mutation PublishStatementOfApplicabilityDialogMutation(

--- a/apps/console/src/pages/organizations/third-parties/_components/CreateContactDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/CreateContactDialog.tsx
@@ -33,10 +33,10 @@ import { type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { CreateContactDialogMutation } from "#/__generated__/core/CreateContactDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 type Props = {
   children: ReactNode;

--- a/apps/console/src/pages/organizations/third-parties/_components/CreateRiskAssessmentDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/CreateRiskAssessmentDialog.tsx
@@ -35,11 +35,11 @@ import { type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { CreateRiskAssessmentDialogMutation } from "#/__generated__/core/CreateRiskAssessmentDialogMutation.graphql";
 import { ControlledField } from "#/components/form/ControlledField";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 type Props = {
   children: ReactNode;

--- a/apps/console/src/pages/organizations/third-parties/_components/CreateServiceDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/CreateServiceDialog.tsx
@@ -33,10 +33,10 @@ import { type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { CreateServiceDialogMutation } from "#/__generated__/core/CreateServiceDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 type Props = {
   children: ReactNode;

--- a/apps/console/src/pages/organizations/third-parties/_components/EditBusinessAssociateAgreementDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/EditBusinessAssociateAgreementDialog.tsx
@@ -32,10 +32,10 @@ import {
 } from "@probo/ui";
 import { useTranslation } from "react-i18next";
 import { graphql, useMutation } from "react-relay";
-import { z } from "zod";
 
 import type { EditBusinessAssociateAgreementDialogMutation } from "#/__generated__/core/EditBusinessAssociateAgreementDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const updateBusinessAssociateAgreementMutation = graphql`
   mutation EditBusinessAssociateAgreementDialogMutation(

--- a/apps/console/src/pages/organizations/third-parties/_components/EditContactDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/EditContactDialog.tsx
@@ -32,11 +32,11 @@ import {
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment, useMutation } from "react-relay";
-import { z } from "zod";
 
 import type { EditContactDialog_contact$key } from "#/__generated__/core/EditContactDialog_contact.graphql";
 import type { EditContactDialogUpdateMutation } from "#/__generated__/core/EditContactDialogUpdateMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 type Props = {
   contactKey: EditContactDialog_contact$key;

--- a/apps/console/src/pages/organizations/third-parties/_components/EditDataPrivacyAgreementDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/EditDataPrivacyAgreementDialog.tsx
@@ -32,10 +32,10 @@ import {
 } from "@probo/ui";
 import { useTranslation } from "react-i18next";
 import { graphql, useMutation } from "react-relay";
-import { z } from "zod";
 
 import type { EditDataPrivacyAgreementDialogMutation } from "#/__generated__/core/EditDataPrivacyAgreementDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const updateDataPrivacyAgreementMutation = graphql`
   mutation EditDataPrivacyAgreementDialogMutation(

--- a/apps/console/src/pages/organizations/third-parties/_components/EditServiceDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/EditServiceDialog.tsx
@@ -32,11 +32,11 @@ import {
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment, useMutation } from "react-relay";
-import { z } from "zod";
 
 import type { EditServiceDialog_service$key } from "#/__generated__/core/EditServiceDialog_service.graphql";
 import type { EditServiceDialogUpdateMutation } from "#/__generated__/core/EditServiceDialogUpdateMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 type Props = {
   serviceKey: EditServiceDialog_service$key;

--- a/apps/console/src/pages/organizations/third-parties/_components/UploadBusinessAssociateAgreementDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/UploadBusinessAssociateAgreementDialog.tsx
@@ -34,10 +34,10 @@ import {
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useMutation } from "react-relay";
-import { z } from "zod";
 
 import type { UploadBusinessAssociateAgreementDialogMutation } from "#/__generated__/core/UploadBusinessAssociateAgreementDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const uploadBusinessAssociateAgreementMutation = graphql`
   mutation UploadBusinessAssociateAgreementDialogMutation(

--- a/apps/console/src/pages/organizations/third-parties/_components/UploadComplianceReportDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/UploadComplianceReportDialog.tsx
@@ -34,10 +34,10 @@ import {
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useMutation } from "react-relay";
-import { z } from "zod";
 
 import type { UploadComplianceReportDialogMutation } from "#/__generated__/core/UploadComplianceReportDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const uploadComplianceReportMutation = graphql`
   mutation UploadComplianceReportDialogMutation(

--- a/apps/console/src/pages/organizations/third-parties/_components/UploadDataPrivacyAgreementDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/UploadDataPrivacyAgreementDialog.tsx
@@ -34,10 +34,10 @@ import {
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useMutation } from "react-relay";
-import { z } from "zod";
 
 import type { UploadDataPrivacyAgreementDialogMutation } from "#/__generated__/core/UploadDataPrivacyAgreementDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const uploadDataPrivacyAgreementMutation = graphql`
   mutation UploadDataPrivacyAgreementDialogMutation(

--- a/apps/console/src/pages/organizations/third-parties/_components/VettingDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/_components/VettingDialog.tsx
@@ -32,10 +32,10 @@ import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
-import { z } from "zod";
 
 import type { VettingDialogMutation } from "#/__generated__/core/VettingDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { z } from "#/lib/zod";
 
 const vetMutation = graphql`
   mutation VettingDialogMutation($input: VetThirdPartyInput!) {

--- a/contrib/claude/forms.md
+++ b/contrib/claude/forms.md
@@ -79,7 +79,7 @@ When validation is complex or needs specific messages, parse a zod schema in `on
 
 ```tsx
 import { Form } from "@base-ui/react/form";
-import { z } from "zod";
+import { z } from "#/lib/zod";
 
 const schema = z.object({
   name: z.string().min(1, "measures.form.nameRequired"),

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,6 +78,26 @@ export default defineConfig([
     },
   },
   {
+    // Zod JIT uses eval/new Function; console CSP forbids unsafe-eval. All
+    // zod usage must go through #/lib/zod which sets jitless: true.
+    files: ["apps/console/**"],
+    ignores: ["apps/console/src/lib/zod.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "zod",
+              message:
+                "Import from #/lib/zod (jitless config for CSP), not zod directly.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     // The v2 kit styles with tailwind-variants/lite (no tailwind-merge): the
     // numbered scales (text-1…9, rounded-1…6, shadow-1…6) collide with the
     // color/utility namespaces and tailwind-merge would drop the scale class.


### PR DESCRIPTION
Google's /s2/favicons API redirects to *.gstatic.com, so img-src must allow that CDN. Zod's JIT schema compile uses eval, which CSP forbids; route console through a jitless wrapper and ban direct zod imports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CSP errors by allowing gstatic favicons and making all console `zod` usage jitless (no eval). Adds a `#/lib/zod` wrapper, updates imports, and enforces it with ESLint.

### Tests **`+2`** **`-2`**
Updated CSP tests to expect `https://*.gstatic.com` in img-src for console and compliance-portal.

### App: console **`+96`** **`-68`**
- Added `#/lib/zod` that sets `z.config({ jitless: true })` and re-exports `zod`.
- Replaced all direct `zod` imports with `#/lib/zod`.
- Allowed `https://*.gstatic.com` in img-src to support Google favicon redirects.

### App: compliance-portal **`+1`** **`-1`**
Allowed `https://*.gstatic.com` in img-src to support Google favicon redirects.

### Agents **`+1`** **`-1`**
Updated docs to import `zod` from `#/lib/zod`.

### Other **`+20`** **`-0`**
Added ESLint rule in `apps/console/**` to forbid direct `zod` imports and require `#/lib/zod` (wrapper file is ignored).

<sup>Written for commit d27db1bc2b3335766124459910b8c1445a1ffb31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

