### PR TITLE
Add option to disable Google Consent Mode in the cookie banner SDK

### DIFF
--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -127,18 +127,18 @@ If your site manages Consent Mode itself (for example through an existing GTM se
 
 ```html
 <!-- Script tag -->
-<script src="..." data-banner-id="..." data-base-url="..." data-google-consent-mode="off"></script>
+<script src="..." data-banner-id="..." data-base-url="..." data-gcm-enabled="false"></script>
 
 <!-- Themed component -->
-<probo-cookie-banner banner-id="..." base-url="..." google-consent-mode="off"></probo-cookie-banner>
+<probo-cookie-banner banner-id="..." base-url="..." gcm-enabled="false"></probo-cookie-banner>
 
 <!-- Headless root -->
-<probo-cookie-banner-root banner-id="..." base-url="..." google-consent-mode="off">
+<probo-cookie-banner-root banner-id="..." base-url="..." gcm-enabled="false">
   ...
 </probo-cookie-banner-root>
 ```
 
-Programmatic use of `CookieBannerClient` takes the same switch as an option: `googleConsentMode: false`. Disabling covers all of it — the eager deny-all default, the discovery-mode grant-all, and per-consent updates.
+The attribute accepts `"true"`/`"false"`; any other value logs a warning and keeps the integration enabled. Programmatic use of `CookieBannerClient` takes the same switch as an option: `integrations: [{ name: "gcm", enabled: false }]`. Disabling covers all of it — the eager deny-all default, the discovery-mode grant-all, and per-consent updates.
 
 ## Key Features
 

--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -129,8 +129,13 @@ If your site manages Consent Mode itself (for example through an existing GTM se
 <!-- Script tag -->
 <script src="..." data-banner-id="..." data-base-url="..." data-google-consent-mode="off"></script>
 
-<!-- Themed or headless components -->
+<!-- Themed component -->
 <probo-cookie-banner banner-id="..." base-url="..." google-consent-mode="off"></probo-cookie-banner>
+
+<!-- Headless root -->
+<probo-cookie-banner-root banner-id="..." base-url="..." google-consent-mode="off">
+  ...
+</probo-cookie-banner-root>
 ```
 
 Programmatic use of `CookieBannerClient` takes the same switch as an option: `googleConsentMode: false`. Disabling covers all of it — the eager deny-all default, the discovery-mode grant-all, and per-consent updates.

--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -119,12 +119,28 @@ Style the **host** for font size and color (not inner children). Host styles sti
 <probo-settings-link>Cookie settings</probo-settings-link>
 ```
 
+## Google Consent Mode
+
+The SDK ships with a Google Consent Mode v2 integration, enabled by default: it sends a deny-all `consent default` on load and `consent update` calls mapped from each category's consent types.
+
+If your site manages Consent Mode itself (for example through an existing GTM setup), disable the integration so the SDK never touches `gtag`/`dataLayer`:
+
+```html
+<!-- Script tag -->
+<script src="..." data-banner-id="..." data-base-url="..." data-google-consent-mode="off"></script>
+
+<!-- Themed or headless components -->
+<probo-cookie-banner banner-id="..." base-url="..." google-consent-mode="off"></probo-cookie-banner>
+```
+
+Programmatic use of `CookieBannerClient` takes the same switch as an option: `googleConsentMode: false`. Disabling covers all of it — the eager deny-all default, the discovery-mode grant-all, and per-consent updates.
+
 ## Key Features
 
 - **Multi-regulation compliance** — Supports opt-in (GDPR, ePrivacy) and opt-out (CCPA/CPRA) consent modes, Global Privacy Control (GPC) detection, and per-category cookie controls. Under CCPA the banner starts closed; the settings link (“Your Privacy Choices” + official icon) opens the Privacy Choices panel with sale/sharing opt-out and an SPI rights statement.
 - **Consent audit trail** — Every consent action is recorded server-side with anonymized IP, user agent, per-category choices, and a reference to the exact banner version the visitor saw.
 - **Third-party blocking** — Automatically prevents scripts, iframes, images, and other resources from loading until the visitor grants consent for the matching category.
-- **Built-in integrations** — Syncs consent state with Google Consent Mode v2 and PostHog automatically.
+- **Built-in integrations** — Syncs consent state with Google Consent Mode v2 automatically (can be disabled for sites that manage Consent Mode themselves).
 - **Multi-language support** — Built-in translations for English, French, German, and Spanish. The SDK auto-detects the visitor's language from the page or browser. The CCPA “Your Privacy Choices” link title stays in English (statutory label).
 - **Theming** — Match your brand with CSS custom properties for colors, fonts, border radius, and more. Supports dark mode.
 

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -95,9 +95,7 @@ export class CookieBannerClient {
     this.bannerId = config.bannerId;
     this.visitorId = getVisitorId(config.bannerId);
     this.lang = detectLanguage(config.lang);
-    this.integrations = createDefaultIntegrations({
-      googleConsentMode: config.googleConsentMode,
-    });
+    this.integrations = createDefaultIntegrations(config.integrations);
   }
 
   get loaded(): boolean {

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -95,7 +95,9 @@ export class CookieBannerClient {
     this.bannerId = config.bannerId;
     this.visitorId = getVisitorId(config.bannerId);
     this.lang = detectLanguage(config.lang);
-    this.integrations = createDefaultIntegrations();
+    this.integrations = createDefaultIntegrations({
+      googleConsentMode: config.googleConsentMode,
+    });
   }
 
   get loaded(): boolean {

--- a/packages/cookie-banner/src/components/cookie-banner-root.ts
+++ b/packages/cookie-banner/src/components/cookie-banner-root.ts
@@ -19,7 +19,7 @@
 // SOFTWARE.
 
 import { CookieBannerClient } from "../client";
-import { resolveGoogleConsentMode } from "../integrations";
+import { resolveGcmEnabled } from "../integrations";
 import { resolveLayout } from "../layout";
 import type { BannerConfig, BannerLayout, Regulation } from "../types";
 import { ProboElement } from "./base";
@@ -145,11 +145,14 @@ export class ProboCookieBannerRoot extends ProboElement implements ProboRootElem
     }
 
     const lang = this.getAttribute("lang") ?? undefined;
-    const googleConsentMode = resolveGoogleConsentMode(
-      this.getAttribute("google-consent-mode"),
-    );
+    const gcmEnabled = resolveGcmEnabled(this.getAttribute("gcm-enabled"));
 
-    this._client = new CookieBannerClient({ bannerId, baseUrl, lang, googleConsentMode });
+    this._client = new CookieBannerClient({
+      bannerId,
+      baseUrl,
+      lang,
+      integrations: [{ name: "gcm", enabled: gcmEnabled }],
+    });
 
     try {
       await this._client.load();

--- a/packages/cookie-banner/src/components/cookie-banner-root.ts
+++ b/packages/cookie-banner/src/components/cookie-banner-root.ts
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 import { CookieBannerClient } from "../client";
+import { resolveGoogleConsentMode } from "../integrations";
 import { resolveLayout } from "../layout";
 import type { BannerConfig, BannerLayout, Regulation } from "../types";
 import { ProboElement } from "./base";
@@ -144,8 +145,11 @@ export class ProboCookieBannerRoot extends ProboElement implements ProboRootElem
     }
 
     const lang = this.getAttribute("lang") ?? undefined;
+    const googleConsentMode = resolveGoogleConsentMode(
+      this.getAttribute("google-consent-mode"),
+    );
 
-    this._client = new CookieBannerClient({ bannerId, baseUrl, lang });
+    this._client = new CookieBannerClient({ bannerId, baseUrl, lang, googleConsentMode });
 
     try {
       await this._client.load();

--- a/packages/cookie-banner/src/integrations/index.test.ts
+++ b/packages/cookie-banner/src/integrations/index.test.ts
@@ -18,42 +18,47 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createDefaultIntegrations, resolveGoogleConsentMode } from "./index";
+import { createDefaultIntegrations, resolveGcmEnabled } from "./index";
 
 describe("createDefaultIntegrations", () => {
   it("includes Google Consent Mode by default", () => {
     expect(createDefaultIntegrations()).toHaveLength(1);
-    expect(createDefaultIntegrations({})).toHaveLength(1);
-    expect(createDefaultIntegrations({ googleConsentMode: true })).toHaveLength(1);
+    expect(createDefaultIntegrations([])).toHaveLength(1);
+    expect(createDefaultIntegrations([{ name: "gcm", enabled: true }])).toHaveLength(1);
   });
 
   it("is empty when Google Consent Mode is disabled", () => {
-    expect(createDefaultIntegrations({ googleConsentMode: false })).toHaveLength(0);
+    expect(createDefaultIntegrations([{ name: "gcm", enabled: false }])).toHaveLength(0);
   });
 });
 
-describe("resolveGoogleConsentMode", () => {
-  it("keeps the integration when the attribute is absent", () => {
-    expect(resolveGoogleConsentMode(null)).toBe(true);
+describe("resolveGcmEnabled", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it("disables on \"off\" and \"false\"", () => {
-    expect(resolveGoogleConsentMode("off")).toBe(false);
-    expect(resolveGoogleConsentMode("false")).toBe(false);
+  it("defaults to enabled when the attribute is absent", () => {
+    expect(resolveGcmEnabled(null)).toBe(true);
+  });
+
+  it("parses \"true\" and \"false\"", () => {
+    expect(resolveGcmEnabled("true")).toBe(true);
+    expect(resolveGcmEnabled("false")).toBe(false);
   });
 
   it("normalizes case and whitespace", () => {
-    expect(resolveGoogleConsentMode("OFF")).toBe(false);
-    expect(resolveGoogleConsentMode("False")).toBe(false);
-    expect(resolveGoogleConsentMode(" off ")).toBe(false);
+    expect(resolveGcmEnabled("FALSE")).toBe(false);
+    expect(resolveGcmEnabled(" false ")).toBe(false);
+    expect(resolveGcmEnabled("True")).toBe(true);
   });
 
-  it("keeps the integration for any other value", () => {
-    expect(resolveGoogleConsentMode("on")).toBe(true);
-    expect(resolveGoogleConsentMode("true")).toBe(true);
-    expect(resolveGoogleConsentMode("")).toBe(true);
-    expect(resolveGoogleConsentMode("nonsense")).toBe(true);
+  it("warns and falls back to enabled on invalid values", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(resolveGcmEnabled("off")).toBe(true);
+    expect(resolveGcmEnabled("")).toBe(true);
+    expect(resolveGcmEnabled("nonsense")).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/cookie-banner/src/integrations/index.test.ts
+++ b/packages/cookie-banner/src/integrations/index.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { describe, expect, it } from "vitest";
+
+import { createDefaultIntegrations, resolveGoogleConsentMode } from "./index";
+
+describe("createDefaultIntegrations", () => {
+  it("includes Google Consent Mode by default", () => {
+    expect(createDefaultIntegrations()).toHaveLength(1);
+    expect(createDefaultIntegrations({})).toHaveLength(1);
+    expect(createDefaultIntegrations({ googleConsentMode: true })).toHaveLength(1);
+  });
+
+  it("is empty when Google Consent Mode is disabled", () => {
+    expect(createDefaultIntegrations({ googleConsentMode: false })).toHaveLength(0);
+  });
+});
+
+describe("resolveGoogleConsentMode", () => {
+  it("keeps the integration when the attribute is absent", () => {
+    expect(resolveGoogleConsentMode(null)).toBe(true);
+  });
+
+  it("disables on \"off\" and \"false\"", () => {
+    expect(resolveGoogleConsentMode("off")).toBe(false);
+    expect(resolveGoogleConsentMode("false")).toBe(false);
+  });
+
+  it("keeps the integration for any other value", () => {
+    expect(resolveGoogleConsentMode("on")).toBe(true);
+    expect(resolveGoogleConsentMode("true")).toBe(true);
+    expect(resolveGoogleConsentMode("")).toBe(true);
+    expect(resolveGoogleConsentMode("nonsense")).toBe(true);
+  });
+});

--- a/packages/cookie-banner/src/integrations/index.test.ts
+++ b/packages/cookie-banner/src/integrations/index.test.ts
@@ -44,6 +44,12 @@ describe("resolveGoogleConsentMode", () => {
     expect(resolveGoogleConsentMode("false")).toBe(false);
   });
 
+  it("normalizes case and whitespace", () => {
+    expect(resolveGoogleConsentMode("OFF")).toBe(false);
+    expect(resolveGoogleConsentMode("False")).toBe(false);
+    expect(resolveGoogleConsentMode(" off ")).toBe(false);
+  });
+
   it("keeps the integration for any other value", () => {
     expect(resolveGoogleConsentMode("on")).toBe(true);
     expect(resolveGoogleConsentMode("true")).toBe(true);

--- a/packages/cookie-banner/src/integrations/index.ts
+++ b/packages/cookie-banner/src/integrations/index.ts
@@ -38,8 +38,9 @@ export function createDefaultIntegrations(
 
 // resolveGoogleConsentMode maps the `google-consent-mode` element attribute
 // (and the `data-google-consent-mode` script attribute) to the client option.
-// Only "off" and "false" disable the integration; absent or any other value
-// keeps the default behavior.
+// Only "off" and "false" (case-insensitive, whitespace-tolerant) disable the
+// integration; absent or any other value keeps the default behavior.
 export function resolveGoogleConsentMode(value: string | null): boolean {
-  return value !== "off" && value !== "false";
+  const normalized = value?.trim().toLowerCase();
+  return normalized !== "off" && normalized !== "false";
 }

--- a/packages/cookie-banner/src/integrations/index.ts
+++ b/packages/cookie-banner/src/integrations/index.ts
@@ -21,13 +21,15 @@
 export type { ConsentIntegration } from "./integration";
 export { GoogleConsentModeIntegration } from "./gcm";
 
+import type { IntegrationConfig } from "../types";
 import type { ConsentIntegration } from "./integration";
 import { GoogleConsentModeIntegration } from "./gcm";
 
 export function createDefaultIntegrations(
-  options?: { googleConsentMode?: boolean },
+  configs?: IntegrationConfig[],
 ): ConsentIntegration[] {
-  if (options?.googleConsentMode === false) {
+  const gcm = configs?.find((config) => config.name === "gcm");
+  if (gcm?.enabled === false) {
     return [];
   }
 
@@ -36,11 +38,21 @@ export function createDefaultIntegrations(
   ];
 }
 
-// resolveGoogleConsentMode maps the `google-consent-mode` element attribute
-// (and the `data-google-consent-mode` script attribute) to the client option.
-// Only "off" and "false" (case-insensitive, whitespace-tolerant) disable the
-// integration; absent or any other value keeps the default behavior.
-export function resolveGoogleConsentMode(value: string | null): boolean {
-  const normalized = value?.trim().toLowerCase();
-  return normalized !== "off" && normalized !== "false";
+export function resolveGcmEnabled(value: string | null): boolean {
+  if (value == null) {
+    return true;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true") {
+    return true;
+  }
+  if (normalized === "false") {
+    return false;
+  }
+
+  console.warn(
+    `[probo] invalid gcm-enabled value "${value}": expected "true" or "false", falling back to enabled`,
+  );
+  return true;
 }

--- a/packages/cookie-banner/src/integrations/index.ts
+++ b/packages/cookie-banner/src/integrations/index.ts
@@ -24,8 +24,22 @@ export { GoogleConsentModeIntegration } from "./gcm";
 import type { ConsentIntegration } from "./integration";
 import { GoogleConsentModeIntegration } from "./gcm";
 
-export function createDefaultIntegrations(): ConsentIntegration[] {
+export function createDefaultIntegrations(
+  options?: { googleConsentMode?: boolean },
+): ConsentIntegration[] {
+  if (options?.googleConsentMode === false) {
+    return [];
+  }
+
   return [
     new GoogleConsentModeIntegration(),
   ];
+}
+
+// resolveGoogleConsentMode maps the `google-consent-mode` element attribute
+// (and the `data-google-consent-mode` script attribute) to the client option.
+// Only "off" and "false" disable the integration; absent or any other value
+// keeps the default behavior.
+export function resolveGoogleConsentMode(value: string | null): boolean {
+  return value !== "off" && value !== "false";
 }

--- a/packages/cookie-banner/src/themed-banner/iife.ts
+++ b/packages/cookie-banner/src/themed-banner/iife.ts
@@ -51,9 +51,9 @@ if (script) {
         el.setAttribute("lang", lang.split("-")[0].toLowerCase());
       }
 
-      const gcm = script.getAttribute("data-google-consent-mode");
+      const gcm = script.getAttribute("data-gcm-enabled");
       if (gcm) {
-        el.setAttribute("google-consent-mode", gcm);
+        el.setAttribute("gcm-enabled", gcm);
       }
 
       document.body.appendChild(el);

--- a/packages/cookie-banner/src/themed-banner/iife.ts
+++ b/packages/cookie-banner/src/themed-banner/iife.ts
@@ -51,6 +51,11 @@ if (script) {
         el.setAttribute("lang", lang.split("-")[0].toLowerCase());
       }
 
+      const gcm = script.getAttribute("data-google-consent-mode");
+      if (gcm) {
+        el.setAttribute("google-consent-mode", gcm);
+      }
+
       document.body.appendChild(el);
     };
 

--- a/packages/cookie-banner/src/themed-banner/themed-banner.ts
+++ b/packages/cookie-banner/src/themed-banner/themed-banner.ts
@@ -61,8 +61,8 @@ export class ProboThemedBanner extends HTMLElement {
     const lang = this.getAttribute("lang");
     const langAttr = lang ? ` lang="${esc(lang)}"` : "";
 
-    const gcm = this.getAttribute("google-consent-mode");
-    const gcmAttr = gcm ? ` google-consent-mode="${esc(gcm)}"` : "";
+    const gcm = this.getAttribute("gcm-enabled");
+    const gcmAttr = gcm ? ` gcm-enabled="${esc(gcm)}"` : "";
 
     this.shadow.innerHTML = `
       <style>${THEMED_STYLES}</style>

--- a/packages/cookie-banner/src/themed-banner/themed-banner.ts
+++ b/packages/cookie-banner/src/themed-banner/themed-banner.ts
@@ -61,9 +61,12 @@ export class ProboThemedBanner extends HTMLElement {
     const lang = this.getAttribute("lang");
     const langAttr = lang ? ` lang="${esc(lang)}"` : "";
 
+    const gcm = this.getAttribute("google-consent-mode");
+    const gcmAttr = gcm ? ` google-consent-mode="${esc(gcm)}"` : "";
+
     this.shadow.innerHTML = `
       <style>${THEMED_STYLES}</style>
-      <probo-cookie-banner-root banner-id="${esc(bannerId)}" base-url="${esc(baseUrl)}"${langAttr}></probo-cookie-banner-root>
+      <probo-cookie-banner-root banner-id="${esc(bannerId)}" base-url="${esc(baseUrl)}"${langAttr}${gcmAttr}></probo-cookie-banner-root>
     `;
 
     const root = this.shadow.querySelector("probo-cookie-banner-root") as ProboCookieBannerRoot;

--- a/packages/cookie-banner/src/types.ts
+++ b/packages/cookie-banner/src/types.ts
@@ -117,14 +117,14 @@ export interface ConsentRecord {
   created_at: string;
 }
 
-// CookieBannerClientOptions configures the client. `googleConsentMode`
-// (default true) controls the built-in Google Consent Mode integration;
-// set it to false to skip it entirely — no eager deny-all default, no
-// discovery-mode grant-all, no consent defaults or updates — for sites
-// that manage Consent Mode themselves.
+export interface IntegrationConfig {
+  name: "gcm";
+  enabled: boolean;
+}
+
 export interface CookieBannerClientOptions {
   bannerId: string;
   baseUrl: string;
   lang?: string;
-  googleConsentMode?: boolean;
+  integrations?: IntegrationConfig[];
 }

--- a/packages/cookie-banner/src/types.ts
+++ b/packages/cookie-banner/src/types.ts
@@ -117,8 +117,14 @@ export interface ConsentRecord {
   created_at: string;
 }
 
+// CookieBannerClientOptions configures the client. `googleConsentMode`
+// (default true) controls the built-in Google Consent Mode integration;
+// set it to false to skip it entirely — no eager deny-all default, no
+// discovery-mode grant-all, no consent defaults or updates — for sites
+// that manage Consent Mode themselves.
 export interface CookieBannerClientOptions {
   bannerId: string;
   baseUrl: string;
   lang?: string;
+  googleConsentMode?: boolean;
 }


### PR DESCRIPTION
## Problem

The Google Consent Mode integration in `@probo/cookie-banner` is created unconditionally. For sites that already manage Consent Mode themselves (an existing CMP or GTM setup), this makes the SDK impossible to run alongside without consent side effects:

- `load()` fires `gtag('consent','default', ...)` denying **all seven** consent types before the config fetch — including types like `security_storage` that many sites deliberately leave unset (which Google treats as granted).
- When the config fetch fails, discovery mode fires `consent update` with everything **granted** (#1558), so an outage flips the site's consent signal.
- Both writes race the site's own `default`/`update` calls on `dataLayer`.

This matters in particular for self-hosted operators who want the tracker detection/reporting side of the SDK while keeping an existing, already-audited consent implementation.

A server-side toggle (like `capabilities.resourceReporting` from 0.259.0) can't solve this: `bootstrap()` runs **before** the config fetch, so no config field can suppress the initial deny-all. It has to be a client-side option.

## Change

- `CookieBannerClientOptions.integrations?: IntegrationConfig[]` — per-integration config array (currently one: `{ name: "gcm", enabled: boolean }`), default behavior unchanged for existing users.
- When GCM is disabled, `createDefaultIntegrations()` returns no integrations, so the SDK never touches `gtag`/`dataLayer`: no eager deny-all, no discovery-mode grant-all, no defaults or updates. Detection, consent recording, and resource activation are unaffected.
- Exposed as `gcm-enabled="false"` on `<probo-cookie-banner>` / `<probo-cookie-banner-root>` and `data-gcm-enabled="false"` on the IIFE script tag. The attribute accepts `"true"`/`"false"`; anything else logs a warning and falls back to enabled.
- Attribute parsing lives in a pure `resolveGcmEnabled()` predicate (mirroring `shouldStartResourceDetector`), unit-tested alongside `createDefaultIntegrations()`.
- README: new "Google Consent Mode" section documenting the switch. While editing the integrations bullet I also dropped its stale PostHog mention (integration removed in SDK 0.6.0).

Left `CHANGELOG.md` untouched per the release-time changelog practice; happy to add an Unreleased entry if preferred.

## Testing

- `npm --workspace @probo/cookie-banner run check` / `test` / `build` all pass (9 tests).
- `gcm-enabled` wiring verified present in the built `dist/cookie-banner.iife.js`.
- `lint-js` steps (`@probo/skills` validate, `make relay`, root eslint + n8n lint) run locally and pass.