### PR TITLE
Nest capability flags in capabilities objects

### DIFF
--- a/apps/compliance-portal/src/components/TopBar/TopBar.tsx
+++ b/apps/compliance-portal/src/components/TopBar/TopBar.tsx
@@ -46,7 +46,9 @@ const topBarFragment = graphql`
     currentCompliancePortal @required(action: THROW) {
       themedLogoUrl
       entityName
-      rightsRequestsEnabled
+      capabilities {
+        rightsRequests
+      }
       ...TopBarMobileNav_compliancePortal
     }
   }
@@ -71,7 +73,7 @@ export function TopBar({ queryKey }: TopBarProps) {
   const entityName = currentCompliancePortal.entityName;
   const logoUrl = currentCompliancePortal.themedLogoUrl ?? undefined;
   const navItems = TOP_BAR_NAV_ITEMS.filter(
-    item => item.to !== "/requests" || currentCompliancePortal.rightsRequestsEnabled,
+    item => item.to !== "/requests" || currentCompliancePortal.capabilities.rightsRequests,
   );
 
   const slots = topBar();

--- a/apps/compliance-portal/src/components/TopBar/TopBarMobileNav.tsx
+++ b/apps/compliance-portal/src/components/TopBar/TopBarMobileNav.tsx
@@ -66,7 +66,9 @@ const topBarMobileNavFragment = graphql`
 
 const topBarMobileNavCompliancePortalFragment = graphql`
   fragment TopBarMobileNav_compliancePortal on CompliancePortal {
-    rightsRequestsEnabled
+    capabilities {
+      rightsRequests
+    }
   }
 `;
 
@@ -106,7 +108,7 @@ export function TopBarMobileNav({ identityKey, compliancePortalKey }: TopBarMobi
     : null;
 
   const navItems = TOP_BAR_NAV_ITEMS.filter(
-    item => item.to !== "/requests" || compliancePortal.rightsRequestsEnabled,
+    item => item.to !== "/requests" || compliancePortal.capabilities.rightsRequests,
   );
 
   const close = () => setOpen(false);

--- a/apps/compliance-portal/src/pages/requests/RequestsPage.tsx
+++ b/apps/compliance-portal/src/pages/requests/RequestsPage.tsx
@@ -50,7 +50,9 @@ import { requestsLayout } from "./variants";
 export const requestsPageQuery = graphql`
   query RequestsPageQuery {
     currentCompliancePortal @required(action: THROW) {
-      rightsRequestsEnabled
+      capabilities {
+        rightsRequests
+      }
     }
     viewer {
       email
@@ -95,7 +97,7 @@ export function RequestsPage({ queryRef }: RequestsPageProps) {
   // Disabled capability → explicit 404 before the list fragment is read (the
   // API returns NOT_FOUND for myRightsRequests, which would otherwise surface
   // as Relay's opaque field-error message).
-  if (!currentCompliancePortal.rightsRequestsEnabled) {
+  if (!currentCompliancePortal.capabilities.rightsRequests) {
     throw new NotFoundError();
   }
 

--- a/apps/console/src/hooks/graph/CompliancePortalGraph.ts
+++ b/apps/console/src/hooks/graph/CompliancePortalGraph.ts
@@ -32,7 +32,9 @@ const updateCompliancePortalMutation = graphql`
         id
         active
         searchEngineIndexing
-        rightsRequestsEnabled
+        capabilities {
+          rightsRequests
+        }
         entityName
         description
         websiteUrl

--- a/apps/console/src/pages/organizations/compliance-portals/configuration/overview/_components/CompliancePortalStatusSection.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/configuration/overview/_components/CompliancePortalStatusSection.tsx
@@ -31,7 +31,9 @@ const fragment = graphql`
     id
     active
     searchEngineIndexing
-    rightsRequestsEnabled
+    capabilities {
+      rightsRequests
+    }
     canUpdate: permission(action: "compliance-portal:portal:update")
   }
 `;
@@ -72,12 +74,12 @@ export function CompliancePortalStatusSection(props: {
     });
   };
 
-  const handleToggleRightsRequests = async (rightsRequestsEnabled: boolean) => {
+  const handleToggleRightsRequests = async (rightsRequests: boolean) => {
     await updateCompliancePortal({
       variables: {
         input: {
           compliancePortalId: compliancePortal.id,
-          rightsRequestsEnabled,
+          capabilities: { rightsRequests },
         },
       },
     });
@@ -140,7 +142,7 @@ export function CompliancePortalStatusSection(props: {
             </p>
           </div>
           <Toggle
-            checked={compliancePortal.rightsRequestsEnabled}
+            checked={compliancePortal.capabilities.rightsRequests}
             onChange={checked => void handleToggleRightsRequests(checked)}
             disabled={!compliancePortal.canUpdate}
             aria-label={t("statusSection.rightsRequests.title")}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/settings/_components/BannerSettingsForm.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/settings/_components/BannerSettingsForm.tsx
@@ -37,7 +37,9 @@ const bannerSettingsFormFragment = graphql`
     privacyPolicyUrl
     consentExpiryDays
     defaultLanguage
-    resourceReportingEnabled
+    capabilities {
+      resourceReporting
+    }
   }
 `;
 
@@ -51,7 +53,9 @@ const updateBannerMutation = graphql`
         privacyPolicyUrl
         consentExpiryDays
         defaultLanguage
-        resourceReportingEnabled
+        capabilities {
+          resourceReporting
+        }
         latestVersion {
           id
           version
@@ -90,7 +94,7 @@ export function BannerSettingsForm({ cookieBannerKey }: BannerSettingsFormProps)
       privacyPolicyUrl: banner.privacyPolicyUrl ?? "",
       consentExpiryDays: String(banner.consentExpiryDays),
       defaultLanguage: banner.defaultLanguage,
-      resourceReportingEnabled: banner.resourceReportingEnabled,
+      resourceReportingEnabled: banner.capabilities.resourceReporting,
     },
   });
 
@@ -104,7 +108,7 @@ export function BannerSettingsForm({ cookieBannerKey }: BannerSettingsFormProps)
           privacyPolicyUrl: data.privacyPolicyUrl || undefined,
           consentExpiryDays: parseInt(data.consentExpiryDays, 10),
           defaultLanguage: data.defaultLanguage,
-          resourceReportingEnabled: data.resourceReportingEnabled,
+          capabilities: { resourceReporting: data.resourceReportingEnabled },
         },
       },
       onCompleted() {

--- a/e2e/console/cookie_banner_test.go
+++ b/e2e/console/cookie_banner_test.go
@@ -48,7 +48,9 @@ func TestCookieBanner_Create(t *testing.T) {
 							cookiePolicyUrl
 							consentExpiryDays
 							showBranding
-							resourceReportingEnabled
+							capabilities {
+								resourceReporting
+							}
 							defaultLanguage
 							createdAt
 							updatedAt
@@ -65,17 +67,19 @@ func TestCookieBanner_Create(t *testing.T) {
 			CreateCookieBanner struct {
 				CookieBannerEdge struct {
 					Node struct {
-						ID                       string `json:"id"`
-						Name                     string `json:"name"`
-						Origin                   string `json:"origin"`
-						State                    string `json:"state"`
-						CookiePolicyUrl          string `json:"cookiePolicyUrl"`
-						ConsentExpiryDays        int    `json:"consentExpiryDays"`
-						ShowBranding             bool   `json:"showBranding"`
-						ResourceReportingEnabled bool   `json:"resourceReportingEnabled"`
-						DefaultLanguage          string `json:"defaultLanguage"`
-						CreatedAt                string `json:"createdAt"`
-						UpdatedAt                string `json:"updatedAt"`
+						ID                string `json:"id"`
+						Name              string `json:"name"`
+						Origin            string `json:"origin"`
+						State             string `json:"state"`
+						CookiePolicyUrl   string `json:"cookiePolicyUrl"`
+						ConsentExpiryDays int    `json:"consentExpiryDays"`
+						ShowBranding      bool   `json:"showBranding"`
+						Capabilities      struct {
+							ResourceReporting bool `json:"resourceReporting"`
+						} `json:"capabilities"`
+						DefaultLanguage string `json:"defaultLanguage"`
+						CreatedAt       string `json:"createdAt"`
+						UpdatedAt       string `json:"updatedAt"`
 					} `json:"node"`
 				} `json:"cookieBannerEdge"`
 			} `json:"createCookieBanner"`
@@ -99,7 +103,7 @@ func TestCookieBanner_Create(t *testing.T) {
 		assert.Equal(t, "ACTIVE", node.State)
 		assert.Equal(t, "https://example.com/cookies", node.CookiePolicyUrl)
 		assert.Equal(t, 365, node.ConsentExpiryDays)
-		assert.True(t, node.ResourceReportingEnabled)
+		assert.True(t, node.Capabilities.ResourceReporting)
 		assert.Equal(t, "en", node.DefaultLanguage)
 		assert.NotEmpty(t, node.CreatedAt)
 		assert.NotEmpty(t, node.UpdatedAt)
@@ -348,7 +352,9 @@ func TestCookieBanner_Update(t *testing.T) {
 				updateCookieBanner(input: $input) {
 					cookieBanner {
 						id
-						resourceReportingEnabled
+						capabilities {
+							resourceReporting
+						}
 					}
 				}
 			}
@@ -357,22 +363,24 @@ func TestCookieBanner_Update(t *testing.T) {
 		var result struct {
 			UpdateCookieBanner struct {
 				CookieBanner struct {
-					ID                       string `json:"id"`
-					ResourceReportingEnabled bool   `json:"resourceReportingEnabled"`
+					ID           string `json:"id"`
+					Capabilities struct {
+						ResourceReporting bool `json:"resourceReporting"`
+					} `json:"capabilities"`
 				} `json:"cookieBanner"`
 			} `json:"updateCookieBanner"`
 		}
 
 		err := owner.Execute(query, map[string]any{
 			"input": map[string]any{
-				"cookieBannerId":           bannerID,
-				"resourceReportingEnabled": false,
+				"cookieBannerId": bannerID,
+				"capabilities":   map[string]any{"resourceReporting": false},
 			},
 		}, &result)
 
 		require.NoError(t, err)
 		assert.Equal(t, bannerID, result.UpdateCookieBanner.CookieBanner.ID)
-		assert.False(t, result.UpdateCookieBanner.CookieBanner.ResourceReportingEnabled)
+		assert.False(t, result.UpdateCookieBanner.CookieBanner.Capabilities.ResourceReporting)
 	})
 }
 

--- a/packages/n8n-node/nodes/Probo/actions/compliancePortal/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/compliancePortal/create.operation.ts
@@ -68,7 +68,7 @@ export async function execute(
 						slug
 						active
 						searchEngineIndexing
-						rightsRequestsEnabled
+						capabilities { rightsRequests }
 						entityName
 						description
 						websiteUrl

--- a/packages/n8n-node/nodes/Probo/actions/compliancePortal/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/compliancePortal/get.operation.ts
@@ -52,7 +52,7 @@ export async function execute(
 					slug
 					active
 					searchEngineIndexing
-					rightsRequestsEnabled
+					capabilities { rightsRequests }
 					entityName
 					description
 					websiteUrl

--- a/packages/n8n-node/nodes/Probo/actions/compliancePortal/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/compliancePortal/getAll.operation.ts
@@ -87,7 +87,7 @@ export async function execute(
 								slug
 								active
 								searchEngineIndexing
-								rightsRequestsEnabled
+								capabilities { rightsRequests }
 								entityName
 								description
 								websiteUrl

--- a/packages/n8n-node/nodes/Probo/actions/compliancePortal/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/compliancePortal/update.operation.ts
@@ -192,7 +192,7 @@ export async function execute(
 					id
 					active
 					searchEngineIndexing
-					rightsRequestsEnabled
+					capabilities { rightsRequests }
 					entityName
 					description
 					websiteUrl
@@ -215,8 +215,8 @@ export async function execute(
 	};
 	if (active !== undefined) input.active = active;
 	if (searchEngineIndexing) input.searchEngineIndexing = searchEngineIndexing;
-	if (rightsRequestsEnabled === 'true') input.rightsRequestsEnabled = true;
-	if (rightsRequestsEnabled === 'false') input.rightsRequestsEnabled = false;
+	if (rightsRequestsEnabled === 'true') input.capabilities = { rightsRequests: true };
+	if (rightsRequestsEnabled === 'false') input.capabilities = { rightsRequests: false };
 
 	const responseData = await proboApiRequest.call(this, query, { input });
 

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/activate.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/activate.operation.ts
@@ -56,7 +56,7 @@ export async function execute(
 					cookiePolicyUrl
 					consentExpiryDays
 					showBranding
-					resourceReportingEnabled
+					capabilities { resourceReporting }
 					defaultLanguage
 					createdAt
 					updatedAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/create.operation.ts
@@ -134,7 +134,7 @@ export async function execute(
 						cookiePolicyUrl
 						consentExpiryDays
 						showBranding
-						resourceReportingEnabled
+						capabilities { resourceReporting }
 						defaultLanguage
 						createdAt
 						updatedAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/deactivate.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/deactivate.operation.ts
@@ -56,7 +56,7 @@ export async function execute(
 					cookiePolicyUrl
 					consentExpiryDays
 					showBranding
-					resourceReportingEnabled
+					capabilities { resourceReporting }
 					defaultLanguage
 					createdAt
 					updatedAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/get.operation.ts
@@ -56,7 +56,7 @@ export async function execute(
 					cookiePolicyUrl
 					consentExpiryDays
 					showBranding
-					resourceReportingEnabled
+					capabilities { resourceReporting }
 					defaultLanguage
 					createdAt
 					updatedAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/getAll.operation.ts
@@ -91,7 +91,7 @@ export async function execute(
 								cookiePolicyUrl
 								consentExpiryDays
 								showBranding
-								resourceReportingEnabled
+								capabilities { resourceReporting }
 								defaultLanguage
 								createdAt
 								updatedAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
@@ -146,7 +146,7 @@ export async function execute(
 					cookiePolicyUrl
 					consentExpiryDays
 					showBranding
-					resourceReportingEnabled
+					capabilities { resourceReporting }
 					defaultLanguage
 					createdAt
 					updatedAt
@@ -164,7 +164,7 @@ export async function execute(
 		input.privacyPolicyUrl = additionalFields.privacyPolicyUrl === '' ? null : additionalFields.privacyPolicyUrl;
 	}
 	if (additionalFields.resourceReportingEnabled !== undefined) {
-		input.resourceReportingEnabled = additionalFields.resourceReportingEnabled;
+		input.capabilities = { resourceReporting: additionalFields.resourceReportingEnabled };
 	}
 
 	const responseData = await proboApiRequest.call(this, query, { input });

--- a/pkg/cmd/compliance-portal/update/update.go
+++ b/pkg/cmd/compliance-portal/update/update.go
@@ -36,7 +36,9 @@ mutation($input: UpdateCompliancePortalInput!) {
       id
       active
       searchEngineIndexing
-      rightsRequestsEnabled
+      capabilities {
+        rightsRequests
+      }
       entityName
       description
       websiteUrl
@@ -50,15 +52,17 @@ mutation($input: UpdateCompliancePortalInput!) {
 type updateResponse struct {
 	UpdateCompliancePortal struct {
 		CompliancePortal struct {
-			ID                    string  `json:"id"`
-			Active                bool    `json:"active"`
-			SearchEngineIndexing  string  `json:"searchEngineIndexing"`
-			RightsRequestsEnabled bool    `json:"rightsRequestsEnabled"`
-			EntityName            string  `json:"entityName"`
-			Description           *string `json:"description"`
-			WebsiteURL            *string `json:"websiteUrl"`
-			Email                 *string `json:"email"`
-			HeadquarterAddress    *string `json:"headquarterAddress"`
+			ID                   string `json:"id"`
+			Active               bool   `json:"active"`
+			SearchEngineIndexing string `json:"searchEngineIndexing"`
+			Capabilities         struct {
+				RightsRequests bool `json:"rightsRequests"`
+			} `json:"capabilities"`
+			EntityName         string  `json:"entityName"`
+			Description        *string `json:"description"`
+			WebsiteURL         *string `json:"websiteUrl"`
+			Email              *string `json:"email"`
+			HeadquarterAddress *string `json:"headquarterAddress"`
 		} `json:"compliancePortal"`
 	} `json:"updateCompliancePortal"`
 }
@@ -124,7 +128,9 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if cmd.Flags().Changed("rights-requests-enabled") {
-				input["rightsRequestsEnabled"] = flagRightsRequestsEnabled
+				input["capabilities"] = map[string]any{
+					"rightsRequests": flagRightsRequestsEnabled,
+				}
 			}
 
 			if cmd.Flags().Changed("description") {

--- a/pkg/cmd/cookie-banner/update/update.go
+++ b/pkg/cmd/cookie-banner/update/update.go
@@ -105,7 +105,9 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if cmd.Flags().Changed("resource-reporting-enabled") {
-				input["resourceReportingEnabled"] = flagResourceReportingEnabled
+				input["capabilities"] = map[string]any{
+					"resourceReporting": flagResourceReportingEnabled,
+				}
 			}
 
 			if len(input) == 1 {

--- a/pkg/cmd/cookie-banner/view/view.go
+++ b/pkg/cmd/cookie-banner/view/view.go
@@ -43,7 +43,9 @@ query($id: ID!) {
       privacyPolicyUrl
       consentExpiryDays
       showBranding
-      resourceReportingEnabled
+      capabilities {
+        resourceReporting
+      }
       defaultLanguage
       createdAt
       updatedAt
@@ -54,19 +56,21 @@ query($id: ID!) {
 
 type viewResponse struct {
 	Node *struct {
-		Typename                 string  `json:"__typename"`
-		ID                       string  `json:"id"`
-		Name                     string  `json:"name"`
-		Origin                   string  `json:"origin"`
-		State                    string  `json:"state"`
-		CookiePolicyUrl          string  `json:"cookiePolicyUrl"`
-		PrivacyPolicyUrl         *string `json:"privacyPolicyUrl"`
-		ConsentExpiryDays        int     `json:"consentExpiryDays"`
-		ShowBranding             bool    `json:"showBranding"`
-		ResourceReportingEnabled bool    `json:"resourceReportingEnabled"`
-		DefaultLanguage          string  `json:"defaultLanguage"`
-		CreatedAt                string  `json:"createdAt"`
-		UpdatedAt                string  `json:"updatedAt"`
+		Typename          string  `json:"__typename"`
+		ID                string  `json:"id"`
+		Name              string  `json:"name"`
+		Origin            string  `json:"origin"`
+		State             string  `json:"state"`
+		CookiePolicyUrl   string  `json:"cookiePolicyUrl"`
+		PrivacyPolicyUrl  *string `json:"privacyPolicyUrl"`
+		ConsentExpiryDays int     `json:"consentExpiryDays"`
+		ShowBranding      bool    `json:"showBranding"`
+		Capabilities      struct {
+			ResourceReporting bool `json:"resourceReporting"`
+		} `json:"capabilities"`
+		DefaultLanguage string `json:"defaultLanguage"`
+		CreatedAt       string `json:"createdAt"`
+		UpdatedAt       string `json:"updatedAt"`
 	} `json:"node"`
 }
 
@@ -130,7 +134,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("State:"), v.State)
 			_, _ = fmt.Fprintf(out, "%s%d days\n", label.Render("Consent Expiry:"), v.ConsentExpiryDays)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Default Language:"), v.DefaultLanguage)
-			_, _ = fmt.Fprintf(out, "%s%t\n", label.Render("Resource Reporting:"), v.ResourceReportingEnabled)
+			_, _ = fmt.Fprintf(out, "%s%t\n", label.Render("Resource Reporting:"), v.Capabilities.ResourceReporting)
 
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Cookie Policy:"), v.CookiePolicyUrl)
 			if v.PrivacyPolicyUrl != nil && *v.PrivacyPolicyUrl != "" {

--- a/pkg/complianceportal/management/portal_service.go
+++ b/pkg/complianceportal/management/portal_service.go
@@ -49,7 +49,7 @@ type (
 		Active                       *bool
 		Slug                         *string
 		SearchEngineIndexing         *coredata.SearchEngineIndexing
-		RightsRequestsEnabled        *bool
+		Capabilities                 *coredata.CompliancePortalCapabilities
 		NonDisclosureAgreementFileID *gid.GID
 		EntityName                   *string
 		Description                  **string
@@ -404,8 +404,8 @@ func (s *Service) Update(
 				portal.SearchEngineIndexing = *req.SearchEngineIndexing
 			}
 
-			if req.RightsRequestsEnabled != nil {
-				portal.Capabilities.RightsRequests = *req.RightsRequestsEnabled
+			if req.Capabilities != nil {
+				portal.Capabilities = *req.Capabilities
 			}
 
 			if req.EntityName != nil {

--- a/pkg/complianceportal/management/portal_service.go
+++ b/pkg/complianceportal/management/portal_service.go
@@ -49,7 +49,7 @@ type (
 		Active                       *bool
 		Slug                         *string
 		SearchEngineIndexing         *coredata.SearchEngineIndexing
-		Capabilities                 *coredata.CompliancePortalCapabilities
+		Capabilities                 *coredata.CompliancePortalCapabilitiesPatch
 		NonDisclosureAgreementFileID *gid.GID
 		EntityName                   *string
 		Description                  **string
@@ -405,7 +405,7 @@ func (s *Service) Update(
 			}
 
 			if req.Capabilities != nil {
-				portal.Capabilities = *req.Capabilities
+				portal.Capabilities = req.Capabilities.Apply(portal.Capabilities)
 			}
 
 			if req.EntityName != nil {

--- a/pkg/cookiebanner/pattern_analysis_worker_process_test.go
+++ b/pkg/cookiebanner/pattern_analysis_worker_process_test.go
@@ -61,18 +61,18 @@ func seedWorkerFixture(t *testing.T, ctx context.Context, client *pg.Client) wor
 	now := time.Now().UTC().Truncate(time.Microsecond)
 
 	banner := coredata.CookieBanner{
-		ID:                       bannerID,
-		OrganizationID:           organizationID,
-		Name:                     "Worker Test Banner",
-		Origin:                   "https://worker-test-" + bannerID.String() + ".example.com",
-		State:                    coredata.CookieBannerStateActive,
-		CookiePolicyURL:          "https://worker-test.example.com/cookies",
-		ConsentExpiryDays:        180,
-		ShowBranding:             false,
-		ResourceReportingEnabled: true,
-		DefaultLanguage:          "en",
-		CreatedAt:                now,
-		UpdatedAt:                now,
+		ID:                bannerID,
+		OrganizationID:    organizationID,
+		Name:              "Worker Test Banner",
+		Origin:            "https://worker-test-" + bannerID.String() + ".example.com",
+		State:             coredata.CookieBannerStateActive,
+		CookiePolicyURL:   "https://worker-test.example.com/cookies",
+		ConsentExpiryDays: 180,
+		ShowBranding:      false,
+		Capabilities:      coredata.DefaultCookieBannerCapabilities(),
+		DefaultLanguage:   "en",
+		CreatedAt:         now,
+		UpdatedAt:         now,
 	}
 
 	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {

--- a/pkg/cookiebanner/report_detected_trackers_test.go
+++ b/pkg/cookiebanner/report_detected_trackers_test.go
@@ -213,8 +213,8 @@ func TestReportDetectedTrackers_ResourceReportingDisabled(t *testing.T) {
 		ctx,
 		fx.scope,
 		UpdateCookieBannerRequest{
-			CookieBannerID:           fx.banner.ID,
-			ResourceReportingEnabled: new(false),
+			CookieBannerID: fx.banner.ID,
+			Capabilities:   &coredata.CookieBannerCapabilities{ResourceReporting: false},
 		},
 	)
 	require.NoError(t, err)

--- a/pkg/cookiebanner/report_detected_trackers_test.go
+++ b/pkg/cookiebanner/report_detected_trackers_test.go
@@ -214,7 +214,7 @@ func TestReportDetectedTrackers_ResourceReportingDisabled(t *testing.T) {
 		fx.scope,
 		UpdateCookieBannerRequest{
 			CookieBannerID: fx.banner.ID,
-			Capabilities:   &coredata.CookieBannerCapabilities{ResourceReporting: false},
+			Capabilities:   &coredata.CookieBannerCapabilitiesPatch{ResourceReporting: new(false)},
 		},
 	)
 	require.NoError(t, err)

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -69,13 +69,13 @@ type (
 	}
 
 	UpdateCookieBannerRequest struct {
-		CookieBannerID           gid.GID
-		Name                     *string
-		PrivacyPolicyURL         *string
-		CookiePolicyURL          *string
-		ConsentExpiryDays        *int
-		DefaultLanguage          *string
-		ResourceReportingEnabled *bool
+		CookieBannerID    gid.GID
+		Name              *string
+		PrivacyPolicyURL  *string
+		CookiePolicyURL   *string
+		ConsentExpiryDays *int
+		DefaultLanguage   *string
+		Capabilities      *coredata.CookieBannerCapabilities
 	}
 
 	UpdateCookieCategoryRequest struct {
@@ -622,19 +622,19 @@ func (s *Service) CreateCookieBanner(
 			now := time.Now()
 
 			banner = &coredata.CookieBanner{
-				ID:                       gid.New(scope.GetTenantID(), coredata.CookieBannerEntityType),
-				OrganizationID:           req.OrganizationID,
-				Name:                     req.Name,
-				Origin:                   CanonicalizeOrigin(req.Origin),
-				State:                    coredata.CookieBannerStateActive,
-				PrivacyPolicyURL:         req.PrivacyPolicyURL,
-				CookiePolicyURL:          req.CookiePolicyURL,
-				ConsentExpiryDays:        req.ConsentExpiryDays,
-				ShowBranding:             s.showBranding,
-				ResourceReportingEnabled: true,
-				DefaultLanguage:          "en",
-				CreatedAt:                now,
-				UpdatedAt:                now,
+				ID:                gid.New(scope.GetTenantID(), coredata.CookieBannerEntityType),
+				OrganizationID:    req.OrganizationID,
+				Name:              req.Name,
+				Origin:            CanonicalizeOrigin(req.Origin),
+				State:             coredata.CookieBannerStateActive,
+				PrivacyPolicyURL:  req.PrivacyPolicyURL,
+				CookiePolicyURL:   req.CookiePolicyURL,
+				ConsentExpiryDays: req.ConsentExpiryDays,
+				ShowBranding:      s.showBranding,
+				Capabilities:      coredata.DefaultCookieBannerCapabilities(),
+				DefaultLanguage:   "en",
+				CreatedAt:         now,
+				UpdatedAt:         now,
 			}
 
 			if err := banner.Insert(ctx, tx, scope); err != nil {
@@ -916,12 +916,12 @@ func (s *Service) UpdateCookieBanner(
 			cookiePolicyChanged := req.CookiePolicyURL != nil && *req.CookiePolicyURL != banner.CookiePolicyURL
 			expiryChanged := req.ConsentExpiryDays != nil && *req.ConsentExpiryDays != banner.ConsentExpiryDays
 			defaultLangChanged := req.DefaultLanguage != nil && *req.DefaultLanguage != banner.DefaultLanguage
-			resourceReportingChanged := req.ResourceReportingEnabled != nil &&
-				*req.ResourceReportingEnabled != banner.ResourceReportingEnabled
+			capabilitiesChanged := req.Capabilities != nil &&
+				*req.Capabilities != banner.Capabilities
 
 			snapshotChanged := privacyChanged || cookiePolicyChanged || expiryChanged || defaultLangChanged
 
-			if !nameChanged && !snapshotChanged && !resourceReportingChanged {
+			if !nameChanged && !snapshotChanged && !capabilitiesChanged {
 				return nil
 			}
 
@@ -945,8 +945,8 @@ func (s *Service) UpdateCookieBanner(
 				banner.DefaultLanguage = *req.DefaultLanguage
 			}
 
-			if req.ResourceReportingEnabled != nil {
-				banner.ResourceReportingEnabled = *req.ResourceReportingEnabled
+			if req.Capabilities != nil {
+				banner.Capabilities = *req.Capabilities
 			}
 
 			banner.UpdatedAt = time.Now()
@@ -1867,7 +1867,7 @@ func buildBannerConfig(
 		CookiePolicyURL:          snapshot.CookiePolicyURL,
 		ConsentExpiryDays:        snapshot.ConsentExpiryDays,
 		ShowBranding:             banner.ShowBranding,
-		ResourceReportingEnabled: banner.ResourceReportingEnabled,
+		ResourceReportingEnabled: banner.Capabilities.ResourceReporting,
 		Categories:               categories,
 		Texts:                    texts,
 	}
@@ -2175,7 +2175,7 @@ func (s *Service) ReportDetectedTrackers(
 				return fmt.Errorf("cannot load cookie banner: %w", err)
 			}
 
-			if !banner.ResourceReportingEnabled {
+			if !banner.Capabilities.ResourceReporting {
 				req.Resources = nil
 			}
 

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -75,7 +75,7 @@ type (
 		CookiePolicyURL   *string
 		ConsentExpiryDays *int
 		DefaultLanguage   *string
-		Capabilities      *coredata.CookieBannerCapabilities
+		Capabilities      *coredata.CookieBannerCapabilitiesPatch
 	}
 
 	UpdateCookieCategoryRequest struct {
@@ -917,7 +917,7 @@ func (s *Service) UpdateCookieBanner(
 			expiryChanged := req.ConsentExpiryDays != nil && *req.ConsentExpiryDays != banner.ConsentExpiryDays
 			defaultLangChanged := req.DefaultLanguage != nil && *req.DefaultLanguage != banner.DefaultLanguage
 			capabilitiesChanged := req.Capabilities != nil &&
-				*req.Capabilities != banner.Capabilities
+				req.Capabilities.Apply(banner.Capabilities) != banner.Capabilities
 
 			snapshotChanged := privacyChanged || cookiePolicyChanged || expiryChanged || defaultLangChanged
 
@@ -946,7 +946,7 @@ func (s *Service) UpdateCookieBanner(
 			}
 
 			if req.Capabilities != nil {
-				banner.Capabilities = *req.Capabilities
+				banner.Capabilities = req.Capabilities.Apply(banner.Capabilities)
 			}
 
 			banner.UpdatedAt = time.Now()

--- a/pkg/coredata/compliance_portal_capabilities.go
+++ b/pkg/coredata/compliance_portal_capabilities.go
@@ -26,9 +26,15 @@ import (
 	"fmt"
 )
 
-type CompliancePortalCapabilities struct {
-	RightsRequests bool `json:"rights_requests"`
-}
+type (
+	CompliancePortalCapabilities struct {
+		RightsRequests bool `json:"rights_requests"`
+	}
+
+	CompliancePortalCapabilitiesPatch struct {
+		RightsRequests *bool
+	}
+)
 
 func DefaultCompliancePortalCapabilities() CompliancePortalCapabilities {
 	return CompliancePortalCapabilities{
@@ -46,9 +52,9 @@ func (c CompliancePortalCapabilities) Value() (driver.Value, error) {
 }
 
 func (c *CompliancePortalCapabilities) Scan(value any) error {
-	if value == nil {
-		*c = DefaultCompliancePortalCapabilities()
+	*c = DefaultCompliancePortalCapabilities()
 
+	if value == nil {
 		return nil
 	}
 
@@ -64,8 +70,6 @@ func (c *CompliancePortalCapabilities) Scan(value any) error {
 	}
 
 	if len(data) == 0 {
-		*c = DefaultCompliancePortalCapabilities()
-
 		return nil
 	}
 
@@ -74,4 +78,12 @@ func (c *CompliancePortalCapabilities) Scan(value any) error {
 	}
 
 	return nil
+}
+
+func (p CompliancePortalCapabilitiesPatch) Apply(c CompliancePortalCapabilities) CompliancePortalCapabilities {
+	if p.RightsRequests != nil {
+		c.RightsRequests = *p.RightsRequests
+	}
+
+	return c
 }

--- a/pkg/coredata/cookie_banner.go
+++ b/pkg/coredata/cookie_banner.go
@@ -37,22 +37,22 @@ import (
 
 type (
 	CookieBanner struct {
-		ID                          gid.GID           `db:"id"`
-		OrganizationID              gid.GID           `db:"organization_id"`
-		Name                        string            `db:"name"`
-		Origin                      string            `db:"origin"`
-		State                       CookieBannerState `db:"state"`
-		PrivacyPolicyURL            *string           `db:"privacy_policy_url"`
-		CookiePolicyURL             string            `db:"cookie_policy_url"`
-		ConsentExpiryDays           int               `db:"consent_expiry_days"`
-		ShowBranding                bool              `db:"show_branding"`
-		ResourceReportingEnabled    bool              `db:"resource_reporting_enabled"`
-		DefaultLanguage             string            `db:"default_language"`
-		PatternAnalysisRequestedAt  *time.Time        `db:"pattern_analysis_requested_at"`
-		PolicyDocumentID            *gid.GID          `db:"policy_document_id"`
-		PolicyGenerationRequestedAt *time.Time        `db:"policy_generation_requested_at"`
-		CreatedAt                   time.Time         `db:"created_at"`
-		UpdatedAt                   time.Time         `db:"updated_at"`
+		ID                          gid.GID                  `db:"id"`
+		OrganizationID              gid.GID                  `db:"organization_id"`
+		Name                        string                   `db:"name"`
+		Origin                      string                   `db:"origin"`
+		State                       CookieBannerState        `db:"state"`
+		PrivacyPolicyURL            *string                  `db:"privacy_policy_url"`
+		CookiePolicyURL             string                   `db:"cookie_policy_url"`
+		ConsentExpiryDays           int                      `db:"consent_expiry_days"`
+		ShowBranding                bool                     `db:"show_branding"`
+		Capabilities                CookieBannerCapabilities `db:"capabilities"`
+		DefaultLanguage             string                   `db:"default_language"`
+		PatternAnalysisRequestedAt  *time.Time               `db:"pattern_analysis_requested_at"`
+		PolicyDocumentID            *gid.GID                 `db:"policy_document_id"`
+		PolicyGenerationRequestedAt *time.Time               `db:"policy_generation_requested_at"`
+		CreatedAt                   time.Time                `db:"created_at"`
+		UpdatedAt                   time.Time                `db:"updated_at"`
 	}
 
 	CookieBanners []*CookieBanner
@@ -123,7 +123,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
-	resource_reporting_enabled,
+	capabilities,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -178,7 +178,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
-	resource_reporting_enabled,
+	capabilities,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -234,7 +234,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
-	resource_reporting_enabled,
+	capabilities,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -294,7 +294,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
-	resource_reporting_enabled,
+	capabilities,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -351,7 +351,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
-	resource_reporting_enabled,
+	capabilities,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -440,7 +440,7 @@ INSERT INTO cookie_banners (
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
-	resource_reporting_enabled,
+	capabilities,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -458,7 +458,7 @@ INSERT INTO cookie_banners (
 	@cookie_policy_url,
 	@consent_expiry_days,
 	@show_branding,
-	@resource_reporting_enabled,
+	@capabilities,
 	@default_language,
 	@pattern_analysis_requested_at,
 	@policy_document_id,
@@ -479,7 +479,7 @@ INSERT INTO cookie_banners (
 		"cookie_policy_url":              b.CookiePolicyURL,
 		"consent_expiry_days":            b.ConsentExpiryDays,
 		"show_branding":                  b.ShowBranding,
-		"resource_reporting_enabled":     b.ResourceReportingEnabled,
+		"capabilities":                   b.Capabilities,
 		"default_language":               b.DefaultLanguage,
 		"pattern_analysis_requested_at":  b.PatternAnalysisRequestedAt,
 		"policy_document_id":             b.PolicyDocumentID,
@@ -516,7 +516,7 @@ SET
 	cookie_policy_url = @cookie_policy_url,
 	consent_expiry_days = @consent_expiry_days,
 	show_branding = @show_branding,
-	resource_reporting_enabled = @resource_reporting_enabled,
+	capabilities = @capabilities,
 	default_language = @default_language,
 	policy_document_id = @policy_document_id,
 	updated_at = @updated_at
@@ -528,17 +528,17 @@ WHERE
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
-		"id":                         b.ID,
-		"name":                       b.Name,
-		"state":                      b.State,
-		"privacy_policy_url":         b.PrivacyPolicyURL,
-		"cookie_policy_url":          b.CookiePolicyURL,
-		"consent_expiry_days":        b.ConsentExpiryDays,
-		"show_branding":              b.ShowBranding,
-		"resource_reporting_enabled": b.ResourceReportingEnabled,
-		"default_language":           b.DefaultLanguage,
-		"policy_document_id":         b.PolicyDocumentID,
-		"updated_at":                 b.UpdatedAt,
+		"id":                  b.ID,
+		"name":                b.Name,
+		"state":               b.State,
+		"privacy_policy_url":  b.PrivacyPolicyURL,
+		"cookie_policy_url":   b.CookiePolicyURL,
+		"consent_expiry_days": b.ConsentExpiryDays,
+		"show_branding":       b.ShowBranding,
+		"capabilities":        b.Capabilities,
+		"default_language":    b.DefaultLanguage,
+		"policy_document_id":  b.PolicyDocumentID,
+		"updated_at":          b.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())
 
@@ -639,7 +639,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
-	resource_reporting_enabled,
+	capabilities,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,
@@ -733,7 +733,7 @@ SELECT
 	cookie_policy_url,
 	consent_expiry_days,
 	show_branding,
-	resource_reporting_enabled,
+	capabilities,
 	default_language,
 	pattern_analysis_requested_at,
 	policy_document_id,

--- a/pkg/coredata/cookie_banner_capabilities.go
+++ b/pkg/coredata/cookie_banner_capabilities.go
@@ -26,9 +26,15 @@ import (
 	"fmt"
 )
 
-type CookieBannerCapabilities struct {
-	ResourceReporting bool `json:"resource_reporting"`
-}
+type (
+	CookieBannerCapabilities struct {
+		ResourceReporting bool `json:"resource_reporting"`
+	}
+
+	CookieBannerCapabilitiesPatch struct {
+		ResourceReporting *bool
+	}
+)
 
 func DefaultCookieBannerCapabilities() CookieBannerCapabilities {
 	return CookieBannerCapabilities{
@@ -46,9 +52,9 @@ func (c CookieBannerCapabilities) Value() (driver.Value, error) {
 }
 
 func (c *CookieBannerCapabilities) Scan(value any) error {
-	if value == nil {
-		*c = DefaultCookieBannerCapabilities()
+	*c = DefaultCookieBannerCapabilities()
 
+	if value == nil {
 		return nil
 	}
 
@@ -64,8 +70,6 @@ func (c *CookieBannerCapabilities) Scan(value any) error {
 	}
 
 	if len(data) == 0 {
-		*c = DefaultCookieBannerCapabilities()
-
 		return nil
 	}
 
@@ -74,4 +78,12 @@ func (c *CookieBannerCapabilities) Scan(value any) error {
 	}
 
 	return nil
+}
+
+func (p CookieBannerCapabilitiesPatch) Apply(c CookieBannerCapabilities) CookieBannerCapabilities {
+	if p.ResourceReporting != nil {
+		c.ResourceReporting = *p.ResourceReporting
+	}
+
+	return c
 }

--- a/pkg/coredata/cookie_banner_capabilities.go
+++ b/pkg/coredata/cookie_banner_capabilities.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+type CookieBannerCapabilities struct {
+	ResourceReporting bool `json:"resource_reporting"`
+}
+
+func DefaultCookieBannerCapabilities() CookieBannerCapabilities {
+	return CookieBannerCapabilities{
+		ResourceReporting: true,
+	}
+}
+
+func (c CookieBannerCapabilities) Value() (driver.Value, error) {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal cookie banner capabilities: %w", err)
+	}
+
+	return data, nil
+}
+
+func (c *CookieBannerCapabilities) Scan(value any) error {
+	if value == nil {
+		*c = DefaultCookieBannerCapabilities()
+
+		return nil
+	}
+
+	var data []byte
+
+	switch v := value.(type) {
+	case string:
+		data = []byte(v)
+	case []byte:
+		data = v
+	default:
+		return fmt.Errorf("cannot scan cookie banner capabilities: unsupported type %T", value)
+	}
+
+	if len(data) == 0 {
+		*c = DefaultCookieBannerCapabilities()
+
+		return nil
+	}
+
+	if err := json.Unmarshal(data, c); err != nil {
+		return fmt.Errorf("cannot unmarshal cookie banner capabilities: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/cookie_banner_capabilities_test.go
+++ b/pkg/coredata/cookie_banner_capabilities_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestCookieBannerCapabilities_Scan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value any
+		want  bool
+	}{
+		{"null column", nil, true},
+		{"empty bytes", []byte{}, true},
+		{"object without the key", []byte(`{}`), true},
+		{"unrelated key only", []byte(`{"future_capability": true}`), true},
+		{"explicit true", []byte(`{"resource_reporting": true}`), true},
+		{"explicit false", []byte(`{"resource_reporting": false}`), false},
+		{"string payload", `{"resource_reporting": false}`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				var capabilities coredata.CookieBannerCapabilities
+				require.NoError(t, capabilities.Scan(tt.value))
+				assert.Equal(t, tt.want, capabilities.ResourceReporting)
+			},
+		)
+	}
+}
+
+func TestCookieBannerCapabilities_ScanUnsupportedType(t *testing.T) {
+	t.Parallel()
+
+	var capabilities coredata.CookieBannerCapabilities
+	require.Error(t, capabilities.Scan(42))
+}
+
+func TestCookieBannerCapabilitiesPatch_Apply(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"nil member keeps the current value",
+		func(t *testing.T) {
+			t.Parallel()
+
+			current := coredata.CookieBannerCapabilities{ResourceReporting: true}
+			patch := coredata.CookieBannerCapabilitiesPatch{}
+
+			assert.Equal(t, current, patch.Apply(current))
+		},
+	)
+
+	t.Run(
+		"set member overrides the current value",
+		func(t *testing.T) {
+			t.Parallel()
+
+			current := coredata.CookieBannerCapabilities{ResourceReporting: true}
+			patch := coredata.CookieBannerCapabilitiesPatch{ResourceReporting: new(false)}
+
+			assert.False(t, patch.Apply(current).ResourceReporting)
+		},
+	)
+}
+
+func TestCompliancePortalCapabilities_Scan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value any
+		want  bool
+	}{
+		{"null column", nil, true},
+		{"object without the key", []byte(`{}`), true},
+		{"explicit false", []byte(`{"rights_requests": false}`), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				var capabilities coredata.CompliancePortalCapabilities
+				require.NoError(t, capabilities.Scan(tt.value))
+				assert.Equal(t, tt.want, capabilities.RightsRequests)
+			},
+		)
+	}
+}
+
+func TestCompliancePortalCapabilitiesPatch_Apply(t *testing.T) {
+	t.Parallel()
+
+	current := coredata.CompliancePortalCapabilities{RightsRequests: true}
+
+	assert.Equal(
+		t,
+		current,
+		coredata.CompliancePortalCapabilitiesPatch{}.Apply(current),
+	)
+	assert.False(
+		t,
+		coredata.CompliancePortalCapabilitiesPatch{RightsRequests: new(false)}.Apply(current).RightsRequests,
+	)
+}

--- a/pkg/coredata/migrations/20260811T153339Z.sql
+++ b/pkg/coredata/migrations/20260811T153339Z.sql
@@ -1,0 +1,31 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TABLE cookie_banners
+  ADD COLUMN capabilities JSONB NOT NULL DEFAULT '{"resource_reporting": true}'::jsonb;
+
+UPDATE cookie_banners
+  SET capabilities = jsonb_build_object('resource_reporting', resource_reporting_enabled);
+
+ALTER TABLE cookie_banners
+  ALTER COLUMN capabilities DROP DEFAULT;
+
+ALTER TABLE cookie_banners
+  DROP COLUMN resource_reporting_enabled;

--- a/pkg/coredata/tracker_pattern_test.go
+++ b/pkg/coredata/tracker_pattern_test.go
@@ -66,18 +66,18 @@ func seedTrackerPatternFixture(t *testing.T, ctx context.Context, client *pg.Cli
 		}
 
 		banner := &coredata.CookieBanner{
-			ID:                       cookieBannerID,
-			OrganizationID:           organizationID,
-			Name:                     "TrackerPattern Test Banner",
-			Origin:                   "https://tracker-pattern-test.example.com",
-			State:                    coredata.CookieBannerStateActive,
-			CookiePolicyURL:          "https://tracker-pattern-test.example.com/cookies",
-			ConsentExpiryDays:        180,
-			ShowBranding:             false,
-			ResourceReportingEnabled: true,
-			DefaultLanguage:          "en",
-			CreatedAt:                now,
-			UpdatedAt:                now,
+			ID:                cookieBannerID,
+			OrganizationID:    organizationID,
+			Name:              "TrackerPattern Test Banner",
+			Origin:            "https://tracker-pattern-test.example.com",
+			State:             coredata.CookieBannerStateActive,
+			CookiePolicyURL:   "https://tracker-pattern-test.example.com/cookies",
+			ConsentExpiryDays: 180,
+			ShowBranding:      false,
+			Capabilities:      coredata.DefaultCookieBannerCapabilities(),
+			DefaultLanguage:   "en",
+			CreatedAt:         now,
+			UpdatedAt:         now,
 		}
 		if err := banner.Insert(ctx, tx, scope); err != nil {
 			return err

--- a/pkg/server/api/complianceportal/v1/graphql/compliance_portal.graphql
+++ b/pkg/server/api/complianceportal/v1/graphql/compliance_portal.graphql
@@ -1,7 +1,12 @@
+type CompliancePortalCapabilities
+  @goModel(model: "go.probo.inc/probo/pkg/coredata.CompliancePortalCapabilities") {
+  rightsRequests: Boolean!
+}
+
 type CompliancePortal implements Node {
   id: ID!
   active: Boolean!
-  rightsRequestsEnabled: Boolean!
+  capabilities: CompliancePortalCapabilities!
   slug: String!
   logo: File @goField(forceResolver: true)
   darkLogo: File @goField(forceResolver: true)

--- a/pkg/server/api/complianceportal/v1/types/compliance_portal.go
+++ b/pkg/server/api/complianceportal/v1/types/compliance_portal.go
@@ -26,15 +26,15 @@ import (
 
 func NewCompliancePortal(cp *coredata.CompliancePortal) *CompliancePortal {
 	return &CompliancePortal{
-		ID:                    cp.ID,
-		Active:                cp.Active,
-		RightsRequestsEnabled: cp.Capabilities.RightsRequests,
-		Slug:                  cp.Slug,
-		EntityName:            cp.EntityName,
-		Description:           cp.Description,
-		WebsiteURL:            cp.WebsiteURL,
-		Email:                 cp.Email,
-		HeadquarterAddress:    cp.HeadquarterAddress,
+		ID:                 cp.ID,
+		Active:             cp.Active,
+		Capabilities:       &cp.Capabilities,
+		Slug:               cp.Slug,
+		EntityName:         cp.EntityName,
+		Description:        cp.Description,
+		WebsiteURL:         cp.WebsiteURL,
+		Email:              cp.Email,
+		HeadquarterAddress: cp.HeadquarterAddress,
 	}
 }
 

--- a/pkg/server/api/console/v1/compliance_portal_resolvers.go
+++ b/pkg/server/api/console/v1/compliance_portal_resolvers.go
@@ -1215,18 +1215,25 @@ func (r *mutationResolver) UpdateCompliancePortal(ctx context.Context, input typ
 		return nil, err
 	}
 
+	var capabilities *coredata.CompliancePortalCapabilities
+	if input.Capabilities != nil {
+		capabilities = &coredata.CompliancePortalCapabilities{
+			RightsRequests: input.Capabilities.RightsRequests,
+		}
+	}
+
 	compliancePortal, _, err := r.management.Update(
 		ctx, scope,
 		&management.UpdateRequest{
-			ID:                    input.CompliancePortalID,
-			Active:                input.Active,
-			SearchEngineIndexing:  input.SearchEngineIndexing,
-			RightsRequestsEnabled: input.RightsRequestsEnabled,
-			Description:           gqlutils.UnwrapOmittable(input.Description),
-			WebsiteURL:            gqlutils.UnwrapOmittable(input.WebsiteURL),
-			Email:                 gqlutils.UnwrapOmittable(input.Email),
-			HeadquarterAddress:    gqlutils.UnwrapOmittable(input.HeadquarterAddress),
-			EntityName:            input.EntityName,
+			ID:                   input.CompliancePortalID,
+			Active:               input.Active,
+			SearchEngineIndexing: input.SearchEngineIndexing,
+			Capabilities:         capabilities,
+			Description:          gqlutils.UnwrapOmittable(input.Description),
+			WebsiteURL:           gqlutils.UnwrapOmittable(input.WebsiteURL),
+			Email:                gqlutils.UnwrapOmittable(input.Email),
+			HeadquarterAddress:   gqlutils.UnwrapOmittable(input.HeadquarterAddress),
+			EntityName:           input.EntityName,
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/console/v1/compliance_portal_resolvers.go
+++ b/pkg/server/api/console/v1/compliance_portal_resolvers.go
@@ -1215,9 +1215,9 @@ func (r *mutationResolver) UpdateCompliancePortal(ctx context.Context, input typ
 		return nil, err
 	}
 
-	var capabilities *coredata.CompliancePortalCapabilities
+	var capabilities *coredata.CompliancePortalCapabilitiesPatch
 	if input.Capabilities != nil {
-		capabilities = &coredata.CompliancePortalCapabilities{
+		capabilities = &coredata.CompliancePortalCapabilitiesPatch{
 			RightsRequests: input.Capabilities.RightsRequests,
 		}
 	}

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -630,9 +630,9 @@ func (r *mutationResolver) UpdateCookieBanner(ctx context.Context, input types.U
 		return nil, err
 	}
 
-	var capabilities *coredata.CookieBannerCapabilities
+	var capabilities *coredata.CookieBannerCapabilitiesPatch
 	if input.Capabilities != nil {
-		capabilities = &coredata.CookieBannerCapabilities{
+		capabilities = &coredata.CookieBannerCapabilitiesPatch{
 			ResourceReporting: input.Capabilities.ResourceReporting,
 		}
 	}

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -630,17 +630,24 @@ func (r *mutationResolver) UpdateCookieBanner(ctx context.Context, input types.U
 		return nil, err
 	}
 
+	var capabilities *coredata.CookieBannerCapabilities
+	if input.Capabilities != nil {
+		capabilities = &coredata.CookieBannerCapabilities{
+			ResourceReporting: input.Capabilities.ResourceReporting,
+		}
+	}
+
 	banner, err := r.cookieBanner.UpdateCookieBanner(
 		ctx,
 		scope,
 		cookiebanner.UpdateCookieBannerRequest{
-			CookieBannerID:           input.CookieBannerID,
-			Name:                     input.Name,
-			PrivacyPolicyURL:         input.PrivacyPolicyURL,
-			CookiePolicyURL:          input.CookiePolicyURL,
-			ConsentExpiryDays:        input.ConsentExpiryDays,
-			DefaultLanguage:          input.DefaultLanguage,
-			ResourceReportingEnabled: input.ResourceReportingEnabled,
+			CookieBannerID:    input.CookieBannerID,
+			Name:              input.Name,
+			PrivacyPolicyURL:  input.PrivacyPolicyURL,
+			CookiePolicyURL:   input.CookiePolicyURL,
+			ConsentExpiryDays: input.ConsentExpiryDays,
+			DefaultLanguage:   input.DefaultLanguage,
+			Capabilities:      capabilities,
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/console/v1/graphql/compliance_portal.graphql
+++ b/pkg/server/api/console/v1/graphql/compliance_portal.graphql
@@ -836,7 +836,7 @@ input DeleteCompliancePortalInput {
 }
 
 input CompliancePortalCapabilitiesInput {
-    rightsRequests: Boolean!
+    rightsRequests: Boolean
 }
 
 input UpdateCompliancePortalInput {

--- a/pkg/server/api/console/v1/graphql/compliance_portal.graphql
+++ b/pkg/server/api/console/v1/graphql/compliance_portal.graphql
@@ -360,11 +360,18 @@ input CompliancePortalOrder
     field: CompliancePortalOrderField!
 }
 
+type CompliancePortalCapabilities
+    @goModel(
+        model: "go.probo.inc/probo/pkg/coredata.CompliancePortalCapabilities"
+    ) {
+    rightsRequests: Boolean!
+}
+
 type CompliancePortal implements Node {
     id: ID!
     active: Boolean!
     searchEngineIndexing: SearchEngineIndexing!
-    rightsRequestsEnabled: Boolean!
+    capabilities: CompliancePortalCapabilities!
     logo: File @goField(forceResolver: true)
     darkLogo: File @goField(forceResolver: true)
     nda: File @goField(forceResolver: true)
@@ -828,11 +835,15 @@ input DeleteCompliancePortalInput {
     compliancePortalId: ID!
 }
 
+input CompliancePortalCapabilitiesInput {
+    rightsRequests: Boolean!
+}
+
 input UpdateCompliancePortalInput {
     compliancePortalId: ID!
     active: Boolean
     searchEngineIndexing: SearchEngineIndexing
-    rightsRequestsEnabled: Boolean
+    capabilities: CompliancePortalCapabilitiesInput
     entityName: String
     description: String @goField(omittable: true)
     websiteUrl: String @goField(omittable: true)

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -127,6 +127,13 @@ input CookieCategoryFilter
     excludeKind: CookieCategoryKind
 }
 
+type CookieBannerCapabilities
+    @goModel(
+        model: "go.probo.inc/probo/pkg/coredata.CookieBannerCapabilities"
+    ) {
+    resourceReporting: Boolean!
+}
+
 type CookieBanner implements Node {
     id: ID!
     name: String!
@@ -136,7 +143,7 @@ type CookieBanner implements Node {
     cookiePolicyUrl: String!
     consentExpiryDays: Int!
     showBranding: Boolean!
-    resourceReportingEnabled: Boolean!
+    capabilities: CookieBannerCapabilities!
     defaultLanguage: String!
 
     organization: Organization @goField(forceResolver: true)
@@ -661,6 +668,10 @@ input CreateCookieBannerInput {
     consentExpiryDays: Int!
 }
 
+input CookieBannerCapabilitiesInput {
+    resourceReporting: Boolean!
+}
+
 input UpdateCookieBannerInput {
     cookieBannerId: ID!
     name: String
@@ -668,7 +679,7 @@ input UpdateCookieBannerInput {
     cookiePolicyUrl: String
     consentExpiryDays: Int
     defaultLanguage: String
-    resourceReportingEnabled: Boolean
+    capabilities: CookieBannerCapabilitiesInput
 }
 
 input DeleteCookieBannerInput {

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -669,7 +669,7 @@ input CreateCookieBannerInput {
 }
 
 input CookieBannerCapabilitiesInput {
-    resourceReporting: Boolean!
+    resourceReporting: Boolean
 }
 
 input UpdateCookieBannerInput {

--- a/pkg/server/api/console/v1/types/compliance_portal.go
+++ b/pkg/server/api/console/v1/types/compliance_portal.go
@@ -44,17 +44,17 @@ func NewCompliancePortal(tc *coredata.CompliancePortal) *CompliancePortal {
 		Organization: &Organization{
 			ID: tc.OrganizationID,
 		},
-		Active:                tc.Active,
-		SearchEngineIndexing:  tc.SearchEngineIndexing,
-		RightsRequestsEnabled: tc.Capabilities.RightsRequests,
-		Description:           tc.Description,
-		WebsiteURL:            tc.WebsiteURL,
-		Email:                 tc.Email,
-		HeadquarterAddress:    tc.HeadquarterAddress,
-		EntityName:            tc.EntityName,
-		Slug:                  tc.Slug,
-		CreatedAt:             tc.CreatedAt,
-		UpdatedAt:             tc.UpdatedAt,
+		Active:               tc.Active,
+		SearchEngineIndexing: tc.SearchEngineIndexing,
+		Capabilities:         &tc.Capabilities,
+		Description:          tc.Description,
+		WebsiteURL:           tc.WebsiteURL,
+		Email:                tc.Email,
+		HeadquarterAddress:   tc.HeadquarterAddress,
+		EntityName:           tc.EntityName,
+		Slug:                 tc.Slug,
+		CreatedAt:            tc.CreatedAt,
+		UpdatedAt:            tc.UpdatedAt,
 	}
 
 	if tc.LogoFileID != nil {

--- a/pkg/server/api/console/v1/types/cookie_banner.go
+++ b/pkg/server/api/console/v1/types/cookie_banner.go
@@ -72,17 +72,17 @@ func NewCookieBanner(b *coredata.CookieBanner) *CookieBanner {
 		Organization: &Organization{
 			ID: b.OrganizationID,
 		},
-		Name:                     b.Name,
-		Origin:                   b.Origin,
-		State:                    b.State,
-		PrivacyPolicyURL:         b.PrivacyPolicyURL,
-		CookiePolicyURL:          b.CookiePolicyURL,
-		ConsentExpiryDays:        b.ConsentExpiryDays,
-		ShowBranding:             b.ShowBranding,
-		ResourceReportingEnabled: b.ResourceReportingEnabled,
-		DefaultLanguage:          b.DefaultLanguage,
-		CreatedAt:                b.CreatedAt,
-		UpdatedAt:                b.UpdatedAt,
+		Name:              b.Name,
+		Origin:            b.Origin,
+		State:             b.State,
+		PrivacyPolicyURL:  b.PrivacyPolicyURL,
+		CookiePolicyURL:   b.CookiePolicyURL,
+		ConsentExpiryDays: b.ConsentExpiryDays,
+		ShowBranding:      b.ShowBranding,
+		Capabilities:      &b.Capabilities,
+		DefaultLanguage:   b.DefaultLanguage,
+		CreatedAt:         b.CreatedAt,
+		UpdatedAt:         b.UpdatedAt,
 	}
 
 	if b.PolicyDocumentID != nil {

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5028,8 +5028,10 @@ func (r *Resolver) UpdateCompliancePortalTool(ctx context.Context, req *mcp.Call
 		updateReq.SearchEngineIndexing = *sei
 	}
 
-	if rightsRequestsEnabled := UnwrapOmittable(input.RightsRequestsEnabled); rightsRequestsEnabled != nil {
-		updateReq.RightsRequestsEnabled = *rightsRequestsEnabled
+	if capabilities := UnwrapOmittable(input.Capabilities); capabilities != nil && *capabilities != nil {
+		updateReq.Capabilities = &coredata.CompliancePortalCapabilities{
+			RightsRequests: (*capabilities).RightsRequests,
+		}
 	}
 
 	updateReq.Description = UnwrapOmittable(input.Description)
@@ -5663,8 +5665,10 @@ func (r *Resolver) UpdateCookieBannerTool(ctx context.Context, req *mcp.CallTool
 		updateReq.DefaultLanguage = *v
 	}
 
-	if v := UnwrapOmittable(input.ResourceReportingEnabled); v != nil && *v != nil {
-		updateReq.ResourceReportingEnabled = *v
+	if v := UnwrapOmittable(input.Capabilities); v != nil && *v != nil {
+		updateReq.Capabilities = &coredata.CookieBannerCapabilities{
+			ResourceReporting: (*v).ResourceReporting,
+		}
 	}
 
 	banner, err := r.cookieBanner.UpdateCookieBanner(ctx, scope, updateReq)

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5029,7 +5029,7 @@ func (r *Resolver) UpdateCompliancePortalTool(ctx context.Context, req *mcp.Call
 	}
 
 	if capabilities := UnwrapOmittable(input.Capabilities); capabilities != nil && *capabilities != nil {
-		updateReq.Capabilities = &coredata.CompliancePortalCapabilities{
+		updateReq.Capabilities = &coredata.CompliancePortalCapabilitiesPatch{
 			RightsRequests: (*capabilities).RightsRequests,
 		}
 	}
@@ -5666,7 +5666,7 @@ func (r *Resolver) UpdateCookieBannerTool(ctx context.Context, req *mcp.CallTool
 	}
 
 	if v := UnwrapOmittable(input.Capabilities); v != nil && *v != nil {
-		updateReq.Capabilities = &coredata.CookieBannerCapabilities{
+		updateReq.Capabilities = &coredata.CookieBannerCapabilitiesPatch{
 			ResourceReporting: (*v).ResourceReporting,
 		}
 	}

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -10273,6 +10273,15 @@ components:
           type: string
           format: date-time
 
+    CompliancePortalCapabilities:
+      type: object
+      required:
+        - rights_requests
+      properties:
+        rights_requests:
+          type: boolean
+          description: Whether visitors can submit rights requests on the compliance portal
+
     CompliancePortal:
       type: object
       required:
@@ -10280,7 +10289,7 @@ components:
         - organization_id
         - active
         - search_engine_indexing
-        - rights_requests_enabled
+        - capabilities
         - entity_name
         - created_at
         - updated_at
@@ -10293,9 +10302,9 @@ components:
           type: boolean
         search_engine_indexing:
           $ref: "#/components/schemas/SearchEngineIndexing"
-        rights_requests_enabled:
-          type: boolean
-          description: Whether visitors can submit rights requests on the compliance portal
+        capabilities:
+          $ref: "#/components/schemas/CompliancePortalCapabilities"
+          description: Capabilities enabled on the compliance portal
         logo:
           $ref: "#/components/schemas/File"
         dark_logo:
@@ -10576,11 +10585,11 @@ components:
             - type: "null"
           description: Search engine indexing setting
           go.probo.inc/mcpgen/omittable: true
-        rights_requests_enabled:
-          type:
-            - boolean
-            - "null"
-          description: Whether visitors can submit rights requests on the compliance portal
+        capabilities:
+          anyOf:
+            - $ref: "#/components/schemas/CompliancePortalCapabilities"
+            - type: "null"
+          description: Capabilities enabled on the compliance portal
           go.probo.inc/mcpgen/omittable: true
         description:
           type:
@@ -11589,6 +11598,15 @@ components:
         deleted_custom_domain:
           $ref: "#/components/schemas/CustomDomain"
 
+    CookieBannerCapabilities:
+      type: object
+      required:
+        - resource_reporting
+      properties:
+        resource_reporting:
+          type: boolean
+          description: Whether the SDK reports detected resources
+
     CookieBanner:
       type: object
       required:
@@ -11600,7 +11618,7 @@ components:
         - cookie_policy_url
         - consent_expiry_days
         - show_branding
-        - resource_reporting_enabled
+        - capabilities
         - default_language
         - created_at
         - updated_at
@@ -11635,9 +11653,9 @@ components:
         show_branding:
           type: boolean
           description: Whether to show Probo branding
-        resource_reporting_enabled:
-          type: boolean
-          description: Whether the SDK reports detected resources
+        capabilities:
+          $ref: "#/components/schemas/CookieBannerCapabilities"
+          description: Capabilities enabled on the cookie banner
         default_language:
           type: string
           description: Default language code
@@ -12088,10 +12106,11 @@ components:
             - string
             - "null"
           go.probo.inc/mcpgen/omittable: true
-        resource_reporting_enabled:
-          type:
-            - boolean
-            - "null"
+        capabilities:
+          anyOf:
+            - $ref: "#/components/schemas/CookieBannerCapabilities"
+            - type: "null"
+          description: Capabilities enabled on the cookie banner
           go.probo.inc/mcpgen/omittable: true
 
     UpdateCookieBannerOutput:

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -10282,6 +10282,16 @@ components:
           type: boolean
           description: Whether visitors can submit rights requests on the compliance portal
 
+    CompliancePortalCapabilitiesInput:
+      type: object
+      description: Partial update; an omitted capability keeps its current value
+      properties:
+        rights_requests:
+          type:
+            - boolean
+            - "null"
+          description: Whether visitors can submit rights requests on the compliance portal
+
     CompliancePortal:
       type: object
       required:
@@ -10587,9 +10597,9 @@ components:
           go.probo.inc/mcpgen/omittable: true
         capabilities:
           anyOf:
-            - $ref: "#/components/schemas/CompliancePortalCapabilities"
+            - $ref: "#/components/schemas/CompliancePortalCapabilitiesInput"
             - type: "null"
-          description: Capabilities enabled on the compliance portal
+          description: Capabilities to change on the compliance portal
           go.probo.inc/mcpgen/omittable: true
         description:
           type:
@@ -11607,6 +11617,16 @@ components:
           type: boolean
           description: Whether the SDK reports detected resources
 
+    CookieBannerCapabilitiesInput:
+      type: object
+      description: Partial update; an omitted capability keeps its current value
+      properties:
+        resource_reporting:
+          type:
+            - boolean
+            - "null"
+          description: Whether the SDK reports detected resources
+
     CookieBanner:
       type: object
       required:
@@ -12108,9 +12128,9 @@ components:
           go.probo.inc/mcpgen/omittable: true
         capabilities:
           anyOf:
-            - $ref: "#/components/schemas/CookieBannerCapabilities"
+            - $ref: "#/components/schemas/CookieBannerCapabilitiesInput"
             - type: "null"
-          description: Capabilities enabled on the cookie banner
+          description: Capabilities to change on the cookie banner
           go.probo.inc/mcpgen/omittable: true
 
     UpdateCookieBannerOutput:

--- a/pkg/server/api/mcp/v1/types/compliance_portal.go
+++ b/pkg/server/api/mcp/v1/types/compliance_portal.go
@@ -25,20 +25,26 @@ import (
 	"go.probo.inc/probo/pkg/page"
 )
 
+func NewCompliancePortalCapabilities(c coredata.CompliancePortalCapabilities) *CompliancePortalCapabilities {
+	return &CompliancePortalCapabilities{
+		RightsRequests: c.RightsRequests,
+	}
+}
+
 func NewCompliancePortal(tc *coredata.CompliancePortal) *CompliancePortal {
 	return &CompliancePortal{
-		ID:                    tc.ID,
-		OrganizationID:        tc.OrganizationID,
-		Active:                tc.Active,
-		SearchEngineIndexing:  tc.SearchEngineIndexing,
-		RightsRequestsEnabled: tc.Capabilities.RightsRequests,
-		EntityName:            tc.EntityName,
-		Description:           tc.Description,
-		WebsiteURL:            tc.WebsiteURL,
-		Email:                 tc.Email,
-		HeadquarterAddress:    tc.HeadquarterAddress,
-		CreatedAt:             tc.CreatedAt,
-		UpdatedAt:             tc.UpdatedAt,
+		ID:                   tc.ID,
+		OrganizationID:       tc.OrganizationID,
+		Active:               tc.Active,
+		SearchEngineIndexing: tc.SearchEngineIndexing,
+		Capabilities:         NewCompliancePortalCapabilities(tc.Capabilities),
+		EntityName:           tc.EntityName,
+		Description:          tc.Description,
+		WebsiteURL:           tc.WebsiteURL,
+		Email:                tc.Email,
+		HeadquarterAddress:   tc.HeadquarterAddress,
+		CreatedAt:            tc.CreatedAt,
+		UpdatedAt:            tc.UpdatedAt,
 	}
 }
 

--- a/pkg/server/api/mcp/v1/types/cookie_banner.go
+++ b/pkg/server/api/mcp/v1/types/cookie_banner.go
@@ -25,21 +25,27 @@ import (
 	"go.probo.inc/probo/pkg/page"
 )
 
+func NewCookieBannerCapabilities(c coredata.CookieBannerCapabilities) *CookieBannerCapabilities {
+	return &CookieBannerCapabilities{
+		ResourceReporting: c.ResourceReporting,
+	}
+}
+
 func NewCookieBanner(b *coredata.CookieBanner) *CookieBanner {
 	return &CookieBanner{
-		ID:                       b.ID,
-		OrganizationID:           b.OrganizationID,
-		Name:                     b.Name,
-		Origin:                   b.Origin,
-		State:                    CookieBannerState(b.State),
-		PrivacyPolicyURL:         b.PrivacyPolicyURL,
-		CookiePolicyURL:          b.CookiePolicyURL,
-		ConsentExpiryDays:        b.ConsentExpiryDays,
-		ShowBranding:             b.ShowBranding,
-		ResourceReportingEnabled: b.ResourceReportingEnabled,
-		DefaultLanguage:          b.DefaultLanguage,
-		CreatedAt:                b.CreatedAt,
-		UpdatedAt:                b.UpdatedAt,
+		ID:                b.ID,
+		OrganizationID:    b.OrganizationID,
+		Name:              b.Name,
+		Origin:            b.Origin,
+		State:             CookieBannerState(b.State),
+		PrivacyPolicyURL:  b.PrivacyPolicyURL,
+		CookiePolicyURL:   b.CookiePolicyURL,
+		ConsentExpiryDays: b.ConsentExpiryDays,
+		ShowBranding:      b.ShowBranding,
+		Capabilities:      NewCookieBannerCapabilities(b.Capabilities),
+		DefaultLanguage:   b.DefaultLanguage,
+		CreatedAt:         b.CreatedAt,
+		UpdatedAt:         b.UpdatedAt,
 	}
 }
 


### PR DESCRIPTION
Cookie banner resource reporting moves from its own boolean column into a capabilities JSONB column, matching how the compliance portal already stores rights requests. Further flags can then be added without a column per flag.

Both resources now expose that shape through the API too: GraphQL and MCP replace the flat resourceReportingEnabled and rightsRequestsEnabled fields with a nested capabilities object, and the CLI, n8n node, console, and visitor portal follow. The browser-facing banner config keeps its flat resource_reporting_enabled key so already-released cookie banner SDKs keep working.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Nest capability flags under a capabilities object for cookie banners and compliance portals, replacing flat booleans. Updates now accept partial capability patches and scanning starts from defaults, so omitted flags keep their current values; the browser-facing banner config still exposes flat `resource_reporting_enabled` for SDKs.

### Coredata **`+177`** **`-45`**
- Add `CookieBannerCapabilities` JSONB column and type with defaults; migrate from `resource_reporting_enabled`, drop old column.
- Introduce `CookieBannerCapabilitiesPatch` and `CompliancePortalCapabilitiesPatch` with Apply; Scan starts from defaults to preserve missing keys.
- Replace banner field with `Capabilities`; update queries/inserts/updates to read/write JSON.

### GraphQL API **`+93`** **`-52`**
- Replace flat fields with nested `capabilities` types and inputs across console and visitor schemas.
- Resolvers map update inputs to capability patches so omitted fields don’t reset existing values.

### MCP **`+101`** **`-46`**
- Expose `capabilities` in resources and accept partial capability inputs in the spec.
- Resolvers apply capability patches to avoid resetting unknown flags.

### Service **`+30`** **`-30`**
- Use capabilities on create/update and when deciding resource reporting; apply capability patches.
- Keep banner config emitting flat `resource_reporting_enabled` for SDK compatibility.

### App: console **`+17`** **`-9`**
- Read/write nested `capabilities` in status and banner settings; updates send `capabilities` patches.

### App: compliance-portal **`+12`** **`-6`**
- Gate requests nav/page via `capabilities.rightsRequests`.

### Package: n8n-node **`+13`** **`-13`**
- Select nested `capabilities` in queries; update operations send `capabilities` input.

### prb (CLI) **`+39`** **`-27`**
- Update/view commands send/print nested `capabilities`; flags map to `capabilities` patches.

### Tests **`+191`** **`-45`**
- Add unit tests for capability Scan defaults and patch Apply; update e2e and fixtures to new shapes.

<sup>Written for commit 2a67ff91f82ed76b655dbb11bd64e81b43964244. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

