### PR TITLE
Display evidence names in measures

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -2034,7 +2034,7 @@
   },
   "measureEvidencesTab": {
     "pageTitle": "{{name}} - Evidences",
-    "columns": { "description": "Description", "fileType": "File type", "fileSize": "File size", "createdAt": "Created at" },
+    "columns": { "name": "Name", "description": "Description", "fileType": "File type", "fileSize": "File size", "createdAt": "Created at" },
     "messages": { "deleted": "Evidence \"{{name}}\" has been deleted successfully" },
     "errors": { "delete": "Failed to delete evidence" },
     "deleteConfirmation": "This will permanently delete the evidence \"{{name}}\". This action cannot be undone.",

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -4092,6 +4092,7 @@
   "measureEvidencesTab": {
     "pageTitle": "{{name}} - Preuves",
     "columns": {
+      "name": "Nom",
       "description": "Description",
       "fileType": "Type de fichier",
       "fileSize": "Taille du fichier",

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -4088,6 +4088,7 @@
   "measureEvidencesTab": {
     "pageTitle": "{{name}} - Bewijsstukken",
     "columns": {
+      "name": "Naam",
       "description": "Beschrijving",
       "fileType": "Bestandstype",
       "fileSize": "Bestandsgrootte",

--- a/apps/console/src/pages/organizations/measures/tabs/MeasureEvidencesTab.tsx
+++ b/apps/console/src/pages/organizations/measures/tabs/MeasureEvidencesTab.tsx
@@ -145,6 +145,7 @@ export default function MeasureEvidencesTab() {
       <SortableTable {...pagination}>
         <Thead>
           <Tr>
+            <Th>{t("measureEvidencesTab.columns.name")}</Th>
             <Th>{t("measureEvidencesTab.columns.description")}</Th>
             <Th>{t("measureEvidencesTab.columns.fileType")}</Th>
             <Th>{t("measureEvidencesTab.columns.fileSize")}</Th>
@@ -164,7 +165,7 @@ export default function MeasureEvidencesTab() {
           ))}
           {pagination.data.canUploadEvidence && (
             <TrButton
-              colspan={5}
+              colspan={6}
               onClick={() => dialogRef.current?.open()}
               icon={IconPlusLarge}
             >
@@ -257,6 +258,7 @@ function EvidenceRow(props: {
         />
       )}
       <Tr to={evidenceUrl}>
+        <Td>{evidence.file?.fileName || "—"}</Td>
         <Td>
           <span className="text-txt-secondary text-sm line-clamp-2">
             {evidence.description || "—"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore evidence names as a separate column on measure detail pages
- keep generated descriptions visible in their own column
- add localized column labels for English, French, and Dutch

## Testing
- `npm -w @probo/console run check`
- locale JSON parsing validation
- manual browser walkthrough covering tab reload and filename rendering

## Issue
- [ENG-740](https://linear.app/probo/issue/ENG-740/display-evidence-names-in-the-measure)

## Walkthrough
[evidence_name_display_walkthrough.mp4](https://cursor.com/agents/bc-7745d97d-801a-41fd-9005-1e638e7b2cd0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevidence_name_display_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-740](https://linear.app/probo/issue/ENG-740/display-evidence-names-in-the-measure)

<div><a href="https://cursor.com/agents/bc-7745d97d-801a-41fd-9005-1e638e7b2cd0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7745d97d-801a-41fd-9005-1e638e7b2cd0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the evidence name as its own column on the Measures > Evidences tab so files stay identifiable when no generated description exists. Keeps the generated description in a separate column and localizes the new “Name” header; aligns with ENG-740.

### App: console **`+6`** **`-2`**
- Add “Name” column to `MeasureEvidencesTab` (shows `fileName` or “—”); adjust the upload row `colspan` from 5 to 6.
- Required: update any tests or DOM selectors that assumed 5 columns or the description as the first column (now 6 columns, Name appears first).

<sup>Written for commit 3aafab863ed213214e9b87529dbde9f5f3b9b29f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

