### PR TITLE
Show short Windows OS and agent versions

### DIFF
--- a/apps/console/src/pages/organizations/devices/DevicesPage.tsx
+++ b/apps/console/src/pages/organizations/devices/DevicesPage.tsx
@@ -142,6 +142,7 @@ export function DevicesPage({ queryRef }: DevicesPageProps) {
             <Th>{t("devices.fields.state")}</Th>
             <Th>{t("devices.fields.platform")}</Th>
             <Th>{t("devices.fields.osVersion")}</Th>
+            <Th>{t("devices.fields.agentVersion")}</Th>
             <SortableTh field="LAST_SEEN_AT">{t("devices.fields.lastSeen")}</SortableTh>
             <Th></Th>
           </Tr>

--- a/apps/console/src/pages/organizations/devices/_components/DeviceRow.tsx
+++ b/apps/console/src/pages/organizations/devices/_components/DeviceRow.tsx
@@ -49,6 +49,7 @@ const deviceRowFragment = graphql`
     hostname
     platform
     osVersion
+    agentVersion
     lastSeenAt
     owner {
       id
@@ -107,6 +108,7 @@ export function DeviceRow({
         </Td>
         <Td>{displayValue(device.platform, pendingLabel)}</Td>
         <Td>{displayValue(device.osVersion, pendingLabel)}</Td>
+        <Td>{displayValue(device.agentVersion, pendingLabel)}</Td>
         <Td>
           {device.lastSeenAt
             ? dateTimeFormat(i18n.language, device.lastSeenAt)

--- a/pkg/deviceagent/windows_ver.go
+++ b/pkg/deviceagent/windows_ver.go
@@ -21,58 +21,22 @@
 package deviceagent
 
 import (
-	"context"
-	"time"
+	"regexp"
+	"strings"
 )
 
-func platformString() string {
-	return "WINDOWS"
-}
+var windowsVerNumber = regexp.MustCompile(`\d+(?:\.\d+)+`)
 
-func collectOSVersion() string {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	out, _ := runQuiet(ctx, "cmd", "/C", "ver")
-	if out != "" {
-		return parseWindowsVerOutput(out)
+// parseWindowsVerOutput extracts the numeric version from `cmd /C ver` output.
+// The banner label is localized (English "Version", Spanish "Versión",
+// Japanese "バージョン"), so the parser takes the first dotted numeric
+// token rather than stripping a fixed word. Unparseable input is returned
+// trimmed.
+func parseWindowsVerOutput(s string) string {
+	s = strings.TrimSpace(s)
+	if m := windowsVerNumber.FindString(s); m != "" {
+		return m
 	}
 
-	out, _ = runQuiet(ctx, "uname", "-sr")
-
-	return out
-}
-
-func collectHardwareUUID() string {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	// `wmic` is deprecated; `Get-CimInstance` requires PowerShell.
-	out, _ := runQuiet(
-		ctx,
-		"powershell",
-		"-NoProfile",
-		"-Command",
-		"(Get-CimInstance Win32_ComputerSystemProduct).UUID",
-	)
-	if out != "" {
-		return out
-	}
-
-	return hashFallbackUUID()
-}
-
-func collectSerialNumber() string {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	out, _ := runQuiet(
-		ctx,
-		"powershell",
-		"-NoProfile",
-		"-Command",
-		"(Get-CimInstance Win32_BIOS).SerialNumber",
-	)
-
-	return out
+	return s
 }

--- a/pkg/deviceagent/windows_ver_test.go
+++ b/pkg/deviceagent/windows_ver_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package deviceagent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseWindowsVerOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "english version banner",
+			input: "Microsoft Windows [Version 10.0.26200.8875]",
+			want:  "10.0.26200.8875",
+		},
+		{
+			name:  "french version banner",
+			input: "Microsoft Windows [version 10.0.26200.8875]",
+			want:  "10.0.26200.8875",
+		},
+		{
+			name:  "spanish version banner",
+			input: "Microsoft Windows [Versión 10.0.26200.8875]",
+			want:  "10.0.26200.8875",
+		},
+		{
+			name:  "italian version banner",
+			input: "Microsoft Windows [versione 10.0.26200.8875]",
+			want:  "10.0.26200.8875",
+		},
+		{
+			name:  "japanese version banner",
+			input: "Microsoft Windows [バージョン 10.0.26200.8875]",
+			want:  "10.0.26200.8875",
+		},
+		{
+			name:  "russian version banner",
+			input: "Microsoft Windows [Версия 10.0.26200.8875]",
+			want:  "10.0.26200.8875",
+		},
+		{
+			name:  "chinese version banner",
+			input: "Microsoft Windows [版本 10.0.26200.8875]",
+			want:  "10.0.26200.8875",
+		},
+		{
+			name:  "surrounding whitespace",
+			input: "  \nMicrosoft Windows [Version 10.0.26200.8875]\r\n  ",
+			want:  "10.0.26200.8875",
+		},
+		{
+			name:  "already short version",
+			input: "10.0.26200.8875",
+			want:  "10.0.26200.8875",
+		},
+		{
+			name:  "empty brackets fall back to original",
+			input: "Microsoft Windows []",
+			want:  "Microsoft Windows []",
+		},
+		{
+			name:  "version prefix without number falls back",
+			input: "Microsoft Windows [Version]",
+			want:  "Microsoft Windows [Version]",
+		},
+		{
+			name:  "unparseable text",
+			input: "not a windows ver banner",
+			want:  "not a windows ver banner",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				assert.Equal(t, tt.want, parseWindowsVerOutput(tt.input))
+			},
+		)
+	}
+}


### PR DESCRIPTION
cmd /C ver returns a localized banner such as
"Microsoft Windows [Version 10.0.26200.8875]",
which overflows the devices list. Store only
the numeric version, matching Darwin.

The same table now shows the last reported
agent version so rollouts can be tracked
without opening each device.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortens Windows OS version reporting and adds agent version to the devices table. Previously we stored the full localized cmd /C ver banner; we now store only the dotted numeric version to prevent overflow and align with Darwin, and the table shows the last reported agent version to track rollouts.

### Tests **`+109`** **`-0`**
Covers parsing of cmd /C ver across multiple locales, whitespace handling, already-short inputs, and fallbacks when no version is found.

### Service **`+43`** **`-1`**
Introduces parseWindowsVerOutput in `pkg/deviceagent` and uses it in Windows host info collection to extract the first dotted numeric token, falling back to the trimmed original string. Existing devices will report the short version after the next agent check-in.

### App: console **`+3`** **`-0`**
Adds an Agent Version column and requests `agentVersion` in the device row fragment for quick rollout tracking.

<sup>Written for commit 6cc3305326a14a08ad0b51eea9af0b05b5d660ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

