### PR TITLE
Wrap Mermaid analysis labels with line breaks

### DIFF
--- a/pkg/riskmanagement/mermaid.go
+++ b/pkg/riskmanagement/mermaid.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
@@ -203,7 +204,7 @@ func buildDiagramMermaidChart(
 
 	emitBoundary = func(bnd *coredata.RiskAnalysisBoundary, indent string) {
 		alias := boundaryAlias[bnd.ID]
-		fmt.Fprintf(&b, "%ssubgraph %s[\"%s\"]\n", indent, alias, escapeMermaidLabel(bnd.Name))
+		fmt.Fprintf(&b, "%ssubgraph %s[\"%s\"]\n", indent, alias, mermaidLabel(bnd.Name))
 
 		inner := indent + "  "
 		for _, child := range childBoundaries[bnd.ID] {
@@ -239,7 +240,7 @@ func buildDiagramMermaidChart(
 			continue
 		}
 
-		fmt.Fprintf(&b, "  %s -- \"%s\" --> %s\n", src, mermaidEdgeLabel(p.Name), dst)
+		fmt.Fprintf(&b, "  %s -- \"%s\" --> %s\n", src, mermaidLabel(p.Name), dst)
 	}
 
 	processTarget := make(map[gid.GID]gid.GID, len(processes))
@@ -259,7 +260,10 @@ func buildDiagramMermaidChart(
 		}
 
 		tid := fmt.Sprintf("t%d", i)
-		label := escapeMermaidLabel(fmt.Sprintf("%s (%s)", t.Name, t.Category))
+		label := mermaidLabelWidth(
+			fmt.Sprintf("%s (%s)", t.Name, t.Category),
+			mermaidThreatLabelWrapWidth,
+		)
 		fmt.Fprintf(&b, "  %s{{\"%s\"}}\n", tid, label)
 		fmt.Fprintf(&b, "  class %s nodeThreat\n", tid)
 		fmt.Fprintf(&b, "  %s -.-> %s\n", tid, targetAlias)
@@ -275,7 +279,7 @@ func buildDiagramMermaidChart(
 }
 
 func mermaidNodeShape(t coredata.RiskAnalysisNodeType, id, name string) string {
-	label := `"` + escapeMermaidLabel(name) + `"`
+	label := `"` + mermaidLabel(name) + `"`
 
 	switch t {
 	case coredata.RiskAnalysisNodeTypeEntity:
@@ -302,29 +306,56 @@ func mermaidNodeClass(t coredata.RiskAnalysisNodeType) string {
 	}
 }
 
-const mermaidEdgeLabelWrapWidth = 28
+const (
+	mermaidLabelWrapWidth       = 28
+	mermaidThreatLabelWrapWidth = 20
+)
 
-var mermaidLabelReplacer = strings.NewReplacer(
-	"&", "&amp;",
-	`"`, "#quot;",
-	"<", "&lt;",
-	">", "&gt;",
-	"\r\n", " ",
-	"\n", " ",
+var (
+	mermaidLabelReplacer = strings.NewReplacer(
+		"&", "&amp;",
+		`"`, "#quot;",
+		"<", "&lt;",
+		">", "&gt;",
+	)
+
+	mermaidLabelNewlineReplacer = strings.NewReplacer(
+		"\r\n", " ",
+		"\n", " ",
+		"\r", " ",
+	)
 )
 
 func escapeMermaidLabel(s string) string {
 	return mermaidLabelReplacer.Replace(s)
 }
 
-// mermaidEdgeLabel escapes a process name and inserts <br> breaks so long
-// edge labels wrap. Mermaid's wrappingWidth only applies to nodes, not edges.
-func mermaidEdgeLabel(s string) string {
-	return strings.ReplaceAll(wrapWords(escapeMermaidLabel(s), mermaidEdgeLabelWrapWidth), "\n", "<br>")
+// mermaidLabel inserts \n breaks so long text wraps. wrappingWidth only
+// reliably wraps markdown strings (`["`text`"]`); our quoted labels are
+// plain text. Mermaid 11 documents \n as the line break for those, and
+// converts it to <br /> when htmlLabels are enabled.
+func mermaidLabel(s string) string {
+	return mermaidLabelWidth(s, mermaidLabelWrapWidth)
+}
+
+func mermaidLabelWidth(s string, width int) string {
+	s = mermaidLabelNewlineReplacer.Replace(s)
+
+	var b strings.Builder
+
+	for i, line := range strings.Split(wrapWords(s, width), "\n") {
+		if i > 0 {
+			b.WriteString(`\n`)
+		}
+
+		b.WriteString(escapeMermaidLabel(line))
+	}
+
+	return b.String()
 }
 
 func wrapWords(s string, width int) string {
-	if width <= 0 || len(s) <= width {
+	if width <= 0 || utf8.RuneCountInString(s) <= width {
 		return s
 	}
 
@@ -339,7 +370,8 @@ func wrapWords(s string, width int) string {
 	)
 
 	for _, word := range words {
-		if lineLen > 0 && lineLen+1+len(word) > width {
+		wordLen := utf8.RuneCountInString(word)
+		if lineLen > 0 && lineLen+1+wordLen > width {
 			b.WriteByte('\n')
 
 			lineLen = 0
@@ -353,7 +385,7 @@ func wrapWords(s string, width int) string {
 
 		b.WriteString(word)
 
-		lineLen += len(word)
+		lineLen += wordLen
 	}
 
 	return b.String()

--- a/pkg/riskmanagement/mermaid_test.go
+++ b/pkg/riskmanagement/mermaid_test.go
@@ -25,6 +25,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
 )
 
 func TestWrapWords(t *testing.T) {
@@ -67,10 +70,10 @@ func TestWrapWords(t *testing.T) {
 			expected: "Supercalifragilisticexpialidocious",
 		},
 		{
-			name:     "non-ascii counted in bytes not runes",
-			input:    "café café café café café",
+			name:     "non-ascii counted in runes",
+			input:    "café café café café café café",
 			width:    28,
-			expected: "café café café café\ncafé",
+			expected: "café café café café café\ncafé",
 		},
 		{
 			name:     "non-positive width returns input",
@@ -91,7 +94,43 @@ func TestWrapWords(t *testing.T) {
 	}
 }
 
-func TestMermaidEdgeLabel(t *testing.T) {
+func TestEscapeMermaidLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "ampersand uses html entity",
+			input:    "Hold secrets & signing keys",
+			expected: "Hold secrets &amp; signing keys",
+		},
+		{
+			name:     "angle brackets use html entities",
+			input:    "<conversation>",
+			expected: "&lt;conversation&gt;",
+		},
+		{
+			name:     "double quote uses mermaid entity",
+			input:    `say "hello"`,
+			expected: "say #quot;hello#quot;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tt.expected, escapeMermaidLabel(tt.input))
+			},
+		)
+	}
+}
+
+func TestMermaidLabel(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -105,19 +144,49 @@ func TestMermaidEdgeLabel(t *testing.T) {
 			expected: "Store patient records",
 		},
 		{
-			name:     "long label uses br breaks",
+			name:     "long label uses mermaid newline breaks",
 			input:    "Store patient conversation records",
-			expected: "Store patient conversation<br>records",
+			expected: `Store patient conversation\nrecords`,
 		},
 		{
-			name:     "escapes html before inserting br",
+			name:     "wraps on visible text then escapes",
 			input:    "Store patient <conversation> records now",
-			expected: "Store patient<br>&lt;conversation&gt; records<br>now",
+			expected: `Store patient &lt;conversation&gt;\nrecords now`,
 		},
 		{
 			name:     "literal underscore is preserved",
 			input:    "Data_Processing pipeline stage one two",
-			expected: "Data_Processing pipeline<br>stage one two",
+			expected: `Data_Processing pipeline\nstage one two`,
+		},
+		{
+			name:     "ampersand keeps the existing html entity",
+			input:    "Hold secrets & signing keys",
+			expected: "Hold secrets &amp; signing keys",
+		},
+		{
+			name:     "threat-style label wraps at width",
+			input:    "Secret / signing-key leakage (liability)",
+			expected: `Secret / signing-key leakage\n(liability)`,
+		},
+		{
+			name:     "data node label wraps at width",
+			input:    "Credentials, secrets, JWT signing keys",
+			expected: `Credentials, secrets, JWT\nsigning keys`,
+		},
+		{
+			name:     "crlf becomes a space",
+			input:    "hello\r\nworld",
+			expected: "hello world",
+		},
+		{
+			name:     "bare lf becomes a space",
+			input:    "hello\nworld",
+			expected: "hello world",
+		},
+		{
+			name:     "bare cr becomes a space",
+			input:    "hello\rworld",
+			expected: "hello world",
 		},
 	}
 
@@ -126,8 +195,77 @@ func TestMermaidEdgeLabel(t *testing.T) {
 			tt.name,
 			func(t *testing.T) {
 				t.Parallel()
-				assert.Equal(t, tt.expected, mermaidEdgeLabel(tt.input))
+				assert.Equal(t, tt.expected, mermaidLabel(tt.input))
 			},
 		)
 	}
+}
+
+func TestMermaidLabelWidth_ThreatHexagon(t *testing.T) {
+	t.Parallel()
+
+	got := mermaidLabelWidth(
+		"Secret / signing-key leakage (liability)",
+		mermaidThreatLabelWrapWidth,
+	)
+
+	assert.Equal(t, `Secret / signing-key\nleakage (liability)`, got)
+}
+
+func TestBuildDiagramMermaidChart_WrapsLabels(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	sourceID := gid.New(tenantID, coredata.RiskAnalysisNodeEntityType)
+	targetID := gid.New(tenantID, coredata.RiskAnalysisNodeEntityType)
+	processID := gid.New(tenantID, coredata.RiskAnalysisProcessEntityType)
+
+	chart := buildDiagramMermaidChart(
+		coredata.RiskAnalysisNodes{
+			{
+				ID:       sourceID,
+				NodeType: coredata.RiskAnalysisNodeTypeAsset,
+				Name:     "DynamoDB (stage-scoped table)",
+			},
+			{
+				ID:       targetID,
+				NodeType: coredata.RiskAnalysisNodeTypeData,
+				Name:     "Credentials, secrets, JWT signing keys",
+			},
+		},
+		nil,
+		coredata.RiskAnalysisProcesses{
+			{
+				ID:           processID,
+				SourceNodeID: sourceID,
+				TargetNodeID: targetID,
+				Name:         "Hold secrets & signing keys",
+			},
+		},
+		coredata.RiskAnalysisThreats{
+			{
+				ProcessID: processID,
+				Name:      "Secret / signing-key leakage",
+				Category:  "liability",
+			},
+		},
+	)
+
+	require.NotEmpty(t, chart)
+	assert.Contains(t, chart, "flowchart LR")
+	assert.NotContains(t, chart, "htmlLabels:")
+	assert.NotContains(t, chart, "wrappingWidth:")
+	assert.Contains(t, chart, mermaidLabel("Credentials, secrets, JWT signing keys"))
+	assert.Contains(t, chart, mermaidLabel("Hold secrets & signing keys"))
+	assert.Contains(
+		t,
+		chart,
+		mermaidLabelWidth(
+			"Secret / signing-key leakage (liability)",
+			mermaidThreatLabelWrapWidth,
+		),
+	)
+	assert.Contains(t, chart, `\n`)
+	assert.NotContains(t, chart, "<br>")
+	assert.Contains(t, chart, "&amp;")
 }


### PR DESCRIPTION
Quoted flowchart labels no longer auto-wrap after Mermaid 11.13, so long node text was clipped. Insert \n breaks in generated labels. Threat hexagons wrap more tightly because the pointed sides leave less room.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores flowchart label wrapping by inserting `\n` breaks in generated analysis labels. Previously, quoted labels stopped auto-wrapping in Mermaid 11.13 and long text clipped; now labels wrap by rune count with a narrower width for threat hexagons and consistent escaping.

### Service **`+51`** **`-19`**
Replaces boundary, node, and edge label builders to emit quoted plain-text labels with `\n` breaks. Adds rune-aware wrapping with default widths (28 general, 20 for threat hexagons), normalizes CR/LF/CRLF to spaces, escapes `&`, `<`, `>`, and double quotes (`#quot;`), and removes `<br>` insertion and any reliance on `htmlLabels` or `wrappingWidth`.

### Tests **`+148`** **`-10`**
Adds unit and integration tests for escaping, rune-aware wrapping, and chart generation. Verifies labels use `\n` (not `<br>`), no `htmlLabels`/`wrappingWidth` config, newline normalization, and narrower threat label wrapping.

<sup>Written for commit fd4eb0c8366e46f29478c2b601cae526b8a54325. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

