### PR TITLE
Fix npm audit findings and trim unnecessary overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -887,7 +887,6 @@
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
       "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/estree": "^1.0.8",
@@ -905,7 +904,6 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.4.tgz",
       "integrity": "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@apm-js-collab/code-transformer": "^0.18.1",
@@ -921,7 +919,6 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
       "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@apm-js-collab/code-transformer": "^0.18.0",
@@ -1481,7 +1478,6 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
       "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -1494,7 +1490,6 @@
       "version": "6.12.4",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
       "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -1509,7 +1504,6 @@
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
       "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
@@ -1519,7 +1513,6 @@
       "version": "6.43.8",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.8.tgz",
       "integrity": "sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.7.0",
@@ -2473,20 +2466,19 @@
       }
     },
     "node_modules/@langchain/classic": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/@langchain/classic/-/classic-1.0.27.tgz",
-      "integrity": "sha512-dMq8rgt3cy/QoHrB6HIKobievyW00DfuZcASG0aMy47Pf5TQq3vZM2tLT1kkCBe2yJnncQwqmAzxoEgFLJZrcw==",
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/@langchain/classic/-/classic-1.0.41.tgz",
+      "integrity": "sha512-m6uIp6qrS/D/QKUvE0M/FZ7gm6g4khXzWROh0clYaDjmb3q+kUuNWdAthHFB6c4Gd7PY4O6jKGj8qMqhceaDGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@langchain/openai": "1.4.1",
+        "@langchain/openai": "1.5.6",
         "@langchain/textsplitters": "1.0.1",
         "handlebars": "^4.7.9",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^5.2.2",
         "jsonpointer": "^5.0.1",
         "openapi-types": "^12.1.3",
-        "uuid": "^10.0.0",
-        "yaml": "^2.8.3",
+        "yaml": "^2.9.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
@@ -2496,7 +2488,7 @@
         "langsmith": ">=0.4.0 <1.0.0"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.0.0",
+        "@langchain/core": "^1.2.5",
         "cheerio": "*",
         "peggy": "^5.1.0",
         "typeorm": "*"
@@ -2514,21 +2506,44 @@
       }
     },
     "node_modules/@langchain/classic/node_modules/@langchain/openai": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.4.1.tgz",
-      "integrity": "sha512-jaHk4TnLqWrQ1KYmavvwCImW6x8pBy6LLTK73tzSMg7HBLbq0g/l7EkpMcxZWDOvyufuCXUqO2bj47apcOhw6Q==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.5.6.tgz",
+      "integrity": "sha512-1cesvhCXw30tMYWXXQaK2gN4aDIKq266LcMSjZn7O/kue/vPnCOAxiwy54HcGQQf7m/sVKfhOn4QwVRObSeAsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.12",
-        "openai": "^6.32.0",
+        "openai": "^6.41.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.38"
+        "@langchain/core": "^1.2.5"
+      }
+    },
+    "node_modules/@langchain/classic/node_modules/js-yaml": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/@langchain/classic/node_modules/openai": {
@@ -2563,11 +2578,12 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-nXmyH0FbcsASlRmC9sbqX0gjQdxgB9KcS13vkw9PMaH0zzylwZkGFU9sY0XCPa2/AokmaNTU9DOW3IUDfAtQow==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.5.tgz",
+      "integrity": "sha512-4lXj3fTPQYGdEtOG9gWDnvmp6wpXNMo9MmWzfZxxPUxMcjulZJa93pYAZ90luFLg2YVdVuUl2tuwdD7tY5K9MA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "@standard-schema/spec": "^1.1.0",
@@ -2615,9 +2631,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.28",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.28.tgz",
-      "integrity": "sha512-4j3XuM0PvtmAbL8mPfBS99ez3+ytRfgbOpAR/nOeaejTRF3Q9dNw2QnaGLGng8wLPtGLoSj+SYgUOVxy9Bv9vg==",
+      "version": "1.9.29",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.29.tgz",
+      "integrity": "sha512-W+ccugM5EzBHvaOieyYxlSbhAy6HWF8Tyn6b/BlTWuFd8xtcnQOz2WuFyofcAc9+aQHE+6yHJfIywGOvjxS+bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2761,14 +2777,12 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
       "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@lezer/highlight": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.3.0"
@@ -2778,7 +2792,6 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
       "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
@@ -2788,7 +2801,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
       "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@mermaid-js/parser": {
@@ -2801,9 +2813,9 @@
       }
     },
     "node_modules/@n8n_io/ai-assistant-sdk": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@n8n_io/ai-assistant-sdk/-/ai-assistant-sdk-1.25.0.tgz",
-      "integrity": "sha512-7V4dwVuHIkLdwd7Cx0k1miwr3KttC4rLQ+zVLftBMmSDx6n+0/W4a8BGhwrVHNx6uQwA1UGEWz+wSfO+gtBA4Q==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@n8n_io/ai-assistant-sdk/-/ai-assistant-sdk-1.26.0.tgz",
+      "integrity": "sha512-iVW3dfhg48WipFhiVUjOIqo0MvFv1wrGamvbTUZusMF13NjycicLZSE1Bd4V6nLsLtSqcOfZ1m8LXFrmZyxOOw==",
       "dev": true,
       "license": "LicenseRef-n8n-enterprise",
       "engines": {
@@ -2812,19 +2824,19 @@
       }
     },
     "node_modules/@n8n/ai-node-sdk": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.23.0.tgz",
-      "integrity": "sha512-ToeoLEFOlYfQ0R1rF6Vw8NjWgOS3Y54aQ9kvFMXQupWcHnp552olJo+R9GK7aGJapEsgVzrmiWxHctsqxUd9XA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.25.1.tgz",
+      "integrity": "sha512-xQ7DjKqBt6nirBcGSUuhvbO0NGwYjusOnLQFpFYw6s7fSFcbXJzvBV/RgWGtoA33Dc0K+4ZQTcK/p4cwihmv4A==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/ai-utilities": "0.26.0"
+        "@n8n/ai-utilities": "0.28.1"
       }
     },
     "node_modules/@n8n/ai-utilities": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.26.0.tgz",
-      "integrity": "sha512-PGhiTHYsn7wDfZYNquO1QzeL6DzVlHmkNcTnXdKSNW4xN08nPV2dGxMNk6ldU5Q+fRtfUdCKrisqQlfUYgsKKA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.28.1.tgz",
+      "integrity": "sha512-FygdQIkxUqB5oXF1B8i4813RKJQGaufaJGCOBWH2QADPTqZSK7sI+ygQK6GKjPqjLjO8pk7yUi9UnWRWCkGLjg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
@@ -2833,39 +2845,39 @@
         "@langchain/core": "1.2.0",
         "@langchain/openai": "1.4.4",
         "@langchain/textsplitters": "1.0.1",
-        "@n8n/api-types": "1.33.0",
-        "@n8n/backend-network": "1.7.0",
-        "@n8n/config": "2.31.0",
+        "@n8n/api-types": "1.35.1",
+        "@n8n/backend-network": "1.9.1",
+        "@n8n/config": "2.33.1",
         "@n8n/typescript-config": "1.9.0",
-        "@n8n/utils": "1.41.0",
+        "@n8n/utils": "1.43.0",
         "@thednp/dommatrix": "^2.0.12",
         "js-tiktoken": "1.0.21",
         "langchain": "1.2.30",
         "lodash": "4.18.1",
-        "n8n-workflow": "2.33.0",
+        "n8n-workflow": "2.35.0",
         "pdf-parse": "2.4.5",
         "tmp-promise": "3.0.3",
         "undici": "^6.27.0",
-        "zod": "3.25.67",
+        "zod": "3.25.76",
         "zod-to-json-schema": "3.23.3"
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@langchain/community": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/@langchain/community/-/community-1.1.27.tgz",
-      "integrity": "sha512-s2U3w7QV7QpkFtY1eZMni4poz+nKLFclpDi3a7hUbZ67ttsGaU9WkZ2BiLuzLIs+IFaUvON/KcGkE8EqAl9aPA==",
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/@langchain/community/-/community-1.1.29.tgz",
+      "integrity": "sha512-eJbE0IARueEg+Lljk7SIGGeiSnu5u0mcT0MPIF7UG6jYPNXOpSebwiXsS3aIKOyJZSj0DlmBPv7q0hkLrxDtHA==",
       "deprecated": "This package has been deprecated. See https://github.com/langchain-ai/langchainjs-community/issues/61 for more info",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@langchain/classic": "1.0.27",
-        "@langchain/openai": "1.4.1",
+        "@langchain/classic": "^1.0.27",
+        "@langchain/openai": "^1.4.1",
         "binary-extensions": "^2.2.0",
         "flat": "^5.0.2",
         "js-yaml": "^4.1.1",
         "langsmith": ">=0.4.0 <1.0.0",
         "math-expression-evaluator": "^2.0.0",
-        "uuid": "^10.0.0",
+        "uuid": "^14.0.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
@@ -2969,7 +2981,7 @@
         "notion-to-md": "^3.1.0",
         "officeparser": "^6.0.4",
         "openai": "*",
-        "pdf-parse": "2.4.5",
+        "pdf-parse": "^1.0.0 || ^2.0.0",
         "pg": "^8.11.0",
         "pg-copy-streams": "^7.0.0",
         "pickleparser": "^0.2.1",
@@ -3345,246 +3357,62 @@
         }
       }
     },
-    "node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/openai": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.4.1.tgz",
-      "integrity": "sha512-jaHk4TnLqWrQ1KYmavvwCImW6x8pBy6LLTK73tzSMg7HBLbq0g/l7EkpMcxZWDOvyufuCXUqO2bj47apcOhw6Q==",
+    "node_modules/@n8n/ai-utilities/node_modules/@langchain/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-nXmyH0FbcsASlRmC9sbqX0gjQdxgB9KcS13vkw9PMaH0zzylwZkGFU9sY0XCPa2/AokmaNTU9DOW3IUDfAtQow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
         "js-tiktoken": "^1.0.12",
-        "openai": "^6.32.0",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
         "node": ">=20"
-      },
-      "peerDependencies": {
-        "@langchain/core": "^1.1.38"
       }
     },
-    "node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/@n8n/api-types": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.33.0.tgz",
-      "integrity": "sha512-zFTfRKV+J4e2xiORO3Kjmy6dPdAAf8Ku8ijY3A74f9wPViPO4xTrEQQv8Qw8+/DjdAHZD5+18v0MYwakkglyDw==",
+    "node_modules/@n8n/api-types": {
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.35.1.tgz",
+      "integrity": "sha512-xueM48fLsgmMs2cUfPJr81LY5fD2+hZcXOr5+/kMhR2wSoDJKZ/nXMDqyBjURdOUK1hr432F3mWlan6Q6MsjaA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n_io/ai-assistant-sdk": "1.25.0",
-        "@n8n/permissions": "0.70.0",
-        "n8n-workflow": "2.33.0",
+        "@n8n_io/ai-assistant-sdk": "1.26.0",
+        "@n8n/permissions": "0.72.0",
+        "n8n-workflow": "2.35.0",
         "xss": "1.0.15"
       },
       "peerDependencies": {
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/@n8n/errors": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
-      "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "callsites": "3.1.0"
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/@n8n/expression-runtime": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
-      "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/errors": "0.13.0",
-        "@n8n/tournament": "1.9.0",
-        "isolated-vm": "^6.1.2",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.8",
-        "jssha": "3.3.1",
-        "lodash": "4.18.1",
-        "luxon": "3.7.2",
-        "md5": "2.3.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/@n8n/tournament": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
-      "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "ast-types": "^0.16.1",
-        "esprima-next": "^5.8.4",
-        "recast": "^0.22.0"
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/n8n-workflow": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.0.tgz",
-      "integrity": "sha512-gfmQ26TFpUSFjgeaoajMeAJzDOcIWCgLK+YztdcKRXzu3j4w5MN9L5mWxQPuShSxCLCF/cJcSblNr20vV6MBDA==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@codemirror/autocomplete": "6.20.0",
-        "@n8n/errors": "0.13.0",
-        "@n8n/expression-runtime": "0.24.0",
-        "@n8n/tournament": "1.9.0",
-        "@n8n/utils": "1.41.0",
-        "@sentry/core": "^10.55.0",
-        "@sentry/node": "^10.55.0",
-        "ast-types": "0.16.1",
-        "axios": "1.18.0",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.6",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.8",
-        "json-schema": "0.4.0",
-        "jsonrepair": "3.13.2",
-        "jssha": "3.3.1",
-        "lodash": "4.18.1",
-        "luxon": "3.7.2",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "ssh2": "1.15.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "uuid": "11.1.1",
-        "xml2js": "0.6.2"
-      },
-      "peerDependencies": {
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/openai": {
-      "version": "6.49.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.49.0.tgz",
-      "integrity": "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
-        "@smithy/hash-node": ">=4.3.0 <5",
-        "@smithy/signature-v4": ">=5.4.0 <6",
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-provider-node": {
-          "optional": true
-        },
-        "@smithy/hash-node": {
-          "optional": true
-        },
-        "@smithy/signature-v4": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "zod": "3.25.76"
       }
     },
     "node_modules/@n8n/backend-common": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.33.0.tgz",
-      "integrity": "sha512-s23/vlWPEfjMkHfWA2cUuMegFjr7PG5S5MNzLKqNfiOLFPsYs5bfdE3Us9FzHOmHwDgGr8yB+VLP7dGFdfI/2A==",
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.35.1.tgz",
+      "integrity": "sha512-Sc1hDlyjdkfhvtEPd0wGtHkKzs6oLVy3snDcaaoqV5+8RqBIdPs0GY45cqrpl5bmVsIA/ZCK4SNOMXKWiS/IhA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/config": "2.31.0",
-        "@n8n/constants": "0.32.0",
-        "@n8n/decorators": "1.33.0",
+        "@n8n/config": "2.33.1",
+        "@n8n/constants": "0.34.0",
+        "@n8n/decorators": "1.35.1",
         "@n8n/di": "0.16.0",
-        "@n8n/utils": "1.41.0",
+        "@n8n/utils": "1.43.0",
         "callsites": "3.1.0",
         "flatted": "3.4.2",
         "logform": "2.6.1",
-        "n8n-workflow": "2.33.0",
+        "n8n-workflow": "2.35.0",
         "picocolors": "1.0.1",
         "reflect-metadata": "0.2.2",
         "stream-json": "1.9.1",
         "winston": "3.14.2",
         "yargs-parser": "21.1.1"
-      }
-    },
-    "node_modules/@n8n/backend-common/node_modules/@n8n/errors": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
-      "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "callsites": "3.1.0"
-      }
-    },
-    "node_modules/@n8n/backend-common/node_modules/@n8n/expression-runtime": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
-      "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/errors": "0.13.0",
-        "@n8n/tournament": "1.9.0",
-        "isolated-vm": "^6.1.2",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.8",
-        "jssha": "3.3.1",
-        "lodash": "4.18.1",
-        "luxon": "3.7.2",
-        "md5": "2.3.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/backend-common/node_modules/@n8n/tournament": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
-      "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "ast-types": "^0.16.1",
-        "esprima-next": "^5.8.4",
-        "recast": "^0.22.0"
       }
     },
     "node_modules/@n8n/backend-common/node_modules/callsites": {
@@ -3597,44 +3425,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@n8n/backend-common/node_modules/n8n-workflow": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.0.tgz",
-      "integrity": "sha512-gfmQ26TFpUSFjgeaoajMeAJzDOcIWCgLK+YztdcKRXzu3j4w5MN9L5mWxQPuShSxCLCF/cJcSblNr20vV6MBDA==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@codemirror/autocomplete": "6.20.0",
-        "@n8n/errors": "0.13.0",
-        "@n8n/expression-runtime": "0.24.0",
-        "@n8n/tournament": "1.9.0",
-        "@n8n/utils": "1.41.0",
-        "@sentry/core": "^10.55.0",
-        "@sentry/node": "^10.55.0",
-        "ast-types": "0.16.1",
-        "axios": "1.18.0",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.6",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.8",
-        "json-schema": "0.4.0",
-        "jsonrepair": "3.13.2",
-        "jssha": "3.3.1",
-        "lodash": "4.18.1",
-        "luxon": "3.7.2",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "ssh2": "1.15.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "uuid": "11.1.1",
-        "xml2js": "0.6.2"
-      },
-      "peerDependencies": {
-        "zod": "3.25.67"
-      }
-    },
     "node_modules/@n8n/backend-common/node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
@@ -3642,131 +3432,30 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@n8n/backend-common/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@n8n/backend-network": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@n8n/backend-network/-/backend-network-1.7.0.tgz",
-      "integrity": "sha512-+lO4UDPsjJKPC4TgzIkst7NW4OwpThPlBxayL6Ly8YbazKI7IPeAfAcKsILNxrIfiF2eJZPKzn+PVIwaVfH90Q==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@n8n/backend-network/-/backend-network-1.9.1.tgz",
+      "integrity": "sha512-//LXLQlwU41aNbAeOqKeMltmnjaBsWFaRztQl6b6pSypvgQ4dqNvjo5Cil4Pi9HOyuyIs6r9/f4ggGZ4RynVaw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/backend-common": "1.33.0",
-        "@n8n/config": "2.31.0",
-        "@n8n/constants": "0.32.0",
+        "@n8n/backend-common": "1.35.1",
+        "@n8n/config": "2.33.1",
+        "@n8n/constants": "0.34.0",
         "@n8n/di": "0.16.0",
-        "@n8n/utils": "1.41.0",
+        "@n8n/utils": "1.43.0",
         "axios": "1.18.0",
         "cache-manager": "5.2.3",
         "form-data": "4.0.6",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
         "iconv-lite": "0.6.3",
-        "n8n-workflow": "2.33.0",
+        "n8n-workflow": "2.35.0",
         "proxy-from-env": "^1.1.0",
         "qs": "6.15.2",
         "reflect-metadata": "0.2.2",
-        "undici": "^7.28.0",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/backend-network/node_modules/@n8n/errors": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
-      "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "callsites": "3.1.0"
-      }
-    },
-    "node_modules/@n8n/backend-network/node_modules/@n8n/expression-runtime": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
-      "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/errors": "0.13.0",
-        "@n8n/tournament": "1.9.0",
-        "isolated-vm": "^6.1.2",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.8",
-        "jssha": "3.3.1",
-        "lodash": "4.18.1",
-        "luxon": "3.7.2",
-        "md5": "2.3.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/backend-network/node_modules/@n8n/tournament": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
-      "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "ast-types": "^0.16.1",
-        "esprima-next": "^5.8.4",
-        "recast": "^0.22.0"
-      }
-    },
-    "node_modules/@n8n/backend-network/node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@n8n/backend-network/node_modules/n8n-workflow": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.0.tgz",
-      "integrity": "sha512-gfmQ26TFpUSFjgeaoajMeAJzDOcIWCgLK+YztdcKRXzu3j4w5MN9L5mWxQPuShSxCLCF/cJcSblNr20vV6MBDA==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@codemirror/autocomplete": "6.20.0",
-        "@n8n/errors": "0.13.0",
-        "@n8n/expression-runtime": "0.24.0",
-        "@n8n/tournament": "1.9.0",
-        "@n8n/utils": "1.41.0",
-        "@sentry/core": "^10.55.0",
-        "@sentry/node": "^10.55.0",
-        "ast-types": "0.16.1",
-        "axios": "1.18.0",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.6",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.8",
-        "json-schema": "0.4.0",
-        "jsonrepair": "3.13.2",
-        "jssha": "3.3.1",
-        "lodash": "4.18.1",
-        "luxon": "3.7.2",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "ssh2": "1.15.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "uuid": "11.1.1",
-        "xml2js": "0.6.2"
-      },
-      "peerDependencies": {
-        "zod": "3.25.67"
+        "undici": "^7.29.0",
+        "zod": "3.25.76"
       }
     },
     "node_modules/@n8n/backend-network/node_modules/undici": {
@@ -3779,176 +3468,38 @@
         "node": ">=20.18.1"
       }
     },
-    "node_modules/@n8n/backend-network/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@n8n/config": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.31.0.tgz",
-      "integrity": "sha512-pO4J2CdhpBsSnCL+eOflyQ/SZQCm55nkbXtG5xF3wOtAIeXWAyHKf8FDUX4oIPdtrRDSRto8QXl3IObVeLA2gQ==",
+      "version": "2.33.1",
+      "resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.33.1.tgz",
+      "integrity": "sha512-JTLzvP0s7/Nq+A+mDnue+TZLVyKJmUZNKQ0ki3sqUvo59pbKQ8Ct3GPSMcPV7Jru+f+Q4X2bXNl17+2kAaK3WQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/constants": "0.32.0",
+        "@n8n/constants": "0.34.0",
         "@n8n/di": "0.16.0",
         "reflect-metadata": "0.2.2",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/config/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "zod": "3.25.76"
       }
     },
     "node_modules/@n8n/constants": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.32.0.tgz",
-      "integrity": "sha512-ewF/bQL2bjmHU9Dv5PnW8uDpYw5GlFJ0/nuAp+RDK9OJXXm19ErHb9itLyANvNTLGPQv8bb0BMvHh2kpWaa/8g==",
-      "dev": true,
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.34.0.tgz",
+      "integrity": "sha512-d9iKTQ5ngexLwX9/eD8GmysQ9DBHb4uVmApIvjfd6vC60hckxlpYgSTV0ySeKm00+AUHA+APU6jYe5bQfoxayA==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@n8n/decorators": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.33.0.tgz",
-      "integrity": "sha512-+oCyb6rTHbwrMNAyU1Qd5Tynqmib8x0vlOwQG7zPy9udAtiM4xnllAcC+mMfjkL5qyjg2YaKl4v0kNwkLX2Ylw==",
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.35.1.tgz",
+      "integrity": "sha512-EnihLHjJpLq/Hci99Ra+y0r7CUHDxnm0nxVDTb4XGVc1/4Ev5yEVWthJ0KBVem11OvQ+ujw9M851Rw6jWVaQGA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/api-types": "1.33.0",
-        "@n8n/constants": "0.32.0",
+        "@n8n/api-types": "1.35.1",
+        "@n8n/constants": "0.34.0",
         "@n8n/di": "0.16.0",
-        "@n8n/permissions": "0.70.0",
+        "@n8n/permissions": "0.72.0",
         "lodash": "4.18.1",
-        "n8n-workflow": "2.33.0"
-      }
-    },
-    "node_modules/@n8n/decorators/node_modules/@n8n/api-types": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.33.0.tgz",
-      "integrity": "sha512-zFTfRKV+J4e2xiORO3Kjmy6dPdAAf8Ku8ijY3A74f9wPViPO4xTrEQQv8Qw8+/DjdAHZD5+18v0MYwakkglyDw==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n_io/ai-assistant-sdk": "1.25.0",
-        "@n8n/permissions": "0.70.0",
-        "n8n-workflow": "2.33.0",
-        "xss": "1.0.15"
-      },
-      "peerDependencies": {
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/decorators/node_modules/@n8n/errors": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
-      "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "callsites": "3.1.0"
-      }
-    },
-    "node_modules/@n8n/decorators/node_modules/@n8n/expression-runtime": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
-      "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/errors": "0.13.0",
-        "@n8n/tournament": "1.9.0",
-        "isolated-vm": "^6.1.2",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.8",
-        "jssha": "3.3.1",
-        "lodash": "4.18.1",
-        "luxon": "3.7.2",
-        "md5": "2.3.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/decorators/node_modules/@n8n/tournament": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
-      "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "ast-types": "^0.16.1",
-        "esprima-next": "^5.8.4",
-        "recast": "^0.22.0"
-      }
-    },
-    "node_modules/@n8n/decorators/node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@n8n/decorators/node_modules/n8n-workflow": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.0.tgz",
-      "integrity": "sha512-gfmQ26TFpUSFjgeaoajMeAJzDOcIWCgLK+YztdcKRXzu3j4w5MN9L5mWxQPuShSxCLCF/cJcSblNr20vV6MBDA==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@codemirror/autocomplete": "6.20.0",
-        "@n8n/errors": "0.13.0",
-        "@n8n/expression-runtime": "0.24.0",
-        "@n8n/tournament": "1.9.0",
-        "@n8n/utils": "1.41.0",
-        "@sentry/core": "^10.55.0",
-        "@sentry/node": "^10.55.0",
-        "ast-types": "0.16.1",
-        "axios": "1.18.0",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.6",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.8",
-        "json-schema": "0.4.0",
-        "jsonrepair": "3.13.2",
-        "jssha": "3.3.1",
-        "lodash": "4.18.1",
-        "luxon": "3.7.2",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "ssh2": "1.15.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "uuid": "11.1.1",
-        "xml2js": "0.6.2"
-      },
-      "peerDependencies": {
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/decorators/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "n8n-workflow": "2.35.0"
       }
     },
     "node_modules/@n8n/di": {
@@ -3962,11 +3513,10 @@
       }
     },
     "node_modules/@n8n/errors": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.10.0.tgz",
-      "integrity": "sha512-Qle4gCsx7qtDRMdie3YkjuXPuo369PP32cR9Svb+INwcjLMxNzmnbJ66jFnOmLn0ntwBccUw1IecJ6axwyTgBQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
+      "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "callsites": "3.1.0"
       }
@@ -3976,20 +3526,18 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@n8n/expression-runtime": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.19.0.tgz",
-      "integrity": "sha512-ShRp3TEue2dNaP/PIQzD5DqyYUjkiaIsDVwsyfAvhsdyIUKyishsHsnogv527vjuA/WzH5cYn9X75lFeQA8hZg==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.26.0.tgz",
+      "integrity": "sha512-nbguKeoqS/VuQupHD7ZQn2gSuGEIHnOiApuuQNLzR06mNsGUXydckdwb0oa+3fSIj9BGUZqShBRhOrW8QD4/dQ==",
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
-        "@n8n/errors": "0.10.0",
-        "@n8n/tournament": "1.4.0",
+        "@n8n/errors": "0.13.0",
+        "@n8n/tournament": "1.9.0",
         "isolated-vm": "^6.1.2",
         "jmespath": "0.16.0",
         "js-base64": "3.7.8",
@@ -3999,30 +3547,20 @@
         "md5": "2.3.0",
         "title-case": "3.0.3",
         "transliteration": "2.3.5",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/expression-runtime/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "zod": "3.25.76"
       }
     },
     "node_modules/@n8n/node-cli": {
-      "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.42.0.tgz",
-      "integrity": "sha512-/0zmgZ1thTYHnM5EFWGCgMGaogRX9v3lfHe3CseqDoFXQHk52VJG/EL7h6wdG8HBUVRoPSo0vPnyCPWa+/HHOw==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.44.1.tgz",
+      "integrity": "sha512-jfEsOaiF+5c+82vU8CwseYh/9RtD7Qh//GOV+4JtSJ9bM8iKtMglqUryaYG/tCRSFT6DefMtXCRCAhatfgswXQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
         "@eslint/js": "^9.29.0",
-        "@n8n/ai-node-sdk": "0.23.0",
-        "@n8n/eslint-plugin-community-nodes": "0.27.0",
+        "@n8n/ai-node-sdk": "0.25.1",
+        "@n8n/eslint-plugin-community-nodes": "0.29.0",
         "@oclif/core": "^4.5.2",
         "change-case": "^5.4.4",
         "eslint": "9.29.0",
@@ -4121,9 +3659,9 @@
       }
     },
     "node_modules/@n8n/node-cli/node_modules/@n8n/eslint-plugin-community-nodes": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.27.0.tgz",
-      "integrity": "sha512-qTcdOyhCODOJ2VtDBpvkWFE5+gLuwUQ+D4+AnCzCQLs0Ba/scOxRGviYZYdhwY70HfNcLpakN3xKLccwFMP6Dw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.29.0.tgz",
+      "integrity": "sha512-+TvM0R8JSywAsrQpMTAQQMPwwy8rTaisBAXSDdHQyaTACtzqulXH2Al1gx0M+WwDSDpOOACBb7yTIlCxk8Ne2g==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
@@ -4284,39 +3822,24 @@
       "license": "ISC"
     },
     "node_modules/@n8n/permissions": {
-      "version": "0.70.0",
-      "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.70.0.tgz",
-      "integrity": "sha512-V6egB3bM15Aiu5+124vlX6Uth/9XfveBe0KiujubKr41tMj0YVh78ozuSsQPUpA2OpHGKusdA+Im/EmYjvpPnQ==",
+      "version": "0.72.0",
+      "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.72.0.tgz",
+      "integrity": "sha512-PYQyA15cbn35l/qO5n+XF4NubfaZBAOq/shQrXQtG1/FliYRRheVHT8Y0AX6nJRMmNTtyIeKZxWk140OzUpsoA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/permissions/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "zod": "3.25.76"
       }
     },
     "node_modules/@n8n/tournament": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.4.0.tgz",
-      "integrity": "sha512-llDdmIj3Kdfq2vX/NpLBOUU4kLjhITtIMeJmOSTApAOeAArj1D45ey4D7CFaYcYsPBw6DgF0vxifyskPDlgekw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
+      "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "ast-types": "^0.16.1",
         "esprima-next": "^5.8.4",
         "recast": "^0.22.0"
-      },
-      "engines": {
-        "node": ">=20.15",
-        "pnpm": ">=9.5"
       }
     },
     "node_modules/@n8n/typescript-config": {
@@ -4327,13 +3850,12 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@n8n/utils": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.41.0.tgz",
-      "integrity": "sha512-wjlYqMYRDI8RGNEEBQXA9Pw5FsgdqP+4tvk6HJ9POB5x9yQyF4PhHt45a2RVz0BAoGwZKuxnunR3T+pE/FbjKQ==",
-      "dev": true,
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.43.0.tgz",
+      "integrity": "sha512-009TCQGkZov/XLIa50EVFxwN8OizM22NW1tkU2MwE+oYixD+OhWTOQe+ZIBI7GvnDyHkWobBBYPdqKa2xsYcSQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/constants": "0.32.0",
+        "@n8n/constants": "0.34.0",
         "nanoid": "3.3.8"
       }
     },
@@ -4633,7 +4155,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -4643,7 +4164,6 @@
       "version": "0.220.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
       "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -4656,7 +4176,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
       "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4672,7 +4191,6 @@
       "version": "0.220.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
       "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.220.0",
@@ -4690,7 +4208,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
       "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.10.0",
@@ -4707,7 +4224,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
       "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.10.0",
@@ -4725,7 +4241,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
       "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.10.0",
@@ -4744,7 +4259,6 @@
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
       "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -6691,17 +6205,15 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
       "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.69.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
-      "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
-      "dev": true,
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.70.0.tgz",
+      "integrity": "sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==",
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.16.0"
@@ -6711,20 +6223,19 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.69.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.69.0.tgz",
-      "integrity": "sha512-xEXA1YGIiTZbrW6MWV34uS6JGQuQg2ijTI0zed+FsJb9JZKPYel/GZK8Km26vfTVb+yCXFmWZNBesKegNcVdzg==",
-      "dev": true,
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.70.0.tgz",
+      "integrity": "sha512-SPOOVxmKTVIEtqvOKkQT163e/pOwucjS7OPsCHyRs8sFR4nfBNu0EThplyqnvqd5BWBMTPH6WTBQfo+QWHV+HA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/instrumentation": "^0.220.0",
         "@opentelemetry/sdk-trace-base": "^2.9.0",
         "@sentry/conventions": "^0.16.0",
-        "@sentry/core": "10.69.0",
-        "@sentry/node-core": "10.69.0",
-        "@sentry/opentelemetry": "10.69.0",
-        "@sentry/server-utils": "10.69.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/node-core": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
+        "@sentry/server-utils": "10.70.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -6732,15 +6243,14 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.69.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.69.0.tgz",
-      "integrity": "sha512-IgArHczrZJxkgxoffHscj0NxQrG6kCazgmGQnlf3j58J1ec21YaUu8Tu+7G4Lo5tCiW3teQnwlKW1ttMXSqWRw==",
-      "dev": true,
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.70.0.tgz",
+      "integrity": "sha512-oPOEVVNxv5WHtckx2i06Wi9FLWyvOg/1DUeX732jZ4iqT2nupINaMH4nF4f4kSvUThFnxkFSRQxwqOxgzMKhKA==",
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.16.0",
-        "@sentry/core": "10.69.0",
-        "@sentry/opentelemetry": "10.69.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -6772,14 +6282,13 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.69.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.69.0.tgz",
-      "integrity": "sha512-3FyWV6YcEJuvLrlaKGE1dHXCI+1YO0a62w7PkwlRg8yp6K6YXkmdwu9GjqaYD+Ju4tm7uC7mHIsGFQMm0M7pqQ==",
-      "dev": true,
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.70.0.tgz",
+      "integrity": "sha512-UNV/2tqypcUK6FDzerAsFJn1Km/c4VZCYkUZDNbnV5S0cwAq2BYKMo4M5vovaLDBQlxA+Wk9ovbxi5wYjjl9fw==",
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.16.0",
-        "@sentry/core": "10.69.0"
+        "@sentry/core": "10.70.0"
       },
       "engines": {
         "node": ">=18"
@@ -6791,16 +6300,15 @@
       }
     },
     "node_modules/@sentry/server-utils": {
-      "version": "10.69.0",
-      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.69.0.tgz",
-      "integrity": "sha512-0MwHrA8+nNvMIsqf8m3cXwCBlUjr6AS7N6CZvHJtY1DkqEvQqEbD5VIrhzEyHN/KMZIgQ8XeDCQRhjnXFQGRhg==",
-      "dev": true,
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.70.0.tgz",
+      "integrity": "sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==",
       "license": "MIT",
       "dependencies": {
         "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
         "@apm-js-collab/tracing-hooks": "^0.13.0",
         "@sentry/conventions": "^0.16.0",
-        "@sentry/core": "10.69.0",
+        "@sentry/core": "10.70.0",
         "meriyah": "^6.1.4"
       },
       "engines": {
@@ -10091,7 +9599,6 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
@@ -10165,7 +9672,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
       "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "astring": "bin/astring"
@@ -10232,7 +9738,6 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
       "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -10245,7 +9750,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -10258,7 +9762,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -10272,7 +9775,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10451,7 +9953,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
@@ -10541,7 +10042,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
       "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=10.0.0"
@@ -10921,7 +10421,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/clean-stack": {
@@ -11278,11 +10777,34 @@
         "node": ">=4"
       }
     },
+    "node_modules/cosmiconfig/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/cpu-features": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
       "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -11297,7 +10819,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
       "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-fetch": {
@@ -12569,7 +12090,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
       "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -13104,7 +12624,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -13130,7 +12649,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -13498,7 +13016,6 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -14405,7 +13922,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
       "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "cjs-module-lexer": "^2.2.0",
@@ -15165,9 +14681,9 @@
       "license": "ISC"
     },
     "node_modules/isolated-vm": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.1.2.tgz",
-      "integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.2.0.tgz",
+      "integrity": "sha512-UuSlxSHWt2QuJ5WvBhzlIJx2VVZN/a44SqBbEZFKNdvuSyhOvhmyDo8SQ+njVbhnh/njoL/aW0bUTiFYlpweGQ==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -15374,7 +14890,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
@@ -15610,6 +15125,20 @@
       },
       "peerDependencies": {
         "@langchain/core": "^1.1.31"
+      }
+    },
+    "node_modules/langchain/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/langsmith": {
@@ -16193,7 +15722,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -16626,7 +16154,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
       "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=18.0.0"
@@ -17343,7 +16870,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mrmime": {
@@ -17373,32 +16899,40 @@
       }
     },
     "node_modules/n8n-workflow": {
-      "version": "2.28.2",
-      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.28.2.tgz",
-      "integrity": "sha512-fGJ6yxRdgeea5EAywfAplYWDLMRNVMZRFikVTFLCBOInxLRDB89LL66sZHx2SC9dl/FALJAGZ6twY5MyUlc+HA==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.35.0.tgz",
+      "integrity": "sha512-7zHAMHke7umkldot5nI2sjEqN+O8mr5HyUbUlo+OSnwN/wdXg8MZpzFH7H6Rvb03CjyGtd9SpFhiCHsHJvmJCQ==",
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
-        "@n8n/errors": "0.10.0",
-        "@n8n/expression-runtime": "0.19.0",
-        "@n8n/tournament": "1.4.0",
+        "@codemirror/autocomplete": "6.20.0",
+        "@n8n/errors": "0.13.0",
+        "@n8n/expression-runtime": "0.26.0",
+        "@n8n/tournament": "1.9.0",
+        "@n8n/utils": "1.43.0",
+        "@sentry/core": "^10.55.0",
+        "@sentry/node": "^10.55.0",
         "ast-types": "0.16.1",
+        "axios": "1.18.0",
         "callsites": "3.1.0",
         "esprima-next": "5.8.4",
         "form-data": "4.0.6",
         "jmespath": "0.16.0",
         "js-base64": "3.7.8",
+        "json-schema": "0.4.0",
         "jsonrepair": "3.13.2",
         "jssha": "3.3.1",
         "lodash": "4.18.1",
         "luxon": "3.7.2",
         "md5": "2.3.0",
         "recast": "0.22.0",
+        "ssh2": "1.15.0",
         "title-case": "3.0.3",
         "transliteration": "2.3.5",
         "uuid": "11.1.1",
-        "xml2js": "0.6.2",
-        "zod": "3.25.67"
+        "xml2js": "0.6.2"
+      },
+      "peerDependencies": {
+        "zod": "3.25.76"
       }
     },
     "node_modules/n8n-workflow/node_modules/callsites": {
@@ -17406,34 +16940,34 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/n8n-workflow/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+    "node_modules/n8n-workflow/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/nan": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
       "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
-      "dev": true,
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -18435,25 +17969,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/posthog-js": {
@@ -19513,7 +19028,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
       "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
@@ -19605,14 +19119,14 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
-      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^11.0.0",
-        "package-json-from-dist": "^1.0.0"
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
@@ -19856,7 +19370,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
       "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/semver": {
@@ -20131,11 +19644,17 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ssh2": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
       "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
-      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "asn1": "^0.2.6",
@@ -20552,7 +20071,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/style-to-js": {
@@ -21014,7 +20532,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/type-check": {
@@ -22621,7 +22138,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -23017,7 +22533,7 @@
       "version": "0.219.0",
       "license": "MIT",
       "devDependencies": {
-        "@n8n/node-cli": "0.42.0",
+        "@n8n/node-cli": "0.44.1",
         "eslint": "9.29.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,22 +24,10 @@
     "turbo": "^2.10.8"
   },
   "overrides": {
-    "uuid": "^14.0.0",
-    "@langchain/classic": {
-      "uuid": "$uuid"
-    },
-    "@langchain/community": {
-      "uuid": "$uuid"
-    },
-    "langchain": {
-      "uuid": "$uuid"
-    },
-    "n8n-workflow": {
-      "uuid": "$uuid"
-    },
-    "js-yaml": "^4.3.1",
-    "glob": "^13.0.6",
-    "postcss": "8.5.23"
+    "@langchain/classic": "1.0.41",
+    "@langchain/community": "1.1.29",
+    "nanoid": "^3.3.18",
+    "rimraf": "^6.1.3"
   },
   "allowScripts": {
     "esbuild": true,

--- a/packages/n8n-node/nodes/ProboTrigger/ProboTrigger.node.ts
+++ b/packages/n8n-node/nodes/ProboTrigger/ProboTrigger.node.ts
@@ -80,7 +80,6 @@ export class ProboTrigger implements INodeType {
 		version: 1,
 		subtitle: '={{$parameter["events"].join(", ")}}',
 		description: 'Starts a workflow when Probo events occur',
-		usableAsTool: true,
 		defaults: {
 			name: 'Probo Trigger',
 		},

--- a/packages/n8n-node/package.json
+++ b/packages/n8n-node/package.json
@@ -56,7 +56,7 @@
     "n8n-workflow": "*"
   },
   "devDependencies": {
-    "@n8n/node-cli": "0.42.0",
+    "@n8n/node-cli": "0.44.1",
     "eslint": "9.29.0"
   }
 }


### PR DESCRIPTION
Bump @n8n/node-cli, replace leaf uuid/glob/js-yaml/postcss overrides with parent updates where possible, and pin nanoid until @n8n/utils ships a fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes npm audit warnings by replacing broad root overrides with targeted upstream bumps and regenerating the lockfile. Old: root overrides for `uuid`, `glob`, `js-yaml`, and `postcss`; new: adopt upstream versions and pin `nanoid`, with no runtime behavior changes.

### Other **`+310`** **`-806`**
- Replace root overrides with targeted updates: `@langchain/classic@1.0.41`, `@langchain/community@1.1.29`.
- Add `nanoid@^3.3.18` (temporary pin for `@n8n/utils`) and `rimraf@^6.1.3`.
- Regenerate `package-lock.json` to pull audited upstream versions (including `@n8n/*`, Sentry, and `undici`) and reduce size.

### Package: n8n-node **`+1`** **`-2`**
- Bump dev `@n8n/node-cli` to `0.44.1`.
- Remove deprecated `usableAsTool` from Probo Trigger metadata (no behavior change).

<sup>Written for commit f030f60e3c6d17ef6c4830cc92369572734ebc93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

