### PR TITLE
Stop Mermaid from duplicating risk diagram nodes

### DIFF
--- a/packages/ui/src/lib/mermaidConfig.ts
+++ b/packages/ui/src/lib/mermaidConfig.ts
@@ -25,5 +25,9 @@ export const mermaidRenderConfig = {
   markdownAutoWrap: true,
   flowchart: {
     wrappingWidth: 220,
+    subGraphTitleMargin: {
+      top: 16,
+      bottom: 8,
+    },
   },
 } as const;

--- a/pkg/riskmanagement/mermaid.go
+++ b/pkg/riskmanagement/mermaid.go
@@ -190,14 +190,12 @@ func buildDiagramMermaidChart(
 	var b strings.Builder
 	b.WriteString("flowchart LR\n")
 
-	// class statements must live at the flowchart level, not inside a
-	// subgraph block, so collect them and emit once all shapes are written.
-	var classLines []string
+	// `class <subgraphId>` creates a duplicate node on the cluster.
+	var styleLines []string
 
 	emitNode := func(n *coredata.RiskAnalysisNode, indent string) {
 		id := nodeAlias[n.ID]
 		fmt.Fprintf(&b, "%s%s\n", indent, mermaidNodeShape(n.NodeType, id, n.Name))
-		classLines = append(classLines, fmt.Sprintf("  class %s %s", id, mermaidNodeClass(n.NodeType)))
 	}
 
 	var emitBoundary func(bnd *coredata.RiskAnalysisBoundary, indent string)
@@ -205,6 +203,7 @@ func buildDiagramMermaidChart(
 	emitBoundary = func(bnd *coredata.RiskAnalysisBoundary, indent string) {
 		alias := boundaryAlias[bnd.ID]
 		fmt.Fprintf(&b, "%ssubgraph %s[\"%s\"]\n", indent, alias, mermaidLabel(bnd.Name))
+		fmt.Fprintf(&b, "%s  direction TB\n", indent)
 
 		inner := indent + "  "
 		for _, child := range childBoundaries[bnd.ID] {
@@ -217,7 +216,7 @@ func buildDiagramMermaidChart(
 
 		fmt.Fprintf(&b, "%send\n", indent)
 
-		classLines = append(classLines, fmt.Sprintf("  class %s nodeBoundary", alias))
+		styleLines = append(styleLines, fmt.Sprintf("  style %s %s", alias, mermaidBoundaryStyle))
 	}
 
 	for _, bnd := range rootBoundaries {
@@ -228,7 +227,7 @@ func buildDiagramMermaidChart(
 		emitNode(n, "  ")
 	}
 
-	for _, line := range classLines {
+	for _, line := range styleLines {
 		b.WriteString(line + "\n")
 	}
 
@@ -264,13 +263,12 @@ func buildDiagramMermaidChart(
 			fmt.Sprintf("%s (%s)", t.Name, t.Category),
 			mermaidThreatLabelWrapWidth,
 		)
-		fmt.Fprintf(&b, "  %s{{\"%s\"}}\n", tid, label)
-		fmt.Fprintf(&b, "  class %s nodeThreat\n", tid)
+		fmt.Fprintf(&b, "  %s{{\"%s\"}}:::nodeThreat\n", tid, label)
 		fmt.Fprintf(&b, "  %s -.-> %s\n", tid, targetAlias)
 	}
 
 	b.WriteString("  classDef nodeEntity fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a\n")
-	b.WriteString("  classDef nodeBoundary fill:#ffffff,stroke:#b45309,color:#78350f\n")
+	b.WriteString("  classDef nodeBoundary " + mermaidBoundaryStyle + "\n")
 	b.WriteString("  classDef nodeAsset fill:#e5e7eb,stroke:#374151,color:#111827\n")
 	b.WriteString("  classDef nodeData fill:#dcfce7,stroke:#15803d,color:#14532d\n")
 	b.WriteString("  classDef nodeThreat fill:#fee2e2,stroke:#b91c1c,color:#7f1d1d\n")
@@ -280,16 +278,17 @@ func buildDiagramMermaidChart(
 
 func mermaidNodeShape(t coredata.RiskAnalysisNodeType, id, name string) string {
 	label := `"` + mermaidLabel(name) + `"`
+	class := mermaidNodeClass(t)
 
 	switch t {
 	case coredata.RiskAnalysisNodeTypeEntity:
-		return fmt.Sprintf("%s([%s])", id, label)
+		return fmt.Sprintf("%s([%s]):::%s", id, label, class)
 	case coredata.RiskAnalysisNodeTypeData:
-		return fmt.Sprintf("%s[(%s)]", id, label)
+		return fmt.Sprintf("%s[(%s)]:::%s", id, label, class)
 	case coredata.RiskAnalysisNodeTypeAsset:
 		fallthrough
 	default:
-		return fmt.Sprintf("%s[%s]", id, label)
+		return fmt.Sprintf("%s[%s]:::%s", id, label, class)
 	}
 }
 
@@ -309,6 +308,7 @@ func mermaidNodeClass(t coredata.RiskAnalysisNodeType) string {
 const (
 	mermaidLabelWrapWidth       = 28
 	mermaidThreatLabelWrapWidth = 20
+	mermaidBoundaryStyle        = "fill:#ffffff,stroke:#b45309,color:#78350f"
 )
 
 var (

--- a/pkg/riskmanagement/mermaid_test.go
+++ b/pkg/riskmanagement/mermaid_test.go
@@ -268,4 +268,106 @@ func TestBuildDiagramMermaidChart_WrapsLabels(t *testing.T) {
 	assert.Contains(t, chart, `\n`)
 	assert.NotContains(t, chart, "<br>")
 	assert.Contains(t, chart, "&amp;")
+	assert.Contains(t, chart, ":::nodeAsset")
+	assert.Contains(t, chart, ":::nodeData")
+	assert.Contains(t, chart, ":::nodeThreat")
+	assert.NotRegexp(t, `(?m)^\s*class `, chart)
+}
+
+func TestBuildDiagramMermaidChart_BoundaryDoesNotDuplicateInnerNode(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	boundaryID := gid.New(tenantID, coredata.RiskAnalysisBoundaryEntityType)
+	nodeID := gid.New(tenantID, coredata.RiskAnalysisNodeEntityType)
+	processID := gid.New(tenantID, coredata.RiskAnalysisProcessEntityType)
+	sourceID := gid.New(tenantID, coredata.RiskAnalysisNodeEntityType)
+
+	const label = "EU representative and supervisory authority"
+
+	chart := buildDiagramMermaidChart(
+		coredata.RiskAnalysisNodes{
+			{
+				ID:       sourceID,
+				NodeType: coredata.RiskAnalysisNodeTypeAsset,
+				Name:     "Probo",
+			},
+			{
+				ID:         nodeID,
+				BoundaryID: &boundaryID,
+				NodeType:   coredata.RiskAnalysisNodeTypeEntity,
+				Name:       label,
+			},
+		},
+		coredata.RiskAnalysisBoundaries{
+			{
+				ID:   boundaryID,
+				Name: label,
+			},
+		},
+		coredata.RiskAnalysisProcesses{
+			{
+				ID:           processID,
+				SourceNodeID: sourceID,
+				TargetNodeID: nodeID,
+				Name:         "Appoint representative",
+			},
+		},
+		coredata.RiskAnalysisThreats{
+			{
+				ProcessID: processID,
+				Name:      "No EU representative",
+				Category:  "regulatory",
+			},
+		},
+	)
+
+	require.NotEmpty(t, chart)
+	assert.Contains(t, chart, `subgraph b0["`+mermaidLabel(label)+`"]`)
+	assert.Contains(t, chart, "direction TB")
+	assert.Contains(t, chart, mermaidNodeShape(coredata.RiskAnalysisNodeTypeEntity, "n1", label))
+	assert.Contains(t, chart, "  style b0 "+mermaidBoundaryStyle)
+	assert.NotContains(t, chart, "class b0")
+	assert.NotRegexp(t, `(?m)^\s*class `, chart)
+}
+
+func TestBuildDiagramMermaidChart_NestedBoundaryKeepsInnerDirection(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	parentID := gid.New(tenantID, coredata.RiskAnalysisBoundaryEntityType)
+	childID := gid.New(tenantID, coredata.RiskAnalysisBoundaryEntityType)
+	nodeID := gid.New(tenantID, coredata.RiskAnalysisNodeEntityType)
+
+	chart := buildDiagramMermaidChart(
+		coredata.RiskAnalysisNodes{
+			{
+				ID:         nodeID,
+				BoundaryID: &childID,
+				NodeType:   coredata.RiskAnalysisNodeTypeData,
+				Name:       "Customer records",
+			},
+		},
+		coredata.RiskAnalysisBoundaries{
+			{
+				ID:   parentID,
+				Name: "EU",
+			},
+			{
+				ID:               childID,
+				ParentBoundaryID: &parentID,
+				Name:             "Processors",
+			},
+		},
+		nil,
+		nil,
+	)
+
+	require.NotEmpty(t, chart)
+	assert.Regexp(t, `(?m)^\s+subgraph b0\["EU"\]$`, chart)
+	assert.Regexp(t, `(?m)^\s+subgraph b1\["Processors"\]$`, chart)
+	assert.Equal(t, 2, strings.Count(chart, "direction TB"))
+	assert.Contains(t, chart, "  style b0 "+mermaidBoundaryStyle)
+	assert.Contains(t, chart, "  style b1 "+mermaidBoundaryStyle)
+	assert.NotRegexp(t, `(?m)^\s*class `, chart)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes ENG-756.

Risk analysis diagrams (called “scopes” until recently) expose a GraphQL `mermaidChart` field. Mermaid 11 treats a later `class <subgraphId>` statement as a second node with that id, so an entity stadium was drawn on top of its boundary box — the overlapping “EU representative and supervisory authority” labels in the screenshot.

This change:

- Attaches node classes at declaration time (`:::nodeEntity`) instead of a follow-up `class` statement
- Styles boundary clusters with `style`, not `class`
- Puts `direction TB` inside each subgraph and adds `subGraphTitleMargin` so the cluster title no longer sits on the inner node

[Before vs after mermaid overlap](https://cursor.com/agents/bc-3522c37e-ad84-497c-959c-7ad556f6e825/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmermaid_overlap_before_after.webp)

[mermaid_overlap_before_after_walkthrough.mp4](https://cursor.com/agents/bc-3522c37e-ad84-497c-959c-7ad556f6e825/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmermaid_overlap_before_after_walkthrough.mp4)

## Testing

- `go test ./pkg/riskmanagement/` — including a chart that previously duplicated a named boundary + inner entity
- Rendered the generated chart with Mermaid 11.16 (same as `@probo/ui`) against the old `class` syntax


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-756](https://linear.app/probo/issue/ENG-756/fix-graphql-issue-for-risk-first-scope)

<div><a href="https://cursor.com/agents/bc-3522c37e-ad84-497c-959c-7ad556f6e825?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3522c37e-ad84-497c-959c-7ad556f6e825&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Mermaid from duplicating nodes in risk analysis diagrams by attaching node classes at declaration and styling subgraph boundaries. Previously, `class <subgraphId>` in Mermaid 11 created a second node overlapping the boundary; now charts render a single node with correct spacing. Keeps the GraphQL `mermaidChart` contract unchanged and addresses ENG-756.

### Service **`+12`** **`-12`**
- Inline node classes on nodes (`:::nodeEntity`, `:::nodeData`, `:::nodeAsset`, `:::nodeThreat`); replace boundary classing with `style <id> <mermaidBoundaryStyle>` and add `direction TB` inside each subgraph.
- No API shape changes; fixes rendering on Mermaid 11 with no client changes.

### Tests **`+102`** **`-0`**
- Add assertions for inline classes, styled boundaries, per-subgraph direction, and absence of duplicate nodes or stray `class` lines.

### Package: ui **`+4`** **`-0`**
- Set `flowchart.subGraphTitleMargin` in `packages/ui/src/lib/mermaidConfig.ts` to keep subgraph titles off inner nodes.

<sup>Written for commit f9ed58523da163defeb0ca06816c7362ead3bfc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

