### PR TITLE
Add MCP listRiskMeasures for risk to measure lookup

### DIFF
--- a/cmd/probod/CHANGELOG.md
+++ b/cmd/probod/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `probod` (the server, including the bundled `@probo/conso
 
 ## Unreleased
 
+### Added
+
+- MCP `listRiskMeasures` tool to list measures linked to a risk (reverse of `listMeasureRisks`), so callers can discover links to unlink before `deleteRisk`.
+
 ## [0.259.0] - 2026-08-13
 
 ### Added

--- a/cmd/probod/CHANGELOG.md
+++ b/cmd/probod/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to `probod` (the server, including the bundled `@probo/conso
 
 - MCP `listRiskMeasures` tool to list measures linked to a risk (reverse of `listMeasureRisks`), so callers can discover links to unlink before `deleteRisk`.
 
+### Fixed
+
+- Deleting a risk that still has linked measures, documents, or other references now returns a clear "resource is in use" error instead of an opaque internal error.
+
 ## [0.259.0] - 2026-08-13
 
 ### Added

--- a/e2e/mcp/risk_test.go
+++ b/e2e/mcp/risk_test.go
@@ -121,3 +121,76 @@ func TestMCP_Risk_PermissionDenied(t *testing.T) {
 	})
 	assert.Contains(t, msg, "permission denied")
 }
+
+func TestMCP_Risk_ListMeasures(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	mc := testutil.NewMCPClient(t, owner)
+	orgID := owner.GetOrganizationID().String()
+
+	var riskResult struct {
+		Risk struct {
+			ID string `json:"id"`
+		} `json:"risk"`
+	}
+	mc.CallToolInto("addRisk", map[string]any{
+		"organization_id":     orgID,
+		"name":                factory.SafeName("Risk"),
+		"category":            "SECURITY",
+		"treatment":           "MITIGATED",
+		"inherent_likelihood": 2,
+		"inherent_impact":     2,
+	}, &riskResult)
+	require.NotEmpty(t, riskResult.Risk.ID)
+
+	var measureResult struct {
+		Measure struct {
+			ID string `json:"id"`
+		} `json:"measure"`
+	}
+	mc.CallToolInto("addMeasure", map[string]any{
+		"organization_id": orgID,
+		"name":            factory.SafeName("Measure"),
+		"category":        "POLICY",
+	}, &measureResult)
+	require.NotEmpty(t, measureResult.Measure.ID)
+
+	var emptyList struct {
+		Measures []struct {
+			ID string `json:"id"`
+		} `json:"measures"`
+	}
+	mc.CallToolInto("listRiskMeasures", map[string]any{
+		"risk_id": riskResult.Risk.ID,
+	}, &emptyList)
+	assert.Empty(t, emptyList.Measures)
+
+	mc.CallToolInto("linkMeasure", map[string]any{
+		"measure_id":  measureResult.Measure.ID,
+		"resource_id": riskResult.Risk.ID,
+	}, &struct{}{})
+
+	var linkedList struct {
+		Measures []struct {
+			ID string `json:"id"`
+		} `json:"measures"`
+	}
+	mc.CallToolInto("listRiskMeasures", map[string]any{
+		"risk_id": riskResult.Risk.ID,
+	}, &linkedList)
+	require.Len(t, linkedList.Measures, 1)
+	assert.Equal(t, measureResult.Measure.ID, linkedList.Measures[0].ID)
+
+	mc.CallToolInto("unlinkMeasure", map[string]any{
+		"measure_id":  measureResult.Measure.ID,
+		"resource_id": riskResult.Risk.ID,
+	}, &struct{}{})
+
+	var deleteResult struct {
+		DeletedRiskID string `json:"deleted_risk_id"`
+	}
+	mc.CallToolInto("deleteRisk", map[string]any{
+		"id": riskResult.Risk.ID,
+	}, &deleteResult)
+	assert.Equal(t, riskResult.Risk.ID, deleteResult.DeletedRiskID)
+}

--- a/e2e/mcp/risk_test.go
+++ b/e2e/mcp/risk_test.go
@@ -181,6 +181,11 @@ func TestMCP_Risk_ListMeasures(t *testing.T) {
 	require.Len(t, linkedList.Measures, 1)
 	assert.Equal(t, measureResult.Measure.ID, linkedList.Measures[0].ID)
 
+	msg := mc.CallToolExpectToolError("deleteRisk", map[string]any{
+		"id": riskResult.Risk.ID,
+	})
+	assert.Equal(t, "resource is in use", msg)
+
 	mc.CallToolInto("unlinkMeasure", map[string]any{
 		"measure_id":  measureResult.Measure.ID,
 		"resource_id": riskResult.Risk.ID,

--- a/pkg/coredata/risk.go
+++ b/pkg/coredata/risk.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam/policy"
@@ -677,8 +678,17 @@ DELETE FROM risks WHERE %s AND id = @id
 	maps.Copy(args, scope.SQLArguments())
 
 	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+			if pgErr.Code == "23503" || pgErr.Code == "23001" {
+				return ErrResourceInUse
+			}
+		}
 
-	return err
+		return fmt.Errorf("cannot delete risk: %w", err)
+	}
+
+	return nil
 }
 
 func (r *Risks) CountByDocumentID(

--- a/pkg/server/api/console/v1/risk_resolvers.go
+++ b/pkg/server/api/console/v1/risk_resolvers.go
@@ -110,7 +110,12 @@ func (r *mutationResolver) DeleteRisk(ctx context.Context, input types.DeleteRis
 	}
 
 	if err := r.probo.Risks.Delete(ctx, scope, input.RiskID); err != nil {
+		if errors.Is(err, coredata.ErrResourceInUse) {
+			return nil, gqlutils.Conflict(ctx, err)
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot delete risk", log.Error(err))
+
 		return nil, gqlutils.Internal(ctx)
 	}
 

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2558,6 +2558,10 @@ func (r *Resolver) DeleteRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 
 	err = svc.Risks.Delete(ctx, scope, input.ID)
 	if err != nil {
+		if errors.Is(err, coredata.ErrResourceInUse) {
+			return nil, types.DeleteRiskOutput{}, coredata.ErrResourceInUse
+		}
+
 		return nil, types.DeleteRiskOutput{}, fmt.Errorf("failed to delete risk: %w", err)
 	}
 

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -1937,6 +1937,36 @@ func (r *Resolver) ListRiskObligationsTool(ctx context.Context, req *mcp.CallToo
 	return nil, types.NewListRiskObligationsOutput(obligationPage), nil
 }
 
+func (r *Resolver) ListRiskMeasuresTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRiskMeasuresInput) (*mcp.CallToolResult, types.ListRiskMeasuresOutput, error) {
+	scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskGet)
+	if err != nil {
+		return nil, types.ListRiskMeasuresOutput{}, err
+	}
+
+	prb := r.proboSvc
+
+	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
+		Field:     coredata.MeasureOrderFieldCreatedAt,
+		Direction: page.OrderDirectionDesc,
+	}
+
+	if input.OrderBy != nil {
+		pageOrderBy = page.OrderBy[coredata.MeasureOrderField]{
+			Field:     input.OrderBy.Field,
+			Direction: input.OrderBy.Direction,
+		}
+	}
+
+	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
+
+	measurePage, err := prb.Measures.ListForRiskID(ctx, scope, input.RiskID, cursor, coredata.NewMeasureFilter(nil, nil, nil))
+	if err != nil {
+		return nil, types.ListRiskMeasuresOutput{}, fmt.Errorf("failed to list risk measures: %w", err)
+	}
+
+	return nil, types.NewListRiskMeasuresOutput(measurePage), nil
+}
+
 func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkRiskInput) (*mcp.CallToolResult, types.LinkRiskOutput, error) {
 	svc := r.proboSvc
 

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -6529,6 +6529,37 @@ components:
           items:
             $ref: "#/components/schemas/Obligation"
 
+    ListRiskMeasuresInput:
+      type: object
+      required:
+        - risk_id
+      properties:
+        risk_id:
+          $ref: "#/components/schemas/GID"
+          description: Risk ID
+        cursor:
+          $ref: "#/components/schemas/CursorKey"
+          description: Page cursor
+        size:
+          type: integer
+          description: Page size
+        order_by:
+          $ref: "#/components/schemas/MeasureOrderBy"
+          description: Measure order by
+
+    ListRiskMeasuresOutput:
+      type: object
+      required:
+        - measures
+      properties:
+        next_cursor:
+          $ref: "#/components/schemas/CursorKey"
+          description: Next cursor
+        measures:
+          type: array
+          items:
+            $ref: "#/components/schemas/Measure"
+
     LinkRiskInput:
       type: object
       required:
@@ -16284,6 +16315,18 @@ tools:
       $ref: "#/components/schemas/ListRiskObligationsInput"
     outputSchema:
       $ref: "#/components/schemas/ListRiskObligationsOutput"
+  - name: listRiskMeasures
+    title: List Risk Measures
+    description: List measures linked to a risk
+    hints:
+      readonly: true
+      destructive: false
+      idempotent: true
+      openWorld: false
+    inputSchema:
+      $ref: "#/components/schemas/ListRiskMeasuresInput"
+    outputSchema:
+      $ref: "#/components/schemas/ListRiskMeasuresOutput"
   - name: linkRisk
     title: Link Risk
     description: Link a risk to a resource (document, measure, or obligation). The resource type is determined from the resource_id GID.

--- a/pkg/server/api/mcp/v1/types/measure.go
+++ b/pkg/server/api/mcp/v1/types/measure.go
@@ -56,6 +56,25 @@ func NewListControlMeasuresOutput(measurePage *page.Page[*coredata.Measure, core
 	}
 }
 
+func NewListRiskMeasuresOutput(measurePage *page.Page[*coredata.Measure, coredata.MeasureOrderField]) ListRiskMeasuresOutput {
+	measures := make([]*Measure, 0, len(measurePage.Data))
+	for _, v := range measurePage.Data {
+		measures = append(measures, NewMeasure(v))
+	}
+
+	var nextCursor *page.CursorKey
+
+	if len(measurePage.Data) > 0 {
+		cursorKey := measurePage.Data[len(measurePage.Data)-1].CursorKey(measurePage.Cursor.OrderBy.Field)
+		nextCursor = &cursorKey
+	}
+
+	return ListRiskMeasuresOutput{
+		NextCursor: nextCursor,
+		Measures:   measures,
+	}
+}
+
 func NewListMeasuresOutput(measurePage *page.Page[*coredata.Measure, coredata.MeasureOrderField]) ListMeasuresOutput {
 	measures := make([]*Measure, 0, len(measurePage.Data))
 	for _, v := range measurePage.Data {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds MCP `listRiskMeasures` so clients can find linked measures before `deleteRisk`. Deleting a risk with links now returns a clear "resource is in use" conflict instead of an internal error; this is the reverse lookup of `listMeasureRisks`.

### Tests **`+78`** **`-0`**
End-to-end coverage for risk→measure listing, link/unlink, and the conflict error on `deleteRisk`.

### Coredata **`+11`** **`-1`**
`Risks.Delete` maps FK restrict errors (`23503`/`23001`) to `ErrResourceInUse` and wraps unexpected errors with context.

### GraphQL API **`+5`** **`-0`**
`DeleteRisk` returns a conflict when `coredata.ErrResourceInUse` occurs instead of an internal error.

### MCP **`+96`** **`-0`**
Adds `listRiskMeasures` with paging and `order_by`, including resolver and output builder; updates spec with `ListRiskMeasuresInput`/`Output`; `DeleteRiskTool` surfaces `coredata.ErrResourceInUse` to clients.

### Other **`+8`** **`-0`**
Updates `probod` changelog with the new tool and clearer delete error behavior.

<sup>Written for commit 1ae303d75944180d7572112b73ea6bbc0253a158. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

