### PR TITLE
Add Rippling access review support

### DIFF
--- a/pkg/accessreview/drivers/rippling.go
+++ b/pkg/accessreview/drivers/rippling.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+type (
+	RipplingDriver struct {
+		httpClient *http.Client
+		baseURL    string
+	}
+
+	ripplingUsersResponse struct {
+		Results  []ripplingUser `json:"results"`
+		NextLink string         `json:"next_link"`
+	}
+
+	ripplingUser struct {
+		ID          string `json:"id"`
+		CreatedAt   string `json:"created_at"`
+		Active      *bool  `json:"active"`
+		Username    string `json:"username"`
+		DisplayName string `json:"display_name"`
+		Name        struct {
+			Formatted string `json:"formatted"`
+		} `json:"name"`
+		Emails []struct {
+			Value string `json:"value"`
+			Type  string `json:"type"`
+		} `json:"emails"`
+	}
+)
+
+const ripplingUsersPath = "users"
+
+var _ Driver = (*RipplingDriver)(nil)
+
+func NewRipplingDriver(httpClient *http.Client, baseURL string) *RipplingDriver {
+	return &RipplingDriver{
+		httpClient: httpClient,
+		baseURL:    baseURL,
+	}
+}
+
+func (d *RipplingDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
+	endpoint, err := url.JoinPath(d.baseURL, ripplingUsersPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build rippling users URL: %w", err)
+	}
+
+	next := endpoint
+	var records []AccountRecord
+
+	for range maxPaginationPages {
+		resp, err := d.fetchUsersPage(ctx, next)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, user := range resp.Results {
+			email := ripplingEmail(user)
+			if email == "" {
+				continue
+			}
+
+			records = append(records, AccountRecord{
+				Email:       email,
+				FullName:    ripplingFullName(user),
+				Active:      user.Active,
+				MFAStatus:   coredata.MFAStatusUnknown,
+				AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
+				AccountType: coredata.AccessReviewEntryAccountTypeUser,
+				CreatedAt:   parseRFC3339Ptr(user.CreatedAt),
+				ExternalID:  user.ID,
+			})
+		}
+
+		if resp.NextLink == "" {
+			return records, nil
+		}
+
+		next, err = sameHostNextPageURL("rippling", endpoint, resp.NextLink)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, fmt.Errorf("cannot list all rippling accounts: %w", ErrPaginationLimitReached)
+}
+
+func (d *RipplingDriver) fetchUsersPage(ctx context.Context, endpoint string) (*ripplingUsersResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create rippling users request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	httpResp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot execute rippling users request: %w", err)
+	}
+
+	defer func() {
+		_ = httpResp.Body.Close()
+	}()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, fmt.Errorf("cannot fetch rippling users: unexpected status %d", httpResp.StatusCode)
+	}
+
+	var resp ripplingUsersResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("cannot decode rippling users response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+func ripplingEmail(user ripplingUser) string {
+	for _, email := range user.Emails {
+		if strings.EqualFold(email.Type, "WORK") && email.Value != "" {
+			return email.Value
+		}
+	}
+
+	for _, email := range user.Emails {
+		if email.Value != "" {
+			return email.Value
+		}
+	}
+
+	return ""
+}
+
+func ripplingFullName(user ripplingUser) string {
+	for _, name := range []string{user.DisplayName, user.Name.Formatted, user.Username} {
+		if name := strings.TrimSpace(name); name != "" {
+			return name
+		}
+	}
+
+	return ripplingEmail(user)
+}

--- a/pkg/accessreview/drivers/rippling_test.go
+++ b/pkg/accessreview/drivers/rippling_test.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestRipplingDriverListAccounts(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/users", r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+				if r.URL.Query().Get("cursor") == "" {
+					_, err := fmt.Fprintf(
+						w,
+						`{
+							"results": [
+								{
+									"id": "user-1",
+									"created_at": "2026-08-20T14:12:00Z",
+									"active": true,
+									"username": "alice",
+									"display_name": "Alice Admin",
+									"name": {"formatted": "Alice Example"},
+									"emails": [
+										{"value": "alice.personal@example.net", "type": "HOME"},
+										{"value": "alice@example.com", "type": "WORK"}
+									]
+								},
+								{
+									"id": "user-without-email",
+									"active": true,
+									"display_name": "No Email",
+									"emails": []
+								}
+							],
+							"next_link": %q
+						}`,
+						server.URL+"/users?cursor=page-2",
+					)
+					require.NoError(t, err)
+
+					return
+				}
+
+				_, err := fmt.Fprint(
+					w,
+					`{
+						"results": [
+							{
+								"id": "user-2",
+								"active": false,
+								"username": "bob",
+								"name": {"formatted": "Bob Former"},
+								"emails": [{"value": "bob@example.com", "type": "OTHER"}]
+							},
+							{
+								"id": "user-3",
+								"username": "carol",
+								"emails": [{"value": "carol@example.com", "type": "WORK"}]
+							}
+						],
+						"next_link": null
+					}`,
+				)
+				require.NoError(t, err)
+			},
+		),
+	)
+	t.Cleanup(server.Close)
+
+	driver := NewRipplingDriver(server.Client(), server.URL)
+	records, err := driver.ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 3)
+
+	assert.Equal(t, "alice@example.com", records[0].Email)
+	assert.Equal(t, "Alice Admin", records[0].FullName)
+	assert.Equal(t, "user-1", records[0].ExternalID)
+	assert.Equal(t, coredata.MFAStatusUnknown, records[0].MFAStatus)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodUnknown, records[0].AuthMethod)
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, records[0].AccountType)
+	require.NotNil(t, records[0].Active)
+	assert.True(t, *records[0].Active)
+	assert.NotNil(t, records[0].CreatedAt)
+
+	assert.Equal(t, "bob@example.com", records[1].Email)
+	assert.Equal(t, "Bob Former", records[1].FullName)
+	require.NotNil(t, records[1].Active)
+	assert.False(t, *records[1].Active)
+	assert.Nil(t, records[1].CreatedAt)
+
+	assert.Equal(t, "carol@example.com", records[2].Email)
+	assert.Equal(t, "carol", records[2].FullName)
+	assert.Nil(t, records[2].Active)
+}
+
+func TestRipplingDriverRejectsCrossHostPagination(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, _ *http.Request) {
+				_, err := fmt.Fprint(w, `{"results":[],"next_link":"https://example.com/users?cursor=stolen"}`)
+				require.NoError(t, err)
+			},
+		),
+	)
+	t.Cleanup(server.Close)
+
+	driver := NewRipplingDriver(server.Client(), server.URL)
+	_, err := driver.ListAccounts(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-host pagination is not allowed")
+}
+
+func TestRipplingDriverDoesNotLeakErrorBody(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, err := fmt.Fprint(w, `{"detail":"secret provider response"}`)
+				require.NoError(t, err)
+			},
+		),
+	)
+	t.Cleanup(server.Close)
+
+	driver := NewRipplingDriver(server.Client(), server.URL)
+	_, err := driver.ListAccounts(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status 401")
+	assert.NotContains(t, err.Error(), "secret provider response")
+}

--- a/pkg/accessreview/drivers/rippling_test.go
+++ b/pkg/accessreview/drivers/rippling_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,73 +36,10 @@ import (
 func TestRipplingDriverListAccounts(t *testing.T) {
 	t.Parallel()
 
-	var server *httptest.Server
-	server = httptest.NewServer(
-		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, "/users", r.URL.Path)
-				assert.Equal(t, "application/json", r.Header.Get("Accept"))
+	rec := newRecorder(t, "testdata/rippling", "RIPPLING_API_TOKEN")
+	client := newVCRClient(rec, bearerAuth(os.Getenv("RIPPLING_API_TOKEN")))
 
-				if r.URL.Query().Get("cursor") == "" {
-					_, err := fmt.Fprintf(
-						w,
-						`{
-							"results": [
-								{
-									"id": "user-1",
-									"created_at": "2026-08-20T14:12:00Z",
-									"active": true,
-									"username": "alice",
-									"display_name": "Alice Admin",
-									"name": {"formatted": "Alice Example"},
-									"emails": [
-										{"value": "alice.personal@example.net", "type": "HOME"},
-										{"value": "alice@example.com", "type": "WORK"}
-									]
-								},
-								{
-									"id": "user-without-email",
-									"active": true,
-									"display_name": "No Email",
-									"emails": []
-								}
-							],
-							"next_link": %q
-						}`,
-						server.URL+"/users?cursor=page-2",
-					)
-					require.NoError(t, err)
-
-					return
-				}
-
-				_, err := fmt.Fprint(
-					w,
-					`{
-						"results": [
-							{
-								"id": "user-2",
-								"active": false,
-								"username": "bob",
-								"name": {"formatted": "Bob Former"},
-								"emails": [{"value": "bob@example.com", "type": "OTHER"}]
-							},
-							{
-								"id": "user-3",
-								"username": "carol",
-								"emails": [{"value": "carol@example.com", "type": "WORK"}]
-							}
-						],
-						"next_link": null
-					}`,
-				)
-				require.NoError(t, err)
-			},
-		),
-	)
-	t.Cleanup(server.Close)
-
-	driver := NewRipplingDriver(server.Client(), server.URL)
+	driver := NewRipplingDriver(client, "https://rest.ripplingapis.com")
 	records, err := driver.ListAccounts(context.Background())
 	require.NoError(t, err)
 	require.Len(t, records, 3)

--- a/pkg/accessreview/drivers/testdata/rippling.yaml
+++ b/pkg/accessreview/drivers/testdata/rippling.yaml
@@ -1,0 +1,59 @@
+---
+# Hand-authored K7 fixture matching Rippling's published users response schema.
+# Synthetic resource IDs and identities only.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: rest.ripplingapis.com
+        form: {}
+        headers:
+            Accept:
+                - application/json
+        url: https://rest.ripplingapis.com/users
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"results":[{"id":"user-1","created_at":"2026-08-20T14:12:00Z","active":true,"username":"alice","display_name":"Alice Admin","name":{"formatted":"Alice Example"},"emails":[{"value":"alice.personal@example.net","type":"HOME"},{"value":"alice@example.com","type":"WORK"}]},{"id":"user-without-email","active":true,"display_name":"No Email","emails":[]}],"next_link":"https://rest.ripplingapis.com/users?cursor=page-2"}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: rest.ripplingapis.com
+        form:
+            cursor:
+                - page-2
+        headers:
+            Accept:
+                - application/json
+        url: https://rest.ripplingapis.com/users?cursor=page-2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"results":[{"id":"user-2","active":false,"username":"bob","name":{"formatted":"Bob Former"},"emails":[{"value":"bob@example.com","type":"OTHER"}]},{"id":"user-3","username":"carol","emails":[{"value":"carol@example.com","type":"WORK"}]}],"next_link":null}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms

--- a/pkg/connector/provider/builtin.go
+++ b/pkg/connector/provider/builtin.go
@@ -106,6 +106,7 @@ func NewBuiltinRegistryWith(opts ...Option) (*Registry, error) {
 		railwayRegistration(),
 		renderRegistration(),
 		resendRegistration(),
+		ripplingRegistration(),
 		scalewayRegistration(),
 		segmentRegistration(),
 		sendgridRegistration(),

--- a/pkg/connector/provider/rippling.go
+++ b/pkg/connector/provider/rippling.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider
+
+import (
+	"context"
+	"net/http"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/accessreview/drivers"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func ripplingRegistration() *Registration {
+	return &Registration{
+		Provider:       coredata.ConnectorProviderRippling,
+		DisplayName:    "Rippling",
+		SupportsAPIKey: true,
+		Endpoints: Endpoints{
+			APIBase: "https://rest.ripplingapis.com",
+			Probe:   "https://rest.ripplingapis.com/users/",
+		},
+		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
+			return drivers.NewRipplingDriver(c, ep.APIBase), nil
+		},
+	}
+}

--- a/pkg/connector/provider/rippling_test.go
+++ b/pkg/connector/provider/rippling_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/httpclient"
+	"go.probo.inc/probo/pkg/accessreview/drivers"
+	"go.probo.inc/probo/pkg/connector/provider"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestRipplingRegistration(t *testing.T) {
+	t.Parallel()
+
+	registry := provider.NewBuiltinRegistry()
+	reg, ok := registry.Get(coredata.ConnectorProviderRippling)
+	require.True(t, ok)
+
+	assert.Equal(t, "Rippling", reg.DisplayName)
+	assert.True(t, reg.SupportsAPIKey)
+	assert.Empty(t, reg.APIKeyHeader)
+	assert.Empty(t, reg.APIKeyAuthScheme)
+	assert.False(t, reg.APIKeyBasicAuth)
+	assert.Equal(t, "https://rest.ripplingapis.com", reg.Endpoints.APIBase)
+	assert.Equal(t, "https://rest.ripplingapis.com/users/", reg.Endpoints.Probe)
+
+	driver, err := reg.NewDriver(
+		context.Background(),
+		httpclient.DefaultClient(httpclient.WithSSRFProtection()),
+		&coredata.Connector{Provider: coredata.ConnectorProviderRippling},
+		nil,
+		reg.Endpoints,
+	)
+	require.NoError(t, err)
+	assert.IsType(t, &drivers.RipplingDriver{}, driver)
+}

--- a/pkg/coredata/connector_provider.go
+++ b/pkg/coredata/connector_provider.go
@@ -95,6 +95,7 @@ const (
 	ConnectorProviderAuthentik       ConnectorProvider = "AUTHENTIK"
 	ConnectorProviderCalCom          ConnectorProvider = "CAL_COM"
 	ConnectorProviderCalendly        ConnectorProvider = "CALENDLY"
+	ConnectorProviderRippling        ConnectorProvider = "RIPPLING"
 )
 
 var (
@@ -168,6 +169,7 @@ func ConnectorProviders() []ConnectorProvider {
 		ConnectorProviderAuthentik,
 		ConnectorProviderCalCom,
 		ConnectorProviderCalendly,
+		ConnectorProviderRippling,
 	}
 }
 
@@ -237,7 +239,8 @@ func (v ConnectorProvider) IsValid() bool {
 		ConnectorProviderNuki,
 		ConnectorProviderAuthentik,
 		ConnectorProviderCalCom,
-		ConnectorProviderCalendly:
+		ConnectorProviderCalendly,
+		ConnectorProviderRippling:
 		return true
 	}
 

--- a/pkg/coredata/migrations/20260821T153649Z.sql
+++ b/pkg/coredata/migrations/20260821T153649Z.sql
@@ -1,0 +1,21 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TYPE connector_provider ADD VALUE IF NOT EXISTS 'RIPPLING';

--- a/pkg/server/api/console/v1/graphql/connector.graphql
+++ b/pkg/server/api/console/v1/graphql/connector.graphql
@@ -118,6 +118,8 @@ enum ConnectorProvider
     CAL_COM @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderCalCom")
     CALENDLY
         @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderCalendly")
+    RIPPLING
+        @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderRippling")
 }
 
 type ConnectorProviderInfo {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- register Rippling as an API-token access review provider
- list Rippling user accounts with active-state and creation metadata
- follow cursor pagination while preventing cross-host token forwarding
- cover the provider flow with a synthetic K7 cassette plus focused security tests

## Testing
- `go test ./pkg/accessreview/drivers ./pkg/connector/provider ./pkg/coredata ./pkg/server/api/console/v1`
- `go test -race ./pkg/accessreview/drivers ./pkg/connector/provider`
- `go test -race -v ./pkg/accessreview/drivers -run 'TestRippling'`
- `go vet ./pkg/accessreview/drivers ./pkg/connector/provider ./pkg/coredata ./pkg/server/api/console/v1`
- `make go-fmt`

`make lint` cannot complete in the cloud image because `golangci-lint` is not installed; the available targeted vet and formatting checks pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d46bf3a-f682-4bd8-8c11-fc5cd6883520?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d46bf3a-f682-4bd8-8c11-fc5cd6883520&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Rippling as an API‑token access review provider and adds the DB enum needed to store it. Lists Rippling users with safe cursor pagination and surfaces the provider in `coredata` and the Console GraphQL enum.

### Tests **`+165`** **`-0`**
- Covers account mapping, multi‑page pagination, cross‑host next‑link rejection, error body redaction, and provider registration returning a `RipplingDriver`.
- Uses a synthetic K7 cassette for `/users` pagination.

### Coredata **`+25`** **`-1`**
- Adds `ConnectorProviderRippling` to the enum, provider list, and `IsValid()`.
- Introduces a migration to extend the PostgreSQL `connector_provider` type with `RIPPLING`. Run migrations before creating Rippling connectors.

### GraphQL API **`+2`** **`-0`**
- Adds `RIPPLING` to the `ConnectorProvider` enum mapped to `coredata.ConnectorProviderRippling`.

### Service **`+276`** **`-0`**
- Registers the Rippling provider in the builtin registry with API base `https://rest.ripplingapis.com` and probe `https://rest.ripplingapis.com/users/`.
- Implements `RipplingDriver` to fetch `/users`, prefer WORK emails, derive full name, set `MFAStatusUnknown` and `AccountTypeUser`, parse `created_at`, and follow `next_link` only on the same host; returns errors on non‑2xx without leaking response bodies.

<sup>Written for commit 09a8bca52de3499f2a41ee6581711f2556ff500d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

