### PR TITLE
Add controls on mermaid diagrams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20141,6 +20141,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pan-zoom": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/svg-pan-zoom/-/svg-pan-zoom-3.6.2.tgz",
+      "integrity": "sha512-JwnvRWfVKw/Xzfe6jriFyfey/lWJLq4bUh2jwoR5ChWQuQoOH8FEh1l/bEp46iHHKHEJWIyFJETbazraxNWECg==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/tabbable": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
@@ -22981,6 +22987,7 @@
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
+        "svg-pan-zoom": "^3.6.2",
         "tailwind-merge": "^3.4.0",
         "tailwind-variants": "^3.3.0",
         "tailwindcss": "^4.3.1",

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -15,10 +15,13 @@
 import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
-  // v2 components have their own theme-isolated Storybook (.storybook-v2).
+  // v2 has its own Storybook (.storybook-v2). A "!../src/v2/**" stories
+  // entry does not ignore; Storybook treats each item as its own specifier.
   stories: [
-    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
-    "!../src/v2/**",
+    "../src/Atoms/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../src/Molecules/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../src/Layouts/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../src/*.stories.@(js|jsx|mjs|ts|tsx)",
   ],
   addons: [
     import.meta.resolve("@chromatic-com/storybook"),

--- a/packages/ui/.storybook/preview.css
+++ b/packages/ui/.storybook/preview.css
@@ -1,5 +1,21 @@
+/* Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
 @import url("https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "../src/theme.css";
 @source "../../helpers/src";
+@source not "../src/v2";

--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -16,7 +16,6 @@ import type { Preview } from "@storybook/react";
 import { useEffect } from "react";
 import { BrowserRouter } from "react-router";
 
-import "../src/theme.css";
 import "./preview.css";
 
 const preview: Preview = {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,6 +43,7 @@
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
+    "svg-pan-zoom": "^3.6.2",
     "tailwind-merge": "^3.4.0",
     "tailwind-variants": "^3.3.0",
     "tailwindcss": "^4.3.1",

--- a/packages/ui/src/Atoms/Markdown/Markdown.stories.tsx
+++ b/packages/ui/src/Atoms/Markdown/Markdown.stories.tsx
@@ -94,3 +94,31 @@ certum: tempora, telisque. In quaesitique habitavit nostris Scylaceaque potest
 omnia pastoribus meminisse ignara. Sed pando functaque perenni gemitus tibi.`,
   },
 };
+
+export const Mermaid: Story = {
+  args: {
+    content: `You can render UML diagrams using [Mermaid](https://mermaidjs.github.io/). For example, this will produce a sequence diagram:
+
+\`\`\`mermaid
+sequenceDiagram
+Alice ->> Bob: Hello Bob, how are you?
+Bob-->>John: How about you John?
+Bob--x Alice: I am good thanks!
+Bob-x John: I am good thanks!
+Note right of John: Bob thinks a long<br/>long time, so long<br/>that the text does<br/>not fit on a row.
+
+Bob-->Alice: Checking with John...
+Alice->John: Yes... John, how are you?
+\`\`\`
+
+And this will produce a flow chart:
+
+\`\`\`mermaid
+graph LR
+A[Square Rect] -- Link text --> B((Circle))
+A --> C(Round Rect)
+B --> D{Rhombus}
+C --> D
+\`\`\``,
+  },
+};

--- a/packages/ui/src/Atoms/Markdown/MermaidDiagram.tsx
+++ b/packages/ui/src/Atoms/Markdown/MermaidDiagram.tsx
@@ -18,79 +18,148 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { useEffect, useId, useState } from "react";
+import { CornersInIcon, CornersOutIcon } from "@phosphor-icons/react";
+import { clsx } from "clsx";
+import { memo, useCallback, useEffect, useId, useRef, useState } from "react";
+import svgPanZoom from "svg-pan-zoom";
 
 import { mermaidRenderErrorToast, renderMermaidDiagram } from "../../lib/mermaid";
+import { Button } from "../Button/Button";
+import { IconMinusLarge, IconPlusLarge, IconRotateCw } from "../Icons";
 import { useToast } from "../Toasts/Toasts";
+
+import { addMermaidInteractions } from "./MermaidInteractions";
 
 type Props = {
   chart: string;
 };
 
-type MermaidRenderState = {
-  source: string;
-  svg: string | null;
-  hasError: boolean;
-};
-
 export function MermaidDiagram({ chart }: Props) {
+  const svgRef = useRef<SVGElement>(null);
+  const zoomRef = useRef<SvgPanZoom.Instance>(null);
+  const wrapper = useRef<HTMLDivElement>(null);
+  const style = useRef("");
+  const [fullscreen, setFullScreen] = useState(false);
+
+  // Handle fullscreen state change
+  useEffect(() => {
+    function onFullscreenChange() {
+      const isFullScreen = document.fullscreenElement === wrapper.current;
+      svgRef.current?.setAttribute("style", isFullScreen ? "width: 100%; height: 100%;" : style.current);
+      zoomRef.current?.resize();
+      zoomRef.current?.reset();
+      setFullScreen(document.fullscreenElement === wrapper.current);
+    }
+
+    document.addEventListener("fullscreenchange", onFullscreenChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", onFullscreenChange);
+    };
+  }, []);
+
+  const zoomIn = () => {
+    zoomRef.current?.zoomIn();
+  };
+  const zoomOut = () => {
+    zoomRef.current?.zoomOut();
+  };
+  const zoomReset = () => {
+    zoomRef.current?.resetZoom();
+    zoomRef.current?.resetPan();
+  };
+  const toggleFullscreen = () => {
+    if (document.fullscreenElement === wrapper.current) {
+      document.exitFullscreen().catch(console.error);
+      return
+    }
+    wrapper.current?.requestFullscreen().catch(console.error);
+  };
+  const onSVGLoaded = useCallback((svg: SVGElement, zoom: SvgPanZoom.Instance) => {
+    svgRef.current = svg;
+    zoomRef.current = zoom;
+    style.current = svg.getAttribute("style") ?? "";
+  }, []);
+
+  if (!chart) {
+    return null;
+  }
+
+  return (
+    <div className={clsx("relative w-full")} ref={wrapper}>
+      <MermaidSVG
+        source={chart}
+        onSVG={onSVGLoaded}
+      />
+      <div className={clsx("flex flex-col gap-2 absolute", fullscreen ? "bottom-4 right-4" : "bottom-0 right-0")}>
+        <Button
+          icon={fullscreen ? CornersInIcon : CornersOutIcon}
+          onClick={toggleFullscreen}
+          variant="secondary"
+        />
+        <Button variant="secondary" icon={IconRotateCw} onClick={zoomReset} />
+        <Button variant="secondary" icon={IconPlusLarge} onClick={zoomIn} />
+        <Button variant="secondary" icon={IconMinusLarge} onClick={zoomOut} />
+      </div>
+    </div>
+  );
+}
+
+const MermaidSVG = memo(({ source, onSVG }: { source: string; onSVG: (el: SVGElement, zoom: SvgPanZoom.Instance) => void }) => {
   const id = useId().replace(/:/g, "");
-  const [renderState, setRenderState] = useState<MermaidRenderState>({
-    source: "",
-    svg: null,
-    hasError: false,
-  });
   const { toast } = useToast();
+  const [error, setError] = useState(false);
+  const div = useRef<HTMLDivElement>(null);
 
-  const source = (chart ?? "").trim();
-  const svg = renderState.source === source ? renderState.svg : null;
-  const hasError = renderState.source === source && renderState.hasError;
-
+  // Load and render mermaid SVG
   useEffect(() => {
     if (!source) {
       return;
     }
-
-    let cancelled = false;
-
+    let destroy = () => {};
     renderMermaidDiagram(`mermaid-${id}`, source)
-      .then((result) => {
-        if (!cancelled) {
-          setRenderState({
-            source,
-            svg: result.svg,
-            hasError: false,
-          });
+      .then((r) => {
+        const element = div.current;
+        if (!element || element.innerHTML) {
+          return;
         }
+        element.innerHTML = r.svg;
+        r.bindFunctions?.(element);
+        const svg = element.firstElementChild;
+        if (!(svg instanceof SVGElement)) {
+          return;
+        }
+        const { width, height } = svg.getBoundingClientRect();
+        svg.style.aspectRatio = `${width}/${height}`;
+        svg.style.minHeight = "200px";
+        const zoom = svgPanZoom(svg);
+        const removeInteractions = addMermaidInteractions(svg);
+        destroy = () => {
+          zoom.destroy();
+          removeInteractions();
+        };
+        onSVG(svg, zoom);
       })
       .catch(() => {
-        if (!cancelled) {
-          setRenderState({
-            source,
-            svg: null,
-            hasError: true,
-          });
-          toast(mermaidRenderErrorToast);
-        }
+        setError(true);
+        toast(mermaidRenderErrorToast);
       });
 
     return () => {
-      cancelled = true;
+      destroy();
     };
-  }, [source, id, toast]);
+  }, [source, id, toast, onSVG]);
 
-  if (hasError) {
+  if (error) {
     return (
       <pre className="border border-border-solid rounded p-4 bg-transparent font-mono text-sm overflow-x-auto text-inherit">
-        <code>{chart}</code>
+        <code>{source}</code>
       </pre>
     );
   }
 
   return (
-    <div
-      className="flex justify-center my-4"
-      dangerouslySetInnerHTML={svg ? { __html: svg } : undefined}
-    />
+    <div id={id} className="contents" ref={div} />
   );
-}
+});
+
+MermaidSVG.displayName = "MermaidSVG";

--- a/packages/ui/src/Atoms/Markdown/MermaidDiagram.tsx
+++ b/packages/ui/src/Atoms/Markdown/MermaidDiagram.tsx
@@ -70,7 +70,7 @@ export function MermaidDiagram({ chart }: Props) {
   const toggleFullscreen = () => {
     if (document.fullscreenElement === wrapper.current) {
       document.exitFullscreen().catch(console.error);
-      return
+      return;
     }
     wrapper.current?.requestFullscreen().catch(console.error);
   };

--- a/packages/ui/src/Atoms/Markdown/MermaidInteractions.ts
+++ b/packages/ui/src/Atoms/Markdown/MermaidInteractions.ts
@@ -1,0 +1,142 @@
+const DIMMED_OPACITY = "0.3";
+const EMPHASIZED_OPACITY = "1";
+
+type Edge = {
+  id: string;
+  elements: SVGElement[];
+  nodeIDs: [string, string] | null;
+};
+
+// Extract Mermaid's logical node ID from either its data attribute or flowchart DOM ID.
+function getNodeID(node: SVGElement) {
+  // Some Mermaid diagram types expose the logical ID directly.
+  const nodeID = node.getAttribute("data-id");
+  if (nodeID) {
+    return nodeID;
+  }
+
+  // Flowcharts encode it as "...-flowchart-<node ID>-<index>".
+  const id = node.getAttribute("id");
+  return id?.match(/(?:^|-)flowchart-(.+)-\d+$/)?.[1] ?? null;
+}
+
+// Resolve an edge's endpoints by matching Mermaid's L_<source>_<target>_<index> ID.
+function getEdgeNodeIDs(edgeID: string, nodeIDs: string[]) {
+  // Testing known IDs keeps node names containing underscores supported.
+  for (const sourceID of nodeIDs) {
+    for (const targetID of nodeIDs) {
+      if (edgeID.startsWith(`L_${sourceID}_${targetID}_`)) {
+        return [sourceID, targetID] as [string, string];
+      }
+    }
+  }
+
+  return null;
+}
+
+export function addMermaidInteractions(svg: SVGElement) {
+  // Collect nodes and their logical IDs once
+  const nodes = [...svg.querySelectorAll<SVGElement>(".node")];
+  const nodeIDs = nodes.map(getNodeID).filter((id): id is string => id !== null);
+  const edgeElements = [...svg.querySelectorAll<SVGElement>("[data-edge='true']")];
+  // Index edges by ID so clicks on an edge label resolve to the rendered path as well.
+  const edgesByID = new Map<string, Edge>();
+  for (const element of edgeElements) {
+    const id = element.getAttribute("data-id");
+    if (!id) {
+      continue;
+    }
+
+    edgesByID.set(id, {
+      id,
+      elements: [
+        element,
+        // Edge labels are separate SVG groups and must fade with their path.
+        ...svg.querySelectorAll<SVGElement>(`.edgeLabels [data-id='${id}']`),
+      ],
+      nodeIDs: getEdgeNodeIDs(id, nodeIDs),
+    });
+  }
+
+  const visualElements = [
+    ...nodes,
+    ...[...edgesByID.values()].flatMap(edge => edge.elements),
+  ];
+  // Preserve Mermaid's inline styles so reset restores the exact initial rendering.
+  const initialStyles = new Map(
+    visualElements.map(element => [element, element.getAttribute("style")]),
+  );
+
+  // Restore all interactive elements to their original Mermaid styles.
+  function reset() {
+    for (const element of visualElements) {
+      const initialStyle = initialStyles.get(element);
+      if (initialStyle === null) {
+        element.removeAttribute("style");
+      } else {
+        element.setAttribute("style", initialStyle ?? "");
+      }
+    }
+  }
+
+  // Dim the full graph, except for the supplied nodes and edges.
+  function emphasize(nodeIDsToEmphasize: Set<string>, edgeIDsToEmphasize: Set<string>) {
+    for (const node of nodes) {
+      const isEmphasized = nodeIDsToEmphasize.has(getNodeID(node) ?? "");
+      node.style.opacity = isEmphasized ? EMPHASIZED_OPACITY : DIMMED_OPACITY;
+    }
+
+    for (const edge of edgesByID.values()) {
+      const isEmphasized = edgeIDsToEmphasize.has(edge.id);
+      for (const element of edge.elements) {
+        element.style.opacity = isEmphasized ? EMPHASIZED_OPACITY : DIMMED_OPACITY;
+      }
+    }
+  }
+
+  // Use one SVG-level listener so clicks on nested labels and shapes behave consistently.
+  function onClick(event: MouseEvent) {
+    if (!(event.target instanceof Element)) {
+      reset();
+      return;
+    }
+
+    const node = event.target.closest(".node");
+    if (node instanceof SVGElement && svg.contains(node)) {
+      const nodeID = getNodeID(node);
+      if (!nodeID) {
+        reset();
+        return;
+      }
+
+      // A node selection includes every directly connected node and its incident edges.
+      const associatedEdges = [...edgesByID.values()].filter(edge => edge.nodeIDs?.includes(nodeID));
+      emphasize(
+        new Set([nodeID, ...associatedEdges.flatMap(edge => edge.nodeIDs ?? [])]),
+        new Set(associatedEdges.map(edge => edge.id)),
+      );
+      return;
+    }
+
+    const edgeElement = event.target.closest("[data-edge='true'], .edgeLabels [data-id]");
+    const edgeID = edgeElement?.getAttribute("data-id");
+    const edge = edgeID ? edgesByID.get(edgeID) : undefined;
+    if (edge?.nodeIDs) {
+      // An edge selection only keeps that edge and its two endpoint nodes visible.
+      emphasize(new Set(edge.nodeIDs), new Set([edge.id]));
+      return;
+    }
+
+    // Clicking the SVG background clears the active selection.
+    reset();
+  }
+
+  // Attach the delegated click handler after Mermaid has populated the SVG.
+  svg.addEventListener("click", onClick);
+
+  // Let the caller remove the listener and restore the diagram when it unmounts.
+  return () => {
+    svg.removeEventListener("click", onClick);
+    reset();
+  };
+}

--- a/packages/ui/src/RichEditor/MermaidNodeView.tsx
+++ b/packages/ui/src/RichEditor/MermaidNodeView.tsx
@@ -5,96 +5,11 @@
 import { CodeIcon, EyeIcon } from "@phosphor-icons/react";
 import type { ReactNodeViewProps } from "@tiptap/react";
 import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
-import { useEffect, useId, useState } from "react";
+import { useState } from "react";
 
-import { useToast } from "../Atoms/Toasts/Toasts";
-import { mermaidRenderErrorToast, renderMermaidDiagram } from "../lib/mermaid";
+import { MermaidDiagram } from "../Atoms/Markdown/MermaidDiagram";
 
 type MermaidMode = "code" | "preview";
-
-type MermaidRenderState = {
-  source: string;
-  svg: string | null;
-  hasError: boolean;
-};
-
-function MermaidPreview({ chart }: { chart: string }) {
-  const id = useId().replace(/:/g, "");
-  const [renderState, setRenderState] = useState<MermaidRenderState>({
-    source: "",
-    svg: null,
-    hasError: false,
-  });
-  const { toast } = useToast();
-
-  const source = chart.trim();
-  const svg = renderState.source === source ? renderState.svg : null;
-  const hasError = renderState.source === source && renderState.hasError;
-
-  useEffect(() => {
-    if (source.length === 0) {
-      return;
-    }
-
-    let cancelled = false;
-
-    renderMermaidDiagram(`mermaid-editor-${id}`, source)
-      .then((result) => {
-        if (!cancelled) {
-          setRenderState({
-            source,
-            svg: result.svg,
-            hasError: false,
-          });
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setRenderState({
-            source,
-            svg: null,
-            hasError: true,
-          });
-          toast(mermaidRenderErrorToast);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [source, id, toast]);
-
-  if (source.length === 0) {
-    return (
-      <div className="mermaid-empty">
-        No diagram to display
-      </div>
-    );
-  }
-
-  if (hasError) {
-    return (
-      <div className="mermaid-error">
-        Unable to render diagram. Check the syntax and try again.
-      </div>
-    );
-  }
-
-  if (!svg) {
-    return (
-      <div className="mermaid-empty">
-        Rendering...
-      </div>
-    );
-  }
-
-  return (
-    <div
-      className="mermaid-preview"
-      dangerouslySetInnerHTML={{ __html: svg }}
-    />
-  );
-}
 
 export function MermaidNodeView({ node }: ReactNodeViewProps) {
   const isMermaid = node.attrs.language === "mermaid";
@@ -143,7 +58,7 @@ function MermaidBlock({ node }: { node: ReactNodeViewProps["node"] }) {
         </pre>
 
         {mode === "preview" && (
-          <MermaidPreview chart={node.textContent} />
+          <MermaidDiagram chart={node.textContent.trim()} />
         )}
       </div>
     </NodeViewWrapper>

--- a/packages/ui/src/rich-editor.css
+++ b/packages/ui/src/rich-editor.css
@@ -103,6 +103,11 @@
         pre {
             @apply my-0 rounded-lg border-none;
         }
+
+        svg {
+            max-width: none!important;
+            aspect-ratio: none!important;
+        }
     }
 
     .mermaid-toolbar {
@@ -123,19 +128,4 @@
         }
     }
 
-    .mermaid-preview {
-        @apply flex justify-center p-6 min-h-24;
-
-        svg {
-            @apply max-w-full h-auto;
-        }
-    }
-
-    .mermaid-error {
-        @apply p-4 text-sm font-mono text-txt-danger;
-    }
-
-    .mermaid-empty {
-        @apply p-4 text-sm text-txt-tertiary text-center;
-    }
 }


### PR DESCRIPTION
Add controls to better visualize mermaid graphs inside markdown content

- Zoom and Pan with mouse support
- Zoom using buttons
- Fullscreen mode
- Highlight on node click for chart graph

I chose to use a simpler library than d3 to limit the footprint for this first version. 

<img width="711" height="282" alt="image" src="https://github.com/user-attachments/assets/709c61d4-0399-4042-b71d-ae0b9833b007" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pan/zoom controls, fullscreen, and click-to-highlight for Mermaid diagrams in Markdown and the TipTap editor preview. Previously diagrams were static; now users can zoom via mouse or toolbar, reset, toggle fullscreen, and highlight nodes/edges, with background click clearing the selection.

### Package: `ui` **`+313`** **`-150`**
Introduces a shared `MermaidDiagram` that uses `svg-pan-zoom`, adds a compact toolbar (zoom in/out, reset, fullscreen), preserves SVG aspect ratio with a minimum height, and handles fullscreen lifecycle. Adds delegated click interactions to emphasize a node with its neighbors and connecting edges, or an edge with its endpoints; background click resets. Replaces the editor’s custom preview with `MermaidDiagram` and simplifies related CSS (override global SVG sizing constraints). Updates Storybook to scope v1 stories (Atoms/Molecules/Layouts, root) and moves the theme import to `preview.css`. Adds Markdown stories with Mermaid examples.

### Other **`+7`** **`-0`**
Updates the lockfile to add the `svg-pan-zoom` dependency.

<sup>Written for commit c0c79e476245ad388de25cedd174a07a1ce44f84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

