### PR TITLE
Fall back to schema defaults for absent node attrs

### DIFF
--- a/pkg/prosemirror/html_renderer_test.go
+++ b/pkg/prosemirror/html_renderer_test.go
@@ -418,3 +418,58 @@ func TestRenderHTML_UnknownMarkType(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown type")
 }
+
+func TestRenderHTML_NodesWithoutAttrs(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		raw      string
+		expected string
+	}{
+		{
+			name:     "heading",
+			raw:      `{"type":"heading","content":[{"type":"text","text":"X"}]}`,
+			expected: `<h1>X</h1>`,
+		},
+		{
+			name:     "ordered list",
+			raw:      `{"type":"orderedList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"item"}]}]}]}`,
+			expected: `<ol><li><p>item</p></li></ol>`,
+		},
+		{
+			name:     "table cell",
+			raw:      `{"type":"tableCell","content":[{"type":"paragraph","content":[{"type":"text","text":"X"}]}]}`,
+			expected: `<td><p>X</p></td>`,
+		},
+		{
+			name:     "table header",
+			raw:      `{"type":"tableHeader","content":[{"type":"paragraph","content":[{"type":"text","text":"X"}]}]}`,
+			expected: `<th><p>X</p></th>`,
+		},
+		{
+			name:     "empty attrs object",
+			raw:      `{"type":"tableCell","attrs":{},"content":[{"type":"paragraph","content":[{"type":"text","text":"X"}]}]}`,
+			expected: `<td><p>X</p></td>`,
+		},
+		{
+			name:     "image",
+			raw:      `{"type":"image"}`,
+			expected: `<img src="">`,
+		},
+	} {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				var n Node
+				require.NoError(t, json.Unmarshal([]byte(tc.raw), &n))
+
+				got, err := RenderHTML(n)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, got)
+			},
+		)
+	}
+}

--- a/pkg/prosemirror/node.go
+++ b/pkg/prosemirror/node.go
@@ -129,8 +129,14 @@ func Parse(s string) (Node, error) {
 }
 
 // HeadingAttrs parses and returns the heading attributes from a heading node.
+// Attributes are optional in the Tiptap schema: a node that omits them, or
+// omits individual keys, takes the schema defaults.
 func (n Node) HeadingAttrs() (HeadingAttrs, error) {
-	var a HeadingAttrs
+	a := HeadingAttrs{Level: 1}
+	if len(n.Attrs) == 0 {
+		return a, nil
+	}
+
 	if err := json.Unmarshal(n.Attrs, &a); err != nil {
 		return a, fmt.Errorf("cannot parse heading attrs: %w", err)
 	}
@@ -154,7 +160,11 @@ func (n Node) CodeBlockAttrs() (CodeBlockAttrs, error) {
 
 // OrderedListAttrs parses and returns the ordered list attributes.
 func (n Node) OrderedListAttrs() (OrderedListAttrs, error) {
-	var a OrderedListAttrs
+	a := OrderedListAttrs{Start: 1}
+	if len(n.Attrs) == 0 {
+		return a, nil
+	}
+
 	if err := json.Unmarshal(n.Attrs, &a); err != nil {
 		return a, fmt.Errorf("cannot parse ordered list attrs: %w", err)
 	}
@@ -165,6 +175,10 @@ func (n Node) OrderedListAttrs() (OrderedListAttrs, error) {
 // ImageAttrs parses and returns the image attributes.
 func (n Node) ImageAttrs() (ImageAttrs, error) {
 	var a ImageAttrs
+	if len(n.Attrs) == 0 {
+		return a, nil
+	}
+
 	if err := json.Unmarshal(n.Attrs, &a); err != nil {
 		return a, fmt.Errorf("cannot parse image attrs: %w", err)
 	}
@@ -174,7 +188,11 @@ func (n Node) ImageAttrs() (ImageAttrs, error) {
 
 // TableCellAttrs parses and returns the table cell/header attributes.
 func (n Node) TableCellAttrs() (TableCellAttrs, error) {
-	var a TableCellAttrs
+	a := TableCellAttrs{Colspan: 1, Rowspan: 1}
+	if len(n.Attrs) == 0 {
+		return a, nil
+	}
+
 	if err := json.Unmarshal(n.Attrs, &a); err != nil {
 		return a, fmt.Errorf("cannot parse table cell attrs: %w", err)
 	}

--- a/pkg/prosemirror/node_test.go
+++ b/pkg/prosemirror/node_test.go
@@ -560,3 +560,105 @@ func TestNodeWithNoAttrs(t *testing.T) {
 	require.NotNil(t, n.Content[0].Text)
 	assert.Equal(t, "Hello", *n.Content[0].Text)
 }
+
+func TestAttrs_SchemaDefaults(t *testing.T) {
+	t.Parallel()
+
+	// The renderer only emits colspan/rowspan above 1, so nothing else in the
+	// tree tells a defaulted cell from a zero-valued one.
+	for _, tc := range []struct {
+		name  string
+		raw   string
+		check func(*testing.T, Node)
+	}{
+		{
+			name: "heading",
+			raw:  `{"type":"heading","content":[{"type":"text","text":"X"}]}`,
+			check: func(t *testing.T, n Node) {
+				attrs, err := n.HeadingAttrs()
+				require.NoError(t, err)
+				assert.Equal(t, 1, attrs.Level)
+			},
+		},
+		{
+			name: "heading with empty attrs",
+			raw:  `{"type":"heading","attrs":{},"content":[{"type":"text","text":"X"}]}`,
+			check: func(t *testing.T, n Node) {
+				attrs, err := n.HeadingAttrs()
+				require.NoError(t, err)
+				assert.Equal(t, 1, attrs.Level)
+			},
+		},
+		{
+			name: "ordered list",
+			raw:  `{"type":"orderedList"}`,
+			check: func(t *testing.T, n Node) {
+				attrs, err := n.OrderedListAttrs()
+				require.NoError(t, err)
+				assert.Equal(t, 1, attrs.Start)
+				assert.Nil(t, attrs.Type)
+			},
+		},
+		{
+			name: "ordered list with empty attrs",
+			raw:  `{"type":"orderedList","attrs":{}}`,
+			check: func(t *testing.T, n Node) {
+				attrs, err := n.OrderedListAttrs()
+				require.NoError(t, err)
+				assert.Equal(t, 1, attrs.Start)
+			},
+		},
+		{
+			name: "table cell",
+			raw:  `{"type":"tableCell"}`,
+			check: func(t *testing.T, n Node) {
+				attrs, err := n.TableCellAttrs()
+				require.NoError(t, err)
+				assert.Equal(t, 1, attrs.Colspan)
+				assert.Equal(t, 1, attrs.Rowspan)
+				assert.Nil(t, attrs.Colwidth)
+			},
+		},
+		{
+			name: "table header with empty attrs",
+			raw:  `{"type":"tableHeader","attrs":{}}`,
+			check: func(t *testing.T, n Node) {
+				attrs, err := n.TableCellAttrs()
+				require.NoError(t, err)
+				assert.Equal(t, 1, attrs.Colspan)
+				assert.Equal(t, 1, attrs.Rowspan)
+			},
+		},
+		{
+			name: "code block",
+			raw:  `{"type":"codeBlock"}`,
+			check: func(t *testing.T, n Node) {
+				attrs, err := n.CodeBlockAttrs()
+				require.NoError(t, err)
+				assert.Nil(t, attrs.Language)
+			},
+		},
+		{
+			name: "image",
+			raw:  `{"type":"image"}`,
+			check: func(t *testing.T, n Node) {
+				attrs, err := n.ImageAttrs()
+				require.NoError(t, err)
+				assert.Empty(t, attrs.Src)
+				assert.Nil(t, attrs.Alt)
+			},
+		},
+	} {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				var n Node
+				require.NoError(t, json.Unmarshal([]byte(tc.raw), &n))
+
+				tc.check(t, n)
+			},
+		)
+	}
+}


### PR DESCRIPTION
## Problem

`prosemirror` node attribute accessors unmarshal `n.Attrs` unconditionally, so a node that omits `attrs` fails with `unexpected end of JSON input`. Attributes are optional in the Tiptap schema — the editor renders such a document fine by applying the schema defaults — but one attr-less table cell aborts `RenderHTML` for the whole document.

`docgen.ProseMirrorJSONToHTML` turns any render error into `<p>{escaped JSON}</p>`, so the failure surfaces as a PDF whose body is the raw ProseMirror JSON: document export, the employee signature screen, and the approval review screen all show JSON where the document should be. Nothing logs, and the same document looks correct in the editor.

## Reproduce

```go
n, err := prosemirror.Parse(`{"type":"tableCell","content":[{"type":"paragraph","content":[{"type":"text","text":"X"}]}]}`)
// err == nil

_, err = prosemirror.RenderHTML(n)
// cannot render td node: cannot parse table cell attrs: unexpected end of JSON input
```

Same shape for `{"type":"heading","content":[…]}` (renders as `invalid level 0`), `{"type":"orderedList","content":[…]}` and `{"type":"image"}`.

End to end: create a document whose content JSON omits `attrs` on table cells — `createDocument` accepts it and `SanitizeDocumentJSON` preserves it — open it in the editor (correct), then export the version as PDF or open it on the approval review screen: the body is the JSON dump.

## Fix

Apply the Tiptap schema defaults when `attrs` is absent — heading `level: 1`, ordered list `start: 1`, table cell/header `colspan`/`rowspan: 1` — mirroring the guard `CodeBlockAttrs` already had. Explicit values still win, and `"attrs":{}` with individual keys missing now gets the same defaults.

Verified against a real 13-page document that previously rendered as JSON; it now renders identically to the same document with full cell attrs.

## Note, not changed here

`ProseMirrorJSONToHTML` converting any render error into an escaped-JSON body means a rendering bug ships silently into an approval-grade, watermarked PDF that someone is asked to sign. Surfacing the error instead looks safer, but it changes export behaviour, so I left it out of this PR — happy to follow up if you want it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fall back to Tiptap schema defaults when ProseMirror nodes omit attrs so documents render instead of failing. Previously, missing attrs caused unmarshal errors that surfaced as escaped JSON in PDFs and approval/signature screens; now `RenderHTML` renders those nodes using defaults.

### Tests **`+157`** **`-0`**
Add renderer and accessor coverage for nodes without attrs and with empty attrs objects: heading (level 1), ordered list (start 1), table cell/header (colspan/rowspan 1), image (empty src), and code block (nil language). Assert both HTML output and per-accessor defaults.

### Service **`+21`** **`-3`**
Return schema defaults when `n.Attrs` is absent or empty in `HeadingAttrs`, `OrderedListAttrs`, `ImageAttrs`, and `TableCellAttrs`, matching the existing `CodeBlockAttrs` guard; explicit values still win. Behavior change: heading level defaults to 1; ordered list start to 1; table cell/header colspan/rowspan to 1; empty `attrs: {}` treated the same.

<sup>Written for commit 53a2f104f67964d1d6420ba1678d989f15ab1dbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

