### PR TITLE
Report Windows posture without English CLI

### DIFF
--- a/contrib/seed.sh
+++ b/contrib/seed.sh
@@ -834,9 +834,9 @@ posture_evidence() {
       ;;
     WINDOWS:DISK_ENCRYPTION)
       case "$status" in
-        PASS) jq -nc '{raw:"Conversion Status: Fully Encrypted\n    Percentage Encrypted: 100%"}' ;;
-        FAIL) jq -nc '{raw:"Conversion Status: Fully Decrypted\n    Percentage Encrypted: 0%"}' ;;
-        *) jq -nc '{note:"manage-bde not found"}' ;;
+        PASS) jq -nc '{backend:"Get-BitLockerVolume",volumes:{ "C:":"On"}}' ;;
+        FAIL) jq -nc '{backend:"Get-BitLockerVolume",volumes:{ "C:":"Off"},encryption_percentage:100}' ;;
+        *) jq -nc '{note:"Get-BitLockerVolume not available"}' ;;
       esac
       ;;
     DARWIN:SCREEN_LOCK)
@@ -897,9 +897,9 @@ posture_evidence() {
       ;;
     WINDOWS:TIME_SYNC)
       case "$status" in
-        PASS) jq -nc '{raw:"Leap Indicator: 0(no warning)\nStratum: 4 (secondary reference)\nSource: time.windows.com,0x8\nPoll Interval: 10"}' ;;
-        FAIL) jq -nc '{raw:"Leap Indicator: 3(not synchronized)\nStratum: 0 (unspecified)\nSource: Local CMOS Clock\nPoll Interval: 10"}' ;;
-        *) jq -nc '{note:"w32tm unavailable"}' ;;
+        PASS) jq -nc '{backend:"w32time",w32time_status:"Running",w32time_type:"NTP",ntp_server:"time.windows.com,0x8"}' ;;
+        FAIL) jq -nc '{backend:"w32time",w32time_status:"Stopped",w32time_type:"NTP"}' ;;
+        *) jq -nc '{error:"exit status 0x80070426",stderr:""}' ;;
       esac
       ;;
     DARWIN:OS_VERSION)
@@ -957,9 +957,9 @@ posture_evidence() {
       ;;
     WINDOWS:PASSWORD_POLICY)
       case "$status" in
-        PASS) jq -nc '{raw:"Minimum password length:                        8\n"}' ;;
-        FAIL) jq -nc '{raw:"Minimum password length:                        0\n"}' ;;
-        *) jq -nc '{error:"net accounts failed"}' ;;
+        PASS) jq -nc '{min_password_length:8}' ;;
+        FAIL) jq -nc '{min_password_length:0}' ;;
+        *) jq -nc '{error:"MinPasswordLength unavailable"}' ;;
       esac
       ;;
     # REMOTE_LOGIN is inverted: PASS means remote access is Off / denied.

--- a/pkg/coredata/device_posture_value.go
+++ b/pkg/coredata/device_posture_value.go
@@ -332,26 +332,6 @@ func firstNonEmptyString(values ...string) string {
 	return ""
 }
 
-// parseLabeledInt finds lines like "Minimum password length: 8".
-func parseLabeledInt(raw, label string) (int, bool) {
-	if raw == "" || label == "" {
-		return 0, false
-	}
-
-	lower := strings.ToLower(raw)
-	label = strings.ToLower(label)
-
-	idx := strings.Index(lower, label)
-	if idx < 0 {
-		return 0, false
-	}
-
-	rest := raw[idx+len(label):]
-	rest = strings.TrimLeft(rest, " \t.:")
-
-	return parseLeadingInt(rest)
-}
-
 // parseAssignedInt finds assignments like "minpasswordlen=8".
 func parseAssignedInt(raw, key string) (int, bool) {
 	if raw == "" || key == "" {

--- a/pkg/coredata/device_posture_value_checks.go
+++ b/pkg/coredata/device_posture_value_checks.go
@@ -48,6 +48,10 @@ func parseDiskEncryptionValue(ev map[string]any) DevicePostureValue {
 		return parseLinuxDiskEncryptionValue(ev, present)
 	}
 
+	if backendOf(ev) == "get-bitlockervolume" {
+		return parseWindowsBitLockerValue(ev)
+	}
+
 	raw := lowerStringEvidence(ev, "raw")
 	switch {
 	case raw == "":
@@ -56,14 +60,6 @@ func parseDiskEncryptionValue(ev map[string]any) DevicePostureValue {
 		return onOffValue(true)
 	case strings.Contains(raw, "filevault is off"):
 		return onOffValue(false)
-	case strings.Contains(raw, "percentage encrypted: 100"),
-		strings.Contains(raw, "fully encrypted"),
-		strings.Contains(raw, "protection on"):
-		return onOffValue(true)
-	case strings.Contains(raw, "percentage encrypted: 0"),
-		strings.Contains(raw, "fully decrypted"),
-		strings.Contains(raw, "protection off"):
-		return onOffValue(false)
 	case strings.Contains(raw, "components"):
 		// FreeBSD geli prints a "Name Status Components" table with one row per
 		// encrypted provider; ACTIVE is the only status meaning attached.
@@ -71,6 +67,20 @@ func parseDiskEncryptionValue(ev map[string]any) DevicePostureValue {
 	}
 
 	return unknownValue()
+}
+
+func parseWindowsBitLockerValue(ev map[string]any) DevicePostureValue {
+	if stringEvidence(ev, "error") != "" {
+		return unknownValue()
+	}
+
+	allOn, any := allValuesMatch(stringMapEvidence(ev, "volumes"), "on")
+	if !any {
+		// No OS volumes, or the BitLocker cmdlet is missing (Home).
+		return onOffValue(false)
+	}
+
+	return onOffValue(allOn)
 }
 
 func parseLinuxDiskEncryptionValue(
@@ -333,6 +343,10 @@ func parseNetshFirewallValue(ev map[string]any) DevicePostureValue {
 }
 
 func parseTimeSyncValue(ev map[string]any) DevicePostureValue {
+	if status := stringEvidence(ev, "w32time_status"); status != "" {
+		return parseWindowsTimeSyncValue(status, stringEvidence(ev, "w32time_type"))
+	}
+
 	raw := lowerStringEvidence(ev, "raw")
 	switch {
 	case raw == "":
@@ -349,14 +363,22 @@ func parseTimeSyncValue(ev map[string]any) DevicePostureValue {
 		return onOffValue(false)
 	case strings.Contains(raw, "is running"):
 		return onOffValue(true)
-	case strings.Contains(raw, "local cmos clock"):
-		// Windows w32tm: the local clock is not a synchronisation source.
-		return onOffValue(false)
-	case strings.Contains(raw, "source:"):
-		return onOffValue(true)
 	}
 
 	return unknownValue()
+}
+
+func parseWindowsTimeSyncValue(status, typ string) DevicePostureValue {
+	if !strings.EqualFold(status, "Running") {
+		return onOffValue(false)
+	}
+
+	switch strings.ToUpper(strings.TrimSpace(typ)) {
+	case "NTP", "NT5DS", "ALLSYNC":
+		return onOffValue(true)
+	}
+
+	return onOffValue(false)
 }
 
 func parseAutoUpdateValue(ev map[string]any) DevicePostureValue {
@@ -428,20 +450,16 @@ func parsePasswordPolicyValue(ev map[string]any) DevicePostureValue {
 		return minPasswordLengthValue(minLen)
 	}
 
+	if minLen, ok := numberEvidence(ev, "min_password_length"); ok {
+		return minPasswordLengthValue(minLen)
+	}
+
 	if parseError := lowerStringEvidence(ev, "parse_error"); parseError != "" {
 		if strings.Contains(parseError, "not set") {
 			return noneValue()
 		}
 
 		return unknownValue()
-	}
-
-	// Windows `net accounts`.
-	if minLen, ok := parseLabeledInt(
-		stringEvidence(ev, "raw"),
-		"minimum password length",
-	); ok {
-		return minPasswordLengthValue(minLen)
 	}
 
 	// FreeBSD /etc/login.conf.

--- a/pkg/coredata/device_posture_value_test.go
+++ b/pkg/coredata/device_posture_value_test.go
@@ -114,9 +114,43 @@ func TestParseDevicePostureValue_DiskEncryption(t *testing.T) {
 				wantKind: coredata.DevicePostureValueKindUnknown,
 			},
 			{
-				name:     "windows manage-bde missing does not surface the note",
+				name:     "windows Get-BitLockerVolume protection on",
 				checkKey: "DISK_ENCRYPTION",
-				evidence: map[string]any{"note": "manage-bde not found"},
+				evidence: map[string]any{
+					"backend": "Get-BitLockerVolume",
+					"volumes": map[string]any{"C:": "On"},
+				},
+				wantKind: coredata.DevicePostureValueKindOn,
+			},
+			{
+				name:     "windows Get-BitLockerVolume protection off at 100 percent",
+				checkKey: "DISK_ENCRYPTION",
+				evidence: map[string]any{
+					"backend":               "Get-BitLockerVolume",
+					"encryption_percentage": float64(100),
+					"volumes": map[string]any{
+						"C:": "Off",
+					},
+				},
+				wantKind: coredata.DevicePostureValueKindOff,
+			},
+			{
+				name:     "windows Get-BitLockerVolume not available is off",
+				checkKey: "DISK_ENCRYPTION",
+				evidence: map[string]any{
+					"backend": "Get-BitLockerVolume",
+					"note":    "Get-BitLockerVolume not available",
+				},
+				wantKind: coredata.DevicePostureValueKindOff,
+			},
+			{
+				name:     "windows Get-BitLockerVolume collection error is unknown",
+				checkKey: "DISK_ENCRYPTION",
+				evidence: map[string]any{
+					"backend": "Get-BitLockerVolume",
+					"error":   "exit status 1",
+					"stderr":  "Access is denied.",
+				},
 				wantKind: coredata.DevicePostureValueKindUnknown,
 			},
 			{
@@ -281,18 +315,33 @@ func TestParseDevicePostureValue_TimeSync(t *testing.T) {
 				wantKind: coredata.DevicePostureValueKindOff,
 			},
 			{
-				name:     "windows w32tm with a real source",
+				name:     "windows w32time service running with NTP",
 				checkKey: "TIME_SYNC",
 				evidence: map[string]any{
-					"raw": "Leap Indicator: 0(no warning)\nStratum: 4 (secondary reference)\nSource: time.windows.com,0x8\nPoll Interval: 10",
+					"backend":        "w32time",
+					"w32time_status": "Running",
+					"w32time_type":   "NTP",
+					"ntp_server":     "time.windows.com,0x8",
 				},
 				wantKind: coredata.DevicePostureValueKindOn,
 			},
 			{
-				name:     "windows w32tm falling back to the local clock",
+				name:     "windows w32time service stopped is off",
 				checkKey: "TIME_SYNC",
 				evidence: map[string]any{
-					"raw": "Leap Indicator: 3(not synchronized)\nStratum: 0 (unspecified)\nSource: Local CMOS Clock\nPoll Interval: 10",
+					"backend":        "w32time",
+					"w32time_status": "Stopped",
+					"w32time_type":   "NTP",
+				},
+				wantKind: coredata.DevicePostureValueKindOff,
+			},
+			{
+				name:     "windows w32time running with NoSync is off",
+				checkKey: "TIME_SYNC",
+				evidence: map[string]any{
+					"backend":        "w32time",
+					"w32time_status": "Running",
+					"w32time_type":   "NoSync",
 				},
 				wantKind: coredata.DevicePostureValueKindOff,
 			},
@@ -450,11 +499,16 @@ func TestParseDevicePostureValue_PasswordPolicy(t *testing.T) {
 				wantKind: coredata.DevicePostureValueKindNone,
 			},
 			{
-				name:     "windows net accounts minimum length",
-				checkKey: "PASSWORD_POLICY",
-				evidence: map[string]any{
-					"raw": "Force user logoff how long after time expires?:       Never\nMinimum password age (days):                    0\nMaximum password age (days):                    42\nMinimum password length:                        8\n",
-				},
+				name:       "windows min password length zero",
+				checkKey:   "PASSWORD_POLICY",
+				evidence:   map[string]any{"min_password_length": float64(0)},
+				wantKind:   coredata.DevicePostureValueKindMinPasswordLength,
+				wantNumber: new(0),
+			},
+			{
+				name:       "windows min password length eight",
+				checkKey:   "PASSWORD_POLICY",
+				evidence:   map[string]any{"min_password_length": float64(8)},
 				wantKind:   coredata.DevicePostureValueKindMinPasswordLength,
 				wantNumber: new(8),
 			},
@@ -804,18 +858,40 @@ func TestParseDevicePostureValue_AgreesWithAgentStatus(t *testing.T) {
 			agentStatus: coredata.DevicePostureStatusPass,
 		},
 		{
-			name:     "windows bitlocker fully encrypted",
+			name:     "windows bitlocker protection on",
 			checkKey: "DISK_ENCRYPTION",
 			evidence: map[string]any{
-				"raw": "Conversion Status: Fully Encrypted\n    Percentage Encrypted: 100%",
+				"backend": "Get-BitLockerVolume",
+				"volumes": map[string]any{"C:": "On"},
 			},
 			agentStatus: coredata.DevicePostureStatusPass,
 		},
 		{
-			name:     "windows bitlocker fully decrypted",
+			name:     "windows bitlocker protection off",
 			checkKey: "DISK_ENCRYPTION",
 			evidence: map[string]any{
-				"raw": "Conversion Status: Fully Decrypted\n    Percentage Encrypted: 0%",
+				"backend": "Get-BitLockerVolume",
+				"volumes": map[string]any{"C:": "Off"},
+			},
+			agentStatus: coredata.DevicePostureStatusFail,
+		},
+		{
+			name:     "windows w32time running NTP",
+			checkKey: "TIME_SYNC",
+			evidence: map[string]any{
+				"backend":        "w32time",
+				"w32time_status": "Running",
+				"w32time_type":   "NTP",
+			},
+			agentStatus: coredata.DevicePostureStatusPass,
+		},
+		{
+			name:     "windows w32time service stopped",
+			checkKey: "TIME_SYNC",
+			evidence: map[string]any{
+				"backend":        "w32time",
+				"w32time_status": "Stopped",
+				"w32time_type":   "NTP",
 			},
 			agentStatus: coredata.DevicePostureStatusFail,
 		},

--- a/pkg/deviceagent/checks/checks_windows.go
+++ b/pkg/deviceagent/checks/checks_windows.go
@@ -22,6 +22,7 @@ package checks
 
 import (
 	"context"
+	"strconv"
 	"strings"
 )
 
@@ -44,21 +45,39 @@ func powershell(ctx context.Context, script string) CmdResult {
 }
 
 func windowsDiskEncryption(ctx context.Context) Result {
-	if !CommandExists("manage-bde.exe") && !CommandExists("manage-bde") {
-		return unknown(map[string]any{"note": "manage-bde not found"})
-	}
+	out := powershell(
+		ctx,
+		`(Get-BitLockerVolume | Where-Object { $_.VolumeType -eq 'OperatingSystem' } | `+
+			`Sort-Object MountPoint | `+
+			`ForEach-Object { "$($_.MountPoint)=$($_.ProtectionStatus)" }) -join ";"`,
+	)
 
-	out := RunCommand(ctx, "manage-bde", "-status")
-
-	ev := map[string]any{"raw": truncate(out.Stdout, 600)}
+	ev := map[string]any{"backend": "Get-BitLockerVolume"}
 	if out.Err != nil {
+		lower := strings.ToLower(out.Stderr + " " + errString(out.Err))
+		if strings.Contains(lower, "not recognized") ||
+			strings.Contains(lower, "not found") {
+			ev["note"] = "Get-BitLockerVolume not available"
+
+			return fail(ev)
+		}
+
+		ev["error"] = out.Err.Error()
+		ev["stderr"] = out.Stderr
+
 		return unknown(ev)
 	}
 
-	lower := strings.ToLower(out.Stdout)
-	if strings.Contains(lower, "percentage encrypted: 100") ||
-		strings.Contains(lower, "fully encrypted") ||
-		strings.Contains(lower, "protection on") {
+	volumes, allProtected := parseWindowsBitLockerVolumes(out.Stdout)
+
+	ev["volumes"] = volumes
+	if len(volumes) == 0 {
+		ev["note"] = "Get-BitLockerVolume not available"
+
+		return fail(ev)
+	}
+
+	if allProtected {
 		return pass(ev)
 	}
 
@@ -214,38 +233,6 @@ func windowsFirewall(ctx context.Context) Result {
 	return fail(ev)
 }
 
-// parseWindowsFirewallProfiles parses "Domain=True;Private=True;Public=True"
-// from Get-NetFirewallProfile output, returning per-profile state and
-// whether every profile is enabled.
-func parseWindowsFirewallProfiles(s string) (map[string]string, bool) {
-	profiles := map[string]string{}
-	allEnabled := true
-	any := false
-
-	for profile := range strings.SplitSeq(s, ";") {
-		parts := strings.SplitN(strings.TrimSpace(profile), "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-
-		name := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-
-		if name == "" {
-			continue
-		}
-
-		profiles[name] = value
-		any = true
-
-		if !strings.EqualFold(value, "true") {
-			allEnabled = false
-		}
-	}
-
-	return profiles, any && allEnabled
-}
-
 // parseNetshFirewallStates extracts per-profile "State <ON|OFF>" lines
 // from `netsh advfirewall show allprofiles state`. It is whitespace- and
 // case-insensitive.
@@ -279,7 +266,12 @@ func parseNetshFirewallStates(s string) ([]string, bool) {
 }
 
 func windowsTimeSync(ctx context.Context) Result {
-	out := RunCommand(ctx, "w32tm", "/query", "/status")
+	out := powershell(
+		ctx,
+		`$s = Get-Service w32time; `+
+			`$p = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Parameters'; `+
+			`"$($s.Status);$($p.Type);$($p.NtpServer)"`,
+	)
 	if out.Err != nil {
 		return unknown(
 			map[string]any{
@@ -289,11 +281,36 @@ func windowsTimeSync(ctx context.Context) Result {
 		)
 	}
 
-	ev := map[string]any{"raw": truncate(out.Stdout, 400)}
+	parts := strings.SplitN(strings.TrimSpace(out.Stdout), ";", 3)
 
-	lower := strings.ToLower(out.Stdout)
-	if strings.Contains(lower, "source:") && !strings.Contains(lower, "local cmos clock") {
+	var status, typ, ntpServer string
+	if len(parts) >= 1 {
+		status = strings.TrimSpace(parts[0])
+	}
+
+	if len(parts) >= 2 {
+		typ = strings.TrimSpace(parts[1])
+	}
+
+	if len(parts) >= 3 {
+		ntpServer = strings.TrimSpace(parts[2])
+	}
+
+	ev := map[string]any{
+		"backend":        "w32time",
+		"w32time_status": status,
+		"w32time_type":   typ,
+	}
+	if ntpServer != "" {
+		ev["ntp_server"] = ntpServer
+	}
+
+	if windowsTimeSyncOn(status, typ) {
 		return pass(ev)
+	}
+
+	if status == "" {
+		return unknown(ev)
 	}
 
 	return fail(ev)
@@ -381,7 +398,10 @@ func windowsAutoUpdate(ctx context.Context) Result {
 }
 
 func windowsPasswordPolicy(ctx context.Context) Result {
-	out := RunCommand(ctx, "net", "accounts")
+	out := powershell(
+		ctx,
+		`([ADSI]"WinNT://$env:COMPUTERNAME").InvokeGet('MinPasswordLength')`,
+	)
 	if out.Err != nil {
 		return unknown(
 			map[string]any{
@@ -391,10 +411,18 @@ func windowsPasswordPolicy(ctx context.Context) Result {
 		)
 	}
 
-	ev := map[string]any{"raw": truncate(out.Stdout, 400)}
+	minLen, err := strconv.Atoi(strings.TrimSpace(out.Stdout))
+	if err != nil {
+		return unknown(
+			map[string]any{
+				"error": "invalid MinPasswordLength",
+				"raw":   truncate(out.Stdout, 80),
+			},
+		)
+	}
 
-	lower := strings.ToLower(out.Stdout)
-	if strings.Contains(lower, "minimum password length") && !strings.Contains(lower, "length:                  0") {
+	ev := map[string]any{"min_password_length": minLen}
+	if minLen > 0 {
 		return pass(ev)
 	}
 

--- a/pkg/deviceagent/checks/runcmd_paths_windows.go
+++ b/pkg/deviceagent/checks/runcmd_paths_windows.go
@@ -27,12 +27,9 @@ import (
 )
 
 var windowsCommandPaths = map[string][]string{
-	"manage-bde": {`%s\System32\manage-bde.exe`},
-	"net":        {`%s\System32\net.exe`},
 	"netsh":      {`%s\System32\netsh.exe`},
 	"powershell": {`%s\System32\WindowsPowerShell\v1.0\powershell.exe`},
 	"sc":         {`%s\System32\sc.exe`},
-	"w32tm":      {`%s\System32\w32tm.exe`},
 }
 
 func commandCandidates(cmd string) []string {

--- a/pkg/deviceagent/checks/windows_posture.go
+++ b/pkg/deviceagent/checks/windows_posture.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package checks
+
+import "strings"
+
+// parseWindowsJoinedPairs parses "K=V;K2=V2" produced by PowerShell
+// `-join ";"`. Malformed segments and empty keys are skipped. SplitN
+// with n=2 keeps BitLocker keys like "C:" intact in "C:=On".
+func parseWindowsJoinedPairs(s string) map[string]string {
+	out := map[string]string{}
+
+	for pair := range strings.SplitSeq(s, ";") {
+		parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		name := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		if name == "" {
+			continue
+		}
+
+		out[name] = value
+	}
+
+	return out
+}
+
+func windowsAllValuesEqualFold(m map[string]string, want string) bool {
+	if len(m) == 0 {
+		return false
+	}
+
+	for _, v := range m {
+		if !strings.EqualFold(v, want) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// parseWindowsBitLockerVolumes parses "C:=On;D:=Off" from Get-BitLockerVolume
+// output, returning per-volume ProtectionStatus and whether every volume is
+// protected.
+func parseWindowsBitLockerVolumes(s string) (map[string]string, bool) {
+	volumes := parseWindowsJoinedPairs(s)
+
+	return volumes, windowsAllValuesEqualFold(volumes, "on")
+}
+
+// parseWindowsFirewallProfiles parses "Domain=True;Private=True;Public=True"
+// from Get-NetFirewallProfile output, returning per-profile state and
+// whether every profile is enabled.
+func parseWindowsFirewallProfiles(s string) (map[string]string, bool) {
+	profiles := parseWindowsJoinedPairs(s)
+
+	return profiles, windowsAllValuesEqualFold(profiles, "true")
+}
+
+func windowsTimeSyncOn(status, typ string) bool {
+	if !strings.EqualFold(strings.TrimSpace(status), "Running") {
+		return false
+	}
+
+	switch strings.ToUpper(strings.TrimSpace(typ)) {
+	case "NTP", "NT5DS", "ALLSYNC":
+		return true
+	}
+
+	return false
+}

--- a/pkg/deviceagent/checks/windows_posture_test.go
+++ b/pkg/deviceagent/checks/windows_posture_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseWindowsBitLockerVolumes(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"operating system volume protected",
+		func(t *testing.T) {
+			t.Parallel()
+
+			volumes, allProtected := parseWindowsBitLockerVolumes("C:=On")
+			require.Equal(t, map[string]string{"C:": "On"}, volumes)
+			assert.True(t, allProtected)
+		},
+	)
+
+	t.Run(
+		"operating system volume unprotected at full encryption",
+		func(t *testing.T) {
+			t.Parallel()
+
+			volumes, allProtected := parseWindowsBitLockerVolumes("C:=Off")
+			require.Equal(t, map[string]string{"C:": "Off"}, volumes)
+			assert.False(t, allProtected)
+		},
+	)
+
+	t.Run(
+		"empty output is unprotected",
+		func(t *testing.T) {
+			t.Parallel()
+
+			volumes, allProtected := parseWindowsBitLockerVolumes("")
+			require.Empty(t, volumes)
+			assert.False(t, allProtected)
+		},
+	)
+}
+
+func TestParseWindowsFirewallProfiles(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"all profiles enabled",
+		func(t *testing.T) {
+			t.Parallel()
+
+			profiles, allEnabled := parseWindowsFirewallProfiles(
+				"Domain=True;Private=True;Public=True",
+			)
+			require.Equal(
+				t,
+				map[string]string{
+					"Domain":  "True",
+					"Private": "True",
+					"Public":  "True",
+				},
+				profiles,
+			)
+			assert.True(t, allEnabled)
+		},
+	)
+
+	t.Run(
+		"one profile disabled",
+		func(t *testing.T) {
+			t.Parallel()
+
+			profiles, allEnabled := parseWindowsFirewallProfiles(
+				"Domain=True;Private=False;Public=True",
+			)
+			require.Equal(
+				t,
+				map[string]string{
+					"Domain":  "True",
+					"Private": "False",
+					"Public":  "True",
+				},
+				profiles,
+			)
+			assert.False(t, allEnabled)
+		},
+	)
+
+	t.Run(
+		"empty output is not enabled",
+		func(t *testing.T) {
+			t.Parallel()
+
+			profiles, allEnabled := parseWindowsFirewallProfiles("")
+			require.Empty(t, profiles)
+			assert.False(t, allEnabled)
+		},
+	)
+}
+
+func TestParseWindowsJoinedPairs(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"malformed segment skipped",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(
+				t,
+				map[string]string{"Domain": "True", "Public": "True"},
+				parseWindowsJoinedPairs("Domain=True;not-a-pair;Public=True"),
+			)
+		},
+	)
+
+	t.Run(
+		"whitespace around keys and values",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(
+				t,
+				map[string]string{"C:": "On", "D:": "Off"},
+				parseWindowsJoinedPairs(" C: = On ; D: = Off "),
+			)
+		},
+	)
+
+	t.Run(
+		"trailing semicolon",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(
+				t,
+				map[string]string{"Domain": "True"},
+				parseWindowsJoinedPairs("Domain=True;"),
+			)
+		},
+	)
+}
+
+func TestWindowsTimeSyncOn(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"running NTP is on",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.True(t, windowsTimeSyncOn("Running", "NTP"))
+		},
+	)
+
+	t.Run(
+		"stopped service is off",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.False(t, windowsTimeSyncOn("Stopped", "NTP"))
+		},
+	)
+
+	t.Run(
+		"running NoSync is off",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.False(t, windowsTimeSyncOn("Running", "NoSync"))
+		},
+	)
+
+	t.Run(
+		"running NT5DS is on",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.True(t, windowsTimeSyncOn("Running", "NT5DS"))
+		},
+	)
+}


### PR DESCRIPTION
French manage-bde and net accounts output never matched the English substring parser, so the console showed Unknown. w32tm also exited 0x80070426 when the time service was stopped, which the parser could not classify.

Collect BitLocker protection, MinPasswordLength, and W32Time state as structured fields instead. A suspended BitLocker volume and a stopped time service now display Off, not Unknown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report Windows device posture using structured PowerShell data instead of parsing English CLI output. Previously, BitLocker, password policy, and time sync often showed Unknown on non-English systems or when W32Time was stopped; now BitLocker Off/suspended and a stopped time service report Off, and min password length is numeric.

### Coredata **`+38`** **`-40`**
Parses Windows BitLocker from `volumes` when `backend` is `Get-BitLockerVolume`; missing OS volumes or cmdlet availability now evaluate as Off, and collection errors remain Unknown. Classifies time sync from `w32time_status` and `w32time_type` (Running + NTP/NT5DS/ALLSYNC is On; otherwise Off). Reads `min_password_length` directly and removes Windows string parsing helpers.

### Service **`+171`** **`-53`**
Replaces CLI scraping with PowerShell in `pkg/deviceagent/checks`: uses `Get-BitLockerVolume` for OS volumes, reads W32Time service status and type from service/registry, and gets ADSI `MinPasswordLength`. Emits structured fields: `backend`, `volumes`, `w32time_status`, `w32time_type`, `ntp_server`, and `min_password_length`. Drops reliance on `manage-bde`, `w32tm`, and `net`; adds helpers to parse BitLocker volumes, firewall profiles, and time sync state.

### Tests **`+296`** **`-15`**
Adds unit tests for Windows helpers and updates posture parsing tests to assert structured evidence and new classifications.

### Other **`+9`** **`-9`**
Updates `contrib/seed.sh` to emit structured Windows evidence for BitLocker, time sync, and password policy.

<sup>Written for commit eb16a4ff263b222e2f5ee831da266989ca4770f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

