### PR TITLE
Deny auditors access-review data

### DIFF
--- a/e2e/mcp/access_review_rbac_test.go
+++ b/e2e/mcp/access_review_rbac_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+func TestMCP_AccessReview_AuditorPermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	auditor := testutil.NewClientInOrg(t, testutil.RoleAuditor, owner)
+	auditorMCP := testutil.NewMCPClient(t, auditor)
+	input := map[string]any{
+		"organization_id": owner.GetOrganizationID().String(),
+	}
+
+	campaignsMessage := auditorMCP.CallToolExpectToolError("listAccessReviewCampaigns", input)
+	assert.Contains(t, campaignsMessage, "permission denied")
+	assert.NotContains(t, campaignsMessage, "pq:")
+	assert.NotContains(t, campaignsMessage, "sql:")
+
+	sourcesMessage := auditorMCP.CallToolExpectToolError("listAccessReviewSources", input)
+	assert.Contains(t, sourcesMessage, "permission denied")
+	assert.NotContains(t, sourcesMessage, "pq:")
+	assert.NotContains(t, sourcesMessage, "sql:")
+}

--- a/pkg/accessreview/policies.go
+++ b/pkg/accessreview/policies.go
@@ -54,6 +54,16 @@ var ReadAccessPolicy = policy.NewPolicy(
 	).WithSID("access-review-read-access").When(organizationCondition),
 ).WithDescription("Read-only access-review access")
 
+var AuditorDenyPolicy = policy.NewPolicy(
+	"access-review:auditor-deny",
+	"Access Review Auditor Deny",
+	policy.Deny(
+		"access-review:campaign:*",
+		"access-review:entry:*",
+		"access-review:source:*",
+	).WithSID("deny-auditor-access-review"),
+).WithDescription("Prevents auditors from accessing organization access-review data")
+
 // DriverCatalogPolicy grants every authenticated identity read access to the
 // global access-review driver catalog. The catalog is deployment-scoped and has
 // no organization scoping, so the allow has no condition.
@@ -74,5 +84,6 @@ func PolicySet() *iam.PolicySet {
 		AddRolePolicy("OWNER", FullAccessPolicy).
 		AddRolePolicy("ADMIN", FullAccessPolicy).
 		AddRolePolicy("VIEWER", ReadAccessPolicy).
+		AddRolePolicy("AUDITOR", AuditorDenyPolicy).
 		AddIdentityScopedPolicy(DriverCatalogPolicy)
 }

--- a/pkg/accessreview/policies_test.go
+++ b/pkg/accessreview/policies_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package accessreview_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.probo.inc/probo/pkg/accessreview"
+	"go.probo.inc/probo/pkg/iam/policy"
+)
+
+func TestPolicySet_AuditorCannotAccessReviewData(t *testing.T) {
+	t.Parallel()
+
+	policySet := accessreview.PolicySet()
+	policies := append(
+		policySet.RolePolicies["AUDITOR"],
+		policy.NewPolicy(
+			"test:access-review-allow",
+			"Test Access Review Allow",
+			policy.Allow("access-review:*"),
+		),
+	)
+	evaluator := policy.NewEvaluator()
+
+	actions := []string{
+		accessreview.ActionCampaignGet,
+		accessreview.ActionCampaignList,
+		accessreview.ActionCampaignCreate,
+		accessreview.ActionCampaignUpdate,
+		accessreview.ActionCampaignDelete,
+		accessreview.ActionCampaignStart,
+		accessreview.ActionCampaignClose,
+		accessreview.ActionCampaignCancel,
+		accessreview.ActionCampaignAddSource,
+		accessreview.ActionCampaignRemoveSource,
+		accessreview.ActionEntryGet,
+		accessreview.ActionEntryList,
+		accessreview.ActionEntryDecide,
+		accessreview.ActionEntryFlag,
+		accessreview.ActionSourceGet,
+		accessreview.ActionSourceList,
+		accessreview.ActionSourceCreate,
+		accessreview.ActionSourceUpdate,
+		accessreview.ActionSourceDelete,
+		accessreview.ActionSourceSync,
+	}
+
+	for _, action := range actions {
+		action := action
+		t.Run(
+			action,
+			func(t *testing.T) {
+				t.Parallel()
+
+				result := evaluator.Evaluate(
+					policy.AuthorizationRequest{Action: action},
+					policies,
+				)
+
+				assert.Equal(t, policy.DecisionDeny, result.Decision)
+			},
+		)
+	}
+}
+
+func TestPolicySet_AuditorCanListDriverCatalog(t *testing.T) {
+	t.Parallel()
+
+	policySet := accessreview.PolicySet()
+	policies := append(
+		policySet.RolePolicies["AUDITOR"],
+		policySet.IdentityScopedPolicies...,
+	)
+	evaluator := policy.NewEvaluator()
+
+	result := evaluator.Evaluate(
+		policy.AuthorizationRequest{Action: accessreview.ActionDriverCatalogList},
+		policies,
+	)
+
+	assert.Equal(t, policy.DecisionAllow, result.Decision)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an explicit deny for auditor access to Access Review campaigns, entries, and sources
- preserve authenticated access to the global driver catalog
- cover deny precedence in unit tests and verify MCP campaign/source listing is rejected end to end

## Testing
- `go test ./pkg/accessreview ./pkg/iam/...`
- targeted `TestMCP_AccessReview_AuditorPermissionDenied` end-to-end test

Linear: ENG-757
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-757](https://linear.app/probo/issue/ENG-757/restrict-mcp-access-to-access-review-for-auditors)

<div><a href="https://cursor.com/agents/bc-8aca301e-81cb-46bf-ad28-ca636f08c938?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8aca301e-81cb-46bf-ad28-ca636f08c938&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly denies auditors access to Access Review campaigns, entries, and sources while keeping the global driver catalog available to authenticated users. Previously, auditors could access these resources via allows; now an explicit deny enforces least privilege and causes MCP tools to return permission denied. Aligns with Linear ENG-757.

### Service **`+11`** **`-0`**
Adds `AuditorDenyPolicy` in `pkg/accessreview` to deny `access-review:campaign:*`, `access-review:entry:*`, and `access-review:source:*`, and attaches it to the `AUDITOR` role in `PolicySet`. Deny precedence ensures auditors cannot access organization access-review data even if an allow is present. Preserves `DriverCatalogPolicy` so authenticated users can still list the global driver catalog.

### Tests **`+151`** **`-0`**
Adds unit tests to verify deny precedence across all access-review actions and to confirm auditors can still list the driver catalog. Adds an end-to-end MCP test that ensures `listAccessReviewCampaigns` and `listAccessReviewSources` return permission denied and do not leak SQL errors.

<sup>Written for commit 228d2ff1400d7b2b96e737c3cea6573033f4a940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

