### PR TITLE
Persist measure_id on task update

### DIFF
--- a/pkg/coredata/task.go
+++ b/pkg/coredata/task.go
@@ -585,7 +585,8 @@ SET
   time_estimate = @time_estimate,
   updated_at = @updated_at,
   assigned_to_profile_id = @assigned_to_profile_id,
-  deadline = @deadline
+  deadline = @deadline,
+  measure_id = @measure_id
 WHERE %s
     AND id = @task_id
 `
@@ -602,6 +603,7 @@ WHERE %s
 		"updated_at":             t.UpdatedAt,
 		"assigned_to_profile_id": t.AssignedToID,
 		"deadline":               t.Deadline,
+		"measure_id":             t.MeasureID,
 	}
 
 	maps.Copy(args, scope.SQLArguments())


### PR DESCRIPTION
### Problem

Linking a measure to an **existing** task does not persist. `updateTask` returns success — the payload carries the measure and `updatedAt` is bumped — but a refetch shows `task.measure: null` and the task is absent from `measure.tasks`.

In the console this surfaces as a task that never appears under its measure, and an edit dialog where the measure select is the only field with no previous value (it prefills from `task.measure?.id`, which was never stored).

Creating a task with a measure is unaffected — the INSERT lists `measure_id`.

### Cause

`Task.Update` in `pkg/coredata/task.go` omits `measure_id` from the `SET` clause. `TaskService.Update` validates the measure and assigns `task.MeasureID` (`pkg/probo/task_service.go`), so the write reports success while the column is never written.

### Fix

Add `measure_id` to the SET clause and the named args. This also makes clearing the measure work, which `TaskService.Update` already handles by setting `task.MeasureID = nil`.

### Reproduce

1. Create a task with no measure.
2. `updateTask` with a valid `measureId` — the payload shows the measure.
3. Re-query the task: `measure` is `null`; `measure.tasks` totalCount is unchanged.

Verified against v0.258.0; the SET clause is identical on v0.259.0 and current main.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task updates so linking or clearing a measure on an existing task persists. Previously, `updateTask` returned success but did not write `measure_id`, so refetching showed `measure: null` and the task was missing from `measure.tasks`; now the update writes `measure_id` (or NULL) and reads reflect the change.

### Coredata **`+3`** **`-1`**

Adds `measure_id` to the `UPDATE ... SET` clause and the named args in `pkg/coredata/task.go`. This aligns with `TaskService.Update`, ensuring measure links persist on update and allowing measure removal by writing NULL. INSERT behavior remains unchanged.

<sup>Written for commit 7c0d02f3c732b7a15933a07ec6727ee926d642ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

