### PR TITLE
Add Cal.com and Calendly access review drivers

### DIFF
--- a/packages/ui/src/Atoms/ThirdParties/CalCom.tsx
+++ b/packages/ui/src/Atoms/ThirdParties/CalCom.tsx
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import type { ComponentProps } from "react";
+
+export function CalCom(props: ComponentProps<"svg">) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M2.408 14.488C1.035 14.488 0 13.4 0 12.058c0-1.346.982-2.443 2.408-2.443.758 0 1.282.233 1.691.765l-.66.55a1.343 1.343 0 0 0-1.03-.442c-.93 0-1.44.711-1.44 1.57 0 .86.559 1.557 1.44 1.557.413 0 .765-.147 1.043-.443l.651.573c-.391.51-.929.743-1.695.743zM6.948 10.913h.89v3.49h-.89v-.51c-.185.362-.493.604-1.083.604-.943 0-1.695-.82-1.695-1.826 0-1.007.752-1.825 1.695-1.825.585 0 .898.241 1.083.604zm.026 1.758c0-.546-.374-.998-.964-.998-.568 0-.938.457-.938.998 0 .528.37.998.938.998.586 0 .964-.456.964-.998zM8.467 9.503h.89v4.895h-.89zM9.752 13.937a.53.53 0 0 1 .542-.528c.313 0 .533.242.533.528a.527.527 0 0 1-.533.537.534.534 0 0 1-.542-.537zM14.23 13.839c-.33.403-.832.658-1.426.658a1.806 1.806 0 0 1-1.84-1.826c0-1.007.778-1.825 1.84-1.825.572 0 1.07.241 1.4.622l-.687.577c-.172-.215-.396-.376-.713-.376-.568 0-.938.456-.938.998 0 .541.37.997.938.997.343 0 .58-.179.757-.42zM14.305 12.671c0-1.007.78-1.825 1.84-1.825 1.061 0 1.84.818 1.84 1.825 0 1.007-.779 1.826-1.84 1.826-1.06-.005-1.84-.82-1.84-1.826zm2.778 0c0-.546-.37-.998-.938-.998-.568-.004-.937.452-.937.998 0 .542.37.998.937.998.568 0 .938-.456.938-.998zM24 12.269v2.13h-.89v-1.911c0-.604-.281-.864-.704-.864-.396 0-.678.197-.678.864v1.91h-.89v-1.91c0-.604-.285-.864-.704-.864-.396 0-.744.197-.744.864v1.91h-.89v-3.49h.89v.484c.185-.376.52-.564 1.035-.564.489 0 .898.241 1.123.649.224-.417.554-.65 1.153-.65.731.005 1.299.56 1.299 1.442z"
+        fill="#000000"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/Atoms/ThirdParties/Calendly.tsx
+++ b/packages/ui/src/Atoms/ThirdParties/Calendly.tsx
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import type { ComponentProps } from "react";
+
+export function Calendly(props: ComponentProps<"svg">) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M19.655 14.262c.281 0 .557.023.828.064 0 .005-.005.01-.005.014-.105.267-.234.534-.381.786l-1.219 2.106c-1.112 1.936-3.177 3.127-5.411 3.127h-2.432c-2.23 0-4.294-1.191-5.412-3.127l-1.218-2.106a6.251 6.251 0 0 1 0-6.252l1.218-2.106C6.736 4.832 8.8 3.641 11.035 3.641h2.432c2.23 0 4.294 1.191 5.411 3.127l1.219 2.106c.147.252.271.519.381.786 0 .004.005.009.005.014-.267.041-.543.064-.828.064-1.816 0-2.501-.607-3.291-1.306-.764-.676-1.711-1.517-3.44-1.517h-1.029c-1.251 0-2.387.455-3.2 1.278-.796.805-1.233 1.904-1.233 3.099v1.411c0 1.196.437 2.295 1.233 3.099.813.823 1.949 1.278 3.2 1.278h1.034c1.729 0 2.676-.841 3.439-1.517.791-.703 1.471-1.306 3.287-1.301Zm.005-3.237c.399 0 .794-.036 1.179-.11-.002-.004-.002-.01-.002-.014-.073-.414-.193-.823-.349-1.218.731-.12 1.407-.396 1.986-.819 0-.004-.005-.013-.005-.018-.331-1.085-.832-2.101-1.489-3.03-.649-.915-1.435-1.719-2.331-2.395-1.867-1.398-4.088-2.138-6.428-2.138-1.448 0-2.855.28-4.175.841-1.273.543-2.423 1.315-3.407 2.299S2.878 6.552 2.341 7.83c-.557 1.324-.842 2.726-.842 4.175 0 1.448.281 2.855.842 4.174.542 1.274 1.314 2.423 2.298 3.407s2.129 1.761 3.407 2.299c1.324.556 2.727.841 4.175.841 2.34 0 4.561-.74 6.428-2.137a10.815 10.815 0 0 0 2.331-2.396c.652-.929 1.158-1.949 1.489-3.03 0-.004.005-.014.005-.018-.579-.423-1.255-.699-1.986-.819.161-.395.276-.804.349-1.218.005-.009.005-.014.005-.023.869.166 1.692.506 2.404 1.035.685.505.552 1.075.446 1.416C22.184 20.437 17.619 24 12.221 24c-6.625 0-12-5.375-12-12s5.37-12 12-12c5.398 0 9.963 3.563 11.471 8.464.106.341.239.915-.446 1.421-.717.529-1.535.873-2.404 1.034.128.716.128 1.45 0 2.166-.387-.074-.782-.11-1.182-.11-4.184 0-3.968 2.823-6.736 2.823h-1.029c-1.899 0-3.15-1.357-3.15-3.095v-1.411c0-1.738 1.251-3.094 3.15-3.094h1.034c2.768 0 2.552 2.823 6.731 2.827Z"
+        fill="#006BFF"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/Atoms/ThirdParties/ThirdPartyLogo.stories.tsx
+++ b/packages/ui/src/Atoms/ThirdParties/ThirdPartyLogo.stories.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ThirdPartyLogo } from "./ThirdPartyLogo";
+
+const meta = {
+  title: "Atoms/ThirdParties/ThirdPartyLogo",
+  component: ThirdPartyLogo,
+  args: {
+    height: 48,
+    width: 48,
+  },
+} satisfies Meta<typeof ThirdPartyLogo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CalCom: Story = {
+  args: {
+    thirdParty: "CAL_COM",
+  },
+};
+
+export const Calendly: Story = {
+  args: {
+    thirdParty: "CALENDLY",
+  },
+};

--- a/packages/ui/src/Atoms/ThirdParties/ThirdPartyLogo.tsx
+++ b/packages/ui/src/Atoms/ThirdParties/ThirdPartyLogo.tsx
@@ -28,6 +28,8 @@ import { BetterStack } from "./BetterStack";
 import { Bitbucket } from "./Bitbucket";
 import { Brevo } from "./Brevo";
 import { Brex } from "./Brex";
+import { CalCom } from "./CalCom";
+import { Calendly } from "./Calendly";
 import { Clerk } from "./Clerk";
 import { ClickHouse } from "./ClickHouse";
 import { ClickUp } from "./ClickUp";
@@ -93,6 +95,8 @@ const thirdParties: Record<string, FC<ComponentProps<"svg">>> = {
   BITBUCKET: Bitbucket,
   BREVO: Brevo,
   BREX: Brex,
+  CAL_COM: CalCom,
+  CALENDLY: Calendly,
   CLERK: Clerk,
   CLICKHOUSE: ClickHouse,
   CLICKUP: ClickUp,

--- a/packages/ui/src/Atoms/ThirdParties/index.ts
+++ b/packages/ui/src/Atoms/ThirdParties/index.ts
@@ -6,6 +6,8 @@ export { BetterStack } from "./BetterStack";
 export { Bitbucket } from "./Bitbucket";
 export { Brevo } from "./Brevo";
 export { Brex } from "./Brex";
+export { CalCom } from "./CalCom";
+export { Calendly } from "./Calendly";
 export { Clerk } from "./Clerk";
 export { ClickHouse } from "./ClickHouse";
 export { ClickUp } from "./ClickUp";

--- a/pkg/accessreview/drivers/calcom.go
+++ b/pkg/accessreview/drivers/calcom.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -34,8 +35,10 @@ import (
 
 const (
 	calComMePath        = "/v2/me"
+	calComTeamsPath     = "/v2/teams"
 	calComPageSize      = 250
 	calComOrganizations = "organizations"
+	calComTeams         = "teams"
 	calComMemberships   = "memberships"
 )
 
@@ -47,8 +50,19 @@ type (
 
 	calComMeResponse struct {
 		Data struct {
+			ID             int64  `json:"id"`
+			Name           string `json:"name"`
+			Email          string `json:"email"`
 			OrganizationID *int64 `json:"organizationId"`
 		} `json:"data"`
+	}
+
+	calComTeam struct {
+		ID int64 `json:"id"`
+	}
+
+	calComTeamsResponse struct {
+		Data []calComTeam `json:"data"`
 	}
 
 	calComMembership struct {
@@ -63,6 +77,13 @@ type (
 
 	calComMembershipsResponse struct {
 		Data []calComMembership `json:"data"`
+	}
+
+	calComAccountAggregate struct {
+		record  AccountRecord
+		roles   map[string]struct{}
+		active  bool
+		isAdmin bool
 	}
 )
 
@@ -79,43 +100,34 @@ func (d *CalComDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error
 	}
 
 	if me.Data.OrganizationID == nil {
-		return nil, fmt.Errorf("cannot list cal.com accounts: authenticated user has no organization")
-	}
-
-	var records []AccountRecord
-
-	for page := range maxPaginationPages {
-		memberships, err := d.fetchMembershipsPage(ctx, *me.Data.OrganizationID, page*calComPageSize)
+		teams, err := d.fetchTeams(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("cannot fetch cal.com memberships page: %w", err)
+			return nil, fmt.Errorf("cannot discover cal.com teams: %w", err)
 		}
 
-		for _, membership := range memberships.Data {
-			email := strings.TrimSpace(membership.User.Email)
-			if email == "" {
-				continue
+		if len(teams.Data) == 0 {
+			return calComSoloRecord(me), nil
+		}
+
+		var memberships []calComMembership
+		for _, team := range teams.Data {
+			teamMemberships, err := d.fetchAllMemberships(ctx, calComTeams, team.ID)
+			if err != nil {
+				return nil, fmt.Errorf("cannot fetch cal.com team memberships: %w", err)
 			}
 
-			role := strings.ToUpper(strings.TrimSpace(membership.Role))
-			records = append(records, AccountRecord{
-				Email:       email,
-				FullName:    strings.TrimSpace(membership.User.Name),
-				Roles:       calComRoles(role),
-				Active:      new(membership.Accepted),
-				IsAdmin:     new(role == "OWNER" || role == "ADMIN"),
-				MFAStatus:   coredata.MFAStatusUnknown,
-				AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
-				AccountType: coredata.AccessReviewEntryAccountTypeUser,
-				ExternalID:  strconv.FormatInt(membership.UserID, 10),
-			})
+			memberships = append(memberships, teamMemberships...)
 		}
 
-		if len(memberships.Data) < calComPageSize {
-			return records, nil
-		}
+		return calComMembershipRecords(memberships), nil
 	}
 
-	return nil, fmt.Errorf("cannot list all cal.com accounts: %w", ErrPaginationLimitReached)
+	memberships, err := d.fetchAllMemberships(ctx, calComOrganizations, *me.Data.OrganizationID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot fetch cal.com organization memberships: %w", err)
+	}
+
+	return calComMembershipRecords(memberships), nil
 }
 
 func (d *CalComDriver) fetchMe(ctx context.Context) (*calComMeResponse, error) {
@@ -149,16 +161,70 @@ func (d *CalComDriver) fetchMe(ctx context.Context) (*calComMeResponse, error) {
 	return &resp, nil
 }
 
+func (d *CalComDriver) fetchTeams(ctx context.Context) (*calComTeamsResponse, error) {
+	endpoint, err := url.JoinPath(d.baseURL, calComTeamsPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build cal.com teams URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create cal.com teams request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	httpResp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot execute cal.com teams request: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, fmt.Errorf("cannot fetch cal.com teams: unexpected status %d", httpResp.StatusCode)
+	}
+
+	var resp calComTeamsResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("cannot decode cal.com teams response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+func (d *CalComDriver) fetchAllMemberships(
+	ctx context.Context,
+	resource string,
+	resourceID int64,
+) ([]calComMembership, error) {
+	var memberships []calComMembership
+
+	for page := range maxPaginationPages {
+		resp, err := d.fetchMembershipsPage(ctx, resource, resourceID, page*calComPageSize)
+		if err != nil {
+			return nil, fmt.Errorf("cannot fetch cal.com memberships page: %w", err)
+		}
+
+		memberships = append(memberships, resp.Data...)
+		if len(resp.Data) < calComPageSize {
+			return memberships, nil
+		}
+	}
+
+	return nil, fmt.Errorf("cannot list all cal.com memberships: %w", ErrPaginationLimitReached)
+}
+
 func (d *CalComDriver) fetchMembershipsPage(
 	ctx context.Context,
-	organizationID int64,
+	resource string,
+	resourceID int64,
 	skip int,
 ) (*calComMembershipsResponse, error) {
 	endpoint, err := url.JoinPath(
 		d.baseURL,
 		"v2",
-		calComOrganizations,
-		strconv.FormatInt(organizationID, 10),
+		resource,
+		strconv.FormatInt(resourceID, 10),
 		calComMemberships,
 	)
 	if err != nil {
@@ -192,6 +258,87 @@ func (d *CalComDriver) fetchMembershipsPage(
 	}
 
 	return &resp, nil
+}
+
+func calComSoloRecord(me *calComMeResponse) []AccountRecord {
+	email := strings.TrimSpace(me.Data.Email)
+	if email == "" {
+		return []AccountRecord{}
+	}
+
+	return []AccountRecord{
+		{
+			Email:       email,
+			FullName:    strings.TrimSpace(me.Data.Name),
+			Roles:       []string{},
+			Active:      new(true),
+			IsAdmin:     new(false),
+			MFAStatus:   coredata.MFAStatusUnknown,
+			AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
+			AccountType: coredata.AccessReviewEntryAccountTypeUser,
+			ExternalID:  strconv.FormatInt(me.Data.ID, 10),
+		},
+	}
+}
+
+func calComMembershipRecords(memberships []calComMembership) []AccountRecord {
+	order := make([]string, 0)
+	byUser := make(map[string]*calComAccountAggregate)
+
+	for _, membership := range memberships {
+		email := strings.TrimSpace(membership.User.Email)
+		if email == "" {
+			continue
+		}
+
+		externalID := strconv.FormatInt(membership.UserID, 10)
+		key := externalID
+		if membership.UserID == 0 {
+			externalID = ""
+			key = strings.ToLower(email)
+		}
+
+		aggregate, ok := byUser[key]
+		if !ok {
+			aggregate = &calComAccountAggregate{
+				record: AccountRecord{
+					Email:       email,
+					FullName:    strings.TrimSpace(membership.User.Name),
+					MFAStatus:   coredata.MFAStatusUnknown,
+					AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
+					AccountType: coredata.AccessReviewEntryAccountTypeUser,
+					ExternalID:  externalID,
+				},
+				roles: make(map[string]struct{}),
+			}
+			byUser[key] = aggregate
+			order = append(order, key)
+		}
+
+		role := strings.ToUpper(strings.TrimSpace(membership.Role))
+		for _, name := range calComRoles(role) {
+			aggregate.roles[name] = struct{}{}
+		}
+		aggregate.active = aggregate.active || membership.Accepted
+		aggregate.isAdmin = aggregate.isAdmin || role == "OWNER" || role == "ADMIN"
+	}
+
+	records := make([]AccountRecord, 0, len(order))
+	for _, key := range order {
+		aggregate := byUser[key]
+		roles := make([]string, 0, len(aggregate.roles))
+		for role := range aggregate.roles {
+			roles = append(roles, role)
+		}
+		sort.Strings(roles)
+
+		aggregate.record.Roles = roles
+		aggregate.record.Active = new(aggregate.active)
+		aggregate.record.IsAdmin = new(aggregate.isAdmin)
+		records = append(records, aggregate.record)
+	}
+
+	return records
 }
 
 func calComRoles(role string) []string {

--- a/pkg/accessreview/drivers/calcom.go
+++ b/pkg/accessreview/drivers/calcom.go
@@ -80,10 +80,12 @@ type (
 	}
 
 	calComAccountAggregate struct {
-		record  AccountRecord
-		roles   map[string]struct{}
-		active  bool
-		isAdmin bool
+		record       AccountRecord
+		roles        map[string]struct{}
+		active       bool
+		isAdmin      bool
+		adminKnown   bool
+		adminUnknown bool
 	}
 )
 
@@ -276,7 +278,6 @@ func calComSoloRecord(me *calComMeResponse) []AccountRecord {
 			FullName:    strings.TrimSpace(me.Data.Name),
 			Roles:       []string{},
 			Active:      new(true),
-			IsAdmin:     new(false),
 			MFAStatus:   coredata.MFAStatusUnknown,
 			AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
 			AccountType: coredata.AccessReviewEntryAccountTypeUser,
@@ -326,7 +327,14 @@ func calComMembershipRecords(memberships []calComMembership) []AccountRecord {
 		}
 
 		aggregate.active = aggregate.active || membership.Accepted
-		aggregate.isAdmin = aggregate.isAdmin || role == "OWNER" || role == "ADMIN"
+
+		isAdmin, known := calComRoleIsAdmin(role)
+		if known {
+			aggregate.adminKnown = true
+			aggregate.isAdmin = aggregate.isAdmin || isAdmin
+		} else {
+			aggregate.adminUnknown = true
+		}
 	}
 
 	records := make([]AccountRecord, 0, len(order))
@@ -342,7 +350,14 @@ func calComMembershipRecords(memberships []calComMembership) []AccountRecord {
 
 		aggregate.record.Roles = roles
 		aggregate.record.Active = new(aggregate.active)
-		aggregate.record.IsAdmin = new(aggregate.isAdmin)
+
+		switch {
+		case aggregate.isAdmin:
+			aggregate.record.IsAdmin = new(true)
+		case aggregate.adminKnown && !aggregate.adminUnknown:
+			aggregate.record.IsAdmin = new(false)
+		}
+
 		records = append(records, aggregate.record)
 	}
 
@@ -361,5 +376,16 @@ func calComRoles(role string) []string {
 		return []string{}
 	default:
 		return []string{role}
+	}
+}
+
+func calComRoleIsAdmin(role string) (bool, bool) {
+	switch role {
+	case "OWNER", "ADMIN":
+		return true, true
+	case "MEMBER":
+		return false, true
+	default:
+		return false, false
 	}
 }

--- a/pkg/accessreview/drivers/calcom.go
+++ b/pkg/accessreview/drivers/calcom.go
@@ -148,6 +148,7 @@ func (d *CalComDriver) fetchMe(ctx context.Context) (*calComMeResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot execute cal.com profile request: %w", err)
 	}
+
 	defer func() { _ = httpResp.Body.Close() }()
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {

--- a/pkg/accessreview/drivers/calcom.go
+++ b/pkg/accessreview/drivers/calcom.go
@@ -52,7 +52,6 @@ type (
 	}
 
 	calComMembership struct {
-		ID       int64  `json:"id"`
 		UserID   int64  `json:"userId"`
 		Accepted bool   `json:"accepted"`
 		Role     string `json:"role"`

--- a/pkg/accessreview/drivers/calcom.go
+++ b/pkg/accessreview/drivers/calcom.go
@@ -110,6 +110,7 @@ func (d *CalComDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error
 		}
 
 		var memberships []calComMembership
+
 		for _, team := range teams.Data {
 			teamMemberships, err := d.fetchAllMemberships(ctx, calComTeams, team.ID)
 			if err != nil {
@@ -178,6 +179,7 @@ func (d *CalComDriver) fetchTeams(ctx context.Context) (*calComTeamsResponse, er
 	if err != nil {
 		return nil, fmt.Errorf("cannot execute cal.com teams request: %w", err)
 	}
+
 	defer func() { _ = httpResp.Body.Close() }()
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
@@ -246,6 +248,7 @@ func (d *CalComDriver) fetchMembershipsPage(
 	if err != nil {
 		return nil, fmt.Errorf("cannot execute cal.com memberships request: %w", err)
 	}
+
 	defer func() { _ = httpResp.Body.Close() }()
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
@@ -292,6 +295,7 @@ func calComMembershipRecords(memberships []calComMembership) []AccountRecord {
 		}
 
 		externalID := strconv.FormatInt(membership.UserID, 10)
+
 		key := externalID
 		if membership.UserID == 0 {
 			externalID = ""
@@ -319,6 +323,7 @@ func calComMembershipRecords(memberships []calComMembership) []AccountRecord {
 		for _, name := range calComRoles(role) {
 			aggregate.roles[name] = struct{}{}
 		}
+
 		aggregate.active = aggregate.active || membership.Accepted
 		aggregate.isAdmin = aggregate.isAdmin || role == "OWNER" || role == "ADMIN"
 	}
@@ -326,10 +331,12 @@ func calComMembershipRecords(memberships []calComMembership) []AccountRecord {
 	records := make([]AccountRecord, 0, len(order))
 	for _, key := range order {
 		aggregate := byUser[key]
+
 		roles := make([]string, 0, len(aggregate.roles))
 		for role := range aggregate.roles {
 			roles = append(roles, role)
 		}
+
 		sort.Strings(roles)
 
 		aggregate.record.Roles = roles

--- a/pkg/accessreview/drivers/calcom.go
+++ b/pkg/accessreview/drivers/calcom.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+const (
+	calComMePath        = "/v2/me"
+	calComPageSize      = 250
+	calComOrganizations = "organizations"
+	calComMemberships   = "memberships"
+)
+
+type (
+	CalComDriver struct {
+		httpClient *http.Client
+		baseURL    string
+	}
+
+	calComMeResponse struct {
+		Data struct {
+			OrganizationID *int64 `json:"organizationId"`
+		} `json:"data"`
+	}
+
+	calComMembership struct {
+		ID       int64  `json:"id"`
+		UserID   int64  `json:"userId"`
+		Accepted bool   `json:"accepted"`
+		Role     string `json:"role"`
+		User     struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"user"`
+	}
+
+	calComMembershipsResponse struct {
+		Data []calComMembership `json:"data"`
+	}
+)
+
+var _ Driver = (*CalComDriver)(nil)
+
+func NewCalComDriver(httpClient *http.Client, baseURL string) *CalComDriver {
+	return &CalComDriver{httpClient: httpClient, baseURL: baseURL}
+}
+
+func (d *CalComDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
+	me, err := d.fetchMe(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot discover cal.com organization: %w", err)
+	}
+
+	if me.Data.OrganizationID == nil {
+		return nil, fmt.Errorf("cannot list cal.com accounts: authenticated user has no organization")
+	}
+
+	var records []AccountRecord
+
+	for page := range maxPaginationPages {
+		memberships, err := d.fetchMembershipsPage(ctx, *me.Data.OrganizationID, page*calComPageSize)
+		if err != nil {
+			return nil, fmt.Errorf("cannot fetch cal.com memberships page: %w", err)
+		}
+
+		for _, membership := range memberships.Data {
+			email := strings.TrimSpace(membership.User.Email)
+			if email == "" {
+				continue
+			}
+
+			role := strings.ToUpper(strings.TrimSpace(membership.Role))
+			records = append(records, AccountRecord{
+				Email:       email,
+				FullName:    strings.TrimSpace(membership.User.Name),
+				Roles:       calComRoles(role),
+				Active:      new(membership.Accepted),
+				IsAdmin:     new(role == "OWNER" || role == "ADMIN"),
+				MFAStatus:   coredata.MFAStatusUnknown,
+				AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
+				AccountType: coredata.AccessReviewEntryAccountTypeUser,
+				ExternalID:  strconv.FormatInt(membership.UserID, 10),
+			})
+		}
+
+		if len(memberships.Data) < calComPageSize {
+			return records, nil
+		}
+	}
+
+	return nil, fmt.Errorf("cannot list all cal.com accounts: %w", ErrPaginationLimitReached)
+}
+
+func (d *CalComDriver) fetchMe(ctx context.Context) (*calComMeResponse, error) {
+	endpoint, err := url.JoinPath(d.baseURL, calComMePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build cal.com profile URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create cal.com profile request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	httpResp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot execute cal.com profile request: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, fmt.Errorf("cannot fetch cal.com profile: unexpected status %d", httpResp.StatusCode)
+	}
+
+	var resp calComMeResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("cannot decode cal.com profile response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+func (d *CalComDriver) fetchMembershipsPage(
+	ctx context.Context,
+	organizationID int64,
+	skip int,
+) (*calComMembershipsResponse, error) {
+	endpoint, err := url.JoinPath(
+		d.baseURL,
+		"v2",
+		calComOrganizations,
+		strconv.FormatInt(organizationID, 10),
+		calComMemberships,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build cal.com memberships URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create cal.com memberships request: %w", err)
+	}
+
+	query := req.URL.Query()
+	query.Set("take", strconv.Itoa(calComPageSize))
+	query.Set("skip", strconv.Itoa(skip))
+	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
+
+	httpResp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot execute cal.com memberships request: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, fmt.Errorf("cannot fetch cal.com memberships: unexpected status %d", httpResp.StatusCode)
+	}
+
+	var resp calComMembershipsResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("cannot decode cal.com memberships response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+func calComRoles(role string) []string {
+	switch role {
+	case "OWNER":
+		return []string{"Owner"}
+	case "ADMIN":
+		return []string{"Admin"}
+	case "MEMBER":
+		return []string{"Member"}
+	case "":
+		return []string{}
+	default:
+		return []string{role}
+	}
+}

--- a/pkg/accessreview/drivers/calcom_test.go
+++ b/pkg/accessreview/drivers/calcom_test.go
@@ -158,8 +158,42 @@ func TestCalComDriver_ListAccountsSolo(t *testing.T) {
 	assert.Equal(t, "Solo User", records[0].FullName)
 	assert.Empty(t, records[0].Roles)
 	assert.Equal(t, new(true), records[0].Active)
-	assert.Equal(t, new(false), records[0].IsAdmin)
+	assert.Nil(t, records[0].IsAdmin)
 	assert.Equal(t, "42", records[0].ExternalID)
 	assert.Equal(t, coredata.MFAStatusUnknown, records[0].MFAStatus)
 	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, records[0].AccountType)
+}
+
+func TestCalComMembershipRecords_AdminSignal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		roles    []string
+		expected *bool
+	}{
+		{name: "member is known non-admin", roles: []string{"MEMBER"}, expected: new(false)},
+		{name: "owner is known admin", roles: []string{"OWNER"}, expected: new(true)},
+		{name: "empty role is unknown", roles: []string{""}},
+		{name: "unrecognized role is unknown", roles: []string{"SUPER_ADMIN"}},
+		{name: "member plus unknown stays unknown", roles: []string{"MEMBER", "SUPER_ADMIN"}},
+		{name: "owner plus unknown stays known admin", roles: []string{"OWNER", "SUPER_ADMIN"}, expected: new(true)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			memberships := make([]calComMembership, len(tt.roles))
+			for i, role := range tt.roles {
+				memberships[i].UserID = 42
+				memberships[i].User.Email = "user@example.com"
+				memberships[i].Role = role
+			}
+
+			records := calComMembershipRecords(memberships)
+			require.Len(t, records, 1)
+			assert.Equal(t, tt.expected, records[0].IsAdmin)
+		})
+	}
 }

--- a/pkg/accessreview/drivers/calcom_test.go
+++ b/pkg/accessreview/drivers/calcom_test.go
@@ -106,19 +106,85 @@ func TestCalComDriver_ListAccounts(t *testing.T) {
 	assert.Equal(t, "7777", pendingAdmin.ExternalID)
 }
 
-func TestCalComDriver_ListAccountsWithoutOrganization(t *testing.T) {
+func TestCalComDriver_ListAccountsWithTeams(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"status":"success","data":{"organizationId":null}}`))
+
+		switch r.URL.Path {
+		case "/v2/me":
+			assert.Equal(t, http.MethodGet, r.Method)
+			_, _ = w.Write(
+				[]byte(`{"status":"success","data":{"id":100,"name":"Key Owner","email":"owner@example.com","organizationId":null}}`),
+			)
+		case "/v2/teams":
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Empty(t, r.URL.RawQuery)
+			_, _ = w.Write([]byte(`{"status":"success","data":[{"id":7},{"id":9}]}`))
+		case "/v2/teams/7/memberships":
+			assert.Equal(t, strconv.Itoa(calComPageSize), r.URL.Query().Get("take"))
+			assert.Equal(t, "0", r.URL.Query().Get("skip"))
+			_, _ = w.Write(
+				[]byte(`{"status":"success","data":[{"userId":100,"accepted":false,"role":"MEMBER","user":{"name":"Shared User","email":"shared@example.com"}},{"userId":101,"accepted":true,"role":"MEMBER","user":{"name":"Team Seven User","email":"seven@example.com"}}]}`),
+			)
+		case "/v2/teams/9/memberships":
+			assert.Equal(t, strconv.Itoa(calComPageSize), r.URL.Query().Get("take"))
+			assert.Equal(t, "0", r.URL.Query().Get("skip"))
+			_, _ = w.Write(
+				[]byte(`{"status":"success","data":[{"userId":100,"accepted":true,"role":"OWNER","user":{"name":"Shared User","email":"shared@example.com"}},{"userId":102,"accepted":true,"role":"ADMIN","user":{"name":"Team Nine User","email":"nine@example.com"}}]}`),
+			)
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 	t.Cleanup(server.Close)
 
 	driver := NewCalComDriver(server.Client(), server.URL)
 	records, err := driver.ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 3)
 
-	require.Error(t, err)
-	assert.Nil(t, records)
-	assert.Contains(t, err.Error(), "authenticated user has no organization")
+	assert.Equal(t, "100", records[0].ExternalID)
+	assert.Equal(t, []string{"Member", "Owner"}, records[0].Roles)
+	assert.Equal(t, new(true), records[0].Active)
+	assert.Equal(t, new(true), records[0].IsAdmin)
+	assert.Equal(t, "101", records[1].ExternalID)
+	assert.Equal(t, []string{"Member"}, records[1].Roles)
+	assert.Equal(t, "102", records[2].ExternalID)
+	assert.Equal(t, []string{"Admin"}, records[2].Roles)
+}
+
+func TestCalComDriver_ListAccountsSolo(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/v2/me":
+			_, _ = w.Write(
+				[]byte(`{"status":"success","data":{"id":42,"name":" Solo User ","email":" solo@example.com ","organizationId":null}}`),
+			)
+		case "/v2/teams":
+			_, _ = w.Write([]byte(`{"status":"success","data":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	driver := NewCalComDriver(server.Client(), server.URL)
+	records, err := driver.ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+
+	assert.Equal(t, "solo@example.com", records[0].Email)
+	assert.Equal(t, "Solo User", records[0].FullName)
+	assert.Empty(t, records[0].Roles)
+	assert.Equal(t, new(true), records[0].Active)
+	assert.Equal(t, new(false), records[0].IsAdmin)
+	assert.Equal(t, "42", records[0].ExternalID)
+	assert.Equal(t, coredata.MFAStatusUnknown, records[0].MFAStatus)
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, records[0].AccountType)
 }

--- a/pkg/accessreview/drivers/calcom_test.go
+++ b/pkg/accessreview/drivers/calcom_test.go
@@ -44,6 +44,7 @@ func TestCalComDriver_ListAccounts(t *testing.T) {
 		switch r.URL.Path {
 		case "/v2/me":
 			assert.Equal(t, http.MethodGet, r.Method)
+
 			_, _ = w.Write([]byte(`{"status":"success","data":{"organizationId":42}}`))
 		case "/v2/organizations/42/memberships":
 			assert.Equal(t, strconv.Itoa(calComPageSize), r.URL.Query().Get("take"))

--- a/pkg/accessreview/drivers/calcom_test.go
+++ b/pkg/accessreview/drivers/calcom_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestCalComDriver_ListAccounts(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/v2/me":
+			assert.Equal(t, http.MethodGet, r.Method)
+			_, _ = w.Write([]byte(`{"status":"success","data":{"organizationId":42}}`))
+		case "/v2/organizations/42/memberships":
+			assert.Equal(t, strconv.Itoa(calComPageSize), r.URL.Query().Get("take"))
+
+			skip, err := strconv.Atoi(r.URL.Query().Get("skip"))
+			require.NoError(t, err)
+
+			if skip == 0 {
+				memberships := make([]map[string]any, calComPageSize)
+				for i := range memberships {
+					role := "MEMBER"
+					if i == 0 {
+						role = "OWNER"
+					}
+
+					memberships[i] = map[string]any{
+						"id":       i + 1000,
+						"userId":   i + 2000,
+						"accepted": true,
+						"role":     role,
+						"user": map[string]any{
+							"name":  fmt.Sprintf("User %d", i),
+							"email": fmt.Sprintf("user%d@example.com", i),
+						},
+					}
+				}
+
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"status": "success", "data": memberships}))
+
+				return
+			}
+
+			assert.Equal(t, calComPageSize, skip)
+			_, _ = w.Write(
+				[]byte(`{"status":"success","data":[{"id":9999,"userId":7777,"accepted":false,"role":"ADMIN","user":{"name":"Pending Admin","email":"admin@example.com"}}]}`),
+			)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	driver := NewCalComDriver(server.Client(), server.URL)
+	records, err := driver.ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, calComPageSize+1)
+
+	assert.Equal(t, "user0@example.com", records[0].Email)
+	assert.Equal(t, "User 0", records[0].FullName)
+	assert.Equal(t, []string{"Owner"}, records[0].Roles)
+	assert.Equal(t, new(true), records[0].Active)
+	assert.Equal(t, new(true), records[0].IsAdmin)
+	assert.Equal(t, "2000", records[0].ExternalID)
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, records[0].AccountType)
+
+	pendingAdmin := records[calComPageSize]
+	assert.Equal(t, "admin@example.com", pendingAdmin.Email)
+	assert.Equal(t, []string{"Admin"}, pendingAdmin.Roles)
+	assert.Equal(t, new(false), pendingAdmin.Active)
+	assert.Equal(t, new(true), pendingAdmin.IsAdmin)
+	assert.Equal(t, "7777", pendingAdmin.ExternalID)
+}
+
+func TestCalComDriver_ListAccountsWithoutOrganization(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"organizationId":null}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	driver := NewCalComDriver(server.Client(), server.URL)
+	records, err := driver.ListAccounts(context.Background())
+
+	require.Error(t, err)
+	assert.Nil(t, records)
+	assert.Contains(t, err.Error(), "authenticated user has no organization")
+}

--- a/pkg/accessreview/drivers/calcom_test.go
+++ b/pkg/accessreview/drivers/calcom_test.go
@@ -78,6 +78,7 @@ func TestCalComDriver_ListAccounts(t *testing.T) {
 			}
 
 			assert.Equal(t, calComPageSize, skip)
+
 			_, _ = w.Write(
 				[]byte(`{"status":"success","data":[{"id":9999,"userId":7777,"accepted":false,"role":"ADMIN","user":{"name":"Pending Admin","email":"admin@example.com"}}]}`),
 			)

--- a/pkg/accessreview/drivers/calcom_test.go
+++ b/pkg/accessreview/drivers/calcom_test.go
@@ -48,7 +48,7 @@ func TestCalComDriver_ListAccounts(t *testing.T) {
 			assert.Equal(t, strconv.Itoa(calComPageSize), r.URL.Query().Get("take"))
 
 			skip, err := strconv.Atoi(r.URL.Query().Get("skip"))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			if skip == 0 {
 				memberships := make([]map[string]any, calComPageSize)
@@ -70,7 +70,7 @@ func TestCalComDriver_ListAccounts(t *testing.T) {
 					}
 				}
 
-				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"status": "success", "data": memberships}))
+				assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"status": "success", "data": memberships}))
 
 				return
 			}

--- a/pkg/accessreview/drivers/calcom_test.go
+++ b/pkg/accessreview/drivers/calcom_test.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"testing"
 
@@ -106,41 +107,13 @@ func TestCalComDriver_ListAccounts(t *testing.T) {
 	assert.Equal(t, "7777", pendingAdmin.ExternalID)
 }
 
-func TestCalComDriver_ListAccountsWithTeams(t *testing.T) {
+func TestCalComDriver(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+	rec := newRecorder(t, "testdata/calcom", "CAL_COM_API_KEY")
+	client := newVCRClient(rec, bearerAuth(os.Getenv("CAL_COM_API_KEY")))
 
-		switch r.URL.Path {
-		case "/v2/me":
-			assert.Equal(t, http.MethodGet, r.Method)
-			_, _ = w.Write(
-				[]byte(`{"status":"success","data":{"id":100,"name":"Key Owner","email":"owner@example.com","organizationId":null}}`),
-			)
-		case "/v2/teams":
-			assert.Equal(t, http.MethodGet, r.Method)
-			assert.Empty(t, r.URL.RawQuery)
-			_, _ = w.Write([]byte(`{"status":"success","data":[{"id":7},{"id":9}]}`))
-		case "/v2/teams/7/memberships":
-			assert.Equal(t, strconv.Itoa(calComPageSize), r.URL.Query().Get("take"))
-			assert.Equal(t, "0", r.URL.Query().Get("skip"))
-			_, _ = w.Write(
-				[]byte(`{"status":"success","data":[{"userId":100,"accepted":false,"role":"MEMBER","user":{"name":"Shared User","email":"shared@example.com"}},{"userId":101,"accepted":true,"role":"MEMBER","user":{"name":"Team Seven User","email":"seven@example.com"}}]}`),
-			)
-		case "/v2/teams/9/memberships":
-			assert.Equal(t, strconv.Itoa(calComPageSize), r.URL.Query().Get("take"))
-			assert.Equal(t, "0", r.URL.Query().Get("skip"))
-			_, _ = w.Write(
-				[]byte(`{"status":"success","data":[{"userId":100,"accepted":true,"role":"OWNER","user":{"name":"Shared User","email":"shared@example.com"}},{"userId":102,"accepted":true,"role":"ADMIN","user":{"name":"Team Nine User","email":"nine@example.com"}}]}`),
-			)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	driver := NewCalComDriver(server.Client(), server.URL)
+	driver := NewCalComDriver(client, "https://api.cal.com")
 	records, err := driver.ListAccounts(context.Background())
 	require.NoError(t, err)
 	require.Len(t, records, 3)

--- a/pkg/accessreview/drivers/calendly.go
+++ b/pkg/accessreview/drivers/calendly.go
@@ -175,9 +175,11 @@ func (d *CalendlyDriver) fetchMembershipsPage(
 	query := req.URL.Query()
 	query.Set("organization", organization)
 	query.Set("count", strconv.Itoa(calendlyPageSize))
+
 	if pageToken != "" {
 		query.Set("page_token", pageToken)
 	}
+
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
 

--- a/pkg/accessreview/drivers/calendly.go
+++ b/pkg/accessreview/drivers/calendly.go
@@ -51,7 +51,6 @@ type (
 	}
 
 	calendlyMembership struct {
-		URI  string `json:"uri"`
 		Role string `json:"role"`
 		User struct {
 			URI       string `json:"uri"`

--- a/pkg/accessreview/drivers/calendly.go
+++ b/pkg/accessreview/drivers/calendly.go
@@ -51,9 +51,8 @@ type (
 	}
 
 	calendlyMembership struct {
-		Role      string                `json:"role"`
-		User      calendlyUserReference `json:"user"`
-		CreatedAt string                `json:"created_at"`
+		Role string                `json:"role"`
+		User calendlyUserReference `json:"user"`
 	}
 
 	calendlyUserReference struct {
@@ -153,10 +152,6 @@ func (d *CalendlyDriver) ListAccounts(ctx context.Context) ([]AccountRecord, err
 				AccountType: coredata.AccessReviewEntryAccountTypeUser,
 				ExternalID:  strings.TrimSpace(user.URI),
 				CreatedAt:   parseRFC3339Ptr(user.CreatedAt),
-			}
-
-			if record.CreatedAt == nil {
-				record.CreatedAt = parseRFC3339Ptr(membership.CreatedAt)
 			}
 
 			if isAdmin, known := calendlyRoleIsAdmin(role); known {

--- a/pkg/accessreview/drivers/calendly.go
+++ b/pkg/accessreview/drivers/calendly.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+const (
+	calendlyCurrentUserPath = "/users/me"
+	calendlyMembershipsPath = "/organization_memberships"
+	calendlyPageSize        = 100
+)
+
+type (
+	CalendlyDriver struct {
+		httpClient *http.Client
+		baseURL    string
+	}
+
+	calendlyCurrentUserResponse struct {
+		Resource struct {
+			CurrentOrganization string `json:"current_organization"`
+		} `json:"resource"`
+	}
+
+	calendlyMembership struct {
+		URI  string `json:"uri"`
+		Role string `json:"role"`
+		User struct {
+			URI       string `json:"uri"`
+			Name      string `json:"name"`
+			Email     string `json:"email"`
+			CreatedAt string `json:"created_at"`
+		} `json:"user"`
+	}
+
+	calendlyMembershipsResponse struct {
+		Collection []calendlyMembership `json:"collection"`
+		Pagination struct {
+			NextPageToken string `json:"next_page_token"`
+		} `json:"pagination"`
+	}
+)
+
+var _ Driver = (*CalendlyDriver)(nil)
+
+func NewCalendlyDriver(httpClient *http.Client, baseURL string) *CalendlyDriver {
+	return &CalendlyDriver{httpClient: httpClient, baseURL: baseURL}
+}
+
+func (d *CalendlyDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
+	currentUser, err := d.fetchCurrentUser(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot discover calendly organization: %w", err)
+	}
+
+	organization := strings.TrimSpace(currentUser.Resource.CurrentOrganization)
+	if organization == "" {
+		return nil, fmt.Errorf("cannot list calendly accounts: authenticated user has no organization")
+	}
+
+	var (
+		records   []AccountRecord
+		pageToken string
+	)
+
+	for range maxPaginationPages {
+		memberships, err := d.fetchMembershipsPage(ctx, organization, pageToken)
+		if err != nil {
+			return nil, fmt.Errorf("cannot fetch calendly memberships page: %w", err)
+		}
+
+		for _, membership := range memberships.Collection {
+			email := strings.TrimSpace(membership.User.Email)
+			if email == "" {
+				continue
+			}
+
+			role := strings.ToLower(strings.TrimSpace(membership.Role))
+			records = append(records, AccountRecord{
+				Email:       email,
+				FullName:    strings.TrimSpace(membership.User.Name),
+				Roles:       calendlyRoles(role),
+				IsAdmin:     new(role == "owner" || role == "admin"),
+				MFAStatus:   coredata.MFAStatusUnknown,
+				AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
+				AccountType: coredata.AccessReviewEntryAccountTypeUser,
+				ExternalID:  strings.TrimSpace(membership.User.URI),
+				CreatedAt:   parseRFC3339Ptr(membership.User.CreatedAt),
+			})
+		}
+
+		if memberships.Pagination.NextPageToken == "" {
+			return records, nil
+		}
+
+		pageToken = memberships.Pagination.NextPageToken
+	}
+
+	return nil, fmt.Errorf("cannot list all calendly accounts: %w", ErrPaginationLimitReached)
+}
+
+func (d *CalendlyDriver) fetchCurrentUser(ctx context.Context) (*calendlyCurrentUserResponse, error) {
+	endpoint, err := url.JoinPath(d.baseURL, calendlyCurrentUserPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build calendly current user URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create calendly current user request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	httpResp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot execute calendly current user request: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, fmt.Errorf("cannot fetch calendly current user: unexpected status %d", httpResp.StatusCode)
+	}
+
+	var resp calendlyCurrentUserResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("cannot decode calendly current user response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+func (d *CalendlyDriver) fetchMembershipsPage(
+	ctx context.Context,
+	organization string,
+	pageToken string,
+) (*calendlyMembershipsResponse, error) {
+	endpoint, err := url.JoinPath(d.baseURL, calendlyMembershipsPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build calendly memberships URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create calendly memberships request: %w", err)
+	}
+
+	query := req.URL.Query()
+	query.Set("organization", organization)
+	query.Set("count", strconv.Itoa(calendlyPageSize))
+	if pageToken != "" {
+		query.Set("page_token", pageToken)
+	}
+	req.URL.RawQuery = query.Encode()
+	req.Header.Set("Accept", "application/json")
+
+	httpResp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot execute calendly memberships request: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, fmt.Errorf("cannot fetch calendly memberships: unexpected status %d", httpResp.StatusCode)
+	}
+
+	var resp calendlyMembershipsResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("cannot decode calendly memberships response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+func calendlyRoles(role string) []string {
+	switch role {
+	case "owner":
+		return []string{"Owner"}
+	case "admin":
+		return []string{"Admin"}
+	case "user":
+		return []string{"User"}
+	case "":
+		return []string{}
+	default:
+		return []string{role}
+	}
+}

--- a/pkg/accessreview/drivers/calendly.go
+++ b/pkg/accessreview/drivers/calendly.go
@@ -301,6 +301,7 @@ func calendlyUserEndpoint(baseURL, userURI string) (string, error) {
 	}
 
 	basePath := strings.TrimSuffix(base.EscapedPath(), "/")
+
 	userPathPrefix := basePath + "/users/"
 	if !strings.HasPrefix(user.EscapedPath(), userPathPrefix) {
 		return "", fmt.Errorf("calendly user URI must identify a user resource")

--- a/pkg/accessreview/drivers/calendly.go
+++ b/pkg/accessreview/drivers/calendly.go
@@ -51,13 +51,20 @@ type (
 	}
 
 	calendlyMembership struct {
-		Role string `json:"role"`
-		User struct {
-			URI       string `json:"uri"`
-			Name      string `json:"name"`
-			Email     string `json:"email"`
-			CreatedAt string `json:"created_at"`
-		} `json:"user"`
+		Role      string                `json:"role"`
+		User      calendlyUserReference `json:"user"`
+		CreatedAt string                `json:"created_at"`
+	}
+
+	calendlyUserReference struct {
+		URI       string `json:"uri"`
+		Name      string `json:"name"`
+		Email     string `json:"email"`
+		CreatedAt string `json:"created_at"`
+	}
+
+	calendlyUserResponse struct {
+		Resource calendlyUserReference `json:"resource"`
 	}
 
 	calendlyMembershipsResponse struct {
@@ -72,6 +79,26 @@ var _ Driver = (*CalendlyDriver)(nil)
 
 func NewCalendlyDriver(httpClient *http.Client, baseURL string) *CalendlyDriver {
 	return &CalendlyDriver{httpClient: httpClient, baseURL: baseURL}
+}
+
+func (u *calendlyUserReference) UnmarshalJSON(data []byte) error {
+	var uri string
+	if err := json.Unmarshal(data, &uri); err == nil {
+		u.URI = uri
+
+		return nil
+	}
+
+	type embeddedUser calendlyUserReference
+
+	var user embeddedUser
+	if err := json.Unmarshal(data, &user); err != nil {
+		return fmt.Errorf("cannot decode calendly membership user: %w", err)
+	}
+
+	*u = calendlyUserReference(user)
+
+	return nil
 }
 
 func (d *CalendlyDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
@@ -97,23 +124,46 @@ func (d *CalendlyDriver) ListAccounts(ctx context.Context) ([]AccountRecord, err
 		}
 
 		for _, membership := range memberships.Collection {
-			email := strings.TrimSpace(membership.User.Email)
+			user := membership.User
+			if strings.TrimSpace(user.Email) == "" && strings.TrimSpace(user.URI) != "" {
+				fetched, err := d.fetchUser(ctx, user.URI)
+				if err != nil {
+					return nil, fmt.Errorf("cannot fetch calendly membership user: %w", err)
+				}
+
+				if fetched.Resource.URI == "" {
+					fetched.Resource.URI = user.URI
+				}
+
+				user = fetched.Resource
+			}
+
+			email := strings.TrimSpace(user.Email)
 			if email == "" {
 				continue
 			}
 
 			role := strings.ToLower(strings.TrimSpace(membership.Role))
-			records = append(records, AccountRecord{
+			record := AccountRecord{
 				Email:       email,
-				FullName:    strings.TrimSpace(membership.User.Name),
+				FullName:    strings.TrimSpace(user.Name),
 				Roles:       calendlyRoles(role),
-				IsAdmin:     new(role == "owner" || role == "admin"),
 				MFAStatus:   coredata.MFAStatusUnknown,
 				AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
 				AccountType: coredata.AccessReviewEntryAccountTypeUser,
-				ExternalID:  strings.TrimSpace(membership.User.URI),
-				CreatedAt:   parseRFC3339Ptr(membership.User.CreatedAt),
-			})
+				ExternalID:  strings.TrimSpace(user.URI),
+				CreatedAt:   parseRFC3339Ptr(user.CreatedAt),
+			}
+
+			if record.CreatedAt == nil {
+				record.CreatedAt = parseRFC3339Ptr(membership.CreatedAt)
+			}
+
+			if isAdmin, known := calendlyRoleIsAdmin(role); known {
+				record.IsAdmin = new(isAdmin)
+			}
+
+			records = append(records, record)
 		}
 
 		if memberships.Pagination.NextPageToken == "" {
@@ -203,6 +253,81 @@ func (d *CalendlyDriver) fetchMembershipsPage(
 	return &resp, nil
 }
 
+func (d *CalendlyDriver) fetchUser(ctx context.Context, userURI string) (*calendlyUserResponse, error) {
+	endpoint, err := calendlyUserEndpoint(d.baseURL, userURI)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build calendly user URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create calendly user request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	httpResp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot execute calendly user request: %w", err)
+	}
+
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, fmt.Errorf("cannot fetch calendly user: unexpected status %d", httpResp.StatusCode)
+	}
+
+	var resp calendlyUserResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("cannot decode calendly user response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+func calendlyUserEndpoint(baseURL, userURI string) (string, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse calendly base URL: %w", err)
+	}
+
+	user, err := url.Parse(userURI)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse calendly user URI: %w", err)
+	}
+
+	if !strings.EqualFold(user.Scheme, base.Scheme) || !strings.EqualFold(user.Host, base.Host) || user.User != nil {
+		return "", fmt.Errorf("calendly user URI must use the configured API host")
+	}
+
+	basePath := strings.TrimSuffix(base.EscapedPath(), "/")
+	userPathPrefix := basePath + "/users/"
+	if !strings.HasPrefix(user.EscapedPath(), userPathPrefix) {
+		return "", fmt.Errorf("calendly user URI must identify a user resource")
+	}
+
+	escapedID := strings.TrimPrefix(user.EscapedPath(), userPathPrefix)
+	if escapedID == "" || strings.Contains(escapedID, "/") {
+		return "", fmt.Errorf("calendly user URI must identify one user resource")
+	}
+
+	userID, err := url.PathUnescape(escapedID)
+	if err != nil {
+		return "", fmt.Errorf("cannot decode calendly user id: %w", err)
+	}
+
+	if strings.ContainsAny(userID, `/\`) || isDotSegment(userID) {
+		return "", fmt.Errorf("calendly user URI contains an invalid user id")
+	}
+
+	endpoint, err := url.JoinPath(baseURL, "users", url.PathEscape(userID))
+	if err != nil {
+		return "", fmt.Errorf("cannot join calendly user URL: %w", err)
+	}
+
+	return endpoint, nil
+}
+
 func calendlyRoles(role string) []string {
 	switch role {
 	case "owner":
@@ -215,5 +340,16 @@ func calendlyRoles(role string) []string {
 		return []string{}
 	default:
 		return []string{role}
+	}
+}
+
+func calendlyRoleIsAdmin(role string) (bool, bool) {
+	switch role {
+	case "owner", "admin":
+		return true, true
+	case "user":
+		return false, true
+	default:
+		return false, false
 	}
 }

--- a/pkg/accessreview/drivers/calendly.go
+++ b/pkg/accessreview/drivers/calendly.go
@@ -143,6 +143,7 @@ func (d *CalendlyDriver) fetchCurrentUser(ctx context.Context) (*calendlyCurrent
 	if err != nil {
 		return nil, fmt.Errorf("cannot execute calendly current user request: %w", err)
 	}
+
 	defer func() { _ = httpResp.Body.Close() }()
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
@@ -187,6 +188,7 @@ func (d *CalendlyDriver) fetchMembershipsPage(
 	if err != nil {
 		return nil, fmt.Errorf("cannot execute calendly memberships request: %w", err)
 	}
+
 	defer func() { _ = httpResp.Body.Close() }()
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {

--- a/pkg/accessreview/drivers/calendly_test.go
+++ b/pkg/accessreview/drivers/calendly_test.go
@@ -22,6 +22,7 @@ package drivers
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -55,9 +56,11 @@ func TestCalendlyDriver(t *testing.T) {
 	assert.Equal(t, new(createdAt), records[0].CreatedAt)
 	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, records[0].AccountType)
 
+	membershipCreatedAt := time.Date(2026, time.February, 3, 4, 5, 6, 0, time.UTC)
+
 	assert.Equal(t, []string{"User"}, records[1].Roles)
 	assert.Equal(t, new(false), records[1].IsAdmin)
-	assert.Nil(t, records[1].CreatedAt)
+	assert.Equal(t, new(membershipCreatedAt), records[1].CreatedAt)
 }
 
 func TestCalendlyDriver_ListAccountsWithoutOrganization(t *testing.T) {
@@ -75,4 +78,81 @@ func TestCalendlyDriver_ListAccountsWithoutOrganization(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, records)
 	assert.Contains(t, err.Error(), "authenticated user has no organization")
+}
+
+func TestCalendlyUserReference_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("URI", func(t *testing.T) {
+		t.Parallel()
+
+		var user calendlyUserReference
+		require.NoError(t, json.Unmarshal([]byte(`"https://api.calendly.com/users/U1"`), &user))
+		assert.Equal(t, "https://api.calendly.com/users/U1", user.URI)
+	})
+
+	t.Run("embedded user", func(t *testing.T) {
+		t.Parallel()
+
+		var user calendlyUserReference
+		require.NoError(t, json.Unmarshal(
+			[]byte(`{"uri":"https://api.calendly.com/users/U1","name":"User","email":"user@example.com"}`),
+			&user,
+		))
+		assert.Equal(t, "https://api.calendly.com/users/U1", user.URI)
+		assert.Equal(t, "user@example.com", user.Email)
+	})
+}
+
+func TestCalendlyUserEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		userURI string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "valid user",
+			userURI: "https://api.calendly.com/users/U1",
+			want:    "https://api.calendly.com/users/U1",
+		},
+		{
+			name:    "cross host",
+			userURI: "https://example.com/users/U1",
+			wantErr: true,
+		},
+		{
+			name:    "non-user path",
+			userURI: "https://api.calendly.com/oauth/token",
+			wantErr: true,
+		},
+		{
+			name:    "nested user path",
+			userURI: "https://api.calendly.com/users/U1/secret",
+			wantErr: true,
+		},
+		{
+			name:    "encoded path traversal",
+			userURI: "https://api.calendly.com/users/%2e%2e",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := calendlyUserEndpoint("https://api.calendly.com", tt.userURI)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/pkg/accessreview/drivers/calendly_test.go
+++ b/pkg/accessreview/drivers/calendly_test.go
@@ -45,6 +45,7 @@ func TestCalendlyDriver(t *testing.T) {
 	require.Len(t, records, 2)
 
 	createdAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+
 	assert.Equal(t, "owner@example.com", records[0].Email)
 	assert.Equal(t, "Owner User", records[0].FullName)
 	assert.Equal(t, []string{"Owner"}, records[0].Roles)

--- a/pkg/accessreview/drivers/calendly_test.go
+++ b/pkg/accessreview/drivers/calendly_test.go
@@ -56,11 +56,11 @@ func TestCalendlyDriver(t *testing.T) {
 	assert.Equal(t, new(createdAt), records[0].CreatedAt)
 	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, records[0].AccountType)
 
-	membershipCreatedAt := time.Date(2026, time.February, 3, 4, 5, 6, 0, time.UTC)
+	memberCreatedAt := time.Date(2026, time.February, 4, 5, 6, 7, 0, time.UTC)
 
 	assert.Equal(t, []string{"User"}, records[1].Roles)
 	assert.Equal(t, new(false), records[1].IsAdmin)
-	assert.Equal(t, new(membershipCreatedAt), records[1].CreatedAt)
+	assert.Equal(t, new(memberCreatedAt), records[1].CreatedAt)
 }
 
 func TestCalendlyDriver_ListAccountsWithoutOrganization(t *testing.T) {

--- a/pkg/accessreview/drivers/calendly_test.go
+++ b/pkg/accessreview/drivers/calendly_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -32,41 +33,13 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 )
 
-func TestCalendlyDriver_ListAccounts(t *testing.T) {
+func TestCalendlyDriver(t *testing.T) {
 	t.Parallel()
 
-	const organizationURI = "https://api.calendly.com/organizations/ORG"
+	rec := newRecorder(t, "testdata/calendly", "CALENDLY_TOKEN")
+	client := newVCRClient(rec, bearerAuth(os.Getenv("CALENDLY_TOKEN")))
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		switch r.URL.Path {
-		case "/users/me":
-			assert.Equal(t, http.MethodGet, r.Method)
-			_, _ = w.Write([]byte(`{"resource":{"current_organization":"` + organizationURI + `"}}`))
-		case "/organization_memberships":
-			assert.Equal(t, organizationURI, r.URL.Query().Get("organization"))
-			assert.Equal(t, "100", r.URL.Query().Get("count"))
-
-			if r.URL.Query().Get("page_token") == "" {
-				_, _ = w.Write(
-					[]byte(`{"collection":[{"uri":"https://api.calendly.com/organization_memberships/M1","role":"owner","user":{"uri":"https://api.calendly.com/users/U1","name":"Owner User","email":"owner@example.com","created_at":"2026-01-02T03:04:05Z"}}],"pagination":{"next_page_token":"next"}}`),
-				)
-
-				return
-			}
-
-			assert.Equal(t, "next", r.URL.Query().Get("page_token"))
-			_, _ = w.Write(
-				[]byte(`{"collection":[{"uri":"https://api.calendly.com/organization_memberships/M2","role":"user","user":{"uri":"https://api.calendly.com/users/U2","name":"Member User","email":"member@example.com"}}],"pagination":{"next_page_token":null}}`),
-			)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	driver := NewCalendlyDriver(server.Client(), server.URL)
+	driver := NewCalendlyDriver(client, "https://api.calendly.com")
 	records, err := driver.ListAccounts(context.Background())
 	require.NoError(t, err)
 	require.Len(t, records, 2)

--- a/pkg/accessreview/drivers/calendly_test.go
+++ b/pkg/accessreview/drivers/calendly_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestCalendlyDriver_ListAccounts(t *testing.T) {
+	t.Parallel()
+
+	const organizationURI = "https://api.calendly.com/organizations/ORG"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/users/me":
+			assert.Equal(t, http.MethodGet, r.Method)
+			_, _ = w.Write([]byte(`{"resource":{"current_organization":"` + organizationURI + `"}}`))
+		case "/organization_memberships":
+			assert.Equal(t, organizationURI, r.URL.Query().Get("organization"))
+			assert.Equal(t, "100", r.URL.Query().Get("count"))
+
+			if r.URL.Query().Get("page_token") == "" {
+				_, _ = w.Write(
+					[]byte(`{"collection":[{"uri":"https://api.calendly.com/organization_memberships/M1","role":"owner","user":{"uri":"https://api.calendly.com/users/U1","name":"Owner User","email":"owner@example.com","created_at":"2026-01-02T03:04:05Z"}}],"pagination":{"next_page_token":"next"}}`),
+				)
+
+				return
+			}
+
+			assert.Equal(t, "next", r.URL.Query().Get("page_token"))
+			_, _ = w.Write(
+				[]byte(`{"collection":[{"uri":"https://api.calendly.com/organization_memberships/M2","role":"user","user":{"uri":"https://api.calendly.com/users/U2","name":"Member User","email":"member@example.com"}}],"pagination":{"next_page_token":null}}`),
+			)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	driver := NewCalendlyDriver(server.Client(), server.URL)
+	records, err := driver.ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+
+	createdAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	assert.Equal(t, "owner@example.com", records[0].Email)
+	assert.Equal(t, "Owner User", records[0].FullName)
+	assert.Equal(t, []string{"Owner"}, records[0].Roles)
+	assert.Equal(t, new(true), records[0].IsAdmin)
+	assert.Nil(t, records[0].Active)
+	assert.Equal(t, "https://api.calendly.com/users/U1", records[0].ExternalID)
+	assert.Equal(t, new(createdAt), records[0].CreatedAt)
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, records[0].AccountType)
+
+	assert.Equal(t, []string{"User"}, records[1].Roles)
+	assert.Equal(t, new(false), records[1].IsAdmin)
+	assert.Nil(t, records[1].CreatedAt)
+}
+
+func TestCalendlyDriver_ListAccountsWithoutOrganization(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resource":{"current_organization":""}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	driver := NewCalendlyDriver(server.Client(), server.URL)
+	records, err := driver.ListAccounts(context.Background())
+
+	require.Error(t, err)
+	assert.Nil(t, records)
+	assert.Contains(t, err.Error(), "authenticated user has no organization")
+}

--- a/pkg/accessreview/drivers/testdata/calcom.yaml
+++ b/pkg/accessreview/drivers/testdata/calcom.yaml
@@ -1,0 +1,117 @@
+---
+# Hand-authored K7 fixture matching Cal.com's published v2 response schemas.
+# Synthetic IDs and identities only.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.cal.com
+        form: {}
+        headers:
+            Accept:
+                - application/json
+        url: https://api.cal.com/v2/me
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"status":"success","data":{"id":100,"name":"K7 Owner","email":"owner@example.com","organizationId":null}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.cal.com
+        form: {}
+        headers:
+            Accept:
+                - application/json
+        url: https://api.cal.com/v2/teams
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"status":"success","data":[{"id":7,"name":"K7"},{"id":9,"name":"K7 Security"}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.cal.com
+        form:
+            skip:
+                - "0"
+            take:
+                - "250"
+        headers:
+            Accept:
+                - application/json
+        url: https://api.cal.com/v2/teams/7/memberships?skip=0&take=250
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"status":"success","data":[{"userId":100,"accepted":false,"role":"MEMBER","user":{"name":"Shared User","email":"shared@example.com"}},{"userId":101,"accepted":true,"role":"MEMBER","user":{"name":"Team Seven User","email":"seven@example.com"}}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.cal.com
+        form:
+            skip:
+                - "0"
+            take:
+                - "250"
+        headers:
+            Accept:
+                - application/json
+        url: https://api.cal.com/v2/teams/9/memberships?skip=0&take=250
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"status":"success","data":[{"userId":100,"accepted":true,"role":"OWNER","user":{"name":"Shared User","email":"shared@example.com"}},{"userId":102,"accepted":true,"role":"ADMIN","user":{"name":"Team Nine User","email":"nine@example.com"}}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms

--- a/pkg/accessreview/drivers/testdata/calendly.yaml
+++ b/pkg/accessreview/drivers/testdata/calendly.yaml
@@ -136,7 +136,7 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"resource":{"uri":"https://api.calendly.com/users/U2","name":"Member User","email":"member@example.com"}}'
+        body: '{"resource":{"uri":"https://api.calendly.com/users/U2","name":"Member User","email":"member@example.com","created_at":"2026-02-04T05:06:07Z"}}'
         headers:
             Content-Type:
                 - application/json

--- a/pkg/accessreview/drivers/testdata/calendly.yaml
+++ b/pkg/accessreview/drivers/testdata/calendly.yaml
@@ -1,0 +1,93 @@
+---
+# Hand-authored K7 fixture matching Calendly's published v2 response schemas.
+# Synthetic resource IDs and identities only.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.calendly.com
+        form: {}
+        headers:
+            Accept:
+                - application/json
+        url: https://api.calendly.com/users/me
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resource":{"uri":"https://api.calendly.com/users/K7OWNER","name":"K7 Owner","email":"owner@example.com","current_organization":"https://api.calendly.com/organizations/K7"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.calendly.com
+        form:
+            count:
+                - "100"
+            organization:
+                - https://api.calendly.com/organizations/K7
+        headers:
+            Accept:
+                - application/json
+        url: https://api.calendly.com/organization_memberships?count=100&organization=https%3A%2F%2Fapi.calendly.com%2Forganizations%2FK7
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"collection":[{"uri":"https://api.calendly.com/organization_memberships/M1","role":"owner","user":{"uri":"https://api.calendly.com/users/U1","name":"Owner User","email":"owner@example.com","created_at":"2026-01-02T03:04:05Z"}}],"pagination":{"next_page_token":"next"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.calendly.com
+        form:
+            count:
+                - "100"
+            organization:
+                - https://api.calendly.com/organizations/K7
+            page_token:
+                - next
+        headers:
+            Accept:
+                - application/json
+        url: https://api.calendly.com/organization_memberships?count=100&organization=https%3A%2F%2Fapi.calendly.com%2Forganizations%2FK7&page_token=next
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"collection":[{"uri":"https://api.calendly.com/organization_memberships/M2","role":"user","user":{"uri":"https://api.calendly.com/users/U2","name":"Member User","email":"member@example.com"}}],"pagination":{"next_page_token":null}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms

--- a/pkg/accessreview/drivers/testdata/calendly.yaml
+++ b/pkg/accessreview/drivers/testdata/calendly.yaml
@@ -52,7 +52,7 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"collection":[{"uri":"https://api.calendly.com/organization_memberships/M1","role":"owner","user":{"uri":"https://api.calendly.com/users/U1","name":"Owner User","email":"owner@example.com","created_at":"2026-01-02T03:04:05Z"}}],"pagination":{"next_page_token":"next"}}'
+        body: '{"collection":[{"uri":"https://api.calendly.com/organization_memberships/M1","role":"owner","user":"https://api.calendly.com/users/U1","created_at":"2026-01-01T00:00:00Z"}],"pagination":{"next_page_token":"next"}}'
         headers:
             Content-Type:
                 - application/json
@@ -60,6 +60,32 @@ interactions:
         code: 200
         duration: 50ms
     - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.calendly.com
+        form: {}
+        headers:
+            Accept:
+                - application/json
+        url: https://api.calendly.com/users/U1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resource":{"uri":"https://api.calendly.com/users/U1","name":"Owner User","email":"owner@example.com","created_at":"2026-01-02T03:04:05Z"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms
+    - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -84,7 +110,33 @@ interactions:
         proto_minor: 0
         content_length: -1
         uncompressed: true
-        body: '{"collection":[{"uri":"https://api.calendly.com/organization_memberships/M2","role":"user","user":{"uri":"https://api.calendly.com/users/U2","name":"Member User","email":"member@example.com"}}],"pagination":{"next_page_token":null}}'
+        body: '{"collection":[{"uri":"https://api.calendly.com/organization_memberships/M2","role":"user","user":"https://api.calendly.com/users/U2","created_at":"2026-02-03T04:05:06Z"}],"pagination":{"next_page_token":null}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.calendly.com
+        form: {}
+        headers:
+            Accept:
+                - application/json
+        url: https://api.calendly.com/users/U2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"resource":{"uri":"https://api.calendly.com/users/U2","name":"Member User","email":"member@example.com"}}'
         headers:
             Content-Type:
                 - application/json

--- a/pkg/connector/provider/builtin.go
+++ b/pkg/connector/provider/builtin.go
@@ -65,6 +65,8 @@ func NewBuiltinRegistryWith(opts ...Option) (*Registry, error) {
 		bitbucketRegistration(),
 		brevoRegistration(),
 		brexRegistration(),
+		calComRegistration(),
+		calendlyRegistration(),
 		clickhouseRegistration(),
 		clickupRegistration(),
 		cloudflareRegistration(),

--- a/pkg/connector/provider/calcom.go
+++ b/pkg/connector/provider/calcom.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider
+
+import (
+	"context"
+	"net/http"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/accessreview/drivers"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func calComRegistration() *Registration {
+	return &Registration{
+		Provider:       coredata.ConnectorProviderCalCom,
+		DisplayName:    "Cal.com",
+		SupportsAPIKey: true,
+		Endpoints: Endpoints{
+			APIBase: "https://api.cal.com",
+			Probe:   "https://api.cal.com/v2/me",
+		},
+		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
+			return drivers.NewCalComDriver(c, ep.APIBase), nil
+		},
+	}
+}

--- a/pkg/connector/provider/calcom_test.go
+++ b/pkg/connector/provider/calcom_test.go
@@ -18,36 +18,43 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package provider
+package provider_test
 
 import (
-	"context"
-	"net/http"
+	"testing"
 
-	"go.gearno.de/kit/log"
-	"go.probo.inc/probo/pkg/accessreview/drivers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/connector"
+	"go.probo.inc/probo/pkg/connector/provider"
 	"go.probo.inc/probo/pkg/coredata"
 )
 
-func calComRegistration() *Registration {
-	return &Registration{
-		Provider:       coredata.ConnectorProviderCalCom,
-		DisplayName:    "Cal.com",
-		SupportsAPIKey: true,
-		Endpoints: Endpoints{
-			Auth:    "https://app.cal.com/auth/oauth2/authorize",
-			Token:   "https://api.cal.com/v2/auth/oauth2/token",
-			APIBase: "https://api.cal.com",
-			Probe:   "https://api.cal.com/v2/me",
-		},
-		OAuth2Scopes: []string{
-			"PROFILE_READ",
-			"TEAM_PROFILE_READ",
-			"TEAM_MEMBERSHIP_READ",
-			"ORG_MEMBERSHIP_READ",
-		},
-		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
-			return drivers.NewCalComDriver(c, ep.APIBase), nil
-		},
+func TestCalComRegistration(t *testing.T) {
+	t.Parallel()
+
+	expectedScopes := []string{
+		"PROFILE_READ",
+		"TEAM_PROFILE_READ",
+		"TEAM_MEMBERSHIP_READ",
+		"ORG_MEMBERSHIP_READ",
 	}
+
+	r := provider.NewBuiltinRegistry()
+	reg, ok := r.Get(coredata.ConnectorProviderCalCom)
+	require.True(t, ok)
+
+	assert.True(t, reg.SupportsAPIKey)
+	assert.Equal(t, expectedScopes, reg.OAuth2Scopes)
+
+	oauthConnector := &connector.OAuth2Connector{}
+	require.NoError(t, r.ApplyOAuth2Defaults(
+		string(coredata.ConnectorProviderCalCom),
+		"https://example.com/callback",
+		oauthConnector,
+	))
+
+	assert.Equal(t, "https://app.cal.com/auth/oauth2/authorize", oauthConnector.AuthURL)
+	assert.Equal(t, "https://api.cal.com/v2/auth/oauth2/token", oauthConnector.TokenURL)
+	assert.Equal(t, expectedScopes, oauthConnector.RegisteredScopes)
 }

--- a/pkg/connector/provider/calendly.go
+++ b/pkg/connector/provider/calendly.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider
+
+import (
+	"context"
+	"net/http"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/accessreview/drivers"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func calendlyRegistration() *Registration {
+	return &Registration{
+		Provider:       coredata.ConnectorProviderCalendly,
+		DisplayName:    "Calendly",
+		SupportsAPIKey: true,
+		Endpoints: Endpoints{
+			APIBase: "https://api.calendly.com",
+			Probe:   "https://api.calendly.com/users/me",
+		},
+		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
+			return drivers.NewCalendlyDriver(c, ep.APIBase), nil
+		},
+	}
+}

--- a/pkg/connector/provider/calendly.go
+++ b/pkg/connector/provider/calendly.go
@@ -40,7 +40,7 @@ func calendlyRegistration() *Registration {
 			APIBase: "https://api.calendly.com",
 			Probe:   "https://api.calendly.com/users/me",
 		},
-		OAuth2Scopes: []string{"organizations:read"},
+		OAuth2Scopes: []string{"users:read", "organizations:read"},
 		RequiresPKCE: true,
 		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
 			return drivers.NewCalendlyDriver(c, ep.APIBase), nil

--- a/pkg/connector/provider/calendly_test.go
+++ b/pkg/connector/provider/calendly_test.go
@@ -18,32 +18,38 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package provider
+package provider_test
 
 import (
-	"context"
-	"net/http"
+	"testing"
 
-	"go.gearno.de/kit/log"
-	"go.probo.inc/probo/pkg/accessreview/drivers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/connector"
+	"go.probo.inc/probo/pkg/connector/provider"
 	"go.probo.inc/probo/pkg/coredata"
 )
 
-func calendlyRegistration() *Registration {
-	return &Registration{
-		Provider:       coredata.ConnectorProviderCalendly,
-		DisplayName:    "Calendly",
-		SupportsAPIKey: true,
-		Endpoints: Endpoints{
-			Auth:    "https://auth.calendly.com/oauth/authorize",
-			Token:   "https://auth.calendly.com/oauth/token",
-			APIBase: "https://api.calendly.com",
-			Probe:   "https://api.calendly.com/users/me",
-		},
-		OAuth2Scopes: []string{"organizations:read"},
-		RequiresPKCE: true,
-		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
-			return drivers.NewCalendlyDriver(c, ep.APIBase), nil
-		},
-	}
+func TestCalendlyRegistration(t *testing.T) {
+	t.Parallel()
+
+	r := provider.NewBuiltinRegistry()
+	reg, ok := r.Get(coredata.ConnectorProviderCalendly)
+	require.True(t, ok)
+
+	assert.True(t, reg.SupportsAPIKey)
+	assert.True(t, reg.RequiresPKCE)
+	assert.Equal(t, []string{"organizations:read"}, reg.OAuth2Scopes)
+
+	oauthConnector := &connector.OAuth2Connector{}
+	require.NoError(t, r.ApplyOAuth2Defaults(
+		string(coredata.ConnectorProviderCalendly),
+		"https://example.com/callback",
+		oauthConnector,
+	))
+
+	assert.Equal(t, "https://auth.calendly.com/oauth/authorize", oauthConnector.AuthURL)
+	assert.Equal(t, "https://auth.calendly.com/oauth/token", oauthConnector.TokenURL)
+	assert.Equal(t, []string{"organizations:read"}, oauthConnector.RegisteredScopes)
+	assert.True(t, oauthConnector.RequiresPKCE)
 }

--- a/pkg/connector/provider/calendly_test.go
+++ b/pkg/connector/provider/calendly_test.go
@@ -39,7 +39,7 @@ func TestCalendlyRegistration(t *testing.T) {
 
 	assert.True(t, reg.SupportsAPIKey)
 	assert.True(t, reg.RequiresPKCE)
-	assert.Equal(t, []string{"organizations:read"}, reg.OAuth2Scopes)
+	assert.Equal(t, []string{"users:read", "organizations:read"}, reg.OAuth2Scopes)
 
 	oauthConnector := &connector.OAuth2Connector{}
 	require.NoError(t, r.ApplyOAuth2Defaults(
@@ -50,6 +50,6 @@ func TestCalendlyRegistration(t *testing.T) {
 
 	assert.Equal(t, "https://auth.calendly.com/oauth/authorize", oauthConnector.AuthURL)
 	assert.Equal(t, "https://auth.calendly.com/oauth/token", oauthConnector.TokenURL)
-	assert.Equal(t, []string{"organizations:read"}, oauthConnector.RegisteredScopes)
+	assert.Equal(t, []string{"users:read", "organizations:read"}, oauthConnector.RegisteredScopes)
 	assert.True(t, oauthConnector.RequiresPKCE)
 }

--- a/pkg/coredata/connector_provider.go
+++ b/pkg/coredata/connector_provider.go
@@ -93,6 +93,8 @@ const (
 	ConnectorProviderUpCloud         ConnectorProvider = "UPCLOUD"
 	ConnectorProviderNuki            ConnectorProvider = "NUKI"
 	ConnectorProviderAuthentik       ConnectorProvider = "AUTHENTIK"
+	ConnectorProviderCalCom          ConnectorProvider = "CAL_COM"
+	ConnectorProviderCalendly        ConnectorProvider = "CALENDLY"
 )
 
 var (
@@ -164,6 +166,8 @@ func ConnectorProviders() []ConnectorProvider {
 		ConnectorProviderUpCloud,
 		ConnectorProviderNuki,
 		ConnectorProviderAuthentik,
+		ConnectorProviderCalCom,
+		ConnectorProviderCalendly,
 	}
 }
 
@@ -231,7 +235,9 @@ func (v ConnectorProvider) IsValid() bool {
 		ConnectorProviderGoogleAnalytics,
 		ConnectorProviderUpCloud,
 		ConnectorProviderNuki,
-		ConnectorProviderAuthentik:
+		ConnectorProviderAuthentik,
+		ConnectorProviderCalCom,
+		ConnectorProviderCalendly:
 		return true
 	}
 

--- a/pkg/coredata/migrations/20260820T170451Z.sql
+++ b/pkg/coredata/migrations/20260820T170451Z.sql
@@ -1,0 +1,22 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TYPE connector_provider ADD VALUE IF NOT EXISTS 'CAL_COM';
+ALTER TYPE connector_provider ADD VALUE IF NOT EXISTS 'CALENDLY';

--- a/pkg/server/api/console/v1/graphql/connector.graphql
+++ b/pkg/server/api/console/v1/graphql/connector.graphql
@@ -115,6 +115,9 @@ enum ConnectorProvider
         @goEnum(
             value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderAuthentik"
         )
+    CAL_COM @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderCalCom")
+    CALENDLY
+        @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderCalendly")
 }
 
 type ConnectorProviderInfo {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- add Cal.com and Calendly connectors with API-key and OAuth2 authentication
- request only the profile, user, organization, and team read scopes exercised by the drivers
- use Calendly's PKCE flow and Cal.com's confidential-client token flow
- discover organization, team, or solo account context from each authenticated profile
- enumerate and deduplicate Cal.com users across teams when no organization is present
- preserve unknown admin status when providers do not expose a recognized role
- accept Calendly membership users as embedded objects or user URIs, safely fetching URI resources when needed
- map account creation from Calendly user timestamps without mixing in membership-join timestamps
- add branded Cal.com and Calendly SVGs to the shared third-party logo catalog
- migrate PostgreSQL's `connector_provider` enum for `CAL_COM` and `CALENDLY`
- cover calendar integrations with replayable K7 VCR cassettes plus focused edge-case tests

## Testing

- `go test -race ./pkg/accessreview/drivers ./pkg/connector/provider ./pkg/coredata ./pkg/server/api/console/v1`
- `go vet ./pkg/accessreview/drivers ./pkg/connector/provider ./pkg/coredata ./pkg/server/api/console/v1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./pkg/accessreview/drivers/... ./pkg/connector/provider/...`
- `npm -w @probo/ui run check`
- Node 24 ESLint over the changed icon files
- manual browser verification of both actual `ThirdPartyLogo` mappings
- applied both enum additions in a temporary PostgreSQL database and confirmed `SLACK`, `CAL_COM`, and `CALENDLY`
- `make go-fmt`

[calendar_provider_icons_stable.mp4](https://cursor.com/agents/bc-dc4227ea-a32c-45a2-93c2-1f3457de8453/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_provider_icons_stable.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc4227ea-a32c-45a2-93c2-1f3457de8453?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc4227ea-a32c-45a2-93c2-1f3457de8453&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cal.com and Calendly access review drivers so reviews list members with roles, admin status, and key metadata. Calendly now sets CreatedAt from the user record with full RFC3339 precision; both providers support API key and OAuth (Calendly uses PKCE).

### Service **`+1113`** **`-0`**
- Cal.com driver: discover org/team/solo context, paginate memberships, de-duplicate users across teams, map roles, and set Active from membership acceptance; mark IsAdmin only when the role is recognized.
- Calendly driver: discover current org, paginate memberships, accept embedded users or user URIs, validate URIs against the configured API host, fetch user profiles when needed, map roles, and set CreatedAt from the user record with full precision.
- Register `CAL_COM` and `CALENDLY` in the builtin provider registry with OAuth endpoints and scopes; enable PKCE for Calendly.

### Tests **`+472`** **`-0`**
- Exercise org/team discovery, pagination and de-duplication, role/admin mapping, Calendly user-URI decoding and endpoint validation, and precise CreatedAt handling.
- Include K7 VCR cassettes for both drivers.

### Coredata **`+29`** **`-1`**
- Add `CAL_COM` and `CALENDLY` to the `connector_provider` enum and migration.
- Required: apply DB migrations.

### GraphQL API **`+3`** **`-0`**
- Add `CAL_COM` and `CALENDLY` to the `ConnectorProvider` enum.
- Required: regenerate GraphQL client types if your client consumes this enum.

### Package: ui **`+125`** **`-0`**
- Add `CalCom` and `Calendly` SVGs and register them in `ThirdPartyLogo`; add a Storybook example.

<sup>Written for commit eb19323f46414a8ca89f378f4ac79d686eded289. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

