### PR TITLE
Fix Asana access reviews failing on every sync

### DIFF
--- a/cmd/probod/CHANGELOG.md
+++ b/cmd/probod/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to `probod` (the server, including the bundled `@probo/conso
 
 - authentik as an access review source, connected with an API-intent token and the instance URL. MFA status is derived from the instance's authenticator devices, and stays unknown rather than disabled when a device kind is unreadable
 
+### Fixed
+
+- Asana access reviews failed to fetch any account. The workspace memberships endpoint the driver reads is reachable only with Asana's full `default` scope, so a connector granted `users:read` and `workspaces:read` connected successfully and then got 403 on every sync. Asana admin, guest and view-only flags now stay unknown when the API withholds them instead of being reported as false
+
+### Changed
+
+- **Operators running their own Asana OAuth app must switch it to "Full permissions" in the Asana developer console before upgrading.** Asana publishes no granular scope covering workspace memberships and rejects an authorize request that mixes `default` with granular scopes, so an app left on granular scopes refuses both new connections and reconnects. Existing Asana connectors keep their old grant and must be reconnected once
+
 ## [0.261.1] - 2026-08-17
 
 ### Fixed

--- a/pkg/accessreview/drivers/asana.go
+++ b/pkg/accessreview/drivers/asana.go
@@ -32,6 +32,11 @@ import (
 
 // AsanaDriver fetches workspace memberships via the Asana REST API.
 // MFA and last-login are not available from the API.
+//
+// The workspace-scoped memberships query filters to active memberships, so
+// deactivated members are absent rather than returned with is_active false,
+// and is_active covers invitees who never accepted. Removals therefore reach a
+// campaign as entries missing from the fetch, not as inactive ones.
 type AsanaDriver struct {
 	httpClient   *http.Client
 	workspaceGID string
@@ -67,12 +72,16 @@ type (
 		Email string `json:"email"`
 	}
 
+	// The membership flags are pointers: this endpoint answers with
+	// WorkspaceMembershipCompact and only adds them because opt_fields asks
+	// for them, so an absent flag must stay unknown rather than decode to
+	// false.
 	asanaMembership struct {
 		User       asanaMembershipUser `json:"user"`
-		IsAdmin    bool                `json:"is_admin"`
-		IsGuest    bool                `json:"is_guest"`
-		IsViewOnly bool                `json:"is_view_only"`
-		IsActive   bool                `json:"is_active"`
+		IsAdmin    *bool               `json:"is_admin"`
+		IsGuest    *bool               `json:"is_guest"`
+		IsViewOnly *bool               `json:"is_view_only"`
+		IsActive   *bool               `json:"is_active"`
 		CreatedAt  string              `json:"created_at"`
 	}
 
@@ -122,8 +131,8 @@ func (d *AsanaDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error)
 					FullName:    m.User.Name,
 					ExternalID:  m.User.GID,
 					Roles:       asanaRoles(m.IsAdmin, m.IsGuest, m.IsViewOnly),
-					Active:      new(m.IsActive),
-					IsAdmin:     new(m.IsAdmin),
+					Active:      m.IsActive,
+					IsAdmin:     m.IsAdmin,
 					MFAStatus:   coredata.MFAStatusUnknown,
 					AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
 					AccountType: coredata.AccessReviewEntryAccountTypeUser,
@@ -172,16 +181,23 @@ func (d *AsanaDriver) queryMemberships(ctx context.Context, endpoint string) (*a
 	return &page, nil
 }
 
-func asanaRoles(isAdmin, isGuest, isViewOnly bool) []string {
+// asanaRoles derives the workspace role from the membership flags. A set flag
+// classifies on its own, but "Member" means "none of the three", so it is only
+// reachable once all three came back false. Inferring it from a partial
+// response would assert precisely what Asana withheld: an account whose
+// is_guest was omitted could be a guest.
+func asanaRoles(isAdmin, isGuest, isViewOnly *bool) []string {
 	switch {
-	case isAdmin:
+	case isAdmin != nil && *isAdmin:
 		return []string{"Admin"}
-	case isGuest:
+	case isGuest != nil && *isGuest:
 		return []string{"Guest"}
-	case isViewOnly:
+	case isViewOnly != nil && *isViewOnly:
 		return []string{"View only"}
-	default:
+	case isAdmin != nil && isGuest != nil && isViewOnly != nil:
 		return []string{"Member"}
+	default:
+		return nil
 	}
 }
 

--- a/pkg/accessreview/drivers/asana_test.go
+++ b/pkg/accessreview/drivers/asana_test.go
@@ -22,6 +22,7 @@ package drivers
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
 	"time"
@@ -45,39 +46,23 @@ func TestAsanaDriver(t *testing.T) {
 	driver := NewAsanaDriver(client, workspaceGID, "https://app.asana.com/api/1.0")
 	records, err := driver.ListAccounts(context.Background())
 	require.NoError(t, err)
-	require.NotEmpty(t, records)
+	require.Len(t, records, 1)
 
-	byEmail := map[string]AccountRecord{}
-	for _, r := range records {
-		byEmail[r.Email] = r
-	}
-
-	admin := byEmail["admin@example.com"]
+	admin := records[0]
+	assert.Equal(t, "admin@example.com", admin.Email)
 	assert.Equal(t, "Ada Admin", admin.FullName)
 	assert.Equal(t, "1000000000000001", admin.ExternalID)
 	assert.Equal(t, []string{"Admin"}, admin.Roles)
-	assert.Equal(t, new(true), admin.IsAdmin)
 	assert.Equal(t, coredata.MFAStatusUnknown, admin.MFAStatus)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodUnknown, admin.AuthMethod)
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, admin.AccountType)
+
+	require.NotNil(t, admin.IsAdmin)
+	assert.True(t, *admin.IsAdmin)
 	require.NotNil(t, admin.Active)
 	assert.True(t, *admin.Active)
 	require.NotNil(t, admin.CreatedAt)
-	assert.Equal(t, "2020-01-15T12:00:00Z", admin.CreatedAt.UTC().Format(time.RFC3339))
-
-	member := byEmail["member@example.com"]
-	assert.Equal(t, []string{"Member"}, member.Roles)
-	assert.Equal(t, new(false), member.IsAdmin)
-
-	guest := byEmail["guest@example.com"]
-	assert.Equal(t, []string{"Guest"}, guest.Roles)
-	assert.Equal(t, new(false), guest.IsAdmin)
-
-	viewer := byEmail["viewer@example.com"]
-	assert.Equal(t, []string{"View only"}, viewer.Roles)
-	assert.Equal(t, new(false), viewer.IsAdmin)
-
-	inactive := byEmail["inactive@example.com"]
-	require.NotNil(t, inactive.Active)
-	assert.False(t, *inactive.Active)
+	assert.Equal(t, "2026-05-15T13:12:35Z", admin.CreatedAt.UTC().Format(time.RFC3339))
 }
 
 func TestAsanaRoles(t *testing.T) {
@@ -85,16 +70,23 @@ func TestAsanaRoles(t *testing.T) {
 
 	for _, tc := range []struct {
 		name       string
-		isAdmin    bool
-		isGuest    bool
-		isViewOnly bool
+		isAdmin    *bool
+		isGuest    *bool
+		isViewOnly *bool
 		want       []string
 	}{
-		{name: "admin", isAdmin: true, want: []string{"Admin"}},
-		{name: "guest", isGuest: true, want: []string{"Guest"}},
-		{name: "view only", isViewOnly: true, want: []string{"View only"}},
-		{name: "member", want: []string{"Member"}},
-		{name: "admin wins over guest", isAdmin: true, isGuest: true, want: []string{"Admin"}},
+		{name: "admin", isAdmin: new(true), isGuest: new(false), isViewOnly: new(false), want: []string{"Admin"}},
+		{name: "guest", isAdmin: new(false), isGuest: new(true), isViewOnly: new(false), want: []string{"Guest"}},
+		{name: "view only", isAdmin: new(false), isGuest: new(false), isViewOnly: new(true), want: []string{"View only"}},
+		{name: "member", isAdmin: new(false), isGuest: new(false), isViewOnly: new(false), want: []string{"Member"}},
+		{name: "admin wins over guest", isAdmin: new(true), isGuest: new(true), isViewOnly: new(false), want: []string{"Admin"}},
+		// A set flag classifies even when another is missing.
+		{name: "partial signal still classifies", isAdmin: new(false), isGuest: new(true), want: []string{"Guest"}},
+		// "Member" means none of the three, so a withheld flag blocks it:
+		// the account may be exactly the thing Asana did not report.
+		{name: "member unreachable without is_admin", isGuest: new(false), isViewOnly: new(false), want: nil},
+		{name: "member unreachable without is_guest", isAdmin: new(false), isViewOnly: new(false), want: nil},
+		{name: "no signal at all", want: nil},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -102,4 +94,26 @@ func TestAsanaRoles(t *testing.T) {
 			assert.Equal(t, tc.want, asanaRoles(tc.isAdmin, tc.isGuest, tc.isViewOnly))
 		})
 	}
+}
+
+// TestAsanaMembershipAbsentFlagsStayUnknown pins the decode boundary where the
+// shipped bug lived: this endpoint returns WorkspaceMembershipCompact and adds
+// the privilege flags only because opt_fields asks for them, so a plain bool
+// would turn a withheld flag into an observed false.
+func TestAsanaMembershipAbsentFlagsStayUnknown(t *testing.T) {
+	t.Parallel()
+
+	var page asanaMembershipsPage
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"data":[{"gid":"1","user":{"gid":"2","name":"Ada","email":"ada@example.com"}}]}`),
+		&page,
+	))
+	require.Len(t, page.Data, 1)
+
+	m := page.Data[0]
+	assert.Nil(t, m.IsAdmin)
+	assert.Nil(t, m.IsGuest)
+	assert.Nil(t, m.IsViewOnly)
+	assert.Nil(t, m.IsActive)
+	assert.Nil(t, asanaRoles(m.IsAdmin, m.IsGuest, m.IsViewOnly))
 }

--- a/pkg/accessreview/drivers/testdata/asana.yaml
+++ b/pkg/accessreview/drivers/testdata/asana.yaml
@@ -1,3 +1,7 @@
+# Anonymized from a live recording against the probo.inc Asana workspace on
+# 2026-08-18, using an OAuth token carrying the `default` scope. Workspace,
+# membership and user GIDs, the display name and the email were replaced;
+# the response shape, headers and timing are as Asana sent them.
 ---
 version: 2
 interactions:
@@ -22,17 +26,63 @@ interactions:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 905
-        body: '{"data":[{"user":{"gid":"1000000000000001","name":"Ada Admin","email":"admin@example.com"},"is_admin":true,"is_guest":false,"is_view_only":false,"is_active":true,"created_at":"2020-01-15T12:00:00.000Z"},{"user":{"gid":"1000000000000002","name":"Mia Member","email":"member@example.com"},"is_admin":false,"is_guest":false,"is_view_only":false,"is_active":true,"created_at":"2021-03-01T08:30:00.000Z"},{"user":{"gid":"1000000000000003","name":"Gus Guest","email":"guest@example.com"},"is_admin":false,"is_guest":true,"is_view_only":false,"is_active":true,"created_at":"2022-06-10T16:45:00.000Z"},{"user":{"gid":"1000000000000004","name":"Vic Viewer","email":"viewer@example.com"},"is_admin":false,"is_guest":false,"is_view_only":true,"is_active":true,"created_at":"2023-02-20T09:00:00.000Z"},{"user":{"gid":"1000000000000005","name":"Ian Inactive","email":"inactive@example.com"},"is_admin":false,"is_guest":false,"is_view_only":false,"is_active":false,"created_at":"2019-11-05T14:20:00.000Z"}]}'
+        content_length: 246
+        body: '{"data":[{"gid":"1100000000000001","user":{"gid":"1000000000000001","email":"admin@example.com","name":"Ada Admin"},"is_active":true,"is_admin":true,"is_guest":false,"is_view_only":false,"created_at":"2026-05-15T13:12:35.328Z"}],"next_page":null}'
         headers:
+            Asana-Change:
+                - name=new_user_task_lists;info=https://forum.asana.com/t/update-on-our-planned-api-changes-to-user-task-lists-a-k-a-my-tasks/103828
+                - name=cross_workspace_deprecation;info=https://forum.asana.com/t/change-get-projects-get-users-and-get-tags-will-require-a-workspace-or-team/1031581
+                - name=new_goal_memberships;info=https://forum.asana.com/t/launched-team-sharing-for-goals/378601;affected=true
+                - name=teamless_projects;info=https://forum.asana.com/t/change-teamless-projects/929205
+                - name=goal_sals_api;info=https://forum.asana.com/t/new-change-goal-access-levels-admin-editor-and-viewer/1089758
+                - name=new_user_task_lists;info=https://forum.asana.com/t/update-on-our-planned-api-changes-to-user-task-lists-a-k-a-my-tasks/103828
+                - name=cross_workspace_deprecation;info=https://forum.asana.com/t/change-get-projects-get-users-and-get-tags-will-require-a-workspace-or-team/1031581
+                - name=new_goal_memberships;info=https://forum.asana.com/t/launched-team-sharing-for-goals/378601;affected=true
+                - name=teamless_projects;info=https://forum.asana.com/t/change-teamless-projects/929205
+                - name=goal_sals_api;info=https://forum.asana.com/t/new-change-goal-access-levels-admin-editor-and-viewer/1089758
             Content-Length:
-                - "905"
+                - "246"
+            Content-Security-Policy:
+                - report-uri https://app.asana.com/-/csp_report?report_only=false;default-src 'none';frame-src 'none';frame-ancestors 'none'
+                - report-uri https://app.asana.com/-/csp_report?report_only=false;default-src 'none';frame-src 'none';frame-ancestors 'none'
             Content-Type:
                 - application/json; charset=UTF-8
             Date:
-                - Tue, 04 Aug 2026 18:00:00 GMT
+                - Tue, 18 Aug 2026 09:38:45 GMT
+            Referrer-Policy:
+                - strict-origin-when-cross-origin
+            Server:
+                - istio-envoy
+            Server-Timing:
+                - cdn-upstream-layer;desc="REC",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=165,cdn-upstream-fbl;dur=492,cdn-cache-miss,cdn-pop;desc="CDG52-P2",cdn-rid;desc="j7kXwhtYso0RRhBdGTnxEaEMZad6oEwO5fgbWqUeWD1P8KMgQaLfoA==",cdn-downstream-fbl;dur=514
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubDomains; preload
+            Via:
+                - 1.1 e0720e45d2e7ea5da3d185114a45e51e.cloudfront.net (CloudFront)
+            X-Amz-Cf-Id:
+                - j7kXwhtYso0RRhBdGTnxEaEMZad6oEwO5fgbWqUeWD1P8KMgQaLfoA==
+            X-Amz-Cf-Pop:
+                - CDG52-P2
             X-Asana-Api-Version:
                 - "1.1"
+            X-Asana-Cell:
+                - prod-us1-asana-cell10
+            X-Cache:
+                - Miss from cloudfront
+            X-Content-Type-Options:
+                - nosniff
+            X-Envoy-Upstream-Service-Time:
+                - "242"
+            X-Frame-Options:
+                - DENY
+                - DENY
+            X-Robots-Tag:
+                - none
+            X-Ua-Compatible:
+                - IE=edge,chrome=1
+            X-Xss-Protection:
+                - 1; mode=block
+                - 1; mode=block
         status: 200 OK
         code: 200
-        duration: 50ms
+        duration: 627.923917ms

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -38,6 +38,13 @@ type (
 	// a different set of scopes (e.g. SCIM bridge vs access review).
 	InitiateOptions struct {
 		Scopes []string
+		// GrantedScopes carries what the connector being reconnected was
+		// granted earlier. The authorize request asks for the union of it
+		// and Scopes, so a reconnect never narrows an existing grant on a
+		// provider that replaces rather than merges. It is ignored for a
+		// provider with ExclusiveScopes, which refuses any scope its app
+		// registration no longer offers. Empty on a fresh install.
+		GrantedScopes []string
 		// IncludeGrantedScopes is honored only when the provider has
 		// SupportsIncrementalAuth=true.
 		IncludeGrantedScopes bool

--- a/pkg/connector/oauth2.go
+++ b/pkg/connector/oauth2.go
@@ -224,11 +224,12 @@ func (c *OAuth2Connector) Initiate(
 	opts InitiateOptions,
 	r *http.Request,
 ) (string, error) {
+	// RequestedScopes is filled in by InitiateWithState, which owns the
+	// resolution so the signed state and the authorize request cannot drift.
 	stateData := OAuth2State{
-		OrganizationID:  organizationID.String(),
-		Provider:        provider,
-		ConnectorID:     opts.ConnectorID,
-		RequestedScopes: c.effectiveScopes(opts),
+		OrganizationID: organizationID.String(),
+		Provider:       provider,
+		ConnectorID:    opts.ConnectorID,
 	}
 
 	if r != nil {
@@ -275,6 +276,13 @@ func (c *OAuth2Connector) InitiateWithState(
 		stateData.PKCENonce = nonce
 	}
 
+	// Record what is actually being asked for, overriding whatever the
+	// caller put in the state: the callback falls back to RequestedScopes
+	// when a token response omits `scope`, so a state that disagrees with
+	// the request would persist a grant the connector never asked for.
+	scopes := c.effectiveScopes(opts)
+	stateData.RequestedScopes = scopes
+
 	state, err := statelesstoken.NewToken(salt, OAuth2TokenType, OAuth2TokenTTL, stateData)
 	if err != nil {
 		return "", fmt.Errorf("cannot create state token: %w", err)
@@ -286,7 +294,6 @@ func (c *OAuth2Connector) InitiateWithState(
 	authCodeQuery.Set("redirect_uri", c.RedirectURI)
 	authCodeQuery.Set("response_type", "code")
 
-	scopes := c.effectiveScopes(opts)
 	if len(scopes) > 0 {
 		authCodeQuery.Set("scope", strings.Join(scopes, " "))
 	}

--- a/pkg/connector/oauth2.go
+++ b/pkg/connector/oauth2.go
@@ -60,6 +60,18 @@ type (
 		ExtraAuthParams         map[string]string // Optional: extra params for auth URL (e.g., access_type=offline for Google)
 		TokenEndpointAuth       string            // "post-form" (default), "basic-form", or "basic-json"
 		SupportsIncrementalAuth bool
+		// ExclusiveScopes marks a provider whose authorization server
+		// refuses any scope its app registration does not currently
+		// offer, failing the whole authorize request rather than
+		// ignoring the extras. Such a provider asks for RegisteredScopes
+		// verbatim instead of the union with what the connector was
+		// granted earlier.
+		ExclusiveScopes bool
+		// RegisteredScopes mirrors the provider registration's
+		// OAuth2Scopes. It is authoritative for an ExclusiveScopes
+		// provider, whose authorize request must carry exactly the set
+		// the app is registered for.
+		RegisteredScopes []string
 		// RequiresPKCE enables RFC 7636 PKCE (S256). When true,
 		// InitiateWithState generates a verifier, persists it in the
 		// OAuth2State, and adds code_challenge / code_challenge_method
@@ -177,6 +189,34 @@ func DecodeOAuth2StatePayload(tokenString string) (*statelesstoken.Payload[OAuth
 	return statelesstoken.DecodePayload[OAuth2State](tokenString)
 }
 
+// effectiveScopes resolves what the authorize request will ask for. It backs
+// both the request itself and the RequestedScopes recorded in the state token,
+// which the callback falls back to when a token response omits `scope` — the
+// two must not disagree, or a reconnect persists a narrower grant than it
+// actually obtained.
+//
+// Reconnects normally ask for the union of (old granted ∪ new requested),
+// because most providers replace the grant rather than merge into it. A
+// provider with ExclusiveScopes instead accepts only what its registration
+// declares: it rejects the whole authorize request over a scope it no longer
+// offers, so neither the older grant nor a stale scope carried in by the
+// caller may widen the set.
+func (c *OAuth2Connector) effectiveScopes(opts InitiateOptions) []string {
+	if c.ExclusiveScopes {
+		if len(c.RegisteredScopes) > 0 {
+			return c.RegisteredScopes
+		}
+
+		return opts.Scopes
+	}
+
+	if len(opts.GrantedScopes) == 0 {
+		return opts.Scopes
+	}
+
+	return UnionScopes(opts.GrantedScopes, opts.Scopes)
+}
+
 func (c *OAuth2Connector) Initiate(
 	ctx context.Context,
 	provider string,
@@ -188,7 +228,7 @@ func (c *OAuth2Connector) Initiate(
 		OrganizationID:  organizationID.String(),
 		Provider:        provider,
 		ConnectorID:     opts.ConnectorID,
-		RequestedScopes: opts.Scopes,
+		RequestedScopes: c.effectiveScopes(opts),
 	}
 
 	if r != nil {
@@ -246,8 +286,9 @@ func (c *OAuth2Connector) InitiateWithState(
 	authCodeQuery.Set("redirect_uri", c.RedirectURI)
 	authCodeQuery.Set("response_type", "code")
 
-	if len(opts.Scopes) > 0 {
-		authCodeQuery.Set("scope", strings.Join(opts.Scopes, " "))
+	scopes := c.effectiveScopes(opts)
+	if len(scopes) > 0 {
+		authCodeQuery.Set("scope", strings.Join(scopes, " "))
 	}
 
 	if c.RequiresPKCE {

--- a/pkg/connector/oauth2_test.go
+++ b/pkg/connector/oauth2_test.go
@@ -330,6 +330,64 @@ func TestInitiateWithState_Scopes(t *testing.T) {
 		assert.False(t, parsed.Query().Has("scope"), "scope param should be absent when no scopes provided")
 	})
 
+	t.Run("reconnect unions the earlier grant into the request", func(t *testing.T) {
+		t.Parallel()
+
+		c := &OAuth2Connector{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/cb",
+			AuthURL:      "https://provider.example.com/authorize",
+		}
+
+		orgID := gid.New(gid.NewTenantID(), 0)
+
+		u, err := c.InitiateWithState(
+			context.Background(),
+			OAuth2State{OrganizationID: orgID.String(), Provider: "TEST"},
+			InitiateOptions{
+				Scopes:        []string{"read:user"},
+				GrantedScopes: []string{"write:user"},
+			},
+		)
+		require.NoError(t, err)
+
+		parsed, err := url.Parse(u)
+		require.NoError(t, err)
+		assert.Equal(t, "read:user write:user", parsed.Query().Get("scope"))
+	})
+
+	t.Run("exclusive scopes drop the earlier grant from the request", func(t *testing.T) {
+		t.Parallel()
+
+		// Asana rejects the whole authorize request when it carries a scope
+		// its app registration no longer offers, so a reconnect must ask for
+		// exactly the registered set.
+		c := &OAuth2Connector{
+			ClientID:        "id",
+			ClientSecret:    "secret",
+			RedirectURI:     "https://example.com/cb",
+			AuthURL:         "https://provider.example.com/authorize",
+			ExclusiveScopes: true,
+		}
+
+		orgID := gid.New(gid.NewTenantID(), 0)
+
+		u, err := c.InitiateWithState(
+			context.Background(),
+			OAuth2State{OrganizationID: orgID.String(), Provider: "TEST"},
+			InitiateOptions{
+				Scopes:        []string{"default"},
+				GrantedScopes: []string{"users:read", "workspaces:read"},
+			},
+		)
+		require.NoError(t, err)
+
+		parsed, err := url.Parse(u)
+		require.NoError(t, err)
+		assert.Equal(t, "default", parsed.Query().Get("scope"))
+	})
+
 	t.Run("include_granted_scopes set when provider supports and caller requests", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/connector/oauth2_test.go
+++ b/pkg/connector/oauth2_test.go
@@ -357,6 +357,44 @@ func TestInitiateWithState_Scopes(t *testing.T) {
 		assert.Equal(t, "read:user write:user", parsed.Query().Get("scope"))
 	})
 
+	t.Run("state records the scopes actually requested", func(t *testing.T) {
+		t.Parallel()
+
+		c := &OAuth2Connector{
+			ClientID:     "id",
+			ClientSecret: "secret",
+			RedirectURI:  "https://example.com/cb",
+			AuthURL:      "https://provider.example.com/authorize",
+		}
+
+		orgID := gid.New(gid.NewTenantID(), 0)
+
+		// A stale RequestedScopes in the caller's state must not survive:
+		// the callback falls back to it when the token response omits
+		// `scope`, so it has to match what the authorize request carried.
+		u, err := c.InitiateWithState(
+			context.Background(),
+			OAuth2State{
+				OrganizationID:  orgID.String(),
+				Provider:        "TEST",
+				RequestedScopes: []string{"stale:scope"},
+			},
+			InitiateOptions{
+				Scopes:        []string{"read:user"},
+				GrantedScopes: []string{"write:user"},
+			},
+		)
+		require.NoError(t, err)
+
+		parsed, err := url.Parse(u)
+		require.NoError(t, err)
+		assert.Equal(t, "read:user write:user", parsed.Query().Get("scope"))
+
+		payload, err := DecodeOAuth2StatePayload(parsed.Query().Get("state"))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"read:user", "write:user"}, payload.Data.RequestedScopes)
+	})
+
 	t.Run("exclusive scopes drop the earlier grant from the request", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/connector/provider/apply.go
+++ b/pkg/connector/provider/apply.go
@@ -52,6 +52,8 @@ func (r *Registry) ApplyOAuth2Defaults(p string, redirectURI string, c *connecto
 	c.TokenURL = reg.Endpoints.Token
 	c.TokenEndpointAuth = reg.TokenEndpointAuth
 	c.SupportsIncrementalAuth = reg.SupportsIncrementalAuth
+	c.ExclusiveScopes = reg.ExclusiveScopes
+	c.RegisteredScopes = reg.OAuth2Scopes
 	c.RequiresPKCE = reg.RequiresPKCE
 	c.BuildAuthURLForSite = reg.BuildAuthURLForSite
 	c.BuildTokenURLForDomain = reg.BuildTokenURLForDomain

--- a/pkg/connector/provider/asana.go
+++ b/pkg/connector/provider/asana.go
@@ -42,7 +42,17 @@ func asanaRegistration() *Registration {
 			// prefix, so the version segment stays in APIBase.
 			APIBase: "https://app.asana.com/api/1.0",
 		},
-		OAuth2Scopes: []string{"workspaces:read", "users:read"},
+		// Asana publishes no granular scope for workspace_memberships, the
+		// only endpoint exposing admin/guest/view-only status, and answers a
+		// granular token with 403 "Full permissions are required to use this
+		// endpoint". Requesting "default" is the documented opt-out, and
+		// naming it keeps SourceNeedsReconnect able to spot the connectors
+		// still holding a narrower grant.
+		OAuth2Scopes: []string{"default"},
+		// Asana rejects the whole authorize request when it carries a scope
+		// the app no longer offers, so a reconnect must not replay the
+		// granular grant these connectors were created with.
+		ExclusiveScopes: true,
 		NewDriver: func(_ context.Context, c *http.Client, conn *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
 			s, err := coredata.ConnectorSettings[coredata.AsanaConnectorSettings](conn)
 			if err != nil {

--- a/pkg/connector/provider/asana_test.go
+++ b/pkg/connector/provider/asana_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/connector"
+	"go.probo.inc/probo/pkg/connector/provider"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+// TestAsanaRegistrationScopes pins the registration that the outage turned on.
+// The driver reads /workspaces/{gid}/workspace_memberships, which no granular
+// Asana scope reaches: a token scoped users:read + workspaces:read is answered
+// with 403 "Full permissions are required to use this endpoint", even though
+// the probe, the organization picker and the name resolver all still succeed —
+// so the connector connects green and only the campaign sync fails. Narrowing
+// these scopes again reintroduces exactly that outage.
+func TestAsanaRegistrationScopes(t *testing.T) {
+	t.Parallel()
+
+	r := provider.NewBuiltinRegistry()
+	reg, ok := r.Get(coredata.ConnectorProviderAsana)
+	require.True(t, ok, "asana provider must be registered")
+
+	assert.Equal(t, []string{"default"}, reg.OAuth2Scopes)
+	assert.True(t, reg.ExclusiveScopes, "asana rejects any scope its app no longer offers")
+}
+
+// TestApplyOAuth2Defaults_AsanaExclusiveScopes checks the trait survives the
+// registration -> connector copy, since only the connector sees it at
+// authorize time.
+func TestApplyOAuth2Defaults_AsanaExclusiveScopes(t *testing.T) {
+	t.Parallel()
+
+	r := provider.NewBuiltinRegistry()
+
+	c := &connector.OAuth2Connector{}
+	require.NoError(t, r.ApplyOAuth2Defaults(
+		string(coredata.ConnectorProviderAsana),
+		"https://example.com/cb",
+		c,
+	))
+
+	assert.True(t, c.ExclusiveScopes)
+	assert.Equal(t, []string{"default"}, c.RegisteredScopes)
+}

--- a/pkg/connector/provider/types.go
+++ b/pkg/connector/provider/types.go
@@ -114,6 +114,12 @@ type Registration struct {
 	TokenEndpointAuth       string // "post-form" (default), "basic-form", or "basic-json"
 	SupportsIncrementalAuth bool
 	OAuth2Scopes            []string
+	// ExclusiveScopes marks a provider whose authorization server refuses any
+	// scope outside OAuth2Scopes, so a reconnect must request exactly that set
+	// rather than the union with the connector's earlier grant. Asana is one:
+	// once its app moved to Full Permissions, replaying a stored "users:read"
+	// fails the whole authorize with forbidden_scopes.
+	ExclusiveScopes bool
 	// RequiresPKCE enables RFC 7636 PKCE (S256) on the authorization
 	// request and replays the verifier on the token exchange. Default
 	// false; non-PKCE providers are unaffected.

--- a/pkg/server/api/console/v1/connector_initiate.go
+++ b/pkg/server/api/console/v1/connector_initiate.go
@@ -114,13 +114,14 @@ func handleConnectorInitiate(
 			return
 		}
 
-		// Always request the union of (old granted ∪ new requested).
-		// Union-not-delta because most providers replace rather than
-		// merge. No short-circuit: every reconnect runs the full OAuth
+		// Hand the earlier grant to the connector rather than unioning it
+		// here: whether a reconnect may widen the request or must ask for
+		// exactly the registered scopes is a per-provider OAuth trait. No
+		// short-circuit either way — every reconnect runs the full OAuth
 		// flow so revoked or stale tokens are never silently reused.
 		opts := connector.InitiateOptions{Scopes: requestedScopes, Site: r.URL.Query().Get("site")}
 		if existing != nil {
-			opts.Scopes = connector.UnionScopes(existing.Connection.Scopes(), requestedScopes)
+			opts.GrantedScopes = existing.Connection.Scopes()
 			opts.IncludeGrantedScopes = true
 			opts.ConnectorID = existing.ID.String()
 		}


### PR DESCRIPTION
Asana access reviews have fetched nothing since commit 5ef4978 switched
the driver from `/workspaces/{gid}/users` to
`/workspaces/{gid}/workspace_memberships` to pick up admin, guest and
view-only status. That endpoint is reachable only with Asana's full
`default` scope, and the connector still asked for `users:read` and
`workspaces:read`.

## Verified against the live API

Reproduced with a token carrying exactly the production scope set, and
again with a full-permissions token, against a Probo-owned workspace:

| Call | granular token | `default` token |
| --- | --- | --- |
| probe `/users/me` | 200 | 200 |
| picker `/workspaces` | 200 | 200 |
| name resolver `/workspaces/{gid}` | 200 | 200 |
| old driver `/workspaces/{gid}/users` | 200 | 200 |
| new driver `.../workspace_memberships` | **403** | **200** |

```
{"errors":[{"message":"Full permissions are required to use this endpoint."}]}
```

That asymmetry is the whole bug report: the connector connects green,
picks a workspace and resolves its name, and only the campaign sync
fails. Asana publishes no granular scope for workspace memberships —
their own console lists exactly two matches for "workspace"
(`workspaces:read`, `workspaces.typeahead:read`), and `workspaces:read`
is documented as "basic workspace information, like name and associated
email domains".

## What changed

1. **`OAuth2Scopes` -> `{"default"}`.** Naming it beats sending no scope:
   an empty list makes `missingOAuthScopesForConnector` report nothing
   missing, which both suppresses the reconnect prompt and hides the
   button (`canReconnect` tests `oauth2Scopes.length > 0`).
2. **A provider can pin reconnect to its registered scopes.** Reconnect
   unioned the stored grant into the request, so post-fix a connected
   tenant would have sent `default users:read workspaces:read` — which
   Asana rejects with `forbidden_scopes` (verified). Every existing
   tenant would have had a Reconnect button that bounces. The union now
   lives behind `effectiveScopes` in the connector, where it also keeps
   the authorize request and the state token's `RequestedScopes` in
   agreement. Providers without the trait emit the same scope string as
   before.
3. **Membership flags decode as pointers.** The endpoint returns
   `WorkspaceMembershipCompact` and includes the flags only because
   `opt_fields` asks for them, so plain bools turned a withheld flag into
   an observed `false` — a response without them would have shown a whole
   workspace as deactivated non-admins. `asanaRoles` no longer invents
   "Member" from a partial response.
4. **The cassette is a real recording again.** The previous commit
   replaced a genuine capture with a hand-authored one (4 headers, round
   `50ms`, `Content-Length: 905` for a 993-byte body) that asserted an
   `is_active: false` row this endpoint cannot return. Re-recorded live
   and anonymized — `cassette_safety_test.go` requires synthetic emails —
   with 22 real headers and `Content-Length` recomputed.

## Deploy order matters

Both mismatch directions are rejected at authorize with
`forbidden_scopes`, so the app registration and the code must not
disagree for long. **Flip the Asana app to Full permissions before
deploying** — the deploy is what starts sending customers to reconnect.
The prod and staging Probo apps are already switched; self-hosted
operators must do the same, which the changelog calls out.

Existing connectors keep their old grant and need one reconnect each.

## Worth a reviewer's judgement

- **This widens consent.** `default` is full read-write delegated
  access; the consent screen goes from "Access information across your
  Asana workspace" to "Create and modify tasks, projects, and comments
  on your behalf". Forced by Asana, but customer docs may need updating.
- **`Active` is passed through, not forced to nil.** The workspace-scoped
  query filters to active memberships, so `is_active` is arguably a
  constant, and it counts never-accepted invitees. I kept the source's
  explicit value and documented the limitation; two reviewers argued for
  `nil`. Note it makes no behavioural difference today — the persistence
  layer `COALESCE(@active, TRUE)`s a nil `Active` to true for all ~22
  drivers that honour the three-valued contract, which is a separate
  pre-existing bug worth its own change.
- **`pkg/server/api/console/v1` could not be compiled locally** — its
  gqlgen types are ungenerated, codegen is gated on the console frontend
  build, and `npm install` fails on `isolated-vm` under Node 26 (this
  reproduces on a clean checkout). The change there is one field on a
  struct literal; CI is the check.

Reviewed adversarially by a second model and by Codex before opening;
findings from both are folded in, including the reconnect-union blocker
and the state-token scope mismatch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Asana access reviews failing with 403 on every sync by requesting Asana’s `default` scope and honoring providers that reject unregistered scopes on reconnect. Resolves authorize scopes once so the URL and signed state always match, and preserves unknown membership flags from the API.

### Service **`+162`** **`-23`**
- Asana provider now requests `default` and is `ExclusiveScopes`, preventing reconnects from mixing `default` with granular scopes (`users:read`, `workspaces:read`) that Asana rejects.
- OAuth2: adds `ExclusiveScopes` and `RegisteredScopes`, introduces `effectiveScopes` and `GrantedScopes`; `InitiateWithState` records resolved scopes and overrides stale `RequestedScopes` in caller-supplied state.
- Registry copies `ExclusiveScopes` and `OAuth2Scopes` into the connector so scope resolution happens per provider traits.
- Asana driver decodes membership flags (`is_admin`, `is_guest`, `is_view_only`, `is_active`) as pointers so withheld fields stay unknown; role derivation no longer invents “Member” from partial responses; comments clarify `is_active` semantics.
- Re-records and anonymizes the Asana cassette to match a live `workspace_memberships` response.
- Rollout:
  - Switch your Asana OAuth app to “Full permissions” before deploying.
  - Reconnect existing Asana connectors once to upgrade grants.

### Tests **`+211`** **`-33`**
- Updates Asana driver tests for pointer flags, role derivation on partial responses, and the live cassette.
- Adds OAuth2 tests for scope resolution: unions on reconnect by default, drops earlier grants for `ExclusiveScopes`, and records the exact scopes in state.
- Adds provider tests to pin Asana’s `default` scope and `ExclusiveScopes`, and to verify registry-to-connector propagation.

### GraphQL API **`+5`** **`-4`**
- Initiation handler now passes `GrantedScopes` to the connector and defers scope resolution, keeping the authorize request and state token in sync per provider traits.

### Other **`+8`** **`-0`**
- Updates changelog with the outage cause, fix, and operator actions.

<sup>Written for commit 4047d7427493c2af304e249ecee303cdd105ff04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

