### PR TITLE
Add matrix size to risk analyses

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -2236,14 +2236,16 @@
     "deleteConfirmation": "This will permanently delete this risk assessment and all its diagrams, nodes, processes, and threats. This action cannot be undone.",
     "actions": { "edit": "Edit", "delete": "Delete" },
     "details": "Details",
-    "fields": { "period": "Period", "createdAt": "Created at", "updatedAt": "Updated at" },
+    "fields": { "period": "Period", "matrixSize": "Matrix size", "createdAt": "Created at", "updatedAt": "Updated at" },
+    "matrixSizes": { "3x3": "3×3", "4x4": "4×4", "5x5": "5×5" },
     "diagrams": "Diagrams",
     "emptyDiagrams": "No diagrams yet. Create a diagram to start defining nodes, processes, and threats."
   },
   "riskAnalysesPage": {
     "title": "Risk Analyses",
     "description": "Manage risk analyses with diagrams, nodes, processes, threats, and scenarios.",
-    "columns": { "name": "Name", "description": "Description", "period": "Period", "created": "Created" }
+    "columns": { "name": "Name", "description": "Description", "period": "Period", "matrixSize": "Matrix", "created": "Created" },
+    "matrixSizes": { "3x3": "3×3", "4x4": "4×4", "5x5": "5×5" }
   },
   "riskAnalysisBoundaryActions": {
     "breadcrumb": { "boundaries": "Boundaries" },
@@ -2278,12 +2280,14 @@
   "createRiskAnalysisDialog": {
     "title": "New Risk Analysis",
     "breadcrumb": { "riskAnalyses": "Risk Analyses" },
-    "fields": { "name": "Name", "description": "Description", "periodStart": "Period start", "periodEnd": "Period end" },
+    "fields": { "name": "Name", "description": "Description", "matrixSize": "Matrix size", "periodStart": "Period start", "periodEnd": "Period end" },
+    "matrixSizes": { "3x3": "3×3", "4x4": "4×4", "5x5": "5×5" },
     "validation": {
       "nameRequired": "This field is required",
       "periodStartRequired": "This field is required",
       "periodEndRequired": "This field is required",
-      "periodEndBeforeStart": "Period end must be on or after period start"
+      "periodEndBeforeStart": "Period end must be on or after period start",
+      "matrixSizeRequired": "Matrix size is required"
     },
     "placeholders": { "name": "e.g. Platform Threat Model 2026", "description": "Describe the scope and purpose of this assessment..." },
     "actions": { "create": "Create" }
@@ -2291,7 +2295,8 @@
   "updateRiskAnalysisDialog": {
     "title": "Edit Risk Analysis",
     "breadcrumb": { "riskAnalyses": "Risk Analyses" },
-    "fields": { "name": "Name", "description": "Description", "periodStart": "Period start", "periodEnd": "Period end" },
+    "fields": { "name": "Name", "description": "Description", "matrixSize": "Matrix size", "periodStart": "Period start", "periodEnd": "Period end" },
+    "matrixSizes": { "3x3": "3×3", "4x4": "4×4", "5x5": "5×5" },
     "validation": {
       "nameRequired": "This field is required",
       "periodEndBeforeStart": "Period end must be on or after period start"

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -4750,8 +4750,14 @@
     "details": "Détails",
     "fields": {
       "period": "Période",
+      "matrixSize": "Taille de matrice",
       "createdAt": "Créé le",
       "updatedAt": "Mis à jour le"
+    },
+    "matrixSizes": {
+      "3x3": "3×3",
+      "4x4": "4×4",
+      "5x5": "5×5"
     },
     "diagrams": "Diagrammes",
     "emptyDiagrams": "Aucun diagramme pour l’instant. Créez un diagramme pour commencer à définir des nœuds, des processus et des menaces."
@@ -4763,7 +4769,13 @@
       "name": "Nom",
       "description": "Description",
       "period": "Période",
+      "matrixSize": "Matrice",
       "created": "Créé le"
+    },
+    "matrixSizes": {
+      "3x3": "3×3",
+      "4x4": "4×4",
+      "5x5": "5×5"
     }
   },
   "riskAnalysisBoundaryActions": {
@@ -4855,14 +4867,21 @@
     "fields": {
       "name": "Nom",
       "description": "Description",
+      "matrixSize": "Taille de matrice",
       "periodStart": "Début de période",
       "periodEnd": "Fin de période"
+    },
+    "matrixSizes": {
+      "3x3": "3×3",
+      "4x4": "4×4",
+      "5x5": "5×5"
     },
     "validation": {
       "nameRequired": "Ce champ est requis",
       "periodStartRequired": "Ce champ est requis",
       "periodEndRequired": "Ce champ est requis",
-      "periodEndBeforeStart": "La fin de période doit être égale ou postérieure au début"
+      "periodEndBeforeStart": "La fin de période doit être égale ou postérieure au début",
+      "matrixSizeRequired": "La taille de matrice est requise"
     },
     "placeholders": {
       "name": "ex. Modèle de menace de la plateforme 2026",
@@ -4880,8 +4899,14 @@
     "fields": {
       "name": "Nom",
       "description": "Description",
+      "matrixSize": "Taille de matrice",
       "periodStart": "Début de période",
       "periodEnd": "Fin de période"
+    },
+    "matrixSizes": {
+      "3x3": "3×3",
+      "4x4": "4×4",
+      "5x5": "5×5"
     },
     "validation": {
       "nameRequired": "Ce champ est requis",

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -4746,8 +4746,14 @@
     "details": "Details",
     "fields": {
       "period": "Periode",
+      "matrixSize": "Matrixgrootte",
       "createdAt": "Aangemaakt op",
       "updatedAt": "Bijgewerkt op"
+    },
+    "matrixSizes": {
+      "3x3": "3×3",
+      "4x4": "4×4",
+      "5x5": "5×5"
     },
     "diagrams": "Diagrammen",
     "emptyDiagrams": "Nog geen diagrammen. Maak een diagram aan om nodes, processen en dreigingen te definiëren."
@@ -4759,7 +4765,13 @@
       "name": "Naam",
       "description": "Beschrijving",
       "period": "Periode",
+      "matrixSize": "Matrix",
       "created": "Aangemaakt"
+    },
+    "matrixSizes": {
+      "3x3": "3×3",
+      "4x4": "4×4",
+      "5x5": "5×5"
     }
   },
   "riskAnalysisBoundaryActions": {
@@ -4851,14 +4863,21 @@
     "fields": {
       "name": "Naam",
       "description": "Beschrijving",
+      "matrixSize": "Matrixgrootte",
       "periodStart": "Periode start",
       "periodEnd": "Periode eind"
+    },
+    "matrixSizes": {
+      "3x3": "3×3",
+      "4x4": "4×4",
+      "5x5": "5×5"
     },
     "validation": {
       "nameRequired": "Dit veld is verplicht",
       "periodStartRequired": "Dit veld is verplicht",
       "periodEndRequired": "Dit veld is verplicht",
-      "periodEndBeforeStart": "Periode eind moet op of na periode start liggen"
+      "periodEndBeforeStart": "Periode eind moet op of na periode start liggen",
+      "matrixSizeRequired": "Matrixgrootte is verplicht"
     },
     "placeholders": {
       "name": "bijv. Platform Dreigingsmodel 2026",
@@ -4876,8 +4895,14 @@
     "fields": {
       "name": "Naam",
       "description": "Beschrijving",
+      "matrixSize": "Matrixgrootte",
       "periodStart": "Periode start",
       "periodEnd": "Periode eind"
+    },
+    "matrixSizes": {
+      "3x3": "3×3",
+      "4x4": "4×4",
+      "5x5": "5×5"
     },
     "validation": {
       "nameRequired": "Dit veld is verplicht",

--- a/apps/console/src/components/form/ControlledField.tsx
+++ b/apps/console/src/components/form/ControlledField.tsx
@@ -35,13 +35,15 @@ export function ControlledField<
 >({
   control,
   name,
+  rules,
   ...props
 }: Props<typeof Field, TFieldValues, TName>) {
   return (
     <Controller<TFieldValues, TName>
       control={control}
       name={name}
-      render={({ field }) => (
+      rules={rules}
+      render={({ field, fieldState }) => (
         <>
           <Field
             {...props}
@@ -49,6 +51,7 @@ export function ControlledField<
             // TODO : Find a better way to handle this case (comparing number and string for select create issues)
             value={field.value ? (field.value as readonly string[] | string | number).toString() : ""}
             onValueChange={field.onChange}
+            error={fieldState.error?.message ?? props.error}
           />
         </>
       )}

--- a/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysesPage.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysesPage.tsx
@@ -43,6 +43,7 @@ import { SortableTable, SortableTh } from "#/components/SortableTable";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 
 import { CreateRiskAnalysisDialog } from "./_components/CreateRiskAnalysisDialog";
+import { formatMatrixSize } from "./_components/matrixSize";
 
 export const riskAnalysesPageQuery = graphql`
   query RiskAnalysesPageQuery($organizationId: ID!) {
@@ -89,6 +90,10 @@ const riskAnalysesFragment = graphql`
           period {
             start
             end
+          }
+          matrixSize {
+            rows
+            cols
           }
           createdAt
         }
@@ -153,6 +158,7 @@ export default function RiskAnalysesPage({ queryRef }: RiskAnalysesPageProps) {
             <SortableTh field="NAME">{t("riskAnalysesPage.columns.name")}</SortableTh>
             <Th>{t("riskAnalysesPage.columns.description")}</Th>
             <Th>{t("riskAnalysesPage.columns.period")}</Th>
+            <Th>{t("riskAnalysesPage.columns.matrixSize")}</Th>
             <SortableTh field="CREATED_AT">{t("riskAnalysesPage.columns.created")}</SortableTh>
           </Tr>
         </Thead>
@@ -170,6 +176,9 @@ export default function RiskAnalysesPage({ queryRef }: RiskAnalysesPageProps) {
                 {ra.period
                   ? `${ra.period.start ? dateFormat(i18n.language, ra.period.start) : "—"} – ${ra.period.end ? dateFormat(i18n.language, ra.period.end) : "—"}`
                   : "—"}
+              </Td>
+              <Td className="text-txt-secondary">
+                {formatMatrixSize(ra.matrixSize.rows, ra.matrixSize.cols)}
               </Td>
               <Td className="text-txt-secondary">
                 {dateFormat(i18n.language, ra.createdAt)}

--- a/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysisDetailPage.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysisDetailPage.tsx
@@ -47,6 +47,7 @@ import { useOrganizationId } from "#/hooks/useOrganizationId";
 
 import { CreateDiagramDialog } from "./_components/CreateDiagramDialog";
 import { DiagramCard } from "./_components/DiagramCard";
+import { formatMatrixSize } from "./_components/matrixSize";
 import { UpdateRiskAnalysisDialog } from "./_components/UpdateRiskAnalysisDialog";
 
 export const riskAnalysisDetailPageQuery = graphql`
@@ -59,6 +60,10 @@ export const riskAnalysisDetailPageQuery = graphql`
         period {
           start
           end
+        }
+        matrixSize {
+          rows
+          cols
         }
         createdAt
         updatedAt
@@ -180,6 +185,7 @@ export default function RiskAnalysisDetailPage({ queryRef }: RiskAnalysisDetailP
                   name: ra.name ?? "",
                   description: ra.description,
                   period: ra.period,
+                  matrixSize: ra.matrixSize,
                 }}
                 canDelete={ra.canDelete}
                 onDelete={handleDelete}
@@ -206,13 +212,21 @@ export default function RiskAnalysisDetailPage({ queryRef }: RiskAnalysisDetailP
           {ra.description && (
             <div className="text-sm text-txt-secondary">{ra.description}</div>
           )}
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
             <div>
               <div className="text-xs text-txt-tertiary font-semibold mb-1">
                 {t("riskAnalysisDetailPage.fields.period")}
               </div>
               <div className="text-sm text-txt-primary">
                 {periodLabel}
+              </div>
+            </div>
+            <div>
+              <div className="text-xs text-txt-tertiary font-semibold mb-1">
+                {t("riskAnalysisDetailPage.fields.matrixSize")}
+              </div>
+              <div className="text-sm text-txt-primary">
+                {formatMatrixSize(ra.matrixSize.rows, ra.matrixSize.cols)}
               </div>
             </div>
             <div>

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_components/CreateRiskAnalysisDialog.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_components/CreateRiskAnalysisDialog.tsx
@@ -28,6 +28,7 @@ import {
   Field,
   IconPlusLarge,
   Input,
+  Option,
   useDialogRef,
 } from "@probo/ui";
 import { useForm } from "react-hook-form";
@@ -35,7 +36,14 @@ import { useTranslation } from "react-i18next";
 import { graphql, useMutation } from "react-relay";
 
 import type { CreateRiskAnalysisDialogCreateMutation } from "#/__generated__/core/CreateRiskAnalysisDialogCreateMutation.graphql";
+import { ControlledField } from "#/components/form/ControlledField";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+
+import {
+  matrixSizeFromOption,
+  type RiskAnalysisMatrixSizeOption,
+  riskAnalysisMatrixSizeOptions,
+} from "./matrixSize";
 
 const createMutation = graphql`
   mutation CreateRiskAnalysisDialogCreateMutation(
@@ -52,6 +60,10 @@ const createMutation = graphql`
             start
             end
           }
+          matrixSize {
+            rows
+            cols
+          }
           createdAt
         }
       }
@@ -64,6 +76,7 @@ type FormData = {
   description: string;
   periodStart: string;
   periodEnd: string;
+  matrixSize: RiskAnalysisMatrixSizeOption;
 };
 
 export function CreateRiskAnalysisDialog(props: {
@@ -73,7 +86,7 @@ export function CreateRiskAnalysisDialog(props: {
   const organizationId = useOrganizationId();
   const dialogRef = useDialogRef();
   const [createRiskAnalysis, isCreating] = useMutation<CreateRiskAnalysisDialogCreateMutation>(createMutation);
-  const { register, handleSubmit, reset, formState } = useForm<FormData>({
+  const { register, handleSubmit, reset, control, formState } = useForm<FormData>({
     defaultValues: {
       name: "",
       description: "",
@@ -99,6 +112,7 @@ export function CreateRiskAnalysisDialog(props: {
           name: data.name,
           description: data.description || null,
           period,
+          matrixSize: matrixSizeFromOption(data.matrixSize),
         },
         connections: [props.connectionId],
       },
@@ -140,6 +154,19 @@ export function CreateRiskAnalysisDialog(props: {
             rows={3}
             placeholder={t("createRiskAnalysisDialog.placeholders.description")}
           />
+          <ControlledField
+            control={control}
+            name="matrixSize"
+            type="select"
+            label={t("createRiskAnalysisDialog.fields.matrixSize")}
+            rules={{ required: t("createRiskAnalysisDialog.validation.matrixSizeRequired") }}
+          >
+            {riskAnalysisMatrixSizeOptions.map(size => (
+              <Option key={size.key} value={size.key}>
+                {t(`createRiskAnalysisDialog.matrixSizes.${size.key}`)}
+              </Option>
+            ))}
+          </ControlledField>
           <Field
             label={t("createRiskAnalysisDialog.fields.periodStart")}
             error={formState.errors.periodStart?.message}

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_components/UpdateRiskAnalysisDialog.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_components/UpdateRiskAnalysisDialog.tsx
@@ -31,6 +31,7 @@ import {
   IconPencil,
   IconTrashCan,
   Input,
+  Option,
   useDialogRef,
 } from "@probo/ui";
 import { useForm } from "react-hook-form";
@@ -38,6 +39,15 @@ import { useTranslation } from "react-i18next";
 import { graphql, useMutation } from "react-relay";
 
 import type { UpdateRiskAnalysisDialogMutation } from "#/__generated__/core/UpdateRiskAnalysisDialogMutation.graphql";
+import { ControlledField } from "#/components/form/ControlledField";
+
+import {
+  type MatrixSize,
+  matrixSizeFromOption,
+  matrixSizeKey,
+  type RiskAnalysisMatrixSizeOption,
+  riskAnalysisMatrixSizeOptions,
+} from "./matrixSize";
 
 const updateMutation = graphql`
   mutation UpdateRiskAnalysisDialogMutation(
@@ -52,6 +62,10 @@ const updateMutation = graphql`
           start
           end
         }
+        matrixSize {
+          rows
+          cols
+        }
         updatedAt
       }
     }
@@ -63,6 +77,7 @@ type FormData = {
   description: string;
   periodStart: string;
   periodEnd: string;
+  matrixSize: RiskAnalysisMatrixSizeOption;
 };
 
 export function UpdateRiskAnalysisDialog(props: {
@@ -74,6 +89,7 @@ export function UpdateRiskAnalysisDialog(props: {
       start: string | null | undefined;
       end: string | null | undefined;
     } | null | undefined;
+    matrixSize: MatrixSize;
   };
   canDelete?: boolean;
   onDelete?: () => void;
@@ -81,12 +97,13 @@ export function UpdateRiskAnalysisDialog(props: {
   const { t } = useTranslation();
   const dialogRef = useDialogRef();
   const [updateRiskAnalysis, isUpdating] = useMutation<UpdateRiskAnalysisDialogMutation>(updateMutation);
-  const { register, handleSubmit, formState } = useForm<FormData>({
+  const { register, handleSubmit, control, formState } = useForm<FormData>({
     values: {
       name: props.riskAnalysis.name,
       description: props.riskAnalysis.description ?? "",
       periodStart: toDateInput(props.riskAnalysis.period?.start),
       periodEnd: toDateInput(props.riskAnalysis.period?.end),
+      matrixSize: matrixSizeKey(props.riskAnalysis.matrixSize),
     },
   });
 
@@ -101,6 +118,7 @@ export function UpdateRiskAnalysisDialog(props: {
             start: formatDatetime(data.periodStart) ?? null,
             end: formatDatetime(data.periodEnd) ?? null,
           },
+          matrixSize: matrixSizeFromOption(data.matrixSize),
         },
       },
       onCompleted: () => {
@@ -156,6 +174,18 @@ export function UpdateRiskAnalysisDialog(props: {
               rows={3}
               placeholder={t("updateRiskAnalysisDialog.placeholders.description")}
             />
+            <ControlledField
+              control={control}
+              name="matrixSize"
+              type="select"
+              label={t("updateRiskAnalysisDialog.fields.matrixSize")}
+            >
+              {riskAnalysisMatrixSizeOptions.map(size => (
+                <Option key={size.key} value={size.key}>
+                  {t(`updateRiskAnalysisDialog.matrixSizes.${size.key}`)}
+                </Option>
+              ))}
+            </ControlledField>
             <Field
               label={t("updateRiskAnalysisDialog.fields.periodStart")}
               error={formState.errors.periodStart?.message}

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_components/matrixSize.ts
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_components/matrixSize.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+export const riskAnalysisMatrixSizeOptions = [
+  { key: "3x3", rows: 3, cols: 3 },
+  { key: "4x4", rows: 4, cols: 4 },
+  { key: "5x5", rows: 5, cols: 5 },
+] as const;
+
+export type RiskAnalysisMatrixSizeOption = (typeof riskAnalysisMatrixSizeOptions)[number]["key"];
+
+export type MatrixSize = {
+  rows: number;
+  cols: number;
+};
+
+export function matrixSizeKey(size: MatrixSize): RiskAnalysisMatrixSizeOption {
+  return `${size.rows}x${size.cols}` as RiskAnalysisMatrixSizeOption;
+}
+
+export function matrixSizeFromOption(key: RiskAnalysisMatrixSizeOption): MatrixSize {
+  const option = riskAnalysisMatrixSizeOptions.find(size => size.key === key);
+  if (!option) {
+    throw new Error(`Invalid matrix size "${key}"`);
+  }
+
+  return { rows: option.rows, cols: option.cols };
+}
+
+export function formatMatrixSize(rows: number, cols: number): string {
+  return `${rows}×${cols}`;
+}

--- a/e2e/console/risk_analysis_rbac_test.go
+++ b/e2e/console/risk_analysis_rbac_test.go
@@ -45,6 +45,7 @@ func TestRiskAnalysis_RBAC(t *testing.T) {
 			"input": map[string]any{
 				"organizationId": viewer.GetOrganizationID().String(),
 				"name":           "test",
+				"matrixSize":     map[string]any{"rows": 5, "cols": 5},
 			},
 		})
 		testutil.RequireForbiddenError(t, err, "viewer cannot create risk analysis")

--- a/e2e/console/risk_analysis_test.go
+++ b/e2e/console/risk_analysis_test.go
@@ -40,8 +40,12 @@ func TestRiskAnalysis_Create(t *testing.T) {
 			CreateRiskAnalysis struct {
 				RiskAnalysisEdge struct {
 					Node struct {
-						ID   string `json:"id"`
-						Name string `json:"name"`
+						ID         string `json:"id"`
+						Name       string `json:"name"`
+						MatrixSize struct {
+							Rows int `json:"rows"`
+							Cols int `json:"cols"`
+						} `json:"matrixSize"`
 					} `json:"node"`
 				} `json:"riskAnalysisEdge"`
 			} `json:"createRiskAnalysis"`
@@ -50,19 +54,22 @@ func TestRiskAnalysis_Create(t *testing.T) {
 		err := owner.Execute(`
 			mutation($input: CreateRiskAnalysisInput!) {
 				createRiskAnalysis(input: $input) {
-					riskAnalysisEdge { node { id name } }
+					riskAnalysisEdge { node { id name matrixSize { rows cols } } }
 				}
 			}
 		`, map[string]any{
 			"input": map[string]any{
 				"organizationId": owner.GetOrganizationID().String(),
 				"name":           "Platform Threat Model",
+				"matrixSize":     map[string]any{"rows": 5, "cols": 5},
 			},
 		}, &result)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, result.CreateRiskAnalysis.RiskAnalysisEdge.Node.ID)
 		assert.Equal(t, "Platform Threat Model", result.CreateRiskAnalysis.RiskAnalysisEdge.Node.Name)
+		assert.Equal(t, 5, result.CreateRiskAnalysis.RiskAnalysisEdge.Node.MatrixSize.Rows)
+		assert.Equal(t, 5, result.CreateRiskAnalysis.RiskAnalysisEdge.Node.MatrixSize.Cols)
 	})
 }
 
@@ -400,6 +407,10 @@ func TestRiskAnalysis_Update(t *testing.T) {
 				ID          string  `json:"id"`
 				Name        string  `json:"name"`
 				Description *string `json:"description"`
+				MatrixSize  struct {
+					Rows int `json:"rows"`
+					Cols int `json:"cols"`
+				} `json:"matrixSize"`
 			} `json:"riskAnalysis"`
 		} `json:"updateRiskAnalysis"`
 	}
@@ -407,7 +418,7 @@ func TestRiskAnalysis_Update(t *testing.T) {
 	err := owner.Execute(`
 		mutation($input: UpdateRiskAnalysisInput!) {
 			updateRiskAnalysis(input: $input) {
-				riskAnalysis { id name description }
+				riskAnalysis { id name description matrixSize { rows cols } }
 			}
 		}
 	`, map[string]any{
@@ -415,6 +426,7 @@ func TestRiskAnalysis_Update(t *testing.T) {
 			"id":          raID,
 			"name":        "Updated",
 			"description": "New description",
+			"matrixSize":  map[string]any{"rows": 3, "cols": 3},
 		},
 	}, &result)
 
@@ -422,6 +434,8 @@ func TestRiskAnalysis_Update(t *testing.T) {
 	assert.Equal(t, "Updated", result.UpdateRiskAnalysis.RiskAnalysis.Name)
 	require.NotNil(t, result.UpdateRiskAnalysis.RiskAnalysis.Description)
 	assert.Equal(t, "New description", *result.UpdateRiskAnalysis.RiskAnalysis.Description)
+	assert.Equal(t, 3, result.UpdateRiskAnalysis.RiskAnalysis.MatrixSize.Rows)
+	assert.Equal(t, 3, result.UpdateRiskAnalysis.RiskAnalysis.MatrixSize.Cols)
 }
 
 func TestRiskAnalysisDiagram_Update(t *testing.T) {

--- a/e2e/internal/factory/factory.go
+++ b/e2e/internal/factory/factory.go
@@ -1633,6 +1633,10 @@ func CreateRiskAnalysis(c *testutil.Client, attrs ...Attrs) string {
 	input := map[string]any{
 		"organizationId": c.GetOrganizationID().String(),
 		"name":           a.getString("name", SafeName("Risk Analysis")),
+		"matrixSize": map[string]any{
+			"rows": a.getInt("matrixRows", 5),
+			"cols": a.getInt("matrixCols", 5),
+		},
 	}
 	if desc := a.getStringPtr("description"); desc != nil {
 		input["description"] = *desc

--- a/packages/n8n-node/nodes/Probo/actions/riskAnalysis/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/riskAnalysis/create.operation.ts
@@ -20,6 +20,7 @@
 
 import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { proboApiRequest } from '../../GenericFunctions';
+import { parseRiskAnalysisMatrixSize, riskAnalysisMatrixSizeOptions } from './matrixSize';
 
 export const description: INodeProperties[] = [
 	{
@@ -48,6 +49,22 @@ export const description: INodeProperties[] = [
 		},
 		default: '',
 		description: 'The name of the risk analysis',
+		required: true,
+	},
+	{
+		displayName: 'Matrix Size',
+		name: 'matrixSize',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['riskAnalysis'],
+				operation: ['create'],
+			},
+		},
+		options: [...riskAnalysisMatrixSizeOptions],
+		default: '',
+		description: 'Likelihood/impact matrix size (3×3, 4×4, or 5×5)',
 		required: true,
 	},
 	{
@@ -94,6 +111,7 @@ export async function execute(
 ): Promise<INodeExecutionData> {
 	const organizationId = this.getNodeParameter('organizationId', itemIndex) as string;
 	const name = this.getNodeParameter('name', itemIndex) as string;
+	const matrixSize = this.getNodeParameter('matrixSize', itemIndex) as string;
 	const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as {
 		description?: string;
 		periodStart?: string;
@@ -112,6 +130,10 @@ export async function execute(
 							start
 							end
 						}
+						matrixSize {
+							rows
+							cols
+						}
 						createdAt
 						updatedAt
 					}
@@ -123,6 +145,7 @@ export async function execute(
 	const input: Record<string, unknown> = {
 		organizationId,
 		name,
+		matrixSize: parseRiskAnalysisMatrixSize(matrixSize),
 	};
 	if (additionalFields.description) input.description = additionalFields.description;
 	if (additionalFields.periodStart || additionalFields.periodEnd) {

--- a/packages/n8n-node/nodes/Probo/actions/riskAnalysis/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/riskAnalysis/get.operation.ts
@@ -55,6 +55,10 @@ export async function execute(
 						start
 						end
 					}
+					matrixSize {
+						rows
+						cols
+					}
 					createdAt
 					updatedAt
 				}

--- a/packages/n8n-node/nodes/Probo/actions/riskAnalysis/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/riskAnalysis/getAll.operation.ts
@@ -90,6 +90,10 @@ export async function execute(
 									start
 									end
 								}
+								matrixSize {
+									rows
+									cols
+								}
 								createdAt
 								updatedAt
 							}

--- a/packages/n8n-node/nodes/Probo/actions/riskAnalysis/matrixSize.ts
+++ b/packages/n8n-node/nodes/Probo/actions/riskAnalysis/matrixSize.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+export const riskAnalysisMatrixSizeOptions = [
+	{ name: '3×3', value: '3x3' },
+	{ name: '4×4', value: '4x4' },
+	{ name: '5×5', value: '5x5' },
+] as const;
+
+const riskAnalysisMatrixSizes: Record<string, { rows: number; cols: number }> = {
+	'3x3': { rows: 3, cols: 3 },
+	'4x4': { rows: 4, cols: 4 },
+	'5x5': { rows: 5, cols: 5 },
+};
+
+export function parseRiskAnalysisMatrixSize(value: string): { rows: number; cols: number } {
+	if (!Object.prototype.hasOwnProperty.call(riskAnalysisMatrixSizes, value)) {
+		throw new Error(`Invalid matrix size "${value}"; must be one of 3x3, 4x4, or 5x5`);
+	}
+
+	return riskAnalysisMatrixSizes[value];
+}

--- a/packages/n8n-node/nodes/Probo/actions/riskAnalysis/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/riskAnalysis/update.operation.ts
@@ -20,6 +20,7 @@
 
 import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { proboApiRequest } from '../../GenericFunctions';
+import { parseRiskAnalysisMatrixSize, riskAnalysisMatrixSizeOptions } from './matrixSize';
 
 export const description: INodeProperties[] = [
 	{
@@ -57,6 +58,18 @@ export const description: INodeProperties[] = [
 				description: 'The description of the risk analysis',
 			},
 			{
+				displayName: 'Matrix Size',
+				name: 'matrixSize',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{ name: '(Unchanged)', value: '' },
+					...riskAnalysisMatrixSizeOptions,
+				],
+				default: '',
+				description: 'Likelihood/impact matrix size (3×3, 4×4, or 5×5)',
+			},
+			{
 				displayName: 'Name',
 				name: 'name',
 				type: 'string',
@@ -64,18 +77,18 @@ export const description: INodeProperties[] = [
 				description: 'The name of the risk analysis',
 			},
 			{
-				displayName: 'Period Start',
-				name: 'periodStart',
-				type: 'dateTime',
-				default: '',
-				description: 'Start of the analysis period',
-			},
-			{
 				displayName: 'Period End',
 				name: 'periodEnd',
 				type: 'dateTime',
 				default: '',
 				description: 'End of the analysis period',
+			},
+			{
+				displayName: 'Period Start',
+				name: 'periodStart',
+				type: 'dateTime',
+				default: '',
+				description: 'Start of the analysis period',
 			},
 		],
 	},
@@ -91,6 +104,7 @@ export async function execute(
 		description?: string;
 		periodStart?: string;
 		periodEnd?: string;
+		matrixSize?: string;
 	};
 
 	const query = `
@@ -103,6 +117,10 @@ export async function execute(
 					period {
 						start
 						end
+					}
+					matrixSize {
+						rows
+						cols
 					}
 					createdAt
 					updatedAt
@@ -119,6 +137,9 @@ export async function execute(
 			...(additionalFields.periodStart ? { start: additionalFields.periodStart } : {}),
 			...(additionalFields.periodEnd ? { end: additionalFields.periodEnd } : {}),
 		};
+	}
+	if (additionalFields.matrixSize) {
+		input.matrixSize = parseRiskAnalysisMatrixSize(additionalFields.matrixSize);
 	}
 
 	if (Object.keys(input).length === 1) {

--- a/pkg/cmd/risk-analysis/create/create.go
+++ b/pkg/cmd/risk-analysis/create/create.go
@@ -42,6 +42,10 @@ mutation($input: CreateRiskAnalysisInput!) {
           start
           end
         }
+        matrixSize {
+          rows
+          cols
+        }
         createdAt
         updatedAt
       }
@@ -61,6 +65,10 @@ type createResponse struct {
 					Start *string `json:"start"`
 					End   *string `json:"end"`
 				} `json:"period"`
+				MatrixSize struct {
+					Rows int `json:"rows"`
+					Cols int `json:"cols"`
+				} `json:"matrixSize"`
 				CreatedAt string `json:"createdAt"`
 				UpdatedAt string `json:"updatedAt"`
 			} `json:"node"`
@@ -75,6 +83,8 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 		flagDescription string
 		flagPeriodStart string
 		flagPeriodEnd   string
+		flagMatrixRows  int
+		flagMatrixCols  int
 	)
 
 	cmd := &cobra.Command{
@@ -84,7 +94,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
   prb risk-analysis create
 
   # Create a risk analysis non-interactively
-  prb risk-analysis create --name "Annual Risk Analysis" --period-start 2026-01-01 --period-end 2026-12-31`,
+  prb risk-analysis create --name "Annual Risk Analysis" --matrix-rows 5 --matrix-cols 5 --period-start 2026-01-01 --period-end 2026-12-31`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := f.Config()
 			if err != nil {
@@ -122,6 +132,32 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 						return err
 					}
 				}
+
+				if !cmd.Flags().Changed("matrix-rows") && !cmd.Flags().Changed("matrix-cols") {
+					var matrixSize string
+
+					err := huh.NewSelect[string]().
+						Title("Matrix size").
+						Options(
+							huh.NewOption("3×3", "3"),
+							huh.NewOption("4×4", "4"),
+							huh.NewOption("5×5", "5"),
+						).
+						Value(&matrixSize).
+						Run()
+					if err != nil {
+						return err
+					}
+
+					switch matrixSize {
+					case "3":
+						flagMatrixRows, flagMatrixCols = 3, 3
+					case "4":
+						flagMatrixRows, flagMatrixCols = 4, 4
+					case "5":
+						flagMatrixRows, flagMatrixCols = 5, 5
+					}
+				}
 			}
 
 			if flagName == "" {
@@ -148,6 +184,18 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				}
 
 				input["period"] = period
+			}
+
+			rowsSet := cmd.Flags().Changed("matrix-rows") || flagMatrixRows != 0
+			colsSet := cmd.Flags().Changed("matrix-cols") || flagMatrixCols != 0
+
+			if !rowsSet || !colsSet {
+				return fmt.Errorf("both --matrix-rows and --matrix-cols are required; pass flags or run interactively")
+			}
+
+			input["matrixSize"] = map[string]any{
+				"rows": flagMatrixRows,
+				"cols": flagMatrixCols,
 			}
 
 			data, err := client.Do(
@@ -180,6 +228,8 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagDescription, "description", "", "Risk analysis description")
 	cmd.Flags().StringVar(&flagPeriodStart, "period-start", "", "Period start date (e.g. 2026-01-01)")
 	cmd.Flags().StringVar(&flagPeriodEnd, "period-end", "", "Period end date (e.g. 2026-12-31)")
+	cmd.Flags().IntVar(&flagMatrixRows, "matrix-rows", 0, "Matrix rows (3, 4, or 5; required)")
+	cmd.Flags().IntVar(&flagMatrixCols, "matrix-cols", 0, "Matrix cols (3, 4, or 5; required, must match --matrix-rows)")
 
 	return cmd
 }

--- a/pkg/cmd/risk-analysis/list/list.go
+++ b/pkg/cmd/risk-analysis/list/list.go
@@ -45,6 +45,10 @@ query($id: ID!, $first: Int, $after: CursorKey, $orderBy: RiskAnalysisOrder) {
               start
               end
             }
+            matrixSize {
+              rows
+              cols
+            }
             createdAt
             updatedAt
           }
@@ -67,6 +71,10 @@ type riskAnalysis struct {
 		Start *string `json:"start"`
 		End   *string `json:"end"`
 	} `json:"period"`
+	MatrixSize struct {
+		Rows int `json:"rows"`
+		Cols int `json:"cols"`
+	} `json:"matrixSize"`
 	CreatedAt string `json:"createdAt"`
 	UpdatedAt string `json:"updatedAt"`
 }
@@ -202,11 +210,12 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 					desc,
 					periodStart,
 					periodEnd,
+					fmt.Sprintf("%d×%d", r.MatrixSize.Rows, r.MatrixSize.Cols),
 					cmdutil.FormatTime(r.CreatedAt),
 				})
 			}
 
-			t := cmdutil.NewTable("ID", "NAME", "DESCRIPTION", "PERIOD START", "PERIOD END", "CREATED AT").Rows(rows...)
+			t := cmdutil.NewTable("ID", "NAME", "DESCRIPTION", "PERIOD START", "PERIOD END", "MATRIX SIZE", "CREATED AT").Rows(rows...)
 
 			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
 

--- a/pkg/cmd/risk-analysis/update/update.go
+++ b/pkg/cmd/risk-analysis/update/update.go
@@ -40,6 +40,10 @@ mutation($input: UpdateRiskAnalysisInput!) {
         start
         end
       }
+      matrixSize {
+        rows
+        cols
+      }
       createdAt
       updatedAt
     }
@@ -57,6 +61,10 @@ type updateResponse struct {
 				Start *string `json:"start"`
 				End   *string `json:"end"`
 			} `json:"period"`
+			MatrixSize struct {
+				Rows int `json:"rows"`
+				Cols int `json:"cols"`
+			} `json:"matrixSize"`
 			CreatedAt string `json:"createdAt"`
 			UpdatedAt string `json:"updatedAt"`
 		} `json:"riskAnalysis"`
@@ -69,6 +77,8 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 		flagDescription string
 		flagPeriodStart string
 		flagPeriodEnd   string
+		flagMatrixRows  int
+		flagMatrixCols  int
 	)
 
 	cmd := &cobra.Command{
@@ -119,6 +129,20 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				input["period"] = period
 			}
 
+			rowsChanged := cmd.Flags().Changed("matrix-rows")
+			colsChanged := cmd.Flags().Changed("matrix-cols")
+
+			if rowsChanged || colsChanged {
+				if !rowsChanged || !colsChanged {
+					return fmt.Errorf("both --matrix-rows and --matrix-cols are required")
+				}
+
+				input["matrixSize"] = map[string]any{
+					"rows": flagMatrixRows,
+					"cols": flagMatrixCols,
+				}
+			}
+
 			if len(input) == 1 {
 				return fmt.Errorf("at least one field must be specified for update")
 			}
@@ -152,6 +176,8 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagDescription, "description", "", "Risk analysis description")
 	cmd.Flags().StringVar(&flagPeriodStart, "period-start", "", "Period start date (e.g. 2026-01-01)")
 	cmd.Flags().StringVar(&flagPeriodEnd, "period-end", "", "Period end date (e.g. 2026-12-31)")
+	cmd.Flags().IntVar(&flagMatrixRows, "matrix-rows", 0, "Matrix rows (3, 4, or 5)")
+	cmd.Flags().IntVar(&flagMatrixCols, "matrix-cols", 0, "Matrix cols (3, 4, or 5)")
 
 	return cmd
 }

--- a/pkg/cmd/risk-analysis/view/view.go
+++ b/pkg/cmd/risk-analysis/view/view.go
@@ -42,6 +42,10 @@ query($id: ID!) {
         start
         end
       }
+      matrixSize {
+        rows
+        cols
+      }
       createdAt
       updatedAt
     }
@@ -59,6 +63,10 @@ type viewResponse struct {
 			Start *string `json:"start"`
 			End   *string `json:"end"`
 		} `json:"period"`
+		MatrixSize struct {
+			Rows int `json:"rows"`
+			Cols int `json:"cols"`
+		} `json:"matrixSize"`
 		CreatedAt string `json:"createdAt"`
 		UpdatedAt string `json:"updatedAt"`
 	} `json:"node"`
@@ -142,6 +150,8 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 					_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Period end:"), cmdutil.FormatTime(*r.Period.End))
 				}
 			}
+
+			_, _ = fmt.Fprintf(out, "%s%d×%d\n", label.Render("Matrix size:"), r.MatrixSize.Rows, r.MatrixSize.Cols)
 
 			_, _ = fmt.Fprintln(out)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Created:"), cmdutil.FormatTime(r.CreatedAt))

--- a/pkg/coredata/migrations/20260812T131804Z.sql
+++ b/pkg/coredata/migrations/20260812T131804Z.sql
@@ -1,0 +1,27 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TABLE risk_analyses
+    ADD COLUMN matrix_rows INTEGER NOT NULL DEFAULT 5,
+    ADD COLUMN matrix_cols INTEGER NOT NULL DEFAULT 5;
+
+ALTER TABLE risk_analyses
+    ALTER COLUMN matrix_rows DROP DEFAULT,
+    ALTER COLUMN matrix_cols DROP DEFAULT;

--- a/pkg/coredata/risk_analysis.go
+++ b/pkg/coredata/risk_analysis.go
@@ -42,6 +42,8 @@ type (
 		Description    *string    `db:"description"`
 		PeriodStart    *time.Time `db:"period_start"`
 		PeriodEnd      *time.Time `db:"period_end"`
+		MatrixRows     int        `db:"matrix_rows"`
+		MatrixCols     int        `db:"matrix_cols"`
 		CreatedAt      time.Time  `db:"created_at"`
 		UpdatedAt      time.Time  `db:"updated_at"`
 	}
@@ -139,6 +141,8 @@ SELECT
 	description,
 	period_start,
 	period_end,
+	matrix_rows,
+	matrix_cols,
 	created_at,
 	updated_at
 FROM risk_analyses
@@ -181,6 +185,8 @@ SELECT
 	description,
 	period_start,
 	period_end,
+	matrix_rows,
+	matrix_cols,
 	created_at,
 	updated_at
 FROM risk_analyses
@@ -226,6 +232,8 @@ INSERT INTO risk_analyses (
 	description,
 	period_start,
 	period_end,
+	matrix_rows,
+	matrix_cols,
 	created_at,
 	updated_at
 )
@@ -237,6 +245,8 @@ VALUES (
 	@description,
 	@period_start,
 	@period_end,
+	@matrix_rows,
+	@matrix_cols,
 	@created_at,
 	@updated_at
 )
@@ -250,6 +260,8 @@ VALUES (
 		"description":     ra.Description,
 		"period_start":    ra.PeriodStart,
 		"period_end":      ra.PeriodEnd,
+		"matrix_rows":     ra.MatrixRows,
+		"matrix_cols":     ra.MatrixCols,
 		"created_at":      ra.CreatedAt,
 		"updated_at":      ra.UpdatedAt,
 	}
@@ -274,6 +286,8 @@ SET
 	description = @description,
 	period_start = @period_start,
 	period_end = @period_end,
+	matrix_rows = @matrix_rows,
+	matrix_cols = @matrix_cols,
 	updated_at = @updated_at
 WHERE %s
 	AND id = @id
@@ -286,6 +300,8 @@ WHERE %s
 		"description":  ra.Description,
 		"period_start": ra.PeriodStart,
 		"period_end":   ra.PeriodEnd,
+		"matrix_rows":  ra.MatrixRows,
+		"matrix_cols":  ra.MatrixCols,
 		"updated_at":   ra.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())

--- a/pkg/riskmanagement/service.go
+++ b/pkg/riskmanagement/service.go
@@ -51,11 +51,17 @@ type (
 		End   *time.Time
 	}
 
+	MatrixSize struct {
+		Rows int
+		Cols int
+	}
+
 	CreateRiskAnalysisRequest struct {
 		OrganizationID gid.GID
 		Name           string
 		Description    *string
 		Period         *Period
+		MatrixSize     *MatrixSize
 	}
 
 	UpdateRiskAnalysisRequest struct {
@@ -63,6 +69,7 @@ type (
 		Name        *string
 		Description **string
 		Period      *Period
+		MatrixSize  *MatrixSize
 	}
 
 	CreateRiskAnalysisDiagramRequest struct {
@@ -167,6 +174,8 @@ func (r *CreateRiskAnalysisRequest) Validate() error {
 	v.Check(r.OrganizationID, "organization_id", validator.Required(), validator.GID(coredata.OrganizationEntityType))
 	v.Check(r.Name, "name", validator.Required(), validator.SafeTextNoNewLine(TitleMaxLength))
 	v.Check(r.Description, "description", validator.SafeText(ContentMaxLength))
+	v.Check(r.MatrixSize, "matrix_size", validator.Required())
+	validateMatrixSize(v, r.MatrixSize)
 
 	if r.Period != nil {
 		validatePeriodRange(v, r.Period.Start, r.Period.End)
@@ -180,6 +189,7 @@ func (r *UpdateRiskAnalysisRequest) Validate() error {
 	v.Check(r.ID, "id", validator.Required(), validator.GID(coredata.RiskAnalysisEntityType))
 	v.Check(r.Name, "name", validator.SafeTextNoNewLine(TitleMaxLength))
 	v.Check(r.Description, "description", validator.SafeText(ContentMaxLength))
+	validateMatrixSize(v, r.MatrixSize)
 
 	if r.Period != nil {
 		validatePeriodRange(v, r.Period.Start, r.Period.End)
@@ -201,6 +211,28 @@ func validatePeriodRange(v *validator.Validator, periodStart, periodEnd *time.Ti
 				return &validator.ValidationError{
 					Code:    validator.ErrorCodeOutOfRange,
 					Message: fmt.Sprintf("must be on or after %s", periodStart.Format(time.DateOnly)),
+				}
+			},
+		)
+	}
+}
+
+func validateMatrixSize(v *validator.Validator, size *MatrixSize) {
+	if size == nil {
+		return
+	}
+
+	v.Check(size.Rows, "matrix_size.rows", validator.OneOfSlice([]int{3, 4, 5}))
+	v.Check(size.Cols, "matrix_size.cols", validator.OneOfSlice([]int{3, 4, 5}))
+
+	if size.Rows != size.Cols {
+		v.Check(
+			size.Cols,
+			"matrix_size.cols",
+			func(any) *validator.ValidationError {
+				return &validator.ValidationError{
+					Code:    validator.ErrorCodeInvalidFormat,
+					Message: "must equal matrix_size.rows",
 				}
 			},
 		)
@@ -374,6 +406,8 @@ func (s *Service) Create(ctx context.Context, scope coredata.Scoper, req CreateR
 		OrganizationID: req.OrganizationID,
 		Name:           req.Name,
 		Description:    req.Description,
+		MatrixRows:     req.MatrixSize.Rows,
+		MatrixCols:     req.MatrixSize.Cols,
 		CreatedAt:      now,
 		UpdatedAt:      now,
 	}
@@ -445,6 +479,11 @@ func (s *Service) Update(ctx context.Context, scope coredata.Scoper, req UpdateR
 			if req.Period != nil {
 				ra.PeriodStart = req.Period.Start
 				ra.PeriodEnd = req.Period.End
+			}
+
+			if req.MatrixSize != nil {
+				ra.MatrixRows = req.MatrixSize.Rows
+				ra.MatrixCols = req.MatrixSize.Cols
 			}
 
 			v := validator.New()

--- a/pkg/server/api/console/v1/graphql/base.graphql
+++ b/pkg/server/api/console/v1/graphql/base.graphql
@@ -28,6 +28,18 @@ input PeriodInput {
     end: Datetime
 }
 
+type MatrixSize
+    @goModel(model: "go.probo.inc/probo/pkg/riskmanagement.MatrixSize") {
+    rows: Int!
+    cols: Int!
+}
+
+input MatrixSizeInput
+    @goModel(model: "go.probo.inc/probo/pkg/riskmanagement.MatrixSize") {
+    rows: Int!
+    cols: Int!
+}
+
 interface Node {
     id: ID!
 }

--- a/pkg/server/api/console/v1/graphql/risk_analysis.graphql
+++ b/pkg/server/api/console/v1/graphql/risk_analysis.graphql
@@ -201,6 +201,7 @@ type RiskAnalysis implements Node {
     name: String!
     description: String
     period: Period
+    matrixSize: MatrixSize!
     organization: Organization @goField(forceResolver: true)
 
     diagrams(
@@ -528,6 +529,7 @@ input CreateRiskAnalysisInput {
     name: String!
     description: String
     period: PeriodInput
+    matrixSize: MatrixSizeInput!
 }
 
 input UpdateRiskAnalysisInput {
@@ -535,6 +537,7 @@ input UpdateRiskAnalysisInput {
     name: String
     description: String @goField(omittable: true)
     period: PeriodInput
+    matrixSize: MatrixSizeInput
 }
 
 input DeleteRiskAnalysisInput {

--- a/pkg/server/api/console/v1/risk_analysis_resolvers.go
+++ b/pkg/server/api/console/v1/risk_analysis_resolvers.go
@@ -45,6 +45,7 @@ func (r *mutationResolver) CreateRiskAnalysis(ctx context.Context, input types.C
 			Name:           input.Name,
 			Description:    input.Description,
 			Period:         period,
+			MatrixSize:     input.MatrixSize,
 		},
 	)
 	if err != nil {
@@ -89,6 +90,7 @@ func (r *mutationResolver) UpdateRiskAnalysis(ctx context.Context, input types.U
 			Name:        input.Name,
 			Description: gqlutils.UnwrapOmittable(input.Description),
 			Period:      period,
+			MatrixSize:  input.MatrixSize,
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/console/v1/types/matrix_size.go
+++ b/pkg/server/api/console/v1/types/matrix_size.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package types
+
+import "go.probo.inc/probo/pkg/riskmanagement"
+
+func NewMatrixSize(rows, cols int) *riskmanagement.MatrixSize {
+	return &riskmanagement.MatrixSize{
+		Rows: rows,
+		Cols: cols,
+	}
+}

--- a/pkg/server/api/console/v1/types/risk_analysis.go
+++ b/pkg/server/api/console/v1/types/risk_analysis.go
@@ -72,6 +72,7 @@ func NewRiskAnalysis(ra *coredata.RiskAnalysis) *RiskAnalysis {
 		Name:        ra.Name,
 		Description: ra.Description,
 		Period:      NewPeriod(ra.PeriodStart, ra.PeriodEnd),
+		MatrixSize:  NewMatrixSize(ra.MatrixRows, ra.MatrixCols),
 		Organization: &Organization{
 			ID: ra.OrganizationID,
 		},

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -6449,11 +6449,20 @@ func (r *Resolver) AddRiskAnalysisTool(ctx context.Context, req *mcp.CallToolReq
 		}
 	}
 
+	var matrixSize *riskmanagement.MatrixSize
+	if input.MatrixSize != nil {
+		matrixSize = &riskmanagement.MatrixSize{
+			Rows: input.MatrixSize.Rows,
+			Cols: input.MatrixSize.Cols,
+		}
+	}
+
 	ra, err := r.riskManagement.Create(ctx, scope, riskmanagement.CreateRiskAnalysisRequest{
 		OrganizationID: input.OrganizationID,
 		Name:           input.Name,
 		Description:    input.Description,
 		Period:         period,
+		MatrixSize:     matrixSize,
 	})
 	if err != nil {
 		return nil, types.AddRiskAnalysisOutput{}, fmt.Errorf("failed to create risk analysis: %w", err)
@@ -6478,11 +6487,20 @@ func (r *Resolver) UpdateRiskAnalysisTool(ctx context.Context, req *mcp.CallTool
 		}
 	}
 
+	var matrixSize *riskmanagement.MatrixSize
+	if input.MatrixSize != nil {
+		matrixSize = &riskmanagement.MatrixSize{
+			Rows: input.MatrixSize.Rows,
+			Cols: input.MatrixSize.Cols,
+		}
+	}
+
 	ra, err := r.riskManagement.Update(ctx, scope, riskmanagement.UpdateRiskAnalysisRequest{
 		ID:          input.ID,
 		Name:        input.Name,
 		Description: UnwrapOmittable(input.Description),
 		Period:      period,
+		MatrixSize:  matrixSize,
 	})
 	if err != nil {
 		return nil, types.UpdateRiskAnalysisOutput{}, fmt.Errorf("failed to update risk analysis: %w", err)

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -656,6 +656,30 @@ components:
           format: date-time
           description: End of the period
 
+    MatrixSize:
+      type: object
+      required:
+        - rows
+        - cols
+      description: >
+        Likelihood/impact matrix dimensions. Valid sizes are exactly 3×3, 4×4,
+        or 5×5 — rows and cols must be equal, and each must be 3, 4, or 5.
+      properties:
+        rows:
+          type: integer
+          enum:
+            - 3
+            - 4
+            - 5
+          description: Number of likelihood rows (must equal cols; one of 3, 4, or 5)
+        cols:
+          type: integer
+          enum:
+            - 3
+            - 4
+            - 5
+          description: Number of impact columns (must equal rows; one of 3, 4, or 5)
+
     ListOrganizationsInput:
       type: object
       properties:
@@ -13227,6 +13251,7 @@ components:
         - id
         - organization_id
         - name
+        - matrix_size
         - created_at
         - updated_at
       properties:
@@ -13243,6 +13268,9 @@ components:
         period:
           $ref: "#/components/schemas/Period"
           description: Analysis period
+        matrix_size:
+          $ref: "#/components/schemas/MatrixSize"
+          description: Likelihood/impact matrix size (3×3, 4×4, or 5×5)
         created_at:
           type: string
           format: date-time
@@ -13478,6 +13506,7 @@ components:
       required:
         - organization_id
         - name
+        - matrix_size
       properties:
         organization_id:
           $ref: "#/components/schemas/GID"
@@ -13491,6 +13520,9 @@ components:
         period:
           $ref: "#/components/schemas/Period"
           description: Analysis period
+        matrix_size:
+          $ref: "#/components/schemas/MatrixSize"
+          description: Likelihood/impact matrix size (3×3, 4×4, or 5×5)
 
     AddRiskAnalysisOutput:
       type: object
@@ -13518,6 +13550,9 @@ components:
         period:
           $ref: "#/components/schemas/Period"
           description: Analysis period
+        matrix_size:
+          $ref: "#/components/schemas/MatrixSize"
+          description: Likelihood/impact matrix size (3×3, 4×4, or 5×5)
 
     UpdateRiskAnalysisOutput:
       type: object

--- a/pkg/server/api/mcp/v1/types/matrix_size.go
+++ b/pkg/server/api/mcp/v1/types/matrix_size.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package types
+
+func NewMatrixSize(rows, cols int) *MatrixSize {
+	return &MatrixSize{
+		Rows: rows,
+		Cols: cols,
+	}
+}

--- a/pkg/server/api/mcp/v1/types/risk_analysis.go
+++ b/pkg/server/api/mcp/v1/types/risk_analysis.go
@@ -32,6 +32,7 @@ func NewRiskAnalysis(ra *coredata.RiskAnalysis) *RiskAnalysis {
 		Name:           ra.Name,
 		Description:    ra.Description,
 		Period:         NewPeriod(ra.PeriodStart, ra.PeriodEnd),
+		MatrixSize:     NewMatrixSize(ra.MatrixRows, ra.MatrixCols),
 		CreatedAt:      ra.CreatedAt,
 		UpdatedAt:      ra.UpdatedAt,
 	}


### PR DESCRIPTION
Each analysis needs an explicit likelihood/impact
matrix size so treatment-plan scores can be bounded
correctly. Support 3×3, 4×4, and 5×5 via rows and
cols across GraphQL, MCP, CLI, n8n, and the console.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit likelihood/impact matrix size to each risk analysis (3×3, 4×4, or 5×5) so treatment-plan scores are bounded. Create now requires a matrix size; update may change it; size is validated and surfaced across GraphQL, MCP, CLI, `n8n`, and the console.

### Tests **`+23`** **`-4`**
Updated e2e flows to include matrixSize on create/update and assert returned rows/cols; factory seeds 5×5 by default.

### Coredata **`+43`** **`-0`**
Added NOT NULL `matrix_rows` and `matrix_cols`, backfilled 5×5 via column defaults, then dropped defaults; threaded fields through selects/inserts/updates. Validation is enforced in the service layer.
- Run migration 20260812T131804Z before deploying the API.

### GraphQL API **`+48`** **`-0`**
Added `MatrixSize` type/input; exposed `RiskAnalysis.matrixSize` (non-null); required `matrixSize` on create; accepted on update; wired inputs to the service.

### MCP **`+82`** **`-0`**
Extended spec with `MatrixSize`, required it in add, allowed in update, and mapped rows/cols through resolvers and types.

### prb (CLI) **`+97`** **`-2`**
Create requires `--matrix-rows` and `--matrix-cols` (or interactive selection); update accepts optional size; list/view display matrix size.

### Service **`+39`** **`-0`**
Introduced `MatrixSize` and validation (rows, cols ∈ {3,4,5} and equal); required on create; optional on update; persisted to coredata.

### App: console **`+198`** **`-11`**
Added matrix size select to create/update dialogs with validation, displayed matrix size in list and detail views, updated i18n, and surfaced field errors via `ControlledField`.

### Package: `n8n-node` **`+97`** **`-6`**
Create requires “Matrix Size”, update accepts optional size, `get`/`getAll` responses include `matrixSize`, and a parser validates and maps options to rows/cols.

<sup>Written for commit 40b934a1fea6523e75a477f8af77df314cc20e4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



