### PR TITLE
Fix CORS for cookie-banner reports

### DIFF
--- a/e2e/console/cookie_banner_report_test.go
+++ b/e2e/console/cookie_banner_report_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package console_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
+)
+
+func TestCookieBannerReport_BeaconPayload(t *testing.T) {
+	t.Parallel()
+
+	fixture := setupPublishedCookieBanner(t)
+	cookieName := strings.ReplaceAll(factory.SafeName("beacon-cookie"), " ", "_")
+
+	body, err := json.Marshal(
+		map[string]any{
+			"cookies": []map[string]any{
+				{
+					"name":   cookieName,
+					"source": "script",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	resp := doCookieBannerHTTP(
+		t,
+		fixture.Owner,
+		cookieBannerHTTPOptions{
+			Method:      http.MethodPost,
+			BannerID:    fixture.BannerID,
+			Path:        []string{"report"},
+			Origin:      fixture.Origin,
+			ContentType: "text/plain;charset=UTF-8",
+			Body:        body,
+		},
+	)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode, "report body: %s", string(resp.Body))
+	assert.Equal(t, fixture.Origin, resp.Header.Get("Access-Control-Allow-Origin"))
+
+	const query = `
+		query CookieBannerReportBeaconPayload($id: ID!, $filter: TrackerPatternFilter) {
+			node(id: $id) {
+				... on CookieBanner {
+					trackerPatterns(first: 10, filter: $filter) {
+						totalCount
+						edges {
+							node {
+								pattern
+								trackerType
+							}
+						}
+					}
+				}
+			}
+		}
+	`
+
+	var result struct {
+		Node struct {
+			TrackerPatterns struct {
+				TotalCount int `json:"totalCount"`
+				Edges      []struct {
+					Node struct {
+						Pattern     string `json:"pattern"`
+						TrackerType string `json:"trackerType"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"trackerPatterns"`
+		} `json:"node"`
+	}
+
+	require.NoError(
+		t,
+		fixture.Owner.Execute(
+			query,
+			map[string]any{
+				"id": fixture.BannerID,
+				"filter": map[string]any{
+					"query":       cookieName,
+					"trackerType": "COOKIE",
+				},
+			},
+			&result,
+		),
+	)
+	assert.Equal(t, 1, result.Node.TrackerPatterns.TotalCount)
+	require.Len(t, result.Node.TrackerPatterns.Edges, 1)
+	assert.Equal(t, cookieName, result.Node.TrackerPatterns.Edges[0].Node.Pattern)
+	assert.Equal(t, "COOKIE", result.Node.TrackerPatterns.Edges[0].Node.TrackerType)
+}

--- a/packages/cookie-banner/src/detectors/report-queue.test.ts
+++ b/packages/cookie-banner/src/detectors/report-queue.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ReportQueue } from "./report-queue";
+
+describe("ReportQueue", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("sends unload reports as CORS-safelisted JSON", async () => {
+    vi.useFakeTimers();
+
+    const sendBeacon = vi.fn((_url: string, _data?: BodyInit | null) => true);
+    vi.stubGlobal("navigator", { sendBeacon });
+
+    const reportUrl = new URL("https://api.example.com/banner/report");
+    const queue = new ReportQueue(reportUrl);
+    queue.reportCookie({
+      name: "analytics",
+      max_age_seconds: 3600,
+      source: "script",
+    });
+
+    queue.stop();
+
+    expect(sendBeacon).toHaveBeenCalledOnce();
+    expect(sendBeacon).toHaveBeenCalledWith(reportUrl.toString(), expect.any(Blob));
+    const sentData: unknown = sendBeacon.mock.calls[0]?.[1];
+    expect(sentData).toBeInstanceOf(Blob);
+    if (!(sentData instanceof Blob)) {
+      throw new Error("expected sendBeacon to receive a Blob");
+    }
+
+    expect(sentData.type).toBe("text/plain;charset=utf-8");
+    await expect(sentData.text()).resolves.toBe(
+      JSON.stringify({
+        cookies: [
+          {
+            name: "analytics",
+            max_age_seconds: 3600,
+            source: "script",
+          },
+        ],
+      }),
+    );
+  });
+});

--- a/packages/cookie-banner/src/detectors/report-queue.ts
+++ b/packages/cookie-banner/src/detectors/report-queue.ts
@@ -266,7 +266,9 @@ export class ReportQueue {
     const payload = JSON.stringify(body);
 
     if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
-      const blob = new Blob([payload], { type: "application/json" });
+      const blob = new Blob([payload], {
+        type: "text/plain;charset=UTF-8", // CORS-safelisted content type, so the request is not preflighted.
+      });
       let queued = false;
       try {
         queued = navigator.sendBeacon(this.reportUrl.toString(), blob);

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -425,6 +425,9 @@ func (h *Handler) handleReportDetectedTrackers(w http.ResponseWriter, r *http.Re
 	}
 
 	var body reportDetectedTrackersBody
+	// The unload-safe Beacon transport sends JSON bytes as text/plain so
+	// cross-origin reports remain CORS-safelisted and avoid a preflight.
+	// Decode the body independently of Content-Type to preserve that contract.
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		jsonx.RenderBadRequest(w, fmt.Errorf("invalid request body"))
 		return


### PR DESCRIPTION
Fixes: https://github.com/getprobo/probo/issues/1714

## Problem
Cross-origin cookie-banner unload reports fail because sendBeacon(application/json) requires credentialed CORS:
```
Response to preflight request doesn't pass access control check:
The value of the 'Access-Control-Allow-Credentials' header in the response
is '' which must be 'true' when the request's credentials mode is 'include'.
```

## Fix
text/plain is CORS-safelisted, avoiding the preflight while preserving the JSON body. Probo’s endpoint already successfully parses this payload.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends cookie-banner unload reports as text/plain so cross-origin beacons avoid a failing CORS preflight. Previously we used application/json; now the request is CORS‑safelisted, the payload stays JSON, and the server decodes it independent of Content-Type.

### Tests **`+185`** **`-0`**
Adds an SDK unit test that stubs navigator.sendBeacon and asserts a Blob with type text/plain;charset-utf-8 and the expected JSON body. Adds an e2e test that posts a text/plain beacon body, verifies 204 and Access-Control-Allow-Origin echo, and confirms the tracker is recorded via GraphQL.

### Package: `cookie-banner` **`+3`** **`-1`**
Changes the Beacon Blob content type in ReportQueue to text/plain;charset=UTF-8 so unload reports avoid CORS preflight while keeping the same JSON payload.

### GraphQL API **`+3`** **`-0`**
Documents that the report handler decodes JSON regardless of Content-Type to support unload beacons; behavior remains unchanged.

<sup>Written for commit 2b9f048b45bac7b135e29b6da60df2aa05a9808d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

