### PR TITLE
Allow free-text profile kinds

### DIFF
--- a/apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { formatDatetime, getAssignableRoles, getMembershipRoles, peopleRoles, roles } from "@probo/helpers";
+import { formatDatetime, getAssignableRoles, getMembershipRoles, roles } from "@probo/helpers";
 import { Button, Field, Input, Option } from "@probo/ui";
 import { use } from "react";
 import { useWatch } from "react-hook-form";
@@ -252,19 +252,12 @@ export function PersonForm(props: {
           </div>
         </>
       )}
-      <ControlledField
-        control={control}
-        name="kind"
-        type="select"
+      <Field
+        {...register("kind")}
+        type="text"
         label={t("personForm.fields.type")}
         disabled={disabled || scimManaged}
-      >
-        {peopleRoles.map(role => (
-          <Option key={role} value={role}>
-            {t(`personForm.kinds.${role}`)}
-          </Option>
-        ))}
-      </ControlledField>
+      />
       <Field
         label={t("personForm.fields.position")}
         {...register("position")}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- render the profile kind field as a text input
- preserve existing defaults and SCIM-managed disabled behavior

## Testing
- `npm run check -w @probo/console`
- `node --experimental-strip-types ./node_modules/eslint/bin/eslint.js apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx`
- manually verified create and edit forms accept an arbitrary `Intern` value without submission

[profile_kind_free_text_demo.mp4](https://cursor.com/agents/bc-84a4fd34-652f-46af-9118-a04b38d42836/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprofile_kind_free_text_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84a4fd34-652f-46af-9118-a04b38d42836?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84a4fd34-652f-46af-9118-a04b38d42836&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow free‑text entry for the Person “profile kind” field to support custom values. Previously this field was a select of predefined roles; now it is a text input, keeping the existing default and remaining disabled for SCIM‑managed users.

### App: console **`+5`** **`-12`**
- Replace the `kind` select with a text input in `PersonForm`; remove `peopleRoles` and related `Option` rendering.
- Drop the `peopleRoles` import from `@probo/helpers`.
- No API change: consumers still receive a `kind` string. Review that no UI depends on localized option labels and that validation accepts arbitrary strings.

<sup>Written for commit 41595fc8c410630ba9d3e936288c43f539b7ffb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

