### PR TITLE
CRDT for documents (5/6): migrate wire protocol to automerge-repo + cross-instance fan-out

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -278,6 +278,11 @@ test-automerge-official-fixtures: ## Replay official benchmark-battery documents
 generate-automerge-collaboration-fixtures: ## Regenerate automerge-repo protocol fixtures from the pinned JS packages
 	$(NODE) packages/automerge-conformance/generate-collaboration-fixtures.mjs
 
+.PHONY: test-automerge-repo-interop
+test-automerge-repo-interop: ## Sync a real automerge-repo JS client against the Go gateway
+	AUTOMERGE_REPO_INTEROP_CLIENT=$(CURDIR)/packages/automerge-conformance/collaboration-interop-client.mjs \
+		$(GO_BASE) test -count=1 -run '^TestInterop_' ./pkg/automerge/collaboration
+
 .PHONY: benchmark-prosemirror
 benchmark-prosemirror: ## Benchmark Go rendering and the frontend ProseMirror bridge
 	$(GO_BASE) test -run '^$$' -bench '^BenchmarkRender$$' -benchmem \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,6 +12,7 @@ MKCERT ?=	mkcert
 MKDIR ?=	mkdir -p
 NPM ?=	npm
 NPX ?=	npx
+NODE ?=	node
 OPENSSL ?=	openssl
 AUTOMERGE_BATTERY_OUTPUT ?=	$(CURDIR)/.cache/automerge-battery.json
 AUTOMERGE_BATTERY_FIXTURES ?=	$(CURDIR)/.cache/automerge-battery-fixtures
@@ -272,6 +273,10 @@ test-automerge-official-fixtures: ## Replay official benchmark-battery documents
 	AUTOMERGE_OFFICIAL_BATTERY_FIXTURES=$(AUTOMERGE_BATTERY_FIXTURES) \
 		$(GO_BASE) test -count=1 -run '^TestOfficialBenchmarkBatteryFixtures$$' \
 		./pkg/automerge
+
+.PHONY: generate-automerge-collaboration-fixtures
+generate-automerge-collaboration-fixtures: ## Regenerate automerge-repo protocol fixtures from the pinned JS packages
+	$(NODE) packages/automerge-conformance/generate-collaboration-fixtures.mjs
 
 .PHONY: benchmark-prosemirror
 benchmark-prosemirror: ## Benchmark Go rendering and the frontend ProseMirror bridge

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -292,6 +292,8 @@ fuzz-automerge: ## Fuzz Automerge public, wire, sync, and projection surfaces
 	$(GO_BASE) test -run '^$$' -fuzz '^FuzzDecode$$' -fuzztime=$(AUTOMERGE_FUZZ_TIME) ./pkg/automerge/internal/native
 	$(GO_BASE) test -run '^$$' -fuzz '^FuzzParseSyncMessage$$' -fuzztime=$(AUTOMERGE_FUZZ_TIME) ./pkg/automerge/internal/native
 	$(GO_BASE) test -run '^$$' -fuzz '^FuzzRender$$' -fuzztime=$(AUTOMERGE_FUZZ_TIME) ./pkg/automerge/prosemirror
+	$(GO_BASE) test -run '^$$' -fuzz '^FuzzDecodePresence$$' -fuzztime=$(AUTOMERGE_FUZZ_TIME) ./pkg/automerge/collaboration
+	$(GO_BASE) test -run '^$$' -fuzz '^FuzzDecodeMessage$$' -fuzztime=$(AUTOMERGE_FUZZ_TIME) ./pkg/automerge/collaboration
 
 .PHONY: coverage-report
 coverage-report: test ## Generate HTML coverage report

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/coder/websocket v1.8.15
 	github.com/crewjam/saml v0.5.1
 	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea
+	github.com/fxamacker/cbor/v2 v2.9.2
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/cors v1.2.2
 	github.com/go-git/go-git/v5 v5.19.2
@@ -151,6 +152,7 @@ require (
 	github.com/theupdateframework/go-tuf/v2 v2.4.2 // indirect
 	github.com/transparency-dev/formats v0.1.1 // indirect
 	github.com/transparency-dev/merkle v0.0.2 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeO
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh78=
+github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/getprobo/scim v0.0.0-20260309220528-a952b258e8d3 h1:bn2ml0JxH4DtQqi+CZ+ZPUBo1i3K+4xD0rHczpvpqFk=
 github.com/getprobo/scim v0.0.0-20260309220528-a952b258e8d3/go.mod h1:njybYNBd7EDyRMan05ticVQjPP6ThiuyCDbtRh9+e8A=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
@@ -607,6 +609,8 @@ github.com/vektah/gqlparser/v2 v2.5.36 h1:CN9mKVHgMkc+XftdOWIhb4HEL8wKSYkFAqhf8b
 github.com/vektah/gqlparser/v2 v2.5.36/go.mod h1:cAJ9qwVgPaUkWv6Gn8vn0mqOE0Ui5Pn56wNy5396XWo=
 github.com/vikstrous/dataloadgen v0.0.10 h1:x07XAeEjIWXohvcjRvE72KY8pV5A3sTbKEFmxcj9RNM=
 github.com/vikstrous/dataloadgen v0.0.10/go.mod h1:8vuQVpBH0ODbMKAPUdCAPcOGezoTIhgAjgex51t4vbg=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/package-lock.json
+++ b/package-lock.json
@@ -1042,6 +1042,28 @@
         "node": ">=22.13"
       }
     },
+    "node_modules/@automerge/automerge-repo-network-websocket": {
+      "version": "2.6.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo-network-websocket/-/automerge-repo-network-websocket-2.6.0-alpha.3.tgz",
+      "integrity": "sha512-8iY+aQm0IZfKjwqFAEmwJLT/QP0izwq/F45mtX0L6Bl+JQ0p9ouJcqYwFyhWItlb7vor3NKMb/yp3NCGmy5A4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@automerge/automerge-repo": "2.6.0-alpha.3",
+        "cbor-x": "^1.6.4",
+        "debug": "^4.4.3",
+        "eventemitter3": "^5.0.4",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      }
+    },
+    "node_modules/@automerge/automerge-repo-network-websocket/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/@automerge/automerge-repo/node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -22889,7 +22911,8 @@
       "license": "MIT",
       "dependencies": {
         "@automerge/automerge": "^3.4.0",
-        "@automerge/automerge-repo": "2.6.0-alpha.3"
+        "@automerge/automerge-repo": "2.6.0-alpha.3",
+        "@automerge/automerge-repo-network-websocket": "2.6.0-alpha.3"
       }
     },
     "packages/cookie-banner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1023,6 +1023,31 @@
       "integrity": "sha512-THmghtTNGGt2xsI0pM3o1i3PM8oZKcYFgOj25FOzW7l6e94SQOivNtCwy6xc0I8hVJsQSSotoBNs+yk/9hM2dg==",
       "license": "MIT"
     },
+    "node_modules/@automerge/automerge-repo": {
+      "version": "2.6.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo/-/automerge-repo-2.6.0-alpha.3.tgz",
+      "integrity": "sha512-Rn/KdoVHUQwYU0TXqHyy9PdBgVE009JJWnh2YxT2blk5EnbZckh+RfGfu6ngjMGw0DZcZtJLvK3dKDNdAvtQVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@automerge/automerge": "^3.2.6",
+        "bs58check": "^4.0.0",
+        "cbor-x": "^1.6.4",
+        "debug": "^4.4.3",
+        "eventemitter3": "^5.0.4",
+        "fast-sha256": "^1.3.0",
+        "uuid": "^14.0.1",
+        "xstate": "^5.32.4"
+      },
+      "engines": {
+        "node": ">=22.13"
+      }
+    },
+    "node_modules/@automerge/automerge-repo/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/@automerge/prosemirror": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@automerge/prosemirror/-/prosemirror-0.2.0.tgz",
@@ -1438,6 +1463,84 @@
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.2.tgz",
+      "integrity": "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.2.tgz",
+      "integrity": "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.2.tgz",
+      "integrity": "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.2.tgz",
+      "integrity": "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.2.tgz",
+      "integrity": "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.2.tgz",
+      "integrity": "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
@@ -4545,6 +4648,18 @@
       "integrity": "sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -10400,6 +10515,12 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -10524,6 +10645,25 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -10707,6 +10847,37 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cbor-extract": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.2.tgz",
+      "integrity": "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.1.1"
+      },
+      "bin": {
+        "download-cbor-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-arm": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-x64": "2.2.2",
+        "@cbor-extract/cbor-extract-win32-x64": "2.2.2"
+      }
+    },
+    "node_modules/cbor-x": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.6.5.tgz",
+      "integrity": "sha512-yO64CxnSh6kp+pHNRK9IfwnMvCB+c8HvmUjQY/9l9YRF0/cAPka/tUHLwS64QqUpFCq3/OtbKziVJYXH2EaRig==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "cbor-extract": "^2.2.2"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -12128,7 +12299,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -13253,6 +13424,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.5",
@@ -17540,6 +17717,21 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {
@@ -22519,6 +22711,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/xstate": {
+      "version": "5.32.5",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.32.5.tgz",
+      "integrity": "sha512-ULazi1oe6wGrXl0Frb6otSlkm5HLifbbVTkMk5kkSKqz4TkxJaVpnl6jOJwKeid3ORPxYyZQgNLUSYX9q65SIA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -22686,7 +22888,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@automerge/automerge": "^3.4.0"
+        "@automerge/automerge": "^3.4.0",
+        "@automerge/automerge-repo": "2.6.0-alpha.3"
       }
     },
     "packages/cookie-banner": {

--- a/packages/automerge-conformance/collaboration-interop-client.mjs
+++ b/packages/automerge-conformance/collaboration-interop-client.mjs
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// A real automerge-repo client used as the interop oracle for the Go gateway.
+// It connects to a Go WebSocket server that speaks the repo protocol, finds a
+// document by URL, and prints the materialized document as JSON. It is driven by
+// the Go test in pkg/automerge/collaboration.
+//
+// Usage: node collaboration-interop-client.mjs <wsURL> <automergeUrl>
+
+import { Repo } from "@automerge/automerge-repo";
+import { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
+import process from "node:process";
+
+const [wsURL, documentURL] = process.argv.slice(2);
+
+if (!wsURL || !documentURL) {
+  process.stderr.write("usage: collaboration-interop-client.mjs <wsURL> <automergeUrl>\n");
+  process.exit(2);
+}
+
+const repo = new Repo({
+  network: [new WebSocketClientAdapter(wsURL)],
+});
+
+try {
+  const handle = await repo.find(documentURL, {
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  const doc = handle.doc();
+  process.stdout.write(JSON.stringify(doc ?? null));
+  process.exit(0);
+} catch (error) {
+  process.stderr.write(`interop client failed: ${error?.message ?? error}\n`);
+  process.exit(1);
+}

--- a/packages/automerge-conformance/generate-collaboration-fixtures.mjs
+++ b/packages/automerge-conformance/generate-collaboration-fixtures.mjs
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Generates byte-exact automerge-repo protocol fixtures for the Go collaboration
+// codec, using the pinned packages' own CBOR encoder so the bytes match what the
+// JavaScript client puts on the wire. Run via
+// `make generate-automerge-collaboration-fixtures`.
+
+import { cbor } from "@automerge/automerge-repo";
+import { Buffer } from "node:buffer";
+
+// The presence envelope marker key (PRESENCE_MESSAGE_MARKER in the upstream
+// source). It is a stable protocol constant; the package does not export the
+// constants module, so it is inlined here and documented in PROTOCOL.md.
+const PRESENCE_MESSAGE_MARKER = "__presence";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const outputDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "pkg",
+  "automerge",
+  "collaboration",
+  "testdata",
+);
+
+mkdirSync(outputDir, { recursive: true });
+
+const base64 = value => Buffer.from(value).toString("base64");
+
+// Each presence message, wrapped in the __presence envelope exactly as
+// Presence.broadcast does before DocHandle.broadcast CBOR-encodes it.
+const presenceMessages = {
+  update: { type: "update", channel: "cursor", value: { anchor: "a", head: "b" } },
+  snapshot: { type: "snapshot", state: { cursor: { anchor: "a", head: "b" } } },
+  heartbeat: { type: "heartbeat" },
+  goodbye: { type: "goodbye" },
+};
+
+const fixtures = {};
+
+for (const [name, message] of Object.entries(presenceMessages)) {
+  const envelope = { [PRESENCE_MESSAGE_MARKER]: message };
+  const data = cbor.encode(envelope);
+
+  fixtures[`presence-${name}`] = {
+    description: `Presence ${name} envelope CBOR-encoded as an ephemeral payload`,
+    marker: PRESENCE_MESSAGE_MARKER,
+    envelope,
+    cborBase64: base64(data),
+  };
+
+  // A full ephemeral repo message carrying this presence payload.
+  const ephemeral = {
+    type: "ephemeral",
+    senderId: "peer-a",
+    targetId: "peer-b",
+    documentId: "4NMNnkMhL2wRfvHYuG1uxN",
+    sessionId: "session-a",
+    count: 1,
+    data,
+  };
+
+  fixtures[`ephemeral-${name}`] = {
+    description: `Ephemeral repo message wrapping a presence ${name}`,
+    message: { ...ephemeral, data: base64(ephemeral.data) },
+    payloadCborBase64: base64(data),
+  };
+}
+
+// A round-trip guard: CBOR that decodes back to the envelope it came from.
+fixtures["presence-roundtrip"] = (() => {
+  const envelope = {
+    [PRESENCE_MESSAGE_MARKER]: {
+      type: "update",
+      channel: "cursor",
+      value: { anchor: "AAEC", head: "AwQF" },
+    },
+  };
+  const data = cbor.encode(envelope);
+  const decoded = cbor.decode(data);
+
+  return {
+    description: "CBOR round-trip of a presence update envelope",
+    envelope,
+    cborBase64: base64(data),
+    decodesEqual: JSON.stringify(decoded) === JSON.stringify(envelope),
+  };
+})();
+
+for (const [name, fixture] of Object.entries(fixtures)) {
+  const path = join(outputDir, `${name}.json`);
+  writeFileSync(path, `${JSON.stringify(fixture, null, 2)}\n`);
+  process.stdout.write(`wrote ${path}\n`);
+}

--- a/packages/automerge-conformance/generate-collaboration-fixtures.mjs
+++ b/packages/automerge-conformance/generate-collaboration-fixtures.mjs
@@ -108,6 +108,77 @@ fixtures["presence-roundtrip"] = (() => {
   };
 })();
 
+// Transport-layer frames, encoded with the same repo CBOR helper the WebSocket
+// adapter uses for every frame. Each frame is one CBOR-encoded message.
+const peerMetadata = { isEphemeral: false };
+
+const wireFrames = {
+  "wire-join": {
+    description: "Client join handshake frame",
+    message: {
+      type: "join",
+      senderId: "peer-a",
+      peerMetadata,
+      supportedProtocolVersions: ["1"],
+    },
+  },
+  "wire-peer": {
+    description: "Server peer handshake reply frame",
+    message: {
+      type: "peer",
+      senderId: "server",
+      targetId: "peer-a",
+      peerMetadata,
+      selectedProtocolVersion: "1",
+    },
+  },
+  "wire-error": {
+    description: "Server error frame before closing the socket",
+    message: {
+      type: "error",
+      senderId: "server",
+      targetId: "peer-a",
+      message: "unauthorized",
+    },
+  },
+  "wire-sync": {
+    description: "Framed sync message carrying opaque Automerge sync bytes",
+    message: {
+      type: "sync",
+      senderId: "peer-a",
+      targetId: "server",
+      documentId: "4NMNnkMhL2wRfvHYuG1uxN",
+      data: new Uint8Array([0, 1, 2, 3]),
+    },
+  },
+  "wire-ephemeral": {
+    description: "Framed ephemeral message carrying a presence heartbeat payload",
+    message: {
+      type: "ephemeral",
+      senderId: "peer-a",
+      targetId: "server",
+      documentId: "4NMNnkMhL2wRfvHYuG1uxN",
+      sessionId: "session-a",
+      count: 1,
+      data: cbor.encode({ [PRESENCE_MESSAGE_MARKER]: { type: "heartbeat" } }),
+    },
+  },
+};
+
+for (const [name, frame] of Object.entries(wireFrames)) {
+  const encoded = cbor.encode(frame.message);
+  const message = { ...frame.message };
+  if (message.data instanceof Uint8Array) {
+    message.data = base64(message.data);
+  }
+
+  fixtures[name] = {
+    description: frame.description,
+    message,
+    frameCborBase64: base64(encoded),
+  };
+}
+
 for (const [name, fixture] of Object.entries(fixtures)) {
   const path = join(outputDir, `${name}.json`);
   writeFileSync(path, `${JSON.stringify(fixture, null, 2)}\n`);

--- a/packages/automerge-conformance/package.json
+++ b/packages/automerge-conformance/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "check": "node --check oracle.mjs && node --check generate-parity-inventory.mjs"
+    "check": "node --check oracle.mjs && node --check generate-parity-inventory.mjs && node --check generate-collaboration-fixtures.mjs"
   },
   "dependencies": {
-    "@automerge/automerge": "^3.4.0"
+    "@automerge/automerge": "^3.4.0",
+    "@automerge/automerge-repo": "2.6.0-alpha.3"
   }
 }

--- a/packages/automerge-conformance/package.json
+++ b/packages/automerge-conformance/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "check": "node --check oracle.mjs && node --check generate-parity-inventory.mjs && node --check generate-collaboration-fixtures.mjs"
+    "check": "node --check oracle.mjs && node --check generate-parity-inventory.mjs && node --check generate-collaboration-fixtures.mjs && node --check collaboration-interop-client.mjs"
   },
   "dependencies": {
     "@automerge/automerge": "^3.4.0",

--- a/packages/automerge-conformance/package.json
+++ b/packages/automerge-conformance/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@automerge/automerge": "^3.4.0",
-    "@automerge/automerge-repo": "2.6.0-alpha.3"
+    "@automerge/automerge-repo": "2.6.0-alpha.3",
+    "@automerge/automerge-repo-network-websocket": "2.6.0-alpha.3"
   }
 }

--- a/packages/ui/src/RichEditor/repoDocumentId.test.ts
+++ b/packages/ui/src/RichEditor/repoDocumentId.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  automergeUrl,
+  decodeDocumentId,
+  deriveAutomergeUrl,
+  deriveDocumentId,
+  encodeDocumentId,
+  parseAutomergeUrl,
+  validDocumentId,
+} from "./repoDocumentId";
+
+// A genuine @automerge/automerge-repo document id (the one the Go interop client
+// uses). Decoding it validates our base58check against real upstream output.
+const REAL_REPO_ID = "34YWzjYt5gPJpq5RfXAkPfPcUj1r";
+
+// Canonical outputs of the Go DeriveDocumentID (pkg/automerge/collaboration).
+// Equality here proves the browser and the Go agent derive the same id for a
+// version, which is what makes their sync and presence line up.
+const GO_DERIVED: Record<string, string> = {
+  document_version_2Abc123: "2m7mUm61HVK58xqK8aYTGYLQ4atr",
+  "gid:probo:document_version:01J000000000000000000000":
+    "3r6ksouJrcqDzaHWPGCEzddsAEhW",
+  "hello world": "3ajNHtb2g2k3cYHyXLUJFwQuyr42",
+  "": "4AyyyhobrQ6KECw6yZaZ2Ss2eVuL",
+};
+
+describe("repo document id", () => {
+  it("decodes a real automerge-repo id and round-trips it", async () => {
+    const id = await decodeDocumentId(REAL_REPO_ID);
+    expect(id).toHaveLength(16);
+    expect(await encodeDocumentId(id)).toBe(REAL_REPO_ID);
+    expect(await validDocumentId(REAL_REPO_ID)).toBe(true);
+  });
+
+  it("derives ids that match the Go implementation exactly", async () => {
+    for (const [seed, expected] of Object.entries(GO_DERIVED)) {
+      expect(await deriveDocumentId(seed)).toBe(expected);
+    }
+  });
+
+  it("derives deterministically and per-seed", async () => {
+    const seed = "document_version_9";
+    expect(await deriveDocumentId(seed)).toBe(await deriveDocumentId(seed));
+    expect(await deriveDocumentId(seed)).not.toBe(
+      await deriveDocumentId(seed + "x"),
+    );
+  });
+
+  it("round-trips arbitrary 16-byte ids, including leading zeros", async () => {
+    const cases: Uint8Array[] = [
+      new Uint8Array(16),
+      new Uint8Array([0, 0, 0, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0]),
+      new Uint8Array(16).fill(255),
+      new Uint8Array([
+        0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xaa, 0xbb,
+      ]),
+    ];
+
+    for (const id of cases) {
+      const encoded = await encodeDocumentId(id);
+      expect(await validDocumentId(encoded)).toBe(true);
+      expect(await decodeDocumentId(encoded)).toEqual(id);
+    }
+  });
+
+  it("rejects a corrupted id", async () => {
+    const flipped = REAL_REPO_ID.endsWith("r")
+      ? REAL_REPO_ID.slice(0, -1) + "s"
+      : REAL_REPO_ID.slice(0, -1) + "r";
+    await expect(decodeDocumentId(flipped)).rejects.toThrow();
+
+    await expect(decodeDocumentId("0OIl")).rejects.toThrow();
+    expect(await validDocumentId("")).toBe(false);
+  });
+
+  it("wraps and parses the automerge: scheme", async () => {
+    const url = await deriveAutomergeUrl("document_version_9");
+    const documentId = await parseAutomergeUrl(url);
+    expect(automergeUrl(documentId)).toBe(url);
+    expect(await validDocumentId(documentId)).toBe(true);
+
+    await expect(parseAutomergeUrl(REAL_REPO_ID)).rejects.toThrow();
+    await expect(
+      parseAutomergeUrl("automerge:not-a-valid-id!!"),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/ui/src/RichEditor/repoDocumentId.ts
+++ b/packages/ui/src/RichEditor/repoDocumentId.ts
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// automerge-repo document ids, mirrored byte-for-byte from the Go implementation
+// in pkg/automerge/collaboration/documentid.go so a browser tab and a Go agent
+// compute the same id for a document version without coordinating. This is what
+// lets them share sync and, crucially, ephemeral gossip (presence and cursors):
+// a peer drops an ephemeral frame whose document id it does not recognise.
+//
+// The format is base58check (base58 of the payload followed by the first four
+// bytes of its double SHA-256), the same encoding @automerge/automerge-repo uses
+// for a 16-byte document id.
+
+/** The automerge: URL scheme automerge-repo puts in front of a document id. */
+export const AUTOMERGE_URL_PREFIX = "automerge:";
+
+/** The length of the binary document id automerge-repo base58check-encodes. */
+export const DOCUMENT_ID_BYTE_LENGTH = 16;
+
+// The Bitcoin base58 alphabet automerge-repo's bs58check uses.
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const BASE58_RADIX = 58n;
+
+/** Encodes a 16-byte identifier as an automerge-repo document id. */
+export async function encodeDocumentId(id: Uint8Array): Promise<string> {
+  if (id.length !== DOCUMENT_ID_BYTE_LENGTH) {
+    throw new Error(
+      `automerge document id must be ${DOCUMENT_ID_BYTE_LENGTH} bytes, got ${id.length}`,
+    );
+  }
+
+  return base58CheckEncode(id);
+}
+
+/** Decodes an automerge-repo document id, rejecting a bad checksum or length. */
+export async function decodeDocumentId(
+  documentId: string,
+): Promise<Uint8Array> {
+  const payload = await base58CheckDecode(documentId);
+  if (payload.length !== DOCUMENT_ID_BYTE_LENGTH) {
+    throw new Error(
+      `automerge document id ${JSON.stringify(documentId)} decodes to ${payload.length} bytes, want ${DOCUMENT_ID_BYTE_LENGTH}`,
+    );
+  }
+
+  return payload;
+}
+
+/** Reports whether documentId is a well-formed automerge-repo document id. */
+export async function validDocumentId(documentId: string): Promise<boolean> {
+  try {
+    await decodeDocumentId(documentId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Derives a stable automerge-repo document id from a seed string, such as a
+ * Probo document-version GID, by hashing the seed and taking the first 16 bytes.
+ * Every peer that knows the seed computes the same id.
+ */
+export async function deriveDocumentId(seed: string): Promise<string> {
+  const digest = await sha256(new TextEncoder().encode(seed));
+
+  return base58CheckEncode(digest.slice(0, DOCUMENT_ID_BYTE_LENGTH));
+}
+
+/** Wraps a document id in the automerge: scheme. */
+export function automergeUrl(documentId: string): string {
+  return AUTOMERGE_URL_PREFIX + documentId;
+}
+
+/** Derives a stable automerge: URL from a seed string. */
+export async function deriveAutomergeUrl(seed: string): Promise<string> {
+  return automergeUrl(await deriveDocumentId(seed));
+}
+
+/** Extracts and validates the document id from an automerge: URL. */
+export async function parseAutomergeUrl(url: string): Promise<string> {
+  if (!url.startsWith(AUTOMERGE_URL_PREFIX)) {
+    throw new Error(
+      `automerge url ${JSON.stringify(url)} is missing the ${JSON.stringify(AUTOMERGE_URL_PREFIX)} scheme`,
+    );
+  }
+
+  const documentId = url.slice(AUTOMERGE_URL_PREFIX.length);
+  await decodeDocumentId(documentId);
+
+  return documentId;
+}
+
+async function base58CheckEncode(payload: Uint8Array): Promise<string> {
+  const check = await checksum(payload);
+  const combined = new Uint8Array(payload.length + check.length);
+  combined.set(payload);
+  combined.set(check, payload.length);
+
+  return base58Encode(combined);
+}
+
+async function base58CheckDecode(encoded: string): Promise<Uint8Array> {
+  const decoded = base58Decode(encoded);
+  if (decoded.length < 4) {
+    throw new Error("base58check value is too short to contain a checksum");
+  }
+
+  const payload = decoded.slice(0, decoded.length - 4);
+  const want = decoded.slice(decoded.length - 4);
+  const got = await checksum(payload);
+
+  for (let i = 0; i < 4; i++) {
+    if (got[i] !== want[i]) {
+      throw new Error("base58check checksum mismatch");
+    }
+  }
+
+  return payload;
+}
+
+async function checksum(payload: Uint8Array): Promise<Uint8Array> {
+  const first = await sha256(payload);
+  const second = await sha256(first);
+
+  return second.slice(0, 4);
+}
+
+async function sha256(data: Uint8Array): Promise<Uint8Array> {
+  // Copy into a fresh ArrayBuffer-backed view so the argument is a plain
+  // BufferSource regardless of the input's backing store (SharedArrayBuffer).
+  const bytes = new Uint8Array(data.length);
+  bytes.set(data);
+  const digest = await crypto.subtle.digest("SHA-256", bytes.buffer);
+
+  return new Uint8Array(digest);
+}
+
+function base58Encode(input: Uint8Array): string {
+  let value = 0n;
+  for (const byte of input) {
+    value = value * 256n + BigInt(byte);
+  }
+
+  let encoded = "";
+  while (value > 0n) {
+    const remainder = value % BASE58_RADIX;
+    value = value / BASE58_RADIX;
+    encoded = BASE58_ALPHABET[Number(remainder)] + encoded;
+  }
+
+  // Each leading zero byte is encoded as the alphabet's first character.
+  for (const byte of input) {
+    if (byte !== 0) {
+      break;
+    }
+
+    encoded = BASE58_ALPHABET[0] + encoded;
+  }
+
+  return encoded;
+}
+
+function base58Decode(encoded: string): Uint8Array {
+  let value = 0n;
+  for (const character of encoded) {
+    const index = BASE58_ALPHABET.indexOf(character);
+    if (index < 0) {
+      throw new Error(`invalid base58 character ${JSON.stringify(character)}`);
+    }
+
+    value = value * BASE58_RADIX + BigInt(index);
+  }
+
+  const digits: number[] = [];
+  while (value > 0n) {
+    digits.unshift(Number(value % 256n));
+    value = value / 256n;
+  }
+
+  // Restore the leading zero bytes the encoder wrote as leading '1's.
+  let zeros = 0;
+  for (const character of encoded) {
+    if (character !== BASE58_ALPHABET[0]) {
+      break;
+    }
+
+    zeros++;
+  }
+
+  const result = new Uint8Array(zeros + digits.length);
+  result.set(digits, zeros);
+
+  return result;
+}

--- a/packages/ui/src/RichEditor/repoPresence.test.ts
+++ b/packages/ui/src/RichEditor/repoPresence.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import * as Automerge from "@automerge/automerge";
+import { describe, expect, it } from "vitest";
+
+import {
+  createSchemaAdapter,
+  type RichEditorAutomergeDocument,
+} from "./collaboration";
+import { richEditorCollaborationExtensions } from "./RichEditor";
+import {
+  pmSelectionFromPresence,
+  presenceFromPmSelection,
+} from "./repoPresence";
+
+function seededDocument(
+  text: string,
+): Automerge.Doc<RichEditorAutomergeDocument> {
+  const document = Automerge.from<RichEditorAutomergeDocument>({ body: "" });
+  return Automerge.change(document, (draft) => {
+    Automerge.splice(draft, ["body"], 0, 0, text);
+  });
+}
+
+describe("repo presence mapping", () => {
+  it("round-trips a caret between ProseMirror and Automerge cursors", () => {
+    const adapter = createSchemaAdapter(richEditorCollaborationExtensions);
+    const document = seededDocument("hello world");
+
+    // In a single paragraph, ProseMirror position 1 is the start of the text, so
+    // the "w" of "world" (text offset 6) is at position 7.
+    const selection = presenceFromPmSelection(adapter, document, 7, 7);
+    expect(selection).not.toBeNull();
+
+    const resolved = pmSelectionFromPresence(adapter, document, selection!);
+    expect(resolved).toEqual({ anchorPosition: 7, headPosition: 7 });
+  });
+
+  it("keeps a remote caret anchored across a concurrent insertion", () => {
+    const adapter = createSchemaAdapter(richEditorCollaborationExtensions);
+    let document = seededDocument("hello world");
+
+    const selection = presenceFromPmSelection(adapter, document, 7, 7);
+    expect(selection).not.toBeNull();
+
+    // Someone types three characters at the start of the text.
+    document = Automerge.change(document, (draft) => {
+      Automerge.splice(draft, ["body"], 0, 0, "XX ");
+    });
+
+    // The same stable selection now maps three positions later; a stored
+    // ProseMirror position of 7 would point at the wrong character.
+    const resolved = pmSelectionFromPresence(adapter, document, selection!);
+    expect(resolved).toEqual({ anchorPosition: 10, headPosition: 10 });
+  });
+
+  it("carries a selection range with distinct endpoints", () => {
+    const adapter = createSchemaAdapter(richEditorCollaborationExtensions);
+    const document = seededDocument("hello world");
+
+    // "hello" spans text offsets 0..5, i.e. ProseMirror positions 1..6.
+    const selection = presenceFromPmSelection(adapter, document, 1, 6);
+    expect(selection).not.toBeNull();
+
+    const resolved = pmSelectionFromPresence(adapter, document, selection!);
+    expect(resolved).toEqual({ anchorPosition: 1, headPosition: 6 });
+  });
+});

--- a/packages/ui/src/RichEditor/repoPresence.ts
+++ b/packages/ui/src/RichEditor/repoPresence.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import * as Automerge from "@automerge/automerge";
+import type { SchemaAdapter } from "@automerge/prosemirror";
+// These position-mapping helpers are not re-exported from the package index, so
+// they are imported from the pinned build. They convert between ProseMirror
+// document positions and Automerge text offsets, which is what lets a caret
+// captured in the editor be stored as a stable Automerge cursor and drawn back
+// at the right place after concurrent edits.
+import {
+  amSpliceIdxToPmIdx,
+  pmRangeToAmRange,
+} from "@automerge/prosemirror/dist/traversal.js";
+
+import {
+  createSchemaAdapter,
+  type RichEditorAutomergeDocument,
+} from "./collaboration";
+import { richEditorCollaborationExtensions } from "./RichEditor";
+import {
+  resolveSelection,
+  type TextSelection,
+  textSelection,
+} from "./repoSelection";
+
+// richEditorPresenceAdapter builds the schema adapter used to map positions
+// between ProseMirror and Automerge for presence. It matches the schema the
+// collaborative editor uses, so positions line up.
+export function richEditorPresenceAdapter(): SchemaAdapter {
+  return createSchemaAdapter(richEditorCollaborationExtensions);
+}
+
+// The map key of the rich-text field and the path used to read its spans.
+const textField = "body";
+const textPath: Automerge.Prop[] = [textField];
+
+// A collaborator's caret/selection in ProseMirror position space, ready for the
+// presence decorations.
+export type PmPresenceSelection = {
+  anchorPosition: number;
+  headPosition: number;
+};
+
+// presenceFromPmSelection converts a ProseMirror caret/selection into a stable
+// Automerge-cursor selection to publish over presence. It returns null when a
+// position cannot be mapped (for example a selection on a structural node), so
+// the caller can skip publishing rather than send a bad selection.
+export function presenceFromPmSelection(
+  adapter: SchemaAdapter,
+  document: Automerge.Doc<RichEditorAutomergeDocument>,
+  anchorPosition: number,
+  headPosition: number,
+): TextSelection | null {
+  const spans = Automerge.spans(document, textPath);
+
+  const anchorOffset = pmPositionToAmOffset(adapter, spans, anchorPosition);
+  const headOffset = pmPositionToAmOffset(adapter, spans, headPosition);
+  if (anchorOffset === null || headOffset === null) {
+    return null;
+  }
+
+  return textSelection(document, textField, anchorOffset, headOffset);
+}
+
+// pmSelectionFromPresence resolves a presence selection's stable cursors against
+// the current document and maps them back to ProseMirror positions. It returns
+// null when a cursor no longer resolves (for example the surrounding text was
+// deleted).
+export function pmSelectionFromPresence(
+  adapter: SchemaAdapter,
+  document: Automerge.Doc<RichEditorAutomergeDocument>,
+  selection: TextSelection,
+): PmPresenceSelection | null {
+  const resolved = resolveSelection(document, selection);
+  const spans = Automerge.spans(document, textPath);
+
+  const anchorPosition = amSpliceIdxToPmIdx(adapter, spans, resolved.anchor);
+  const headPosition = amSpliceIdxToPmIdx(adapter, spans, resolved.head);
+  if (anchorPosition === null || headPosition === null) {
+    return null;
+  }
+
+  return { anchorPosition, headPosition };
+}
+
+function pmPositionToAmOffset(
+  adapter: SchemaAdapter,
+  spans: Automerge.Span[],
+  position: number,
+): number | null {
+  const range = pmRangeToAmRange(adapter, spans, {
+    from: position,
+    to: position,
+  });
+
+  return range ? range.start : null;
+}

--- a/packages/ui/src/RichEditor/repoSelection.test.ts
+++ b/packages/ui/src/RichEditor/repoSelection.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import * as Automerge from "@automerge/automerge";
+import { describe, expect, it } from "vitest";
+
+import { isCollapsed, resolveSelection, textSelection } from "./repoSelection";
+
+type Doc = { body: string };
+
+function seededDocument(text: string): Automerge.Doc<Doc> {
+  const document = Automerge.from<Doc>({ body: "" });
+  return Automerge.change(document, (draft) => {
+    Automerge.splice(draft, ["body"], 0, 0, text);
+  });
+}
+
+describe("repo selection", () => {
+  it("resolves a caret to its offset", () => {
+    const document = seededDocument("hello world");
+    const selection = textSelection(document, "body", 6, 6);
+
+    expect(isCollapsed(selection)).toBe(true);
+    expect(resolveSelection(document, selection)).toEqual({
+      anchor: 6,
+      head: 6,
+    });
+  });
+
+  it("keeps a caret anchored across a concurrent insertion", () => {
+    let document = seededDocument("hello world");
+    // Caret on the "w" of "world".
+    const selection = textSelection(document, "body", 6, 6);
+    const before = resolveSelection(document, selection);
+    expect(before).toEqual({ anchor: 6, head: 6 });
+
+    // Someone types three characters at the start of the document.
+    document = Automerge.change(document, (draft) => {
+      Automerge.splice(draft, ["body"], 0, 0, "XX ");
+    });
+
+    // The same cursors now resolve three positions later: an integer offset of
+    // 6 would point at the wrong character.
+    const after = resolveSelection(document, selection);
+    expect(after).toEqual({ anchor: before.anchor + 3, head: before.head + 3 });
+  });
+
+  it("carries a non-collapsed selection range", () => {
+    const document = seededDocument("hello world");
+    const selection = textSelection(document, "body", 0, 5);
+
+    expect(isCollapsed(selection)).toBe(false);
+    expect(resolveSelection(document, selection)).toEqual({
+      anchor: 0,
+      head: 5,
+    });
+  });
+});

--- a/packages/ui/src/RichEditor/repoSelection.ts
+++ b/packages/ui/src/RichEditor/repoSelection.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import * as Automerge from "@automerge/automerge";
+
+// A collaborator's caret or selection carried in automerge-repo presence,
+// expressed with stable Automerge text cursors rather than integer offsets. An
+// offset is invalidated by any concurrent edit before it, so a remote caret
+// drawn from an offset drifts onto the wrong character; a cursor resolves to the
+// position of the same character after arbitrary concurrent edits, which is what
+// keeps remote carets anchored while other people type.
+//
+// The shape (field, anchor, head) mirrors the Go TextSelectionValue in
+// pkg/automerge/collaboration so the two describe the same thing. The cursor
+// values here are the JavaScript Automerge cursor type (a string), which is the
+// representation browser peers exchange; cross-runtime cursor interop with Go
+// agents is a separate concern because the two runtimes encode cursors
+// differently.
+export type TextSelection = {
+  // The Automerge map key of the text object the selection addresses.
+  field: string;
+  // The stable cursor for the fixed end of the selection.
+  anchor: Automerge.Cursor;
+  // The stable cursor for the moving end (the caret). When it equals the anchor
+  // the selection is a collapsed caret.
+  head: Automerge.Cursor;
+};
+
+// A selection resolved back to UTF-16 offsets in the current document, ready for
+// ProseMirror decorations.
+export type ResolvedSelection = {
+  anchor: number;
+  head: number;
+};
+
+// textSelection builds a stable selection from the current caret offsets in a
+// text field. move controls which side of a character a collapsed caret anchors
+// to; "before" keeps it in front of the following character, matching a caret
+// that stays put as text is inserted after it.
+export function textSelection<T>(
+  document: Automerge.Doc<T>,
+  field: string,
+  anchorOffset: number,
+  headOffset: number,
+  move: Automerge.MoveCursor = "before",
+): TextSelection {
+  return {
+    field,
+    anchor: Automerge.getCursor(document, [field], anchorOffset, move),
+    head: Automerge.getCursor(document, [field], headOffset, move),
+  };
+}
+
+// resolveSelection resolves a selection's cursors to offsets in the given
+// document, which may have advanced since the selection was created.
+export function resolveSelection<T>(
+  document: Automerge.Doc<T>,
+  selection: TextSelection,
+): ResolvedSelection {
+  return {
+    anchor: Automerge.getCursorPosition(
+      document,
+      [selection.field],
+      selection.anchor,
+    ),
+    head: Automerge.getCursorPosition(
+      document,
+      [selection.field],
+      selection.head,
+    ),
+  };
+}
+
+// isCollapsed reports whether a selection is a single caret.
+export function isCollapsed(selection: TextSelection): boolean {
+  return selection.anchor === selection.head;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -158,3 +158,9 @@ export type {
   ResolvedSelection,
   TextSelection,
 } from "./RichEditor/repoSelection";
+export {
+  pmSelectionFromPresence,
+  presenceFromPmSelection,
+  richEditorPresenceAdapter,
+} from "./RichEditor/repoPresence";
+export type { PmPresenceSelection } from "./RichEditor/repoPresence";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -149,3 +149,12 @@ export {
   parseAutomergeUrl,
   validDocumentId,
 } from "./RichEditor/repoDocumentId";
+export {
+  isCollapsed,
+  resolveSelection,
+  textSelection,
+} from "./RichEditor/repoSelection";
+export type {
+  ResolvedSelection,
+  TextSelection,
+} from "./RichEditor/repoSelection";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -52,7 +52,12 @@ export { Field } from "./Molecules/Field/Field";
 export { Input } from "./Atoms/Input/Input";
 export { DurationInput } from "./Atoms/Input/DurationInput";
 export { Textarea } from "./Atoms/Textarea/Textarea";
-export { Option, Select, SelectGroup, SelectLabel } from "./Atoms/Select/Select";
+export {
+  Option,
+  Select,
+  SelectGroup,
+  SelectLabel,
+} from "./Atoms/Select/Select";
 export { Label } from "./Atoms/Label/Label";
 export { PropertyRow } from "./Atoms/PropertyRow/PropertyRow";
 export { Table, Tbody, Td, Th, Thead, Tr, TrButton } from "./Atoms/Table/Table";
@@ -133,3 +138,14 @@ export {
   collaborationDebug,
   summarizeAutomergeSpans,
 } from "./RichEditor/collaborationDebug";
+export {
+  AUTOMERGE_URL_PREFIX,
+  DOCUMENT_ID_BYTE_LENGTH,
+  automergeUrl,
+  decodeDocumentId,
+  deriveAutomergeUrl,
+  deriveDocumentId,
+  encodeDocumentId,
+  parseAutomergeUrl,
+  validDocumentId,
+} from "./RichEditor/repoDocumentId";

--- a/pkg/automerge/collaboration/GATEWAY_CONTRACT.md
+++ b/pkg/automerge/collaboration/GATEWAY_CONTRACT.md
@@ -162,7 +162,8 @@ PM → spans conversion runs.
 | Document id derivation + `automerge:` URL (`documentid.go`) | done, tested against a real repo id |
 | Opaque ephemeral fan-out (`BroadcastEphemeral` / `Ephemeral`) | done, tested |
 | Cursor-based selection presence (`TextSelectionValue`) | done, tested |
+| TS `deriveDocumentId` mirror (`@probo/ui`) | done, tested for byte-parity with Go |
 | `/repo` route wiring | pending (needs Postgres integration test) |
 | Server-authoritative seeding | pending (choose conversion location) |
 | Cross-instance ephemeral fan-out | pending (extend `realtime.Events`) |
-| TS `deriveDocumentId` + repo `NetworkAdapter` | pending (frontend) |
+| Repo `NetworkAdapter` targeting `/repo` (frontend) | pending (needs `@automerge/automerge-repo` dep + gateway) |

--- a/pkg/automerge/collaboration/GATEWAY_CONTRACT.md
+++ b/pkg/automerge/collaboration/GATEWAY_CONTRACT.md
@@ -157,6 +157,7 @@ PM → spans conversion runs.
 | Opaque ephemeral fan-out (`BroadcastEphemeral` / `Ephemeral`) | done, tested |
 | Cursor-based selection presence (`TextSelectionValue`) | done, tested |
 | TS `deriveDocumentId` mirror (`@probo/ui`) | done, tested for byte-parity with Go |
+| TS cursor-based selection helper (`@probo/ui` `repoSelection`) | done, tested for cursor stability across concurrent edits (browser↔browser) |
 | `/repo` route wiring | done, driven end-to-end in Go by a real `ClientConn` (Postgres integration + live JS still pending) |
 | ProseMirror → spans forward conversion (`prosemirror.ToSpans`) | done, round-trips the whole shared corpus |
 | Server-authoritative seeding | done, seeds on first open from stored content and materializes over the loop (Postgres lifecycle still to integration-test) |

--- a/pkg/automerge/collaboration/GATEWAY_CONTRACT.md
+++ b/pkg/automerge/collaboration/GATEWAY_CONTRACT.md
@@ -117,10 +117,14 @@ PM → spans conversion runs.
   `Text.getCursor` and resolves them with `Text.getCursorPosition`; the presence
   decorations in `packages/ui/src/RichEditor/presence.ts` render from the resolved
   positions.
-- **Cross-instance ephemeral is still single-instance today.** `realtime.Events`
-  carries only the version id (a "changed" signal) over `NOTIFY`; carrying the
-  ephemeral payload across server instances is a follow-up. Sync already fans out
-  cross-instance via the existing refresh path.
+- **Cross-instance ephemeral** is delivered by publishing the frame over the
+  collaboration `NOTIFY` channel in a typed envelope
+  (`realtime.CollaborationEphemeral`) alongside the bare version-id "changed"
+  signal. The `/repo` loop relays each gossiped frame with
+  `DocumentService.NotifyCollaborationEphemeral`; the receiving instance decodes
+  the envelope in `notifyExternal` and fans it out to local peers, skipping the
+  publishing instance's own echo. Oversized frames fall back to local-only
+  fan-out.
 
 ## 6. Reconnect and revision
 
@@ -156,5 +160,5 @@ PM → spans conversion runs.
 | `/repo` route wiring | done, driven end-to-end in Go by a real `ClientConn` (Postgres integration + live JS still pending) |
 | ProseMirror → spans forward conversion (`prosemirror.ToSpans`) | done, round-trips the whole shared corpus |
 | Server-authoritative seeding | done, seeds on first open from stored content and materializes over the loop (Postgres lifecycle still to integration-test) |
-| Cross-instance ephemeral fan-out | pending (extend `realtime.Events`) |
+| Cross-instance ephemeral fan-out | done, published over the NOTIFY channel and delivered to local peers with self-echo suppression (Postgres delivery still to integration-test) |
 | Repo `NetworkAdapter` targeting `/repo` (frontend) | pending (needs `@automerge/automerge-repo` dep + gateway) |

--- a/pkg/automerge/collaboration/GATEWAY_CONTRACT.md
+++ b/pkg/automerge/collaboration/GATEWAY_CONTRACT.md
@@ -1,0 +1,168 @@
+# Repo collaboration gateway contract
+
+This is the integration contract for migrating Probo's real-time document editing
+from the custom `automerge-sync-v1` WebSocket protocol to the official
+`@automerge/automerge-repo` protocol. It pins the three decisions the gateway and
+the frontend must agree on — **document id**, **auth**, and **seeding** — plus the
+rollout shape. The transport-agnostic protocol drivers it builds on
+(`ServerConn`, `ClientConn`), the hub fan-out primitives, and the presence value
+already exist and are tested; see [`PROTOCOL.md`](PROTOCOL.md).
+
+The custom client being replaced lives in
+`apps/console/src/pages/organizations/documents/description/_lib/AutomergeDocumentHandle.ts`
+(transport) and `packages/ui/src/RichEditor/*` (the ProseMirror ↔ Automerge
+binding and presence decorations). The binding layer is reusable as long as the
+new client still exposes an `@automerge/prosemirror` `DocHandle`; only the
+transport is replaced.
+
+## 1. Routing and scope
+
+Keep the connection **version-scoped by URL path**, exactly as the custom route
+is:
+
+```
+{ws|wss}://{host}/api/console/v1/document-versions/{documentVersionID}/repo
+```
+
+- The `documentVersionID` path segment (a Probo `DocumentVersion` GID) is the
+  single source of truth for **authorization** and **room selection**. It is not
+  the repo document id.
+- A new `/repo` route is added next to the existing `/sync` route so the two
+  protocols coexist during migration. Mount it in the same authenticated router
+  group in `pkg/server/api/console/v1/resolver.go`.
+- One WebSocket serves exactly one document version, matching the hub's
+  one-room-per-version model (`hub.acquire(scope, documentVersionID, ...)`).
+
+Rationale: the repo protocol has no notion of "which Probo resource is this"; the
+path keeps auth and room routing on the proven code path and out of the protocol.
+
+## 2. Document id
+
+The repo document id is **derived deterministically from the version GID**, not
+chosen freely:
+
+```
+documentID  = base58check( sha256(documentVersionID)[:16] )   // DeriveDocumentID
+automergeURL = "automerge:" + documentID                       // DeriveAutomergeURL
+```
+
+- `DeriveDocumentID` / `DeriveAutomergeURL` (this package, `documentid.go`) are
+  the canonical Go implementation; the frontend must implement the identical
+  derivation in TypeScript (same SHA-256, first 16 bytes, bs58check). The Go
+  codec is validated against a real `@automerge/automerge-repo` id, so the two
+  will agree.
+- **Determinism is required, not cosmetic.** All peers of a version must use the
+  same id because ephemeral gossip (presence, cursors) is keyed by document id: a
+  peer silently drops an ephemeral frame whose id it does not recognise. Sync
+  alone would tolerate differing ids (the server re-tags per connection), but
+  presence would not.
+- The server needs **no** id-derivation logic: it uses `NewAdoptingServerConn`,
+  which binds to whatever id the client requests in its first sync/request frame
+  and answers for that id (rejecting any second id on the connection). Go agents
+  that want to open a version compute the URL with `DeriveAutomergeURL(gid)`.
+
+Rationale: derivation gives every browser tab and Go agent the same id with zero
+coordination and no new storage, and it makes presence line up.
+
+## 3. Authentication
+
+Auth is **unchanged** from the custom route; the repo `PeerId` is never trusted.
+
+- **Browser** — a same-origin WebSocket upgrade carries the session cookie
+  automatically. The `/repo` route sits behind the existing middleware
+  (`NewSessionMiddleware`, `NewAPIKeyMiddleware`, `NewOAuth2AccessTokenMiddleware`,
+  `NewIdentityPresenceMiddleware`) and the same `authorize` check
+  (`DocumentVersionGet` + `DocumentUpdate`). No token is placed in the URL.
+- **Go agents / non-browser clients** — present an API key or bearer token as an
+  `Authorization` header on the upgrade request (the WebSocket dialer sets request
+  headers). The same middleware validates it.
+- The authenticated identity is bound to the connection server-side and used for
+  audit and presence attribution. The repo `senderId` in the `join` frame is
+  peer-chosen and is treated purely as a routing label, never as identity.
+
+Rationale: reuses the working auth path and keeps credentials out of URLs and out
+of the peer-chosen protocol fields.
+
+## 4. Seeding
+
+The server is the **document authority and owns seeding**; there is no seed
+field in the repo handshake, and clients never seed via the protocol.
+
+- A collaboration connection is served a materialized Automerge document for the
+  version. The custom `needsSeed` / `seedContent` / seed-owner handshake and
+  `ReleaseCollaborationSeed` machinery are **dropped** from the repo path.
+- **Target implementation** — seed the server-side Automerge document once from
+  the version's stored ProseMirror JSON and persist it, so every connection just
+  syncs an existing document down. Conversion is ProseMirror JSON → Automerge
+  spans.
+- **Open sub-decision (implementation, not protocol):** that conversion lives
+  today only in TypeScript (`packages/ui` schema adapter + `@automerge/prosemirror`
+  `pmNodeToSpans`); Go has the reverse (Automerge → ProseMirror render) but not
+  the forward direction. Two ways to close it, to be chosen when the endpoint is
+  built:
+  1. **Seed at draft creation** — run the existing TS conversion once when a draft
+     version is created (or first opened) and persist the resulting Automerge
+     document. The gateway then always has a document. Simplest; no new Go code.
+  2. **Port the forward conversion to Go** — implement ProseMirror JSON → spans in
+     Go and seed lazily on first open. More code, but keeps seeding server-only
+     with no JS build step.
+- Interim fallback if neither is ready: the first client seeds via the repo
+  `doc-unavailable` → `repo.create()` path. This is a temporary bridge, not the
+  contract, because it reintroduces client-side seeding.
+
+Rationale: server-authoritative seeding matches the CRDT authority model and
+removes fragile handshake state; the only real work is where the one-time
+PM → spans conversion runs.
+
+## 5. Presence and cursors
+
+- Presence rides repo **ephemeral gossip**, not a side JSON channel. The server
+  returns a non-duplicate ephemeral frame from `ServerConn.Receive` as `fanout`
+  and publishes it with `lease.BroadcastEphemeral`; it writes other peers' frames
+  from `lease.Ephemeral` to the socket.
+- A caret/selection is a presence `update` whose value is a `TextSelectionValue`
+  (this package): the addressed text field plus **stable Automerge cursors** for
+  anchor and head, replacing the custom integer `anchorPosition`/`headPosition`.
+  Cursors survive concurrent edits; offsets do not. The frontend builds them with
+  `Text.getCursor` and resolves them with `Text.getCursorPosition`; the presence
+  decorations in `packages/ui/src/RichEditor/presence.ts` render from the resolved
+  positions.
+- **Cross-instance ephemeral is still single-instance today.** `realtime.Events`
+  carries only the version id (a "changed" signal) over `NOTIFY`; carrying the
+  ephemeral payload across server instances is a follow-up. Sync already fans out
+  cross-instance via the existing refresh path.
+
+## 6. Reconnect and revision
+
+- The repo network adapter owns reconnect/backoff and the sync generation model,
+  so the custom `revision` / `ready` / initialization-timeout handshake fields are
+  dropped from the client.
+- The server keeps its debounced persistence and its cross-instance sync refresh
+  (`lease.SchedulePersist`, `lease.Wake`, `RefreshCollaboration`) unchanged; those
+  are independent of the wire protocol.
+
+## 7. Rollout
+
+1. Add the `/repo` route wired to `NewAdoptingServerConn` + the hub, coexisting
+   with `/sync`.
+2. Add the TS `deriveDocumentId` helper (mirroring `DeriveDocumentID`) and a repo
+   `NetworkAdapter` targeting `/repo`, behind a feature flag, reusing the existing
+   `DocHandle`-based binding.
+3. Validate with a Postgres-backed integration test and the live JS interop
+   harness, then flip the flag.
+4. Remove `/sync`, `AutomergeDocumentHandle.ts`, and the DB presence tables once
+   no client uses the custom protocol.
+
+## Status
+
+| Piece | State |
+|---|---|
+| `ServerConn` / `ClientConn` drivers | done, tested |
+| Adopting document id (`NewAdoptingServerConn`) | done, tested |
+| Document id derivation + `automerge:` URL (`documentid.go`) | done, tested against a real repo id |
+| Opaque ephemeral fan-out (`BroadcastEphemeral` / `Ephemeral`) | done, tested |
+| Cursor-based selection presence (`TextSelectionValue`) | done, tested |
+| `/repo` route wiring | pending (needs Postgres integration test) |
+| Server-authoritative seeding | pending (choose conversion location) |
+| Cross-instance ephemeral fan-out | pending (extend `realtime.Events`) |
+| TS `deriveDocumentId` + repo `NetworkAdapter` | pending (frontend) |

--- a/pkg/automerge/collaboration/GATEWAY_CONTRACT.md
+++ b/pkg/automerge/collaboration/GATEWAY_CONTRACT.md
@@ -163,7 +163,7 @@ PM → spans conversion runs.
 | Opaque ephemeral fan-out (`BroadcastEphemeral` / `Ephemeral`) | done, tested |
 | Cursor-based selection presence (`TextSelectionValue`) | done, tested |
 | TS `deriveDocumentId` mirror (`@probo/ui`) | done, tested for byte-parity with Go |
-| `/repo` route wiring | pending (needs Postgres integration test) |
-| Server-authoritative seeding | pending (choose conversion location) |
+| `/repo` route wiring | done, driven end-to-end in Go by a real `ClientConn` (Postgres integration + live JS still pending) |
+| Server-authoritative seeding | pending (choose conversion location); the `/repo` route refuses an unseeded document until then |
 | Cross-instance ephemeral fan-out | pending (extend `realtime.Events`) |
 | Repo `NetworkAdapter` targeting `/repo` (frontend) | pending (needs `@automerge/automerge-repo` dep + gateway) |

--- a/pkg/automerge/collaboration/GATEWAY_CONTRACT.md
+++ b/pkg/automerge/collaboration/GATEWAY_CONTRACT.md
@@ -91,24 +91,14 @@ field in the repo handshake, and clients never seed via the protocol.
 - A collaboration connection is served a materialized Automerge document for the
   version. The custom `needsSeed` / `seedContent` / seed-owner handshake and
   `ReleaseCollaborationSeed` machinery are **dropped** from the repo path.
-- **Target implementation** — seed the server-side Automerge document once from
-  the version's stored ProseMirror JSON and persist it, so every connection just
-  syncs an existing document down. Conversion is ProseMirror JSON → Automerge
-  spans.
-- **Open sub-decision (implementation, not protocol):** that conversion lives
-  today only in TypeScript (`packages/ui` schema adapter + `@automerge/prosemirror`
-  `pmNodeToSpans`); Go has the reverse (Automerge → ProseMirror render) but not
-  the forward direction. Two ways to close it, to be chosen when the endpoint is
-  built:
-  1. **Seed at draft creation** — run the existing TS conversion once when a draft
-     version is created (or first opened) and persist the resulting Automerge
-     document. The gateway then always has a document. Simplest; no new Go code.
-  2. **Port the forward conversion to Go** — implement ProseMirror JSON → spans in
-     Go and seed lazily on first open. More code, but keeps seeding server-only
-     with no JS build step.
-- Interim fallback if neither is ready: the first client seeds via the repo
-  `doc-unavailable` → `repo.create()` path. This is a temporary bridge, not the
-  contract, because it reintroduces client-side seeding.
+- **Implementation (done)** — the conversion was ported to Go
+  (`pkg/automerge/prosemirror.ToSpans`, the inverse of `Render`, validated to
+  round-trip the entire shared ProseMirror corpus). The `/repo` handler seeds
+  lazily on first open: the connection that claims the seed converts the
+  version's stored ProseMirror JSON to spans, writes them into the shared
+  document, and persists; the persist marks the state seeded, so later
+  connections skip it. No JavaScript build step and no draft-creation change are
+  required.
 
 Rationale: server-authoritative seeding matches the CRDT authority model and
 removes fragile handshake state; the only real work is where the one-time
@@ -164,6 +154,7 @@ PM → spans conversion runs.
 | Cursor-based selection presence (`TextSelectionValue`) | done, tested |
 | TS `deriveDocumentId` mirror (`@probo/ui`) | done, tested for byte-parity with Go |
 | `/repo` route wiring | done, driven end-to-end in Go by a real `ClientConn` (Postgres integration + live JS still pending) |
-| Server-authoritative seeding | pending (choose conversion location); the `/repo` route refuses an unseeded document until then |
+| ProseMirror → spans forward conversion (`prosemirror.ToSpans`) | done, round-trips the whole shared corpus |
+| Server-authoritative seeding | done, seeds on first open from stored content and materializes over the loop (Postgres lifecycle still to integration-test) |
 | Cross-instance ephemeral fan-out | pending (extend `realtime.Events`) |
 | Repo `NetworkAdapter` targeting `/repo` (frontend) | pending (needs `@automerge/automerge-repo` dep + gateway) |

--- a/pkg/automerge/collaboration/PROTOCOL.md
+++ b/pkg/automerge/collaboration/PROTOCOL.md
@@ -129,9 +129,69 @@ Each Go codec change must round-trip these. The wire-framing fixtures (join/peer
 handshake, socket frames) are added in the transport phase alongside the pinned
 websocket adapter.
 
+## Transport layer (WebSocket adapter)
+
+Pinned: `@automerge/automerge-repo-network-websocket@2.6.0-alpha.3`. The current
+`WebSocketClientAdapter` and server adapters encode every frame with the same
+repo CBOR helper used for payloads (`useRecords: false`, `tagUint8Array: false`).
+The older `encoder.js` and `WSShared.js` in that package are legacy compat and
+are not used by the current adapters.
+
+Each binary WebSocket frame is exactly one CBOR-encoded message; the WebSocket
+message boundary is the framing, so there is no length prefix of our own. The
+server must read binary frames (not text) and treat each as one message.
+
+Protocol version is `"1"` (`ProtocolV1`).
+
+### Handshake
+
+```text
+client ──▶ join   { type:"join", senderId, peerMetadata, supportedProtocolVersions:["1"] }
+server ──▶ peer   { type:"peer", senderId, targetId, peerMetadata, selectedProtocolVersion:"1" }
+```
+
+- `join` is the first frame the client sends, before it knows the server peer id,
+  so it has no `targetId`.
+- The server replies `peer` selecting a protocol version, or `error`
+  `{ type:"error", senderId, targetId, message }` and then closes the socket.
+- After the handshake, both directions exchange the repo messages from the
+  message-union section (`sync`, `request`, `ephemeral`, `doc-unavailable`, and
+  the two remote-heads messages), each as its own CBOR frame.
+- There is no explicit `leave` frame; a disconnect is the socket closing. A
+  presence `goodbye` (inside an ephemeral) is the graceful application-level
+  signal.
+
+### PeerMetadata
+
+```text
+{ storageId?: string (StorageId), isEphemeral?: boolean }
+```
+
+Both fields are optional. `isEphemeral` marks a peer that does not persist
+documents. Our gateway can present its own metadata and must not trust a peer's
+metadata as identity (see below).
+
+### Gateway responsibilities (transport)
+
+- Accept a binary WebSocket, read `join`, negotiate `"1"`, reply `peer` with a
+  server `senderId`.
+- The repo `PeerId` in `join` is peer-chosen and is **not** a user identity;
+  authenticate the connection out of band (our existing session auth) and bind
+  the authenticated identity to the connection, never to `senderId`.
+- Route `sync`/`request` payloads into the per-peer, per-document
+  `automerge.SyncState`; forward `ephemeral` frames to the room with the existing
+  cross-instance fanout, de-duplicated by `(sessionId, count)`.
+
+## Fixtures
+
+`testdata/` also holds transport fixtures generated from the pinned adapter's own
+CBOR encoder:
+
+- `wire-join.json`, `wire-peer.json`, `wire-error.json` — the handshake frames.
+- `wire-sync.json`, `wire-ephemeral.json` — a framed document message.
+
 ## Deliberately deferred
 
-- WebSocket adapter framing and the join/peer/leave handshake (transport phase).
 - `remote-subscription-change` and `remote-heads-changed` handling (not needed by
   a single-authority gateway; revisit if multi-storage subscription is wanted).
 - Storage adapters: PostgreSQL remains the document authority; we do not adopt

--- a/pkg/automerge/collaboration/PROTOCOL.md
+++ b/pkg/automerge/collaboration/PROTOCOL.md
@@ -260,10 +260,11 @@ or cross-instance notification:
 These need the migrated frontend (and a Postgres-backed integration test) to
 settle, so they are intentionally not encoded as untested production code yet:
 
-- **Cross-instance ephemeral** — `realtime.Events` currently carries only the
-  document-version id (a "changed" signal) over `NOTIFY`. Repo ephemeral gossip
-  across server instances needs the payload carried too, or a separate pub/sub
-  channel. Single-instance fan-out (above) is complete.
+- **Cross-instance ephemeral** — done. Repo ephemeral gossip is published over
+  the collaboration `NOTIFY` channel in a typed envelope
+  (`realtime.CollaborationEphemeral`) that coexists with the bare version-id
+  "changed" signal; the receiving instance fans it out to local peers and
+  suppresses the publisher's own echo.
 - **Seeding** — the legacy handshake ships `SeedContent` for the client to apply;
   the repo protocol has no such field. The repo endpoint must instead seed the
   server-side document (authoritative) before serving, or rely on the first

--- a/pkg/automerge/collaboration/PROTOCOL.md
+++ b/pkg/automerge/collaboration/PROTOCOL.md
@@ -219,6 +219,51 @@ CBOR encoder:
 - `wire-join.json`, `wire-peer.json`, `wire-error.json` — the handshake frames.
 - `wire-sync.json`, `wire-ephemeral.json` — a framed document message.
 
+## Gateway wiring
+
+The protocol drivers (`ServerConn`, `ClientConn`) are transport-agnostic and
+fully tested. Wiring them into the authenticated production WebSocket endpoint
+reuses the existing collaboration hub rather than duplicating rooms, persistence,
+or cross-instance notification:
+
+- **Auth** — mount the repo route inside the same authenticated router group as
+  `/document-versions/{documentVersionID}/sync` and reuse
+  `documentCollaborationHandler.authorize`. The repo `PeerId` is never trusted as
+  identity.
+- **Document authority & persistence** — `hub.acquire` yields a lease over the
+  shared `*automerge.Document`; each connection uses its own
+  `Document.NewSyncState`. Sync fan-out reuses `lease.NotifyPeers`/`lease.Wake`
+  and persistence reuses `lease.SchedulePersist`/`lease.PersistError`, exactly as
+  the legacy handler does.
+- **Document id** — the frontend chooses the `automerge:<id>` URL, so the gateway
+  uses `NewAdoptingServerConn`: it announces nothing on `Start` and binds to the
+  id in the client's first `sync`/`request` frame, then answers for that id and
+  rejects any other. This removes the need for a server/frontend id-derivation
+  contract.
+- **Ephemeral (presence/cursors)** — repo presence travels as opaque `ephemeral`
+  frames, not the legacy structured snapshots. `ServerConn.Receive` returns a
+  non-duplicate ephemeral frame as `fanout`; the handler publishes it with
+  `lease.BroadcastEphemeral`, and reads other peers' frames from
+  `lease.Ephemeral` to write to its socket. This is scoped to one server
+  instance.
+
+### Remaining contract decisions before enabling the endpoint
+
+These need the migrated frontend (and a Postgres-backed integration test) to
+settle, so they are intentionally not encoded as untested production code yet:
+
+- **Cross-instance ephemeral** — `realtime.Events` currently carries only the
+  document-version id (a "changed" signal) over `NOTIFY`. Repo ephemeral gossip
+  across server instances needs the payload carried too, or a separate pub/sub
+  channel. Single-instance fan-out (above) is complete.
+- **Seeding** — the legacy handshake ships `SeedContent` for the client to apply;
+  the repo protocol has no such field. The repo endpoint must instead seed the
+  server-side document (authoritative) before serving, or rely on the first
+  writer. Which of these the frontend expects is undecided.
+- **Auth token transport** — a repo client sets no cookies by default; how the
+  frontend presents the session/bearer credential on the WebSocket upgrade must
+  match `authn` middleware expectations.
+
 ## Deliberately deferred
 
 - `remote-subscription-change` and `remote-heads-changed` handling (not needed by

--- a/pkg/automerge/collaboration/PROTOCOL.md
+++ b/pkg/automerge/collaboration/PROTOCOL.md
@@ -246,6 +246,14 @@ or cross-instance notification:
   `lease.BroadcastEphemeral`, and reads other peers' frames from
   `lease.Ephemeral` to write to its socket. This is scoped to one server
   instance.
+- **Selections/carets** — a caret or selection is published as a presence
+  `update` whose value is a `TextSelectionValue`: the addressed text field plus a
+  stable Automerge anchor and head cursor (the bytes from `Text.Cursor`), never
+  integer offsets. Offsets drift when anyone types before the caret; a cursor
+  resolves (via `Text.CursorPosition`) to the same character after arbitrary
+  concurrent edits, so remote carets stay anchored. The presence layer only
+  transports the cursor bytes, keeping it independent of the CRDT engine; the
+  server and Go agents create and resolve the cursors.
 
 ### Remaining contract decisions before enabling the endpoint
 

--- a/pkg/automerge/collaboration/PROTOCOL.md
+++ b/pkg/automerge/collaboration/PROTOCOL.md
@@ -1,0 +1,138 @@
+# automerge-repo protocol inventory
+
+This package makes the Probo Go server and Go agents speak the same collaboration
+protocol as the JavaScript `@automerge/automerge-repo` client, while keeping our
+own pure-Go CRDT engine (`pkg/automerge`) as the document authority.
+
+Everything here is derived from the pinned upstream source, not from guesswork.
+The wire format upstream ships is **alpha**, so the pinned version is the
+contract and the JS oracle fixtures under `testdata/` are the ground truth. No
+Go decoder or encoder is trusted until it round-trips those fixtures.
+
+## Pinned versions
+
+| Package | Version | Role |
+|---|---|---|
+| `@automerge/automerge` | `3.4.1` (`^3.4.0`) | CRDT core; sync message and cursor bytes |
+| `@automerge/automerge-repo` | `2.6.0-alpha.3` (exact) | repo message union, ephemeral gossip, Presence |
+| `@automerge/automerge-repo-network-websocket` | to pin in the transport phase | WebSocket wire framing and join/peer/leave handshake |
+
+The websocket adapter is a separate package and defines the actual on-socket
+framing. It is intentionally out of scope for this first inventory, which covers
+the message layer and Presence; the transport phase pins and inventories it.
+
+## Layering
+
+A byte on the socket nests three independently versioned layers:
+
+```text
+WebSocket adapter frame        (join / peer / leave + CBOR of the repo message)
+  └── repo message             (sync | request | ephemeral | doc-unavailable | ...)
+        └── payload
+              ├── sync/request: an Automerge V2 sync message (our engine owns this)
+              └── ephemeral:    CBOR of the Presence envelope
+```
+
+Our engine already owns the innermost layer. This package adds the middle layer
+and Presence; the transport phase adds the outermost.
+
+## Repo message union
+
+From `dist/network/messages.d.ts`. Every message carries `senderId` and
+`targetId` (both `PeerId`, a string). Type-specific fields:
+
+| `type` | Fields | Notes |
+|---|---|---|
+| `sync` | `documentId`, `data: Uint8Array` | `data` is an Automerge sync message |
+| `request` | `documentId`, `data: Uint8Array` | initial sync asking whether a peer has the doc |
+| `ephemeral` | `documentId`, `sessionId`, `count: number`, `data: Uint8Array` | gossiped; not persisted |
+| `doc-unavailable` | `documentId` | neither the peer nor its peers have the doc |
+| `remote-subscription-change` | `add?`, `remove?` (`StorageId[]`) | storage-head subscription control |
+| `remote-heads-changed` | `documentId`, `newHeads` | per-storage heads with timestamps |
+
+For our use case the document-scoped subset (`DocMessage`) is what matters:
+`sync`, `request`, `ephemeral`, `doc-unavailable`. The two remote-heads messages
+support cross-storage head subscription, which our single-authority server does
+not need initially; the gateway may ignore them (documented, not silently).
+
+## Ephemeral gossip and de-duplication
+
+Ephemeral messages are forwarded ("gossiped") to peers, so the protocol dedupes
+by `(sessionId, count)`:
+
+- `sessionId` is a random id chosen by a sender at startup.
+- `count` is a per-sender sequence number that strictly increases.
+- A receiver discards any `(sessionId, count)` it has already seen, which breaks
+  forwarding loops.
+
+The gateway must preserve `senderId`, `sessionId`, and `count` unchanged when
+relaying, and must apply the same de-duplication before re-broadcasting.
+
+## Presence envelope
+
+Presence (`dist/presence/`) rides entirely inside the ephemeral `data`. It never
+touches document history. The `data` bytes are the CBOR encoding of a single-key
+envelope:
+
+```jsonc
+{ "__presence": <presence message> }
+```
+
+The marker key is `__presence` (`PRESENCE_MESSAGE_MARKER`). The four presence
+messages:
+
+| `type` | Fields | Meaning |
+|---|---|---|
+| `update` | `channel: string`, `value: any` | one channel's state changed |
+| `snapshot` | `state: any` | full multi-channel state (sent on start and to newcomers) |
+| `heartbeat` | — | liveness when nothing changed |
+| `goodbye` | — | sender is leaving; forget it immediately |
+
+Defaults (`dist/presence/constants.js`):
+
+- heartbeat interval: `15000 ms`
+- peer TTL: `45000 ms` (three missed heartbeats)
+
+A peer is pruned once `peerTtlMs` passes with no message; `goodbye` prunes
+immediately. `value`/`state` are application-defined; our documents will carry an
+Automerge `Cursor` (opaque bytes) for selections rather than integer offsets.
+
+## CBOR encoding
+
+The ephemeral payload uses `cbor-x` configured as:
+
+```js
+new Encoder({ tagUint8Array: false, useRecords: false })
+```
+
+This matters for byte-level parity, and the Go codec must match it:
+
+- `useRecords: false` — plain CBOR maps (major type 5), not cbor-x record
+  extensions. No custom tags for object shapes.
+- `tagUint8Array: false` — a `Uint8Array` is a plain CBOR byte string (major
+  type 2), not wrapped in a typed-array tag.
+- Map key order follows insertion order of the JS object; a tolerant decoder
+  must not depend on key order, and the encoder should reproduce upstream order
+  where a fixture asserts byte identity.
+
+## Fixtures
+
+`testdata/` holds JS-generated fixtures produced by
+`packages/automerge-conformance/generate-collaboration-fixtures.mjs` using the
+pinned packages' own CBOR encoder, so they are byte-exact:
+
+- `presence-*.json` — each presence message type: the JS envelope plus its
+  base64 CBOR `data` bytes.
+- `ephemeral-*.json` — a full ephemeral repo message wrapping a presence payload.
+
+Each Go codec change must round-trip these. The wire-framing fixtures (join/peer
+handshake, socket frames) are added in the transport phase alongside the pinned
+websocket adapter.
+
+## Deliberately deferred
+
+- WebSocket adapter framing and the join/peer/leave handshake (transport phase).
+- `remote-subscription-change` and `remote-heads-changed` handling (not needed by
+  a single-authority gateway; revisit if multi-storage subscription is wanted).
+- Storage adapters: PostgreSQL remains the document authority; we do not adopt
+  repo storage.

--- a/pkg/automerge/collaboration/PROTOCOL.md
+++ b/pkg/automerge/collaboration/PROTOCOL.md
@@ -171,6 +171,35 @@ Both fields are optional. `isEphemeral` marks a peer that does not persist
 documents. Our gateway can present its own metadata and must not trust a peer's
 metadata as identity (see below).
 
+### Sync choreography (server as authority)
+
+The server WebSocket adapter is a pure relay: it performs the handshake and then
+hands every message to the repo's synchronizer. The synchronizer, not the
+adapter, runs the sync protocol, so a gateway that is itself the document
+authority must reproduce the synchronizer's server-side behavior. From
+`DocSynchronizer`:
+
+- Inbound `sync` and `request` are handled identically: apply the payload with
+  `receiveSyncMessage`, then generate outbound messages.
+- The message type the synchronizer emits is `request` only when it does **not**
+  have the document (no heads, empty shared heads, peer status unknown);
+  otherwise it emits `sync`. Our gateway always holds the document, so it
+  **always emits `sync`** and never `request`.
+- `doc-unavailable` is emitted only when the responder has no data and
+  availability settles unavailable. Our gateway always has the document (access
+  is decided by authentication at connect time, returning 404/403 rather than a
+  protocol frame), so it does **not** send `doc-unavailable`.
+- The payload bytes are exactly `generateSyncMessage`/`receiveSyncMessage` from
+  `@automerge/automerge`, which is the same V2 sync protocol
+  `pkg/automerge.SyncState` implements, so repo `sync.data` is one of our sync
+  messages unchanged. This is the interop linchpin and is covered by the existing
+  sync parity suite.
+
+The resulting server loop: on connect, announce by draining
+`GenerateMessage` into `sync` frames; on each inbound `sync`/`request`, call
+`ReceiveMessage` then drain `GenerateMessage` into `sync` frames; forward
+non-duplicate `ephemeral` frames to the room and room frames to the socket.
+
 ### Gateway responsibilities (transport)
 
 - Accept a binary WebSocket, read `join`, negotiate `"1"`, reply `peer` with a

--- a/pkg/automerge/collaboration/client.go
+++ b/pkg/automerge/collaboration/client.go
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import (
+	"context"
+	"fmt"
+)
+
+// ClientConfig configures the client side of a collaboration connection, used by
+// Go agents that participate as repo peers.
+type ClientConfig struct {
+	// ClientPeerID is the peer id the client advertises. It is the client's own
+	// identifier, chosen by the client.
+	ClientPeerID string
+	// PeerMetadata is the metadata the client presents. Optional.
+	PeerMetadata PeerMetadata
+	// DocumentID is the repo document id this connection syncs.
+	DocumentID string
+	// StartsEmpty reports whether the local document has no changes yet, which
+	// selects the first outbound sync message's type: a peer that does not have
+	// the document sends a request, one that already has it sends a sync. This
+	// mirrors the repo synchronizer's isNew rule.
+	StartsEmpty bool
+}
+
+// ClientConn is the synchronous, deterministic driver for the client side of one
+// collaboration connection. Like ServerConn it owns no socket and starts no
+// goroutines: the caller sends the join frame it returns, then feeds inbound
+// frames and sends the frames it returns. A Go agent wraps this with a real
+// socket and its own document.
+//
+// A ClientConn is not safe for concurrent use.
+type ClientConn struct {
+	config       ClientConfig
+	sync         SyncSession
+	serverPeerID string
+	joined       bool
+	sentFirst    bool
+	highestCount map[string]uint64
+}
+
+// NewClientConn creates a client connection driver for one document.
+func NewClientConn(config ClientConfig, sync SyncSession) (*ClientConn, error) {
+	if config.ClientPeerID == "" {
+		return nil, fmt.Errorf("client connection requires a client peer id")
+	}
+
+	if config.DocumentID == "" {
+		return nil, fmt.Errorf("client connection requires a document id")
+	}
+
+	if sync == nil {
+		return nil, fmt.Errorf("client connection requires a sync session")
+	}
+
+	return &ClientConn{
+		config:       config,
+		sync:         sync,
+		highestCount: make(map[string]uint64),
+	}, nil
+}
+
+// Start returns the join frame the client sends first.
+func (c *ClientConn) Start() ([]byte, error) {
+	return EncodeJoinFrame(NewJoinFrame(c.config.ClientPeerID, c.config.PeerMetadata))
+}
+
+// ClientInbound is the result of handling one inbound server frame.
+type ClientInbound struct {
+	// Outgoing frames to send to the server (sync or, for the first message, a
+	// request).
+	Outgoing [][]byte
+	// Ephemeral is a non-duplicate ephemeral message received from the server
+	// (gossiped from another peer), or nil. Its Data is a payload for the
+	// application, for example a presence message.
+	Ephemeral *Message
+	// Unavailable is true when the server reported the document unavailable.
+	Unavailable bool
+	// ServerError carries the message of a server error frame, which precedes the
+	// server closing the connection.
+	ServerError string
+}
+
+// Receive handles one inbound server frame. On the peer reply it completes the
+// handshake and emits the client's initial sync; on a sync or request it applies
+// the payload and emits the resulting sync; on an ephemeral it de-duplicates and
+// surfaces the payload; it reports an error or doc-unavailable frame.
+func (c *ClientConn) Receive(ctx context.Context, frame []byte) (ClientInbound, error) {
+	kind, err := FrameKind(frame)
+	if err != nil {
+		return ClientInbound{}, err
+	}
+
+	switch kind {
+	case FramePeer:
+		peer, err := DecodePeerFrame(frame)
+		if err != nil {
+			return ClientInbound{}, err
+		}
+
+		if peer.SelectedProtocolVersion != ProtocolV1 {
+			return ClientInbound{}, fmt.Errorf("server selected unsupported protocol version %q",
+				peer.SelectedProtocolVersion)
+		}
+
+		c.joined = true
+		c.serverPeerID = peer.SenderID
+
+		outgoing, err := c.drainSync(ctx)
+		if err != nil {
+			return ClientInbound{}, err
+		}
+
+		return ClientInbound{Outgoing: outgoing}, nil
+	case FrameError:
+		errorFrame, err := DecodeErrorFrame(frame)
+		if err != nil {
+			return ClientInbound{}, err
+		}
+
+		return ClientInbound{ServerError: errorFrame.Message}, nil
+	}
+
+	if !c.joined {
+		return ClientInbound{}, fmt.Errorf("received %q before the handshake completed", kind)
+	}
+
+	switch MessageType(kind) {
+	case MessageSync, MessageRequest:
+		message, err := DecodeMessage(frame)
+		if err != nil {
+			return ClientInbound{}, err
+		}
+
+		if err := c.sync.ReceiveMessage(ctx, message.Data); err != nil {
+			return ClientInbound{}, fmt.Errorf("cannot apply inbound sync message: %w", err)
+		}
+
+		outgoing, err := c.drainSync(ctx)
+		if err != nil {
+			return ClientInbound{}, err
+		}
+
+		return ClientInbound{Outgoing: outgoing}, nil
+	case MessageEphemeral:
+		message, err := DecodeMessage(frame)
+		if err != nil {
+			return ClientInbound{}, err
+		}
+
+		if c.seenEphemeral(message) {
+			return ClientInbound{}, nil
+		}
+
+		return ClientInbound{Ephemeral: &message}, nil
+	case MessageDocUnavailable:
+		return ClientInbound{Unavailable: true}, nil
+	default:
+		return ClientInbound{}, nil
+	}
+}
+
+// SyncChanged drains sync frames after the local document changed, so local
+// edits propagate to the server.
+func (c *ClientConn) SyncChanged(ctx context.Context) ([][]byte, error) {
+	if !c.joined {
+		return nil, fmt.Errorf("cannot sync before the handshake completed")
+	}
+
+	return c.drainSync(ctx)
+}
+
+// Ephemeral builds an ephemeral frame carrying an application payload (such as a
+// presence message) for the server to gossip. The caller supplies the session id
+// chosen at startup and a per-session count that must strictly increase.
+func (c *ClientConn) Ephemeral(sessionID string, count uint64, payload []byte) ([]byte, error) {
+	if !c.joined {
+		return nil, fmt.Errorf("cannot send ephemeral before the handshake completed")
+	}
+
+	return EncodeMessage(Message{
+		Type:       MessageEphemeral,
+		SenderID:   c.config.ClientPeerID,
+		TargetID:   c.serverPeerID,
+		DocumentID: c.config.DocumentID,
+		SessionID:  sessionID,
+		Count:      count,
+		Data:       payload,
+	})
+}
+
+// drainSync generates sync frames until the client is up to date. The first
+// outbound message is a request when the local document started empty, matching
+// the repo synchronizer; every later message is a sync.
+func (c *ClientConn) drainSync(ctx context.Context) ([][]byte, error) {
+	var frames [][]byte
+
+	for {
+		message, ok, err := c.sync.GenerateMessage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("cannot generate sync message: %w", err)
+		}
+
+		if !ok {
+			return frames, nil
+		}
+
+		messageType := MessageSync
+		if !c.sentFirst && c.config.StartsEmpty {
+			messageType = MessageRequest
+		}
+
+		c.sentFirst = true
+
+		frame, err := EncodeMessage(Message{
+			Type:       messageType,
+			SenderID:   c.config.ClientPeerID,
+			TargetID:   c.serverPeerID,
+			DocumentID: c.config.DocumentID,
+			Data:       message,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		frames = append(frames, frame)
+	}
+}
+
+func (c *ClientConn) seenEphemeral(message Message) bool {
+	highest, ok := c.highestCount[message.SessionID]
+	if ok && message.Count <= highest {
+		return true
+	}
+
+	c.highestCount[message.SessionID] = message.Count
+
+	return false
+}
+
+// ServerPeerID returns the server's peer id once the handshake has completed.
+func (c *ClientConn) ServerPeerID() string {
+	return c.serverPeerID
+}

--- a/pkg/automerge/collaboration/client_test.go
+++ b/pkg/automerge/collaboration/client_test.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/automerge"
+	"go.probo.inc/probo/pkg/automerge/collaboration"
+)
+
+// clientServerHarness drives a ClientConn against a ServerConn, moving frames
+// between them until both are quiescent, so a test can assert convergence.
+type clientServerHarness struct {
+	t      *testing.T
+	ctx    context.Context
+	client *collaboration.ClientConn
+	server *collaboration.ServerConn
+}
+
+// pump exchanges frames until neither side produces more, starting from the
+// client's join. It bounds the rounds so a protocol bug fails instead of hangs.
+func (h *clientServerHarness) pump() {
+	h.t.Helper()
+
+	join, err := h.client.Start()
+	require.NoError(h.t, err)
+
+	serverOut, accepted, err := h.server.Start(h.ctx, join)
+	require.NoError(h.t, err)
+	require.True(h.t, accepted)
+
+	toClient := serverOut
+	var toServer [][]byte
+
+	for round := 0; round < 50; round++ {
+		var nextToServer [][]byte
+
+		for _, frame := range toClient {
+			inbound, err := h.client.Receive(h.ctx, frame)
+			require.NoError(h.t, err)
+			nextToServer = append(nextToServer, inbound.Outgoing...)
+		}
+
+		toClient = nil
+
+		var nextToClient [][]byte
+
+		for _, frame := range append(toServer, nextToServer...) {
+			reply, _, err := h.server.Receive(h.ctx, frame)
+			require.NoError(h.t, err)
+			nextToClient = append(nextToClient, reply...)
+		}
+
+		toServer = nil
+
+		if len(nextToServer) == 0 && len(nextToClient) == 0 {
+			return
+		}
+
+		toClient = nextToClient
+	}
+
+	h.t.Fatal("client and server did not converge")
+}
+
+func newHarness(
+	t *testing.T,
+	ctx context.Context,
+	client *automerge.Document,
+	clientEmpty bool,
+	server *automerge.Document,
+) *clientServerHarness {
+	t.Helper()
+
+	clientSync, err := client.NewSyncState(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clientSync.Close(ctx) })
+
+	serverSync, err := server.NewSyncState(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSync.Close(ctx) })
+
+	clientConn, err := collaboration.NewClientConn(collaboration.ClientConfig{
+		ClientPeerID: "agent",
+		DocumentID:   "doc-1",
+		StartsEmpty:  clientEmpty,
+	}, clientSync)
+	require.NoError(t, err)
+
+	serverConn, err := collaboration.NewServerConn(
+		collaboration.ServerConfig{ServerPeerID: "server"},
+		"doc-1",
+		serverSync,
+	)
+	require.NoError(t, err)
+
+	return &clientServerHarness{t: t, ctx: ctx, client: clientConn, server: serverConn}
+}
+
+// TestClientConn_LearnsServerDocument syncs an empty Go client from a server
+// that holds the document, driver to driver.
+func TestClientConn_LearnsServerDocument(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	server, err := automerge.New(ctx, actor(1))
+	require.NoError(t, err)
+	defer func() { _ = server.Close(ctx) }()
+
+	text, err := server.CreateText(ctx, "body")
+	require.NoError(t, err)
+	require.NoError(t, text.Splice(ctx, 0, 0, "hello world"))
+	_, err = server.Commit(ctx, "seed", commitTime())
+	require.NoError(t, err)
+
+	client, err := automerge.New(ctx, actor(2))
+	require.NoError(t, err)
+	defer func() { _ = client.Close(ctx) }()
+
+	newHarness(t, ctx, client, true, server).pump()
+
+	serverHeads, err := server.Heads(ctx)
+	require.NoError(t, err)
+	clientHeads, err := client.Heads(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, serverHeads, clientHeads)
+
+	clientText, err := client.Text(ctx, "body")
+	require.NoError(t, err)
+	value, err := clientText.String(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", value)
+}
+
+// TestClientConn_PushesLocalEdits syncs a client that already has content into a
+// server that starts empty, so the request/sync direction is reversed.
+func TestClientConn_PushesLocalEdits(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	server, err := automerge.New(ctx, actor(1))
+	require.NoError(t, err)
+	defer func() { _ = server.Close(ctx) }()
+
+	client, err := automerge.New(ctx, actor(2))
+	require.NoError(t, err)
+	defer func() { _ = client.Close(ctx) }()
+
+	text, err := client.CreateText(ctx, "body")
+	require.NoError(t, err)
+	require.NoError(t, text.Splice(ctx, 0, 0, "from the agent"))
+	_, err = client.Commit(ctx, "edit", commitTime())
+	require.NoError(t, err)
+
+	newHarness(t, ctx, client, false, server).pump()
+
+	serverText, err := server.Text(ctx, "body")
+	require.NoError(t, err)
+	value, err := serverText.String(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "from the agent", value)
+}
+
+// TestClientConn_FirstMessageIsRequestWhenEmpty checks the request/sync
+// selection an empty client uses for its first outbound message.
+func TestClientConn_FirstMessageIsRequestWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	client, err := automerge.New(ctx, actor(2))
+	require.NoError(t, err)
+	defer func() { _ = client.Close(ctx) }()
+
+	sync, err := client.NewSyncState(ctx)
+	require.NoError(t, err)
+	defer func() { _ = sync.Close(ctx) }()
+
+	conn, err := collaboration.NewClientConn(collaboration.ClientConfig{
+		ClientPeerID: "agent", DocumentID: "doc-1", StartsEmpty: true,
+	}, sync)
+	require.NoError(t, err)
+
+	// Complete the handshake with a peer frame so the client emits its first sync.
+	peer, err := collaboration.EncodePeerFrame(collaboration.PeerFrame{
+		Type: collaboration.FramePeer, SenderID: "server", TargetID: "agent",
+		SelectedProtocolVersion: collaboration.ProtocolV1,
+	})
+	require.NoError(t, err)
+
+	inbound, err := conn.Receive(ctx, peer)
+	require.NoError(t, err)
+	require.NotEmpty(t, inbound.Outgoing)
+
+	message, err := collaboration.DecodeMessage(inbound.Outgoing[0])
+	require.NoError(t, err)
+	assert.Equal(t, collaboration.MessageRequest, message.Type,
+		"an empty client's first message is a request")
+}
+
+// TestClientConn_SurfacesServerError reports an error frame to the caller.
+func TestClientConn_SurfacesServerError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	client, err := automerge.New(ctx, actor(2))
+	require.NoError(t, err)
+	defer func() { _ = client.Close(ctx) }()
+
+	sync, err := client.NewSyncState(ctx)
+	require.NoError(t, err)
+	defer func() { _ = sync.Close(ctx) }()
+
+	conn, err := collaboration.NewClientConn(collaboration.ClientConfig{
+		ClientPeerID: "agent", DocumentID: "doc-1", StartsEmpty: true,
+	}, sync)
+	require.NoError(t, err)
+
+	errorFrame, err := collaboration.EncodeErrorFrame(collaboration.ErrorFrame{
+		Type: collaboration.FrameError, SenderID: "server", TargetID: "agent",
+		Message: "unauthorized",
+	})
+	require.NoError(t, err)
+
+	inbound, err := conn.Receive(ctx, errorFrame)
+	require.NoError(t, err)
+	assert.Equal(t, "unauthorized", inbound.ServerError)
+}

--- a/pkg/automerge/collaboration/codec.go
+++ b/pkg/automerge/collaboration/codec.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Package collaboration lets the Go server and Go agents speak the
+// automerge-repo protocol against Probo's own pure-Go CRDT engine. This file
+// defines the shared CBOR modes used for every protocol payload.
+//
+// The wire format is produced upstream by cbor-x. Our decoder accepts what that
+// encoder emits (including its non-canonical 16-bit map-length prefixes) and our
+// encoder produces deterministic CBOR that cbor-x decodes without issue; byte
+// identity with cbor-x is deliberately not a goal, semantic interoperability is.
+// The protocol and its ground-truth fixtures are described in PROTOCOL.md.
+package collaboration
+
+import (
+	"fmt"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+// Resource limits guard the decoder against hostile payloads. Presence values
+// are application-defined, so the bounds are generous but finite.
+const (
+	maxNestedLevels   = 64
+	maxMapPairs       = 4096
+	maxArrayElements  = 65536
+	maxDecodedPayload = 1 << 20 // 1 MiB per ephemeral payload
+)
+
+var (
+	decMode cbor.DecMode
+	encMode cbor.EncMode
+)
+
+func init() {
+	decoder, err := cbor.DecOptions{
+		// Reject streaming payloads: every length must be known up front.
+		IndefLength: cbor.IndefLengthForbidden,
+		// A repeated map key is a malformed or hostile payload, not a merge.
+		DupMapKey: cbor.DupMapKeyEnforcedAPF,
+		// The presence and repo protocols use no CBOR tags; cbor-x emits none
+		// because it is configured with tagUint8Array:false, so any tag is
+		// unexpected and rejected.
+		TagsMd:           cbor.TagsForbidden,
+		MaxNestedLevels:  maxNestedLevels,
+		MaxMapPairs:      maxMapPairs,
+		MaxArrayElements: maxArrayElements,
+	}.DecMode()
+	if err != nil {
+		panic(fmt.Sprintf("collaboration: invalid CBOR decode options: %v", err))
+	}
+
+	// Deterministic core encoding: shortest-form integers and sorted map keys,
+	// so our output is stable and reproducible. cbor-x decodes it regardless of
+	// key order.
+	encoder, err := cbor.CoreDetEncOptions().EncMode()
+	if err != nil {
+		panic(fmt.Sprintf("collaboration: invalid CBOR encode options: %v", err))
+	}
+
+	decMode = decoder
+	encMode = encoder
+}
+
+// unmarshal decodes CBOR into value using the strict shared decode mode, after
+// bounding the payload size.
+func unmarshal(data []byte, value any) error {
+	if len(data) > maxDecodedPayload {
+		return fmt.Errorf("collaboration payload of %d bytes exceeds the %d byte limit",
+			len(data), maxDecodedPayload)
+	}
+
+	return decMode.Unmarshal(data, value)
+}
+
+// marshal encodes value as deterministic CBOR using the shared encode mode.
+func marshal(value any) ([]byte, error) {
+	return encMode.Marshal(value)
+}

--- a/pkg/automerge/collaboration/conn.go
+++ b/pkg/automerge/collaboration/conn.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import (
+	"context"
+	"fmt"
+)
+
+// SyncSession is the subset of an Automerge sync state the connection driver
+// needs. *automerge.SyncState satisfies it, so the driver never touches the
+// CRDT engine directly.
+type SyncSession interface {
+	// GenerateMessage returns the next outbound sync message for this peer, or
+	// ok=false when the peer is up to date.
+	GenerateMessage(ctx context.Context) ([]byte, bool, error)
+	// ReceiveMessage applies an inbound sync message from this peer.
+	ReceiveMessage(ctx context.Context, message []byte) error
+}
+
+// ServerConn is the synchronous, deterministic driver for one collaboration
+// connection on the server side. It owns no socket and spawns no goroutines: the
+// adapter reads a frame, calls the matching method, and sends the frames
+// returned. This keeps the protocol behavior unit-testable and leaves I/O,
+// rooms, and authentication to the server wiring.
+//
+// A ServerConn is not safe for concurrent use; the adapter drives it from one
+// connection goroutine.
+type ServerConn struct {
+	session      *ServerSession
+	sync         SyncSession
+	documentID   string
+	serverPeerID string
+	remotePeerID string
+	started      bool
+}
+
+// NewServerConn creates a connection driver for one document. documentID is the
+// automerge-repo document id this connection is scoped to, and sync is the peer's
+// sync state.
+func NewServerConn(config ServerConfig, documentID string, sync SyncSession) (*ServerConn, error) {
+	session, err := NewServerSession(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if documentID == "" {
+		return nil, fmt.Errorf("server connection requires a document id")
+	}
+
+	if sync == nil {
+		return nil, fmt.Errorf("server connection requires a sync session")
+	}
+
+	return &ServerConn{
+		session:      session,
+		sync:         sync,
+		documentID:   documentID,
+		serverPeerID: config.ServerPeerID,
+	}, nil
+}
+
+// Start processes the client's join frame and returns the frames to send: the
+// handshake reply, then, when accepted, the initial sync frames that announce
+// the document. When accepted is false the single reply is an error frame and
+// the socket should be closed after sending it.
+func (c *ServerConn) Start(ctx context.Context, joinFrame []byte) (out [][]byte, accepted bool, err error) {
+	if c.started {
+		return nil, false, fmt.Errorf("server connection already started")
+	}
+
+	handshake, err := c.session.Accept(joinFrame)
+	if err != nil {
+		return nil, false, err
+	}
+
+	out = append(out, handshake.Reply)
+
+	if !handshake.Accepted {
+		return out, false, nil
+	}
+
+	c.started = true
+	c.remotePeerID = handshake.RemotePeerID
+
+	// Announce: drain the initial sync messages the server has for this peer.
+	syncFrames, err := c.drainSync(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return append(out, syncFrames...), true, nil
+}
+
+// Receive handles one post-handshake frame. A sync or request frame is applied
+// and answered with the resulting sync frames (reply). A non-duplicate ephemeral
+// frame is returned in fanout to publish to the room, unchanged. Duplicate
+// ephemerals, doc-unavailable, and unrecognised control frames yield nothing.
+func (c *ServerConn) Receive(ctx context.Context, frame []byte) (reply [][]byte, fanout []byte, err error) {
+	if !c.started {
+		return nil, nil, fmt.Errorf("received a frame before the connection was started")
+	}
+
+	inbound, err := c.session.Receive(frame)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch inbound.Kind {
+	case InboundSync:
+		if err := c.sync.ReceiveMessage(ctx, inbound.Message.Data); err != nil {
+			return nil, nil, fmt.Errorf("cannot apply inbound sync message: %w", err)
+		}
+
+		frames, err := c.drainSync(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return frames, nil, nil
+	case InboundEphemeral:
+		if inbound.Duplicate {
+			return nil, nil, nil
+		}
+
+		return nil, frame, nil
+	default:
+		// InboundDocUnavailable and InboundIgnored need no server action: the
+		// gateway is the document authority.
+		return nil, nil, nil
+	}
+}
+
+// SyncChanged drains any sync messages produced because the document changed
+// from another source (a peer's merge, a server-side edit). The adapter calls it
+// when the room signals the document advanced.
+func (c *ServerConn) SyncChanged(ctx context.Context) ([][]byte, error) {
+	if !c.started {
+		return nil, fmt.Errorf("cannot sync a connection before it is started")
+	}
+
+	return c.drainSync(ctx)
+}
+
+// drainSync generates sync frames until the peer is up to date. The server is
+// always the document authority, so every generated message is a sync frame,
+// never a request.
+func (c *ServerConn) drainSync(ctx context.Context) ([][]byte, error) {
+	var frames [][]byte
+
+	for {
+		message, ok, err := c.sync.GenerateMessage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("cannot generate sync message: %w", err)
+		}
+
+		if !ok {
+			return frames, nil
+		}
+
+		frame, err := EncodeMessage(Message{
+			Type:       MessageSync,
+			SenderID:   c.serverPeerID,
+			TargetID:   c.remotePeerID,
+			DocumentID: c.documentID,
+			Data:       message,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		frames = append(frames, frame)
+	}
+}
+
+// RemotePeerID returns the connected client's peer id after Start.
+func (c *ServerConn) RemotePeerID() string {
+	return c.remotePeerID
+}

--- a/pkg/automerge/collaboration/conn.go
+++ b/pkg/automerge/collaboration/conn.go
@@ -48,22 +48,42 @@ type ServerConn struct {
 	session      *ServerSession
 	sync         SyncSession
 	documentID   string
+	adoptDocID   bool
 	serverPeerID string
 	remotePeerID string
 	started      bool
 }
 
-// NewServerConn creates a connection driver for one document. documentID is the
-// automerge-repo document id this connection is scoped to, and sync is the peer's
-// sync state.
+// NewServerConn creates a connection driver for a known document. documentID is
+// the automerge-repo document id this connection is scoped to, and sync is the
+// peer's sync state. Use this when the server already knows which document the
+// connection serves and both peers agree on the id; the server announces the
+// document proactively after the handshake.
+//
+// When the id the client will request is not known ahead of time (the common
+// production case, where the frontend picks the automerge:<id> URL), use
+// NewAdoptingServerConn instead.
 func NewServerConn(config ServerConfig, documentID string, sync SyncSession) (*ServerConn, error) {
+	if documentID == "" {
+		return nil, fmt.Errorf("server connection requires a document id")
+	}
+
+	return newServerConn(config, documentID, false, sync)
+}
+
+// NewAdoptingServerConn creates a connection driver that learns its document id
+// from the client's first sync or request frame. Because the id is unknown until
+// then, the server does not announce the document in Start; it answers the
+// client once the client asks for a specific document. Every subsequent frame on
+// the connection must reference the same id.
+func NewAdoptingServerConn(config ServerConfig, sync SyncSession) (*ServerConn, error) {
+	return newServerConn(config, "", true, sync)
+}
+
+func newServerConn(config ServerConfig, documentID string, adopt bool, sync SyncSession) (*ServerConn, error) {
 	session, err := NewServerSession(config)
 	if err != nil {
 		return nil, err
-	}
-
-	if documentID == "" {
-		return nil, fmt.Errorf("server connection requires a document id")
 	}
 
 	if sync == nil {
@@ -74,6 +94,7 @@ func NewServerConn(config ServerConfig, documentID string, sync SyncSession) (*S
 		session:      session,
 		sync:         sync,
 		documentID:   documentID,
+		adoptDocID:   adopt,
 		serverPeerID: config.ServerPeerID,
 	}, nil
 }
@@ -101,6 +122,12 @@ func (c *ServerConn) Start(ctx context.Context, joinFrame []byte) (out [][]byte,
 	c.started = true
 	c.remotePeerID = handshake.RemotePeerID
 
+	// In adopt mode the document id is unknown until the client asks for it, so
+	// there is nothing to announce yet: the client drives with a request frame.
+	if c.adoptDocID {
+		return out, true, nil
+	}
+
 	// Announce: drain the initial sync messages the server has for this peer.
 	syncFrames, err := c.drainSync(ctx)
 	if err != nil {
@@ -126,6 +153,10 @@ func (c *ServerConn) Receive(ctx context.Context, frame []byte) (reply [][]byte,
 
 	switch inbound.Kind {
 	case InboundSync:
+		if err := c.adoptDocumentID(inbound.Message.DocumentID); err != nil {
+			return nil, nil, err
+		}
+
 		if err := c.sync.ReceiveMessage(ctx, inbound.Message.Data); err != nil {
 			return nil, nil, fmt.Errorf("cannot apply inbound sync message: %w", err)
 		}
@@ -160,10 +191,40 @@ func (c *ServerConn) SyncChanged(ctx context.Context) ([][]byte, error) {
 	return c.drainSync(ctx)
 }
 
+// adoptDocumentID binds the connection to the document id the client asked for.
+// A fixed-id connection rejects a mismatching id; an adopting one records the
+// first non-empty id it sees and then holds the peer to it. This guarantees one
+// connection only ever serves a single document.
+func (c *ServerConn) adoptDocumentID(id string) error {
+	if id == "" {
+		return nil
+	}
+
+	if c.documentID == "" {
+		c.documentID = id
+
+		return nil
+	}
+
+	if c.documentID != id {
+		return fmt.Errorf(
+			"connection scoped to document %q received a frame for document %q",
+			c.documentID, id,
+		)
+	}
+
+	return nil
+}
+
 // drainSync generates sync frames until the peer is up to date. The server is
 // always the document authority, so every generated message is a sync frame,
-// never a request.
+// never a request. Before the document id is known (adopt mode, prior to the
+// client's first request) there is nothing to send.
 func (c *ServerConn) drainSync(ctx context.Context) ([][]byte, error) {
+	if c.documentID == "" {
+		return nil, nil
+	}
+
 	var frames [][]byte
 
 	for {
@@ -194,4 +255,11 @@ func (c *ServerConn) drainSync(ctx context.Context) ([][]byte, error) {
 // RemotePeerID returns the connected client's peer id after Start.
 func (c *ServerConn) RemotePeerID() string {
 	return c.remotePeerID
+}
+
+// DocumentID returns the document id this connection serves. For an adopting
+// connection it is empty until the client's first sync or request frame binds
+// it.
+func (c *ServerConn) DocumentID() string {
+	return c.documentID
 }

--- a/pkg/automerge/collaboration/conn_test.go
+++ b/pkg/automerge/collaboration/conn_test.go
@@ -205,6 +205,93 @@ func TestServerConn_SyncChangedDrains(t *testing.T) {
 	assert.Equal(t, []byte{3, 3}, message.Data)
 }
 
+// TestAdoptingServerConn_LearnsDocumentIDFromClient starts without a document id
+// (so it announces nothing) and adopts the id from the client's first sync
+// frame, then answers for that same id.
+func TestAdoptingServerConn_LearnsDocumentIDFromClient(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sync := &scriptedSync{}
+
+	conn, err := NewAdoptingServerConn(ServerConfig{ServerPeerID: "server"}, sync)
+	require.NoError(t, err)
+
+	out, accepted, err := conn.Start(ctx, joinFixture(t))
+	require.NoError(t, err)
+	require.True(t, accepted)
+	require.Len(t, out, 1, "an adopting connection announces nothing until the client asks")
+	assert.Empty(t, conn.DocumentID())
+
+	sync.outbound = [][]byte{{9, 9}}
+
+	inboundSync, err := EncodeMessage(Message{
+		Type: MessageSync, SenderID: "peer-a", TargetID: "server",
+		DocumentID: "client-chosen-doc", Data: []byte{7, 7},
+	})
+	require.NoError(t, err)
+
+	reply, _, err := conn.Receive(ctx, inboundSync)
+	require.NoError(t, err)
+	require.Len(t, reply, 1)
+	assert.Equal(t, "client-chosen-doc", conn.DocumentID())
+
+	message, err := DecodeMessage(reply[0])
+	require.NoError(t, err)
+	assert.Equal(t, "client-chosen-doc", message.DocumentID,
+		"the server answers for the id the client requested")
+}
+
+// TestAdoptingServerConn_RejectsSecondDocument holds the connection to the first
+// document id it adopts.
+func TestAdoptingServerConn_RejectsSecondDocument(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn, err := NewAdoptingServerConn(ServerConfig{ServerPeerID: "server"}, &scriptedSync{})
+	require.NoError(t, err)
+
+	_, _, err = conn.Start(ctx, joinFixture(t))
+	require.NoError(t, err)
+
+	first, err := EncodeMessage(Message{
+		Type: MessageSync, SenderID: "peer-a", TargetID: "server",
+		DocumentID: "doc-a", Data: []byte{1},
+	})
+	require.NoError(t, err)
+	_, _, err = conn.Receive(ctx, first)
+	require.NoError(t, err)
+
+	second, err := EncodeMessage(Message{
+		Type: MessageSync, SenderID: "peer-a", TargetID: "server",
+		DocumentID: "doc-b", Data: []byte{2},
+	})
+	require.NoError(t, err)
+	_, _, err = conn.Receive(ctx, second)
+	require.Error(t, err)
+}
+
+// TestServerConn_RejectsForeignDocument keeps a fixed-id connection from serving
+// a different document than it was constructed for.
+func TestServerConn_RejectsForeignDocument(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newConn(t, &scriptedSync{})
+
+	_, _, err := conn.Start(ctx, joinFixture(t))
+	require.NoError(t, err)
+
+	foreign, err := EncodeMessage(Message{
+		Type: MessageSync, SenderID: "peer-a", TargetID: "server",
+		DocumentID: "other-doc", Data: []byte{1},
+	})
+	require.NoError(t, err)
+
+	_, _, err = conn.Receive(ctx, foreign)
+	require.Error(t, err)
+}
+
 // TestServerConn_RequiresStart refuses frames before the handshake.
 func TestServerConn_RequiresStart(t *testing.T) {
 	t.Parallel()

--- a/pkg/automerge/collaboration/conn_test.go
+++ b/pkg/automerge/collaboration/conn_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedSync is a fake SyncSession: it yields a scripted sequence of outbound
+// messages and records the inbound messages applied to it.
+type scriptedSync struct {
+	outbound [][]byte
+	received [][]byte
+}
+
+func (s *scriptedSync) GenerateMessage(context.Context) ([]byte, bool, error) {
+	if len(s.outbound) == 0 {
+		return nil, false, nil
+	}
+
+	next := s.outbound[0]
+	s.outbound = s.outbound[1:]
+
+	return next, true, nil
+}
+
+func (s *scriptedSync) ReceiveMessage(_ context.Context, message []byte) error {
+	s.received = append(s.received, message)
+
+	return nil
+}
+
+func newConn(t *testing.T, sync SyncSession) *ServerConn {
+	t.Helper()
+
+	conn, err := NewServerConn(ServerConfig{ServerPeerID: "server"}, "doc-1", sync)
+	require.NoError(t, err)
+
+	return conn
+}
+
+func joinFixture(t *testing.T) []byte {
+	t.Helper()
+
+	return decodeBase64(t, readFixture[wireFixture](t, "wire-join.json").FrameCBORBase64)
+}
+
+// TestServerConn_StartAnnouncesInitialSync sends the peer reply then a sync frame
+// for each initial sync message.
+func TestServerConn_StartAnnouncesInitialSync(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sync := &scriptedSync{outbound: [][]byte{{1, 1}, {2, 2}}}
+	conn := newConn(t, sync)
+
+	out, accepted, err := conn.Start(ctx, joinFixture(t))
+	require.NoError(t, err)
+	require.True(t, accepted)
+	require.Len(t, out, 3) // peer reply + two sync frames
+
+	peer, err := DecodePeerFrame(out[0])
+	require.NoError(t, err)
+	assert.Equal(t, ProtocolV1, peer.SelectedProtocolVersion)
+
+	for _, frame := range out[1:] {
+		message, err := DecodeMessage(frame)
+		require.NoError(t, err)
+		assert.Equal(t, MessageSync, message.Type)
+		assert.Equal(t, "server", message.SenderID)
+		assert.Equal(t, "peer-a", message.TargetID)
+		assert.Equal(t, "doc-1", message.DocumentID)
+	}
+}
+
+// TestServerConn_RejectsUnsupportedVersion returns an error frame and does not
+// start.
+func TestServerConn_RejectsUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	join, err := marshal(JoinFrame{
+		Type:                      FrameJoin,
+		SenderID:                  "peer-a",
+		SupportedProtocolVersions: []string{"999"},
+	})
+	require.NoError(t, err)
+
+	conn := newConn(t, &scriptedSync{})
+	out, accepted, err := conn.Start(context.Background(), join)
+	require.NoError(t, err)
+	assert.False(t, accepted)
+	require.Len(t, out, 1)
+
+	_, err = DecodeErrorFrame(out[0])
+	require.NoError(t, err)
+}
+
+// TestServerConn_AppliesInboundSyncAndReplies applies an inbound sync message
+// and answers with the generated sync frames.
+func TestServerConn_AppliesInboundSyncAndReplies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sync := &scriptedSync{}
+	conn := newConn(t, sync)
+
+	_, accepted, err := conn.Start(ctx, joinFixture(t))
+	require.NoError(t, err)
+	require.True(t, accepted)
+
+	// The next generate call yields one reply message.
+	sync.outbound = [][]byte{{9, 9}}
+
+	inboundSync, err := EncodeMessage(Message{
+		Type: MessageSync, SenderID: "peer-a", TargetID: "server",
+		DocumentID: "doc-1", Data: []byte{7, 7},
+	})
+	require.NoError(t, err)
+
+	reply, fanout, err := conn.Receive(ctx, inboundSync)
+	require.NoError(t, err)
+	assert.Nil(t, fanout)
+	require.Len(t, reply, 1)
+
+	assert.Equal(t, [][]byte{{7, 7}}, sync.received)
+
+	message, err := DecodeMessage(reply[0])
+	require.NoError(t, err)
+	assert.Equal(t, MessageSync, message.Type)
+	assert.Equal(t, []byte{9, 9}, message.Data)
+}
+
+// TestServerConn_FansOutEphemeralOnce forwards a fresh ephemeral and drops a
+// duplicate.
+func TestServerConn_FansOutEphemeralOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newConn(t, &scriptedSync{})
+
+	_, _, err := conn.Start(ctx, joinFixture(t))
+	require.NoError(t, err)
+
+	payload, err := EncodePresence(PresenceMessage{Type: PresenceHeartbeat})
+	require.NoError(t, err)
+
+	ephemeral, err := EncodeMessage(Message{
+		Type: MessageEphemeral, SenderID: "peer-a", TargetID: "server",
+		DocumentID: "doc-1", SessionID: "s", Count: 1, Data: payload,
+	})
+	require.NoError(t, err)
+
+	reply, fanout, err := conn.Receive(ctx, ephemeral)
+	require.NoError(t, err)
+	assert.Nil(t, reply)
+	assert.Equal(t, ephemeral, fanout, "a fresh ephemeral is forwarded unchanged")
+
+	_, fanoutAgain, err := conn.Receive(ctx, ephemeral)
+	require.NoError(t, err)
+	assert.Nil(t, fanoutAgain, "a duplicate ephemeral is dropped")
+}
+
+// TestServerConn_SyncChangedDrains produces sync frames when the document
+// advanced from another source.
+func TestServerConn_SyncChangedDrains(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sync := &scriptedSync{}
+	conn := newConn(t, sync)
+
+	_, _, err := conn.Start(ctx, joinFixture(t))
+	require.NoError(t, err)
+
+	sync.outbound = [][]byte{{3, 3}}
+	frames, err := conn.SyncChanged(ctx)
+	require.NoError(t, err)
+	require.Len(t, frames, 1)
+
+	message, err := DecodeMessage(frames[0])
+	require.NoError(t, err)
+	assert.Equal(t, MessageSync, message.Type)
+	assert.Equal(t, []byte{3, 3}, message.Data)
+}
+
+// TestServerConn_RequiresStart refuses frames before the handshake.
+func TestServerConn_RequiresStart(t *testing.T) {
+	t.Parallel()
+
+	conn := newConn(t, &scriptedSync{})
+	_, _, err := conn.Receive(context.Background(), []byte{0xa0})
+	assert.Error(t, err)
+}

--- a/pkg/automerge/collaboration/documentid.go
+++ b/pkg/automerge/collaboration/documentid.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+// AutomergeURLPrefix is the scheme automerge-repo puts in front of a document id
+// to form a document URL, for example "automerge:34YWzjYt5gPJpq5RfXAkPfPcUj1r".
+const AutomergeURLPrefix = "automerge:"
+
+// DocumentIDByteLength is the length of the binary document id automerge-repo
+// base58check-encodes: a 16-byte (128-bit) identifier.
+const DocumentIDByteLength = 16
+
+// base58Alphabet is the Bitcoin base58 alphabet automerge-repo's bs58check uses.
+const base58Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+// EncodeDocumentID encodes a 16-byte identifier as an automerge-repo document id
+// using base58check (base58 of the payload followed by the first four bytes of
+// its double SHA-256), matching @automerge/automerge-repo's binaryToDocumentId.
+func EncodeDocumentID(id [DocumentIDByteLength]byte) string {
+	return base58CheckEncode(id[:])
+}
+
+// DecodeDocumentID decodes an automerge-repo document id back to its 16 bytes,
+// rejecting a bad checksum or a payload that is not 16 bytes long.
+func DecodeDocumentID(documentID string) ([DocumentIDByteLength]byte, error) {
+	var id [DocumentIDByteLength]byte
+
+	payload, err := base58CheckDecode(documentID)
+	if err != nil {
+		return id, fmt.Errorf("invalid automerge document id %q: %w", documentID, err)
+	}
+
+	if len(payload) != DocumentIDByteLength {
+		return id, fmt.Errorf(
+			"automerge document id %q decodes to %d bytes, want %d",
+			documentID, len(payload), DocumentIDByteLength,
+		)
+	}
+
+	copy(id[:], payload)
+
+	return id, nil
+}
+
+// ValidDocumentID reports whether documentID is a well-formed automerge-repo
+// document id (correct base58, checksum, and length).
+func ValidDocumentID(documentID string) bool {
+	_, err := DecodeDocumentID(documentID)
+
+	return err == nil
+}
+
+// DeriveDocumentID derives a stable automerge-repo document id from an arbitrary
+// seed string, such as a Probo document-version GID. It hashes the seed and
+// takes the first 16 bytes, so every peer that knows the seed computes the same
+// id without coordination. This is what lets browser clients and Go agents join
+// the same repo document, and it is required for ephemeral gossip (presence and
+// cursors) to line up, since a peer drops an ephemeral frame whose document id
+// it does not recognise.
+func DeriveDocumentID(seed string) string {
+	digest := sha256.Sum256([]byte(seed))
+
+	var id [DocumentIDByteLength]byte
+	copy(id[:], digest[:DocumentIDByteLength])
+
+	return EncodeDocumentID(id)
+}
+
+// AutomergeURL wraps a document id in the automerge: scheme.
+func AutomergeURL(documentID string) string {
+	return AutomergeURLPrefix + documentID
+}
+
+// DeriveAutomergeURL derives a stable automerge: URL from a seed string.
+func DeriveAutomergeURL(seed string) string {
+	return AutomergeURL(DeriveDocumentID(seed))
+}
+
+// ParseAutomergeURL extracts and validates the document id from an automerge:
+// URL, rejecting a missing scheme or a malformed id.
+func ParseAutomergeURL(url string) (string, error) {
+	documentID, found := strings.CutPrefix(url, AutomergeURLPrefix)
+	if !found {
+		return "", fmt.Errorf("automerge url %q is missing the %q scheme", url, AutomergeURLPrefix)
+	}
+
+	if _, err := DecodeDocumentID(documentID); err != nil {
+		return "", fmt.Errorf("automerge url %q has an invalid document id: %w", url, err)
+	}
+
+	return documentID, nil
+}
+
+// base58CheckEncode appends the 4-byte double-SHA-256 checksum and base58-encodes
+// the result.
+func base58CheckEncode(payload []byte) string {
+	checked := make([]byte, 0, len(payload)+4)
+	checked = append(checked, payload...)
+	checked = append(checked, checksum(payload)...)
+
+	return base58Encode(checked)
+}
+
+// base58CheckDecode base58-decodes the input and verifies its trailing checksum,
+// returning the payload without it.
+func base58CheckDecode(encoded string) ([]byte, error) {
+	decoded, err := base58Decode(encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(decoded) < 4 {
+		return nil, fmt.Errorf("base58check value is too short to contain a checksum")
+	}
+
+	payload := decoded[:len(decoded)-4]
+	want := decoded[len(decoded)-4:]
+
+	got := checksum(payload)
+	if got[0] != want[0] || got[1] != want[1] || got[2] != want[2] || got[3] != want[3] {
+		return nil, fmt.Errorf("base58check checksum mismatch")
+	}
+
+	return payload, nil
+}
+
+// checksum is the first four bytes of the double SHA-256 of the payload.
+func checksum(payload []byte) []byte {
+	first := sha256.Sum256(payload)
+	second := sha256.Sum256(first[:])
+
+	return second[:4]
+}
+
+func base58Encode(input []byte) string {
+	value := new(big.Int).SetBytes(input)
+	radix := big.NewInt(58)
+	remainder := new(big.Int)
+	zero := new(big.Int)
+
+	var reversed []byte
+	for value.Cmp(zero) > 0 {
+		value.DivMod(value, radix, remainder)
+		reversed = append(reversed, base58Alphabet[remainder.Int64()])
+	}
+
+	// Each leading zero byte is encoded as the alphabet's first character.
+	for _, b := range input {
+		if b != 0 {
+			break
+		}
+
+		reversed = append(reversed, base58Alphabet[0])
+	}
+
+	for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
+		reversed[i], reversed[j] = reversed[j], reversed[i]
+	}
+
+	return string(reversed)
+}
+
+func base58Decode(encoded string) ([]byte, error) {
+	value := new(big.Int)
+	radix := big.NewInt(58)
+
+	for _, character := range encoded {
+		index := strings.IndexRune(base58Alphabet, character)
+		if index < 0 {
+			return nil, fmt.Errorf("invalid base58 character %q", character)
+		}
+
+		value.Mul(value, radix)
+		value.Add(value, big.NewInt(int64(index)))
+	}
+
+	decoded := value.Bytes()
+
+	// Restore the leading zero bytes the encoder wrote as leading '1's.
+	zeros := 0
+	for zeros < len(encoded) && encoded[zeros] == base58Alphabet[0] {
+		zeros++
+	}
+
+	result := make([]byte, zeros+len(decoded))
+	copy(result[zeros:], decoded)
+
+	return result, nil
+}

--- a/pkg/automerge/collaboration/documentid_test.go
+++ b/pkg/automerge/collaboration/documentid_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// realRepoDocumentID is a genuine @automerge/automerge-repo document id (the one
+// the interop client uses). Decoding it verifies our base58check implementation
+// against real upstream output rather than against itself: a wrong checksum or
+// alphabet would fail here.
+const realRepoDocumentID = "34YWzjYt5gPJpq5RfXAkPfPcUj1r"
+
+// TestDocumentID_DecodesRealRepoID proves the base58check codec matches the
+// upstream format: a real repo id decodes to exactly 16 bytes and re-encodes to
+// the identical string.
+func TestDocumentID_DecodesRealRepoID(t *testing.T) {
+	t.Parallel()
+
+	id, err := DecodeDocumentID(realRepoDocumentID)
+	require.NoError(t, err)
+
+	assert.Equal(t, realRepoDocumentID, EncodeDocumentID(id),
+		"a real repo id must round-trip byte-identically")
+	assert.True(t, ValidDocumentID(realRepoDocumentID))
+}
+
+// TestDocumentID_RoundTrip encodes and decodes arbitrary 16-byte ids, including
+// ones with leading zero bytes (which base58 encodes specially).
+func TestDocumentID_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string][DocumentIDByteLength]byte{
+		"zero":          {},
+		"leading zeros": {0, 0, 0, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0},
+		"all ones":      {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+		"max":           {255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+		"mixed":         {0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb},
+	}
+
+	for name, id := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			encoded := EncodeDocumentID(id)
+			assert.True(t, ValidDocumentID(encoded))
+
+			decoded, err := DecodeDocumentID(encoded)
+			require.NoError(t, err)
+			assert.Equal(t, id, decoded)
+		})
+	}
+}
+
+// TestDocumentID_RejectsCorruption rejects a bad checksum, a bad character, and
+// the wrong decoded length.
+func TestDocumentID_RejectsCorruption(t *testing.T) {
+	t.Parallel()
+
+	// Flip the last character of a valid id to break its checksum.
+	corrupted := realRepoDocumentID[:len(realRepoDocumentID)-1]
+	if realRepoDocumentID[len(realRepoDocumentID)-1] == 'r' {
+		corrupted += "s"
+	} else {
+		corrupted += "r"
+	}
+
+	_, err := DecodeDocumentID(corrupted)
+	assert.Error(t, err, "a flipped character must fail the checksum")
+
+	_, err = DecodeDocumentID("0OIl") // characters outside the base58 alphabet
+	assert.Error(t, err)
+
+	assert.False(t, ValidDocumentID(""))
+}
+
+// TestDeriveDocumentID_StableAndValid derives ids from seeds (a version GID
+// stands in) and checks they are deterministic, valid, and seed-specific.
+func TestDeriveDocumentID_StableAndValid(t *testing.T) {
+	t.Parallel()
+
+	const seed = "document_version_2Abc123"
+
+	first := DeriveDocumentID(seed)
+	second := DeriveDocumentID(seed)
+
+	assert.Equal(t, first, second, "derivation must be deterministic")
+	assert.True(t, ValidDocumentID(first))
+	assert.NotEqual(t, first, DeriveDocumentID(seed+"x"),
+		"different seeds must derive different ids")
+}
+
+// TestAutomergeURL_RoundTrip wraps and unwraps the automerge: scheme and
+// rejects malformed URLs.
+func TestAutomergeURL_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	url := DeriveAutomergeURL("document_version_9")
+	assert.True(t, len(url) > len(AutomergeURLPrefix))
+
+	documentID, err := ParseAutomergeURL(url)
+	require.NoError(t, err)
+	assert.Equal(t, AutomergeURL(documentID), url)
+	assert.True(t, ValidDocumentID(documentID))
+
+	_, err = ParseAutomergeURL(realRepoDocumentID) // no scheme
+	assert.Error(t, err)
+
+	_, err = ParseAutomergeURL(AutomergeURLPrefix + "not-a-valid-id!!")
+	assert.Error(t, err)
+}

--- a/pkg/automerge/collaboration/fuzz_test.go
+++ b/pkg/automerge/collaboration/fuzz_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import "testing"
+
+// FuzzDecodePresence checks that decoding arbitrary bytes never panics and only
+// ever returns a valid message or an error.
+func FuzzDecodePresence(f *testing.F) {
+	for _, seed := range [][]byte{
+		nil,
+		{0xa0},
+		{0xff},
+		[]byte("not cbor"),
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		message, err := DecodePresence(data)
+		if err != nil {
+			return
+		}
+
+		// A returned message must satisfy the type invariants, and re-encoding it
+		// must succeed and decode back to the same type.
+		if err := message.validate(); err != nil {
+			t.Fatalf("decoded presence message is invalid: %v", err)
+		}
+
+		encoded, err := EncodePresence(message)
+		if err != nil {
+			t.Fatalf("cannot re-encode a decoded presence message: %v", err)
+		}
+
+		again, err := DecodePresence(encoded)
+		if err != nil {
+			t.Fatalf("cannot decode a re-encoded presence message: %v", err)
+		}
+
+		if again.Type != message.Type {
+			t.Fatalf("re-encoded type %q != %q", again.Type, message.Type)
+		}
+	})
+}
+
+// FuzzDecodeMessage checks that decoding arbitrary bytes as a repo message never
+// panics.
+func FuzzDecodeMessage(f *testing.F) {
+	f.Add([]byte{0xa0})
+	f.Add([]byte("garbage"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		message, err := DecodeMessage(data)
+		if err != nil {
+			return
+		}
+
+		if err := message.validate(); err != nil {
+			t.Fatalf("decoded repo message is invalid: %v", err)
+		}
+	})
+}

--- a/pkg/automerge/collaboration/integration_test.go
+++ b/pkg/automerge/collaboration/integration_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/automerge"
+	"go.probo.inc/probo/pkg/automerge/collaboration"
+)
+
+// The production sync state must satisfy the driver's interface with no adapter.
+var _ collaboration.SyncSession = (*automerge.SyncState)(nil)
+
+func actor(value byte) automerge.ActorID {
+	var actorID automerge.ActorID
+	actorID[0] = value
+
+	return actorID
+}
+
+func commitTime() time.Time {
+	return time.Unix(1786147200, 0).UTC()
+}
+
+// TestServerConn_ConvergesRealDocument drives a real Automerge client sync state
+// through the ServerConn loop and confirms the client reconstructs the server's
+// document. This exercises the interop linchpin end to end in Go: the repo sync
+// frame payloads are exactly our engine's sync messages.
+func TestServerConn_ConvergesRealDocument(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Server document: the authority, holding "hello" in a text object.
+	server, err := automerge.New(ctx, actor(1))
+	require.NoError(t, err)
+	defer func() { _ = server.Close(ctx) }()
+
+	text, err := server.CreateText(ctx, "body")
+	require.NoError(t, err)
+	require.NoError(t, text.Splice(ctx, 0, 0, "hello"))
+	_, err = server.Commit(ctx, "seed", commitTime())
+	require.NoError(t, err)
+
+	serverSync, err := server.NewSyncState(ctx)
+	require.NoError(t, err)
+	defer func() { _ = serverSync.Close(ctx) }()
+
+	conn, err := collaboration.NewServerConn(
+		collaboration.ServerConfig{ServerPeerID: "server"},
+		"doc-1",
+		serverSync,
+	)
+	require.NoError(t, err)
+
+	// Client document: empty, learning the document over the connection.
+	client, err := automerge.New(ctx, actor(2))
+	require.NoError(t, err)
+	defer func() { _ = client.Close(ctx) }()
+
+	clientSync, err := client.NewSyncState(ctx)
+	require.NoError(t, err)
+	defer func() { _ = clientSync.Close(ctx) }()
+
+	join, err := collaboration.EncodeJoinFrame(
+		collaboration.NewJoinFrame("peer-a", collaboration.PeerMetadata{}),
+	)
+	require.NoError(t, err)
+
+	// Frames the client still has to process; seeded with the server's announce.
+	toClient, accepted, err := conn.Start(ctx, join)
+	require.NoError(t, err)
+	require.True(t, accepted)
+
+	deliverToClient := func(frames [][]byte) {
+		for _, frame := range frames {
+			kind, err := collaboration.FrameKind(frame)
+			require.NoError(t, err)
+
+			if kind == collaboration.FramePeer {
+				continue
+			}
+
+			message, err := collaboration.DecodeMessage(frame)
+			require.NoError(t, err)
+			require.Equal(t, collaboration.MessageSync, message.Type)
+			require.NoError(t, clientSync.ReceiveMessage(ctx, message.Data))
+		}
+	}
+
+	// Pump until neither side has anything more to send. A generous bound stops a
+	// protocol bug from hanging the test.
+	for round := 0; round < 20; round++ {
+		deliverToClient(toClient)
+		toClient = nil
+
+		message, ok, err := clientSync.GenerateMessage(ctx)
+		require.NoError(t, err)
+
+		if !ok {
+			break
+		}
+
+		frame, err := collaboration.EncodeMessage(collaboration.Message{
+			Type:       collaboration.MessageSync,
+			SenderID:   "peer-a",
+			TargetID:   "server",
+			DocumentID: "doc-1",
+			Data:       message,
+		})
+		require.NoError(t, err)
+
+		reply, fanout, err := conn.Receive(ctx, frame)
+		require.NoError(t, err)
+		assert.Nil(t, fanout)
+
+		toClient = reply
+	}
+
+	serverHeads, err := server.Heads(ctx)
+	require.NoError(t, err)
+
+	clientHeads, err := client.Heads(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, serverHeads, clientHeads, "client must converge to the server frontier")
+
+	clientText, err := client.Text(ctx, "body")
+	require.NoError(t, err)
+
+	value, err := clientText.String(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", value)
+}

--- a/pkg/automerge/collaboration/interop_client_test.go
+++ b/pkg/automerge/collaboration/interop_client_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/automerge"
+	"go.probo.inc/probo/pkg/automerge/collaboration"
+)
+
+// The document id both sides agree on: the real repo client requests this URL
+// and the gateway serves its seeded document under the same id.
+const (
+	interopDocumentID  = "34YWzjYt5gPJpq5RfXAkPfPcUj1r"
+	interopDocumentURL = "automerge:" + interopDocumentID
+)
+
+// TestInterop_RealRepoClientLoadsGoDocument stands up a Go WebSocket server
+// backed by ServerConn and a seeded document, then runs a real
+// @automerge/automerge-repo client against it and asserts the client
+// materializes the server's document. This validates the whole gateway stack
+// (handshake, framing, sync loop) against the actual JavaScript client rather
+// than against our reading of its source.
+//
+// It is gated on AUTOMERGE_REPO_INTEROP_CLIENT (the path to the Node client
+// script) so the default test run does not require Node; the
+// test-automerge-repo-interop make target sets it.
+func TestInterop_RealRepoClientLoadsGoDocument(t *testing.T) {
+	script := os.Getenv("AUTOMERGE_REPO_INTEROP_CLIENT")
+	if script == "" {
+		t.Skip("AUTOMERGE_REPO_INTEROP_CLIENT is not set")
+	}
+
+	ctx := context.Background()
+
+	server, err := automerge.New(ctx, actor(1))
+	require.NoError(t, err)
+	defer func() { _ = server.Close(ctx) }()
+
+	text, err := server.CreateText(ctx, "body")
+	require.NoError(t, err)
+	require.NoError(t, text.Splice(ctx, 0, 0, "hello world"))
+	_, err = server.Commit(ctx, "seed", commitTime())
+	require.NoError(t, err)
+
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serveGateway(t, w, r, server)
+	}))
+	defer httpServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(httpServer.URL, "http")
+
+	runCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	command := exec.CommandContext(runCtx, "node", script, wsURL, interopDocumentURL)
+
+	output, err := command.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("interop client failed: %v\nstderr:\n%s", err, exitErr.Stderr)
+		}
+
+		t.Fatalf("cannot run interop client: %v", err)
+	}
+
+	document := string(output)
+	assert.Contains(t, document, "hello world",
+		"the real repo client must materialize the server's document; got %s", document)
+}
+
+// serveGateway is a minimal repo gateway for the interop test: it accepts a
+// binary WebSocket, runs the ServerConn handshake and sync loop for the seeded
+// document, and echoes each peer's own ephemerals (there is a single client, so
+// fan-out is a no-op).
+func serveGateway(t *testing.T, w http.ResponseWriter, r *http.Request, document *automerge.Document) {
+	t.Helper()
+
+	connection, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true, // test-only: the Node client sends no Origin
+	})
+	if err != nil {
+		return
+	}
+
+	defer func() { _ = connection.Close(websocket.StatusNormalClosure, "") }()
+
+	connection.SetReadLimit(1 << 20)
+
+	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+	defer cancel()
+
+	syncState, err := document.NewSyncState(ctx)
+	if err != nil {
+		return
+	}
+
+	defer func() { _ = syncState.Close(context.Background()) }()
+
+	conn, err := collaboration.NewServerConn(
+		collaboration.ServerConfig{ServerPeerID: "probo-gateway"},
+		interopDocumentID,
+		syncState,
+	)
+	if err != nil {
+		return
+	}
+
+	write := func(frames [][]byte) bool {
+		for _, frame := range frames {
+			if err := connection.Write(ctx, websocket.MessageBinary, frame); err != nil {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	// First frame is the client's join.
+	kind, join, err := connection.Read(ctx)
+	if err != nil || kind != websocket.MessageBinary {
+		return
+	}
+
+	out, accepted, err := conn.Start(ctx, join)
+	if err != nil {
+		return
+	}
+
+	if !write(out) || !accepted {
+		return
+	}
+
+	for {
+		kind, frame, err := connection.Read(ctx)
+		if err != nil {
+			return
+		}
+
+		if kind != websocket.MessageBinary {
+			continue
+		}
+
+		reply, _, err := conn.Receive(ctx, frame)
+		if err != nil {
+			return
+		}
+
+		if !write(reply) {
+			return
+		}
+	}
+}

--- a/pkg/automerge/collaboration/message.go
+++ b/pkg/automerge/collaboration/message.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import "fmt"
+
+// MessageType is the discriminator shared by every repo message.
+type MessageType string
+
+const (
+	// MessageSync carries an Automerge sync message for a document.
+	MessageSync MessageType = "sync"
+	// MessageRequest is the initial sync that also asks whether the peer has the
+	// document at all.
+	MessageRequest MessageType = "request"
+	// MessageEphemeral carries a gossiped, non-persisted payload (such as
+	// presence) for a document.
+	MessageEphemeral MessageType = "ephemeral"
+	// MessageDocUnavailable reports that neither the peer nor its peers hold the
+	// document.
+	MessageDocUnavailable MessageType = "doc-unavailable"
+)
+
+// Message is one document-scoped repo message. It is the layer between the
+// WebSocket adapter framing (added in the transport phase) and the payload: for
+// sync and request Data is an Automerge sync message our engine owns, and for
+// ephemeral Data is a CBOR presence payload.
+//
+// Sync bytes are intentionally left opaque here so this package never
+// re-implements the CRDT wire format.
+type Message struct {
+	Type       MessageType `cbor:"type"`
+	SenderID   string      `cbor:"senderId"`
+	TargetID   string      `cbor:"targetId"`
+	DocumentID string      `cbor:"documentId"`
+
+	// Data is the Automerge sync message for sync and request messages, and the
+	// CBOR presence payload for ephemeral messages.
+	Data []byte `cbor:"data,omitempty"`
+
+	// SessionID and Count identify an ephemeral message for gossip
+	// de-duplication and are unset for other types.
+	SessionID string `cbor:"sessionId,omitempty"`
+	Count     uint64 `cbor:"count,omitempty"`
+}
+
+// validate checks that a message carries exactly the fields its type requires,
+// which guards both directions of the codec.
+func (m Message) validate() error {
+	if m.SenderID == "" {
+		return fmt.Errorf("repo message is missing a sender id")
+	}
+
+	switch m.Type {
+	case MessageSync, MessageRequest:
+		if m.DocumentID == "" {
+			return fmt.Errorf("%s message is missing a document id", m.Type)
+		}
+
+		if len(m.Data) == 0 {
+			return fmt.Errorf("%s message is missing sync data", m.Type)
+		}
+	case MessageEphemeral:
+		if m.DocumentID == "" {
+			return fmt.Errorf("ephemeral message is missing a document id")
+		}
+
+		if m.SessionID == "" {
+			return fmt.Errorf("ephemeral message is missing a session id")
+		}
+
+		if len(m.Data) == 0 {
+			return fmt.Errorf("ephemeral message is missing a payload")
+		}
+	case MessageDocUnavailable:
+		if m.DocumentID == "" {
+			return fmt.Errorf("doc-unavailable message is missing a document id")
+		}
+	default:
+		return fmt.Errorf("unknown repo message type %q", m.Type)
+	}
+
+	return nil
+}
+
+// EncodeMessage encodes a repo message to CBOR. This is the message object the
+// WebSocket adapter frames; the adapter's own framing and handshake are added
+// in the transport phase.
+func EncodeMessage(message Message) ([]byte, error) {
+	if err := message.validate(); err != nil {
+		return nil, err
+	}
+
+	data, err := marshal(message)
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode repo message: %w", err)
+	}
+
+	return data, nil
+}
+
+// DecodeMessage decodes a CBOR repo message and validates it.
+func DecodeMessage(data []byte) (Message, error) {
+	var message Message
+	if err := unmarshal(data, &message); err != nil {
+		return Message{}, fmt.Errorf("cannot decode repo message: %w", err)
+	}
+
+	if err := message.validate(); err != nil {
+		return Message{}, err
+	}
+
+	return message, nil
+}
+
+// DedupeKey identifies an ephemeral message for gossip de-duplication: a
+// receiver discards a (session, count) pair it has already seen, which breaks
+// forwarding loops. It is only meaningful for ephemeral messages.
+type DedupeKey struct {
+	SessionID string
+	Count     uint64
+}
+
+// DedupeKey returns the de-duplication key for an ephemeral message.
+func (m Message) DedupeKey() DedupeKey {
+	return DedupeKey{SessionID: m.SessionID, Count: m.Count}
+}

--- a/pkg/automerge/collaboration/message_test.go
+++ b/pkg/automerge/collaboration/message_test.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type ephemeralFixture struct {
+	Description string `json:"description"`
+	Message     struct {
+		Type       string `json:"type"`
+		SenderID   string `json:"senderId"`
+		TargetID   string `json:"targetId"`
+		DocumentID string `json:"documentId"`
+		SessionID  string `json:"sessionId"`
+		Count      uint64 `json:"count"`
+		Data       string `json:"data"`
+	} `json:"message"`
+	PayloadCBORBase64 string `json:"payloadCborBase64"`
+}
+
+// TestEphemeralFixtureCarriesPresence confirms the ephemeral message fields the
+// JavaScript client sends decode into our Message, and that the payload it
+// carries is exactly a presence payload our presence codec reads.
+func TestEphemeralFixtureCarriesPresence(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		"ephemeral-update.json",
+		"ephemeral-snapshot.json",
+		"ephemeral-heartbeat.json",
+		"ephemeral-goodbye.json",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := readFixture[ephemeralFixture](t, name)
+
+			message := Message{
+				Type:       MessageType(fixture.Message.Type),
+				SenderID:   fixture.Message.SenderID,
+				TargetID:   fixture.Message.TargetID,
+				DocumentID: fixture.Message.DocumentID,
+				SessionID:  fixture.Message.SessionID,
+				Count:      fixture.Message.Count,
+				Data:       decodeBase64(t, fixture.Message.Data),
+			}
+
+			require.NoError(t, message.validate())
+			assert.Equal(t, MessageEphemeral, message.Type)
+			assert.Equal(t, DedupeKey{SessionID: "session-a", Count: 1}, message.DedupeKey())
+
+			// The ephemeral payload is a presence message the presence codec reads.
+			presence, err := DecodePresence(message.Data)
+			require.NoError(t, err)
+			assert.Contains(t,
+				[]PresenceType{PresenceUpdate, PresenceSnapshot, PresenceHeartbeat, PresenceGoodbye},
+				presence.Type,
+			)
+		})
+	}
+}
+
+// TestMessage_RoundTrip encodes and decodes each document-scoped message type.
+func TestMessage_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, message := range []Message{
+		{Type: MessageSync, SenderID: "a", TargetID: "b", DocumentID: "doc", Data: []byte{1, 2, 3}},
+		{Type: MessageRequest, SenderID: "a", TargetID: "b", DocumentID: "doc", Data: []byte{4, 5}},
+		{Type: MessageEphemeral, SenderID: "a", TargetID: "b", DocumentID: "doc", SessionID: "s", Count: 7, Data: []byte{6}},
+		{Type: MessageDocUnavailable, SenderID: "a", TargetID: "b", DocumentID: "doc"},
+	} {
+		t.Run(string(message.Type), func(t *testing.T) {
+			t.Parallel()
+
+			encoded, err := EncodeMessage(message)
+			require.NoError(t, err)
+
+			decoded, err := DecodeMessage(encoded)
+			require.NoError(t, err)
+			assert.Equal(t, message.Type, decoded.Type)
+			assert.Equal(t, message.DocumentID, decoded.DocumentID)
+			assert.Equal(t, message.Data, decoded.Data)
+			assert.Equal(t, message.SessionID, decoded.SessionID)
+			assert.Equal(t, message.Count, decoded.Count)
+		})
+	}
+}
+
+// TestMessage_Validation rejects messages missing type-required fields.
+func TestMessage_Validation(t *testing.T) {
+	t.Parallel()
+
+	cases := []Message{
+		{Type: MessageSync, SenderID: "a", TargetID: "b", DocumentID: "doc"},      // no data
+		{Type: MessageSync, SenderID: "a", TargetID: "b", Data: []byte{1}},        // no doc
+		{Type: MessageEphemeral, SenderID: "a", DocumentID: "d", Data: []byte{1}}, // no session
+		{Type: MessageType("bogus"), SenderID: "a"},
+		{Type: MessageSync},
+	}
+
+	for _, message := range cases {
+		_, err := EncodeMessage(message)
+		assert.Error(t, err)
+	}
+}
+
+// TestDecodeMessage_RejectsDuplicateKeys confirms the strict decoder refuses a
+// duplicate map key rather than silently taking one.
+func TestDecodeMessage_RejectsDuplicateKeys(t *testing.T) {
+	t.Parallel()
+
+	// { "type":"doc-unavailable", "type":"sync", "senderId":"a", ... } built by
+	// hand as CBOR with a duplicated key.
+	duplicate := buildDuplicateKeyCBOR(t)
+
+	_, err := DecodeMessage(duplicate)
+	assert.Error(t, err)
+}
+
+func buildDuplicateKeyCBOR(t *testing.T) []byte {
+	t.Helper()
+
+	// Encode two separate maps and splice a duplicate "type" key by hand would be
+	// fragile; instead assert the decoder mode rejects duplicates via a crafted
+	// map[string] with the same key twice is impossible in Go, so encode a raw
+	// CBOR map literal.
+	//
+	// CBOR: map(4) { "type":"sync", "type":"sync", "senderId":"a", "documentId":"d" }
+	// 0xa4 (map,4)
+	//   "type"(0x64 74797065) "sync"(0x64 73796e63)
+	//   "type"(0x64 74797065) "sync"(0x64 73796e63)
+	//   "senderId"(0x68 ...) "a"(0x61 61)
+	//   "documentId"(0x6a ...) "d"(0x61 64)
+	return []byte{
+		0xa4,
+		0x64, 't', 'y', 'p', 'e', 0x64, 's', 'y', 'n', 'c',
+		0x64, 't', 'y', 'p', 'e', 0x64, 's', 'y', 'n', 'c',
+		0x68, 's', 'e', 'n', 'd', 'e', 'r', 'I', 'd', 0x61, 'a',
+		0x6a, 'd', 'o', 'c', 'u', 'm', 'e', 'n', 't', 'I', 'd', 0x61, 'd',
+	}
+}
+
+// Ensure the fixture files are valid JSON we can parse (guards regeneration).
+func TestFixturesAreParseable(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"presence-roundtrip.json"} {
+		var raw map[string]json.RawMessage
+		fixture := readFixture[map[string]json.RawMessage](t, name)
+		raw = fixture
+		assert.Contains(t, raw, "cborBase64")
+	}
+}

--- a/pkg/automerge/collaboration/presence.go
+++ b/pkg/automerge/collaboration/presence.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+// PresenceMarker is the single envelope key automerge-repo's Presence wraps
+// every message in before it is CBOR-encoded into an ephemeral payload.
+const PresenceMarker = "__presence"
+
+// Presence heartbeat and expiry defaults, matching the upstream constants.
+const (
+	DefaultHeartbeatInterval = 15 * time.Second
+	DefaultPeerTTL           = 3 * DefaultHeartbeatInterval
+)
+
+// PresenceType is the discriminator of a presence message.
+type PresenceType string
+
+const (
+	// PresenceUpdate carries one channel's new value.
+	PresenceUpdate PresenceType = "update"
+	// PresenceSnapshot carries the full multi-channel state, sent on start and
+	// to newly seen peers.
+	PresenceSnapshot PresenceType = "snapshot"
+	// PresenceHeartbeat signals liveness when nothing has changed.
+	PresenceHeartbeat PresenceType = "heartbeat"
+	// PresenceGoodbye tells peers to forget the sender immediately.
+	PresenceGoodbye PresenceType = "goodbye"
+)
+
+// PresenceMessage is one decoded presence event. Value (for an update) and
+// State (for a snapshot) are application-defined and kept as raw CBOR so a
+// caller decodes them into its own type; use Set/Get helpers or the cbor
+// package directly. They are nil for heartbeat and goodbye.
+type PresenceMessage struct {
+	Type    PresenceType
+	Channel string
+	Value   cbor.RawMessage
+	State   cbor.RawMessage
+}
+
+// presenceEnvelope is the CBOR shape on the wire: a single-key map whose key is
+// the presence marker.
+type presenceEnvelope struct {
+	Presence *presenceBody `cbor:"__presence"`
+}
+
+type presenceBody struct {
+	Type    string          `cbor:"type"`
+	Channel string          `cbor:"channel,omitempty"`
+	Value   cbor.RawMessage `cbor:"value,omitempty"`
+	State   cbor.RawMessage `cbor:"state,omitempty"`
+}
+
+// EncodePresence encodes a presence message into the CBOR bytes carried as an
+// ephemeral message's data. It validates that the fields present match the type.
+func EncodePresence(message PresenceMessage) ([]byte, error) {
+	if err := message.validate(); err != nil {
+		return nil, err
+	}
+
+	body := &presenceBody{
+		Type:    string(message.Type),
+		Channel: message.Channel,
+		Value:   message.Value,
+		State:   message.State,
+	}
+
+	data, err := marshal(presenceEnvelope{Presence: body})
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode presence message: %w", err)
+	}
+
+	return data, nil
+}
+
+// DecodePresence decodes the CBOR bytes of an ephemeral message's data into a
+// presence message, rejecting a payload that is not a presence envelope or whose
+// fields do not match its type.
+func DecodePresence(data []byte) (PresenceMessage, error) {
+	var envelope presenceEnvelope
+	if err := unmarshal(data, &envelope); err != nil {
+		return PresenceMessage{}, fmt.Errorf("cannot decode presence envelope: %w", err)
+	}
+
+	if envelope.Presence == nil {
+		return PresenceMessage{}, fmt.Errorf("payload is missing the %q presence marker", PresenceMarker)
+	}
+
+	message := PresenceMessage{
+		Type:    PresenceType(envelope.Presence.Type),
+		Channel: envelope.Presence.Channel,
+		Value:   envelope.Presence.Value,
+		State:   envelope.Presence.State,
+	}
+
+	if err := message.validate(); err != nil {
+		return PresenceMessage{}, err
+	}
+
+	return message, nil
+}
+
+// validate enforces that only the fields meaningful for a type are set, so a
+// malformed cross-type payload (an update with no channel, a heartbeat carrying
+// state) is rejected on both encode and decode.
+func (m PresenceMessage) validate() error {
+	switch m.Type {
+	case PresenceUpdate:
+		if m.Channel == "" {
+			return fmt.Errorf("presence update requires a channel")
+		}
+
+		if m.State != nil {
+			return fmt.Errorf("presence update must not carry snapshot state")
+		}
+	case PresenceSnapshot:
+		if m.Channel != "" || m.Value != nil {
+			return fmt.Errorf("presence snapshot must not carry a channel or value")
+		}
+	case PresenceHeartbeat, PresenceGoodbye:
+		if m.Channel != "" || m.Value != nil || m.State != nil {
+			return fmt.Errorf("presence %s must not carry a channel, value, or state", m.Type)
+		}
+	default:
+		return fmt.Errorf("unknown presence type %q", m.Type)
+	}
+
+	return nil
+}
+
+// MarshalPresenceValue encodes an application value into the raw CBOR carried by
+// an update's Value or a snapshot's State, using the shared deterministic mode.
+func MarshalPresenceValue(value any) (cbor.RawMessage, error) {
+	data, err := marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("cannot encode presence value: %w", err)
+	}
+
+	return data, nil
+}
+
+// UnmarshalValue decodes an update's Value into the given destination.
+func (m PresenceMessage) UnmarshalValue(destination any) error {
+	if m.Value == nil {
+		return fmt.Errorf("presence message has no value")
+	}
+
+	return unmarshal(m.Value, destination)
+}
+
+// UnmarshalState decodes a snapshot's State into the given destination.
+func (m PresenceMessage) UnmarshalState(destination any) error {
+	if m.State == nil {
+		return fmt.Errorf("presence message has no state")
+	}
+
+	return unmarshal(m.State, destination)
+}

--- a/pkg/automerge/collaboration/presence_test.go
+++ b/pkg/automerge/collaboration/presence_test.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type presenceFixture struct {
+	Description string          `json:"description"`
+	Marker      string          `json:"marker"`
+	Envelope    json.RawMessage `json:"envelope"`
+	CBORBase64  string          `json:"cborBase64"`
+}
+
+func readFixture[T any](t *testing.T, name string) T {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+
+	var fixture T
+	require.NoError(t, json.Unmarshal(data, &fixture))
+
+	return fixture
+}
+
+func decodeBase64(t *testing.T, value string) []byte {
+	t.Helper()
+
+	data, err := base64.StdEncoding.DecodeString(value)
+	require.NoError(t, err)
+
+	return data
+}
+
+// TestDecodePresence_MatchesJavaScriptFixtures decodes the exact CBOR the
+// JavaScript client produces for every presence message type.
+func TestDecodePresence_MatchesJavaScriptFixtures(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		fixture string
+		expect  func(t *testing.T, message PresenceMessage)
+	}{
+		{
+			fixture: "presence-update.json",
+			expect: func(t *testing.T, message PresenceMessage) {
+				assert.Equal(t, PresenceUpdate, message.Type)
+				assert.Equal(t, "cursor", message.Channel)
+
+				var value map[string]string
+				require.NoError(t, message.UnmarshalValue(&value))
+				assert.Equal(t, map[string]string{"anchor": "a", "head": "b"}, value)
+			},
+		},
+		{
+			fixture: "presence-snapshot.json",
+			expect: func(t *testing.T, message PresenceMessage) {
+				assert.Equal(t, PresenceSnapshot, message.Type)
+
+				var state map[string]map[string]string
+				require.NoError(t, message.UnmarshalState(&state))
+				assert.Equal(t, map[string]map[string]string{
+					"cursor": {"anchor": "a", "head": "b"},
+				}, state)
+			},
+		},
+		{
+			fixture: "presence-heartbeat.json",
+			expect: func(t *testing.T, message PresenceMessage) {
+				assert.Equal(t, PresenceHeartbeat, message.Type)
+				assert.Nil(t, message.Value)
+				assert.Nil(t, message.State)
+			},
+		},
+		{
+			fixture: "presence-goodbye.json",
+			expect: func(t *testing.T, message PresenceMessage) {
+				assert.Equal(t, PresenceGoodbye, message.Type)
+			},
+		},
+	} {
+		t.Run(testCase.fixture, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := readFixture[presenceFixture](t, testCase.fixture)
+			assert.Equal(t, PresenceMarker, fixture.Marker)
+
+			message, err := DecodePresence(decodeBase64(t, fixture.CBORBase64))
+			require.NoError(t, err)
+
+			testCase.expect(t, message)
+		})
+	}
+}
+
+// TestPresence_RoundTripsThroughJavaScriptBytes proves our re-encoding of a
+// decoded JavaScript payload decodes back to the same message, so a Go peer and
+// a JS peer agree on meaning even though the byte encodings need not be identical.
+func TestPresence_RoundTripsThroughJavaScriptBytes(t *testing.T) {
+	t.Parallel()
+
+	fixture := readFixture[presenceFixture](t, "presence-update.json")
+	original := decodeBase64(t, fixture.CBORBase64)
+
+	message, err := DecodePresence(original)
+	require.NoError(t, err)
+
+	reEncoded, err := EncodePresence(message)
+	require.NoError(t, err)
+
+	roundTripped, err := DecodePresence(reEncoded)
+	require.NoError(t, err)
+	assert.Equal(t, message.Type, roundTripped.Type)
+	assert.Equal(t, message.Channel, roundTripped.Channel)
+
+	var first, second map[string]string
+	require.NoError(t, message.UnmarshalValue(&first))
+	require.NoError(t, roundTripped.UnmarshalValue(&second))
+	assert.Equal(t, first, second)
+}
+
+// TestEncodePresence_BuildsUpdate constructs an update from scratch and confirms
+// it decodes to the same value, the path a Go agent takes when broadcasting.
+func TestEncodePresence_BuildsUpdate(t *testing.T) {
+	t.Parallel()
+
+	value, err := MarshalPresenceValue(map[string]string{"anchor": "x", "head": "y"})
+	require.NoError(t, err)
+
+	data, err := EncodePresence(PresenceMessage{
+		Type:    PresenceUpdate,
+		Channel: "cursor",
+		Value:   value,
+	})
+	require.NoError(t, err)
+
+	message, err := DecodePresence(data)
+	require.NoError(t, err)
+	assert.Equal(t, PresenceUpdate, message.Type)
+
+	var decoded map[string]string
+	require.NoError(t, message.UnmarshalValue(&decoded))
+	assert.Equal(t, map[string]string{"anchor": "x", "head": "y"}, decoded)
+}
+
+// TestEncodePresence_RejectsCrossTypeFields guards the type/field invariants.
+func TestEncodePresence_RejectsCrossTypeFields(t *testing.T) {
+	t.Parallel()
+
+	_, err := EncodePresence(PresenceMessage{Type: PresenceUpdate})
+	assert.Error(t, err, "update without a channel must be rejected")
+
+	state, err := MarshalPresenceValue(map[string]int{"n": 1})
+	require.NoError(t, err)
+
+	_, err = EncodePresence(PresenceMessage{Type: PresenceHeartbeat, State: state})
+	assert.Error(t, err, "heartbeat carrying state must be rejected")
+
+	_, err = EncodePresence(PresenceMessage{Type: PresenceType("bogus")})
+	assert.Error(t, err, "unknown type must be rejected")
+}
+
+// TestDecodePresence_RejectsNonPresencePayload ensures a well-formed CBOR map
+// that is not a presence envelope is refused rather than silently accepted.
+func TestDecodePresence_RejectsNonPresencePayload(t *testing.T) {
+	t.Parallel()
+
+	other, err := marshal(map[string]string{"hello": "world"})
+	require.NoError(t, err)
+
+	_, err = DecodePresence(other)
+	assert.Error(t, err)
+}

--- a/pkg/automerge/collaboration/selection.go
+++ b/pkg/automerge/collaboration/selection.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+// TextSelectionChannel is the conventional presence channel a caret or selection
+// update is published on, so peers know where to look for remote collaborators.
+// It is only a convention; any channel string is valid.
+const TextSelectionChannel = "selection"
+
+// TextSelectionValue is a collaborator's caret or selection carried inside a
+// presence update, expressed with stable Automerge text cursors rather than
+// integer offsets.
+//
+// An integer offset is invalidated by any concurrent edit before it: insert one
+// character at the document start and every downstream offset is off by one, so
+// a remote caret drawn from a stale offset drifts onto the wrong character. A
+// cursor is an opaque, stable address into the sequence; resolving it against
+// the current (or any later) document yields the position of the very character
+// it was created for, which is what keeps a remote caret anchored while other
+// people type. The bytes are exactly the output of pkg/automerge Text.Cursor and
+// are resolved with Text.CursorPosition. This package only transports them, so
+// it stays independent of the CRDT engine.
+type TextSelectionValue struct {
+	// Field is the Automerge map key of the text object the selection addresses
+	// (for example "body"), so a consumer resolves the cursors against the right
+	// object when a document holds more than one text.
+	Field string `cbor:"field"`
+	// Anchor is the stable cursor for the fixed end of the selection (where the
+	// selection started).
+	Anchor []byte `cbor:"anchor"`
+	// Head is the stable cursor for the moving end (the caret). When Head equals
+	// Anchor the selection is a collapsed caret.
+	Head []byte `cbor:"head"`
+}
+
+func (v TextSelectionValue) validate() error {
+	if v.Field == "" {
+		return fmt.Errorf("text selection requires a field")
+	}
+
+	if len(v.Anchor) == 0 {
+		return fmt.Errorf("text selection requires an anchor cursor")
+	}
+
+	if len(v.Head) == 0 {
+		return fmt.Errorf("text selection requires a head cursor")
+	}
+
+	return nil
+}
+
+// Collapsed reports whether the selection is a single caret, that is its anchor
+// and head address the same position.
+func (v TextSelectionValue) Collapsed() bool {
+	return bytes.Equal(v.Anchor, v.Head)
+}
+
+// Encode marshals the selection into the raw CBOR carried by a presence update's
+// Value, validating it first.
+func (v TextSelectionValue) Encode() (cbor.RawMessage, error) {
+	if err := v.validate(); err != nil {
+		return nil, err
+	}
+
+	return MarshalPresenceValue(v)
+}
+
+// DecodeTextSelectionValue decodes a presence update's Value into a selection,
+// rejecting one missing a field or either cursor.
+func DecodeTextSelectionValue(raw cbor.RawMessage) (TextSelectionValue, error) {
+	var value TextSelectionValue
+	if err := unmarshal(raw, &value); err != nil {
+		return TextSelectionValue{}, fmt.Errorf("cannot decode text selection: %w", err)
+	}
+
+	if err := value.validate(); err != nil {
+		return TextSelectionValue{}, err
+	}
+
+	return value, nil
+}
+
+// NewTextSelectionPresence builds a presence update message that publishes a
+// caret or selection on the given channel. An empty channel defaults to
+// TextSelectionChannel.
+func NewTextSelectionPresence(channel string, value TextSelectionValue) (PresenceMessage, error) {
+	if channel == "" {
+		channel = TextSelectionChannel
+	}
+
+	raw, err := value.Encode()
+	if err != nil {
+		return PresenceMessage{}, err
+	}
+
+	return PresenceMessage{Type: PresenceUpdate, Channel: channel, Value: raw}, nil
+}
+
+// TextSelection decodes this presence message's value as a text selection. It is
+// a convenience over UnmarshalValue that also validates the selection shape.
+func (m PresenceMessage) TextSelection() (TextSelectionValue, error) {
+	if m.Type != PresenceUpdate {
+		return TextSelectionValue{}, fmt.Errorf("presence %s does not carry a selection update", m.Type)
+	}
+
+	if m.Value == nil {
+		return TextSelectionValue{}, fmt.Errorf("presence update has no value")
+	}
+
+	return DecodeTextSelectionValue(m.Value)
+}

--- a/pkg/automerge/collaboration/selection_test.go
+++ b/pkg/automerge/collaboration/selection_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/automerge"
+	"go.probo.inc/probo/pkg/automerge/collaboration"
+)
+
+// TestTextSelectionValue_SurvivesConcurrentInsert is the reason presence carries
+// cursors rather than offsets: it round-trips a caret through the presence
+// envelope, then edits the text in front of the caret and shows the same cursor
+// bytes still resolve to the same character. An integer offset would be stale.
+func TestTextSelectionValue_SurvivesConcurrentInsert(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	document, err := automerge.New(ctx, actor(1))
+	require.NoError(t, err)
+	defer func() { _ = document.Close(ctx) }()
+
+	text, err := document.CreateText(ctx, "body")
+	require.NoError(t, err)
+	require.NoError(t, text.Splice(ctx, 0, 0, "hello world"))
+	_, err = document.Commit(ctx, "seed", commitTime())
+	require.NoError(t, err)
+
+	// Put the caret on the "w" of "world".
+	const caretIndex = 6
+
+	cursor, err := text.Cursor(ctx, caretIndex)
+	require.NoError(t, err)
+
+	selection := collaboration.TextSelectionValue{
+		Field:  "body",
+		Anchor: cursor,
+		Head:   cursor,
+	}
+	assert.True(t, selection.Collapsed())
+
+	message, err := collaboration.NewTextSelectionPresence("", selection)
+	require.NoError(t, err)
+	assert.Equal(t, collaboration.TextSelectionChannel, message.Channel)
+
+	payload, err := collaboration.EncodePresence(message)
+	require.NoError(t, err)
+
+	// The remote side decodes the presence frame back into a selection.
+	decodedMessage, err := collaboration.DecodePresence(payload)
+	require.NoError(t, err)
+
+	decoded, err := decodedMessage.TextSelection()
+	require.NoError(t, err)
+	assert.Equal(t, "body", decoded.Field)
+	assert.True(t, decoded.Collapsed())
+
+	positionBefore, err := text.CursorPosition(ctx, automerge.Cursor(decoded.Head))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(caretIndex), positionBefore)
+
+	// Someone types three characters at the very start of the document.
+	require.NoError(t, text.Splice(ctx, 0, 0, "XX "))
+	_, err = document.Commit(ctx, "insert", commitTime())
+	require.NoError(t, err)
+
+	// The very same cursor bytes now resolve three positions later: the caret
+	// stayed anchored to "w". A stored integer offset of 6 would now point at
+	// the wrong character.
+	positionAfter, err := text.CursorPosition(ctx, automerge.Cursor(decoded.Head))
+	require.NoError(t, err)
+	assert.Equal(t, positionBefore+3, positionAfter)
+
+	// The text is ASCII, so the UTF-16 position equals the byte index.
+	value, err := text.String(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(value), int(positionAfter)+1)
+	assert.Equal(t, byte('w'), value[positionAfter])
+}
+
+// TestTextSelectionValue_Validation rejects selections missing a field or a
+// cursor on both encode and decode.
+func TestTextSelectionValue_Validation(t *testing.T) {
+	t.Parallel()
+
+	cursor := []byte{1, 2, 3}
+
+	cases := map[string]collaboration.TextSelectionValue{
+		"missing field":  {Anchor: cursor, Head: cursor},
+		"missing anchor": {Field: "body", Head: cursor},
+		"missing head":   {Field: "body", Anchor: cursor},
+	}
+
+	for name, selection := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := selection.Encode()
+			assert.Error(t, err)
+
+			_, err = collaboration.NewTextSelectionPresence("", selection)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestPresenceMessage_TextSelectionRejectsNonUpdate refuses to read a selection
+// from a heartbeat or goodbye.
+func TestPresenceMessage_TextSelectionRejectsNonUpdate(t *testing.T) {
+	t.Parallel()
+
+	message := collaboration.PresenceMessage{Type: collaboration.PresenceHeartbeat}
+	_, err := message.TextSelection()
+	assert.Error(t, err)
+}

--- a/pkg/automerge/collaboration/session.go
+++ b/pkg/automerge/collaboration/session.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import "fmt"
+
+// ServerConfig configures one server side of a collaboration connection.
+type ServerConfig struct {
+	// ServerPeerID is the peer id the server advertises in its peer reply. It is
+	// the server's own identifier and is unrelated to any client identity.
+	ServerPeerID string
+	// PeerMetadata is the metadata the server presents. Optional.
+	PeerMetadata PeerMetadata
+}
+
+// ServerSession is the transport-agnostic state machine for one collaboration
+// connection as seen by the server. It negotiates the handshake, routes inbound
+// frames, and de-duplicates gossiped ephemeral messages. It performs no I/O and
+// holds no CRDT state, so the server wiring only has to move bytes and act on
+// the returned decisions; document authority stays with pkg/automerge and peer
+// authentication stays with the server connection.
+//
+// A ServerSession is not safe for concurrent use; drive it from one connection
+// goroutine.
+type ServerSession struct {
+	config ServerConfig
+
+	joined       bool
+	remotePeerID string
+
+	// highestCount tracks, per ephemeral session, the greatest count applied.
+	// The protocol guarantees a session's count strictly increases, so a count
+	// at or below the highest already seen is a gossip duplicate. This bounds
+	// memory to one entry per session rather than one per message.
+	highestCount map[string]uint64
+}
+
+// NewServerSession creates a server session. ServerPeerID must be set.
+func NewServerSession(config ServerConfig) (*ServerSession, error) {
+	if config.ServerPeerID == "" {
+		return nil, fmt.Errorf("server session requires a server peer id")
+	}
+
+	return &ServerSession{
+		config:       config,
+		highestCount: make(map[string]uint64),
+	}, nil
+}
+
+// Handshake is the outcome of processing a client join frame.
+type Handshake struct {
+	// Reply is the CBOR frame to send back: a peer frame when Accepted, or an
+	// error frame when not. It is always sent; when not Accepted the socket
+	// should then be closed.
+	Reply []byte
+	// Accepted reports whether the connection may proceed.
+	Accepted bool
+	// RemotePeerID is the client's peer id from the join frame. It is
+	// peer-chosen and must not be treated as an authenticated identity.
+	RemotePeerID string
+}
+
+// Accept processes the client's join frame and produces the server's reply. A
+// malformed frame returns an error. A well-formed join that does not offer a
+// supported protocol version returns an accepted=false handshake carrying an
+// error frame to send before closing.
+func (s *ServerSession) Accept(joinData []byte) (Handshake, error) {
+	if s.joined {
+		return Handshake{}, fmt.Errorf("session already completed its handshake")
+	}
+
+	join, err := DecodeJoinFrame(joinData)
+	if err != nil {
+		return Handshake{}, err
+	}
+
+	if !join.SupportsV1() {
+		reply, encodeErr := EncodeErrorFrame(ErrorFrame{
+			Type:     FrameError,
+			SenderID: s.config.ServerPeerID,
+			TargetID: join.SenderID,
+			Message:  "unsupported protocol version",
+		})
+		if encodeErr != nil {
+			return Handshake{}, encodeErr
+		}
+
+		return Handshake{Reply: reply, Accepted: false, RemotePeerID: join.SenderID}, nil
+	}
+
+	reply, err := EncodePeerFrame(PeerFrame{
+		Type:                    FramePeer,
+		SenderID:                s.config.ServerPeerID,
+		TargetID:                join.SenderID,
+		PeerMetadata:            s.config.PeerMetadata,
+		SelectedProtocolVersion: ProtocolV1,
+	})
+	if err != nil {
+		return Handshake{}, err
+	}
+
+	s.joined = true
+	s.remotePeerID = join.SenderID
+
+	return Handshake{Reply: reply, Accepted: true, RemotePeerID: join.SenderID}, nil
+}
+
+// InboundKind classifies a routed frame for the server wiring.
+type InboundKind int
+
+const (
+	// InboundSync is a sync or request message to feed into the peer's SyncState.
+	InboundSync InboundKind = iota
+	// InboundEphemeral is a gossiped payload to fan out to the room.
+	InboundEphemeral
+	// InboundDocUnavailable reports the peer does not have the document.
+	InboundDocUnavailable
+	// InboundIgnored is a frame the gateway does not act on (for example the
+	// remote-heads messages a single-authority server does not need).
+	InboundIgnored
+)
+
+// Inbound is the decision for one received document frame.
+type Inbound struct {
+	Kind    InboundKind
+	Message Message
+	// Duplicate is true for an ephemeral message already seen for its session,
+	// which must not be re-applied or re-broadcast.
+	Duplicate bool
+}
+
+// Receive routes a document frame received after the handshake. Sync and request
+// frames are returned for the caller to apply to the peer's SyncState; ephemeral
+// frames are de-duplicated by session and count; the remote-heads control
+// messages are ignored by a single-authority gateway.
+func (s *ServerSession) Receive(frameData []byte) (Inbound, error) {
+	if !s.joined {
+		return Inbound{}, fmt.Errorf("received a document frame before the handshake completed")
+	}
+
+	kind, err := FrameKind(frameData)
+	if err != nil {
+		return Inbound{}, err
+	}
+
+	switch MessageType(kind) {
+	case MessageSync, MessageRequest:
+		message, err := DecodeMessage(frameData)
+		if err != nil {
+			return Inbound{}, err
+		}
+
+		return Inbound{Kind: InboundSync, Message: message}, nil
+	case MessageEphemeral:
+		message, err := DecodeMessage(frameData)
+		if err != nil {
+			return Inbound{}, err
+		}
+
+		return Inbound{
+			Kind:      InboundEphemeral,
+			Message:   message,
+			Duplicate: s.seenEphemeral(message),
+		}, nil
+	case MessageDocUnavailable:
+		message, err := DecodeMessage(frameData)
+		if err != nil {
+			return Inbound{}, err
+		}
+
+		return Inbound{Kind: InboundDocUnavailable, Message: message}, nil
+	default:
+		// remote-subscription-change, remote-heads-changed, or anything a newer
+		// peer introduces: acknowledged as a valid frame but not acted on.
+		return Inbound{Kind: InboundIgnored}, nil
+	}
+}
+
+// seenEphemeral records an ephemeral message and reports whether it is a gossip
+// duplicate. A message whose count is at or below the highest already recorded
+// for its session has been seen; the protocol guarantees counts increase.
+func (s *ServerSession) seenEphemeral(message Message) bool {
+	highest, ok := s.highestCount[message.SessionID]
+	if ok && message.Count <= highest {
+		return true
+	}
+
+	s.highestCount[message.SessionID] = message.Count
+
+	return false
+}
+
+// RemotePeerID returns the client's peer id once the handshake has completed.
+func (s *ServerSession) RemotePeerID() string {
+	return s.remotePeerID
+}

--- a/pkg/automerge/collaboration/session_test.go
+++ b/pkg/automerge/collaboration/session_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSession(t *testing.T) *ServerSession {
+	t.Helper()
+
+	session, err := NewServerSession(ServerConfig{ServerPeerID: "server"})
+	require.NoError(t, err)
+
+	return session
+}
+
+// TestServerSession_AcceptsJavaScriptJoin drives the handshake with the exact
+// join frame the JavaScript client emits and checks the peer reply decodes.
+func TestServerSession_AcceptsJavaScriptJoin(t *testing.T) {
+	t.Parallel()
+
+	join := decodeBase64(t, readFixture[wireFixture](t, "wire-join.json").FrameCBORBase64)
+
+	session := newTestSession(t)
+	handshake, err := session.Accept(join)
+	require.NoError(t, err)
+
+	assert.True(t, handshake.Accepted)
+	assert.Equal(t, "peer-a", handshake.RemotePeerID)
+	assert.Equal(t, "peer-a", session.RemotePeerID())
+
+	peer, err := DecodePeerFrame(handshake.Reply)
+	require.NoError(t, err)
+	assert.Equal(t, "server", peer.SenderID)
+	assert.Equal(t, "peer-a", peer.TargetID)
+	assert.Equal(t, ProtocolV1, peer.SelectedProtocolVersion)
+}
+
+// TestServerSession_RejectsUnsupportedVersion returns an error frame, not an
+// error, and does not complete the handshake.
+func TestServerSession_RejectsUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	join, err := marshal(JoinFrame{
+		Type:                      FrameJoin,
+		SenderID:                  "peer-a",
+		SupportedProtocolVersions: []string{"999"},
+	})
+	require.NoError(t, err)
+
+	session := newTestSession(t)
+	handshake, err := session.Accept(join)
+	require.NoError(t, err)
+	assert.False(t, handshake.Accepted)
+
+	errorFrame, err := DecodeErrorFrame(handshake.Reply)
+	require.NoError(t, err)
+	assert.Equal(t, "peer-a", errorFrame.TargetID)
+	assert.NotEmpty(t, errorFrame.Message)
+}
+
+// TestServerSession_RequiresHandshakeFirst refuses document frames before join.
+func TestServerSession_RequiresHandshakeFirst(t *testing.T) {
+	t.Parallel()
+
+	sync, err := EncodeMessage(Message{
+		Type: MessageSync, SenderID: "peer-a", TargetID: "server",
+		DocumentID: "doc", Data: []byte{1},
+	})
+	require.NoError(t, err)
+
+	session := newTestSession(t)
+	_, err = session.Receive(sync)
+	assert.Error(t, err)
+}
+
+func acceptedSession(t *testing.T) *ServerSession {
+	t.Helper()
+
+	session := newTestSession(t)
+	join := decodeBase64(t, readFixture[wireFixture](t, "wire-join.json").FrameCBORBase64)
+	_, err := session.Accept(join)
+	require.NoError(t, err)
+
+	return session
+}
+
+// TestServerSession_RoutesSync classifies a sync frame for the SyncState.
+func TestServerSession_RoutesSync(t *testing.T) {
+	t.Parallel()
+
+	session := acceptedSession(t)
+
+	sync := decodeBase64(t, readFixture[wireFixture](t, "wire-sync.json").FrameCBORBase64)
+	inbound, err := session.Receive(sync)
+	require.NoError(t, err)
+	assert.Equal(t, InboundSync, inbound.Kind)
+	assert.Equal(t, "4NMNnkMhL2wRfvHYuG1uxN", inbound.Message.DocumentID)
+	assert.Equal(t, []byte{0, 1, 2, 3}, inbound.Message.Data)
+}
+
+// TestServerSession_DeduplicatesEphemeral drops a repeated (session,count).
+func TestServerSession_DeduplicatesEphemeral(t *testing.T) {
+	t.Parallel()
+
+	session := acceptedSession(t)
+
+	payload, err := EncodePresence(PresenceMessage{Type: PresenceHeartbeat})
+	require.NoError(t, err)
+
+	frame := func(count uint64) []byte {
+		data, err := EncodeMessage(Message{
+			Type: MessageEphemeral, SenderID: "peer-a", TargetID: "server",
+			DocumentID: "doc", SessionID: "s", Count: count, Data: payload,
+		})
+		require.NoError(t, err)
+
+		return data
+	}
+
+	first, err := session.Receive(frame(1))
+	require.NoError(t, err)
+	assert.Equal(t, InboundEphemeral, first.Kind)
+	assert.False(t, first.Duplicate)
+
+	second, err := session.Receive(frame(2))
+	require.NoError(t, err)
+	assert.False(t, second.Duplicate)
+
+	replay, err := session.Receive(frame(2))
+	require.NoError(t, err)
+	assert.True(t, replay.Duplicate, "a repeated count is a gossip duplicate")
+
+	older, err := session.Receive(frame(1))
+	require.NoError(t, err)
+	assert.True(t, older.Duplicate, "a lower count is already covered")
+
+	// A different session with the same count is not a duplicate.
+	otherSession, err := EncodeMessage(Message{
+		Type: MessageEphemeral, SenderID: "peer-a", TargetID: "server",
+		DocumentID: "doc", SessionID: "s2", Count: 1, Data: payload,
+	})
+	require.NoError(t, err)
+
+	other, err := session.Receive(otherSession)
+	require.NoError(t, err)
+	assert.False(t, other.Duplicate)
+}
+
+// TestServerSession_IgnoresRemoteHeads treats unrecognised control frames as
+// valid-but-ignored rather than errors.
+func TestServerSession_IgnoresRemoteHeads(t *testing.T) {
+	t.Parallel()
+
+	session := acceptedSession(t)
+
+	frame, err := marshal(map[string]any{
+		"type":     "remote-heads-changed",
+		"senderId": "peer-a",
+		"targetId": "server",
+	})
+	require.NoError(t, err)
+
+	inbound, err := session.Receive(frame)
+	require.NoError(t, err)
+	assert.Equal(t, InboundIgnored, inbound.Kind)
+}

--- a/pkg/automerge/collaboration/testdata/ephemeral-goodbye.json
+++ b/pkg/automerge/collaboration/testdata/ephemeral-goodbye.json
@@ -1,0 +1,13 @@
+{
+  "description": "Ephemeral repo message wrapping a presence goodbye",
+  "message": {
+    "type": "ephemeral",
+    "senderId": "peer-a",
+    "targetId": "peer-b",
+    "documentId": "4NMNnkMhL2wRfvHYuG1uxN",
+    "sessionId": "session-a",
+    "count": 1,
+    "data": "uQABal9fcHJlc2VuY2W5AAFkdHlwZWdnb29kYnll"
+  },
+  "payloadCborBase64": "uQABal9fcHJlc2VuY2W5AAFkdHlwZWdnb29kYnll"
+}

--- a/pkg/automerge/collaboration/testdata/ephemeral-heartbeat.json
+++ b/pkg/automerge/collaboration/testdata/ephemeral-heartbeat.json
@@ -1,0 +1,13 @@
+{
+  "description": "Ephemeral repo message wrapping a presence heartbeat",
+  "message": {
+    "type": "ephemeral",
+    "senderId": "peer-a",
+    "targetId": "peer-b",
+    "documentId": "4NMNnkMhL2wRfvHYuG1uxN",
+    "sessionId": "session-a",
+    "count": 1,
+    "data": "uQABal9fcHJlc2VuY2W5AAFkdHlwZWloZWFydGJlYXQ="
+  },
+  "payloadCborBase64": "uQABal9fcHJlc2VuY2W5AAFkdHlwZWloZWFydGJlYXQ="
+}

--- a/pkg/automerge/collaboration/testdata/ephemeral-snapshot.json
+++ b/pkg/automerge/collaboration/testdata/ephemeral-snapshot.json
@@ -1,0 +1,13 @@
+{
+  "description": "Ephemeral repo message wrapping a presence snapshot",
+  "message": {
+    "type": "ephemeral",
+    "senderId": "peer-a",
+    "targetId": "peer-b",
+    "documentId": "4NMNnkMhL2wRfvHYuG1uxN",
+    "sessionId": "session-a",
+    "count": 1,
+    "data": "uQABal9fcHJlc2VuY2W5AAJkdHlwZWhzbmFwc2hvdGVzdGF0ZbkAAWZjdXJzb3K5AAJmYW5jaG9yYWFkaGVhZGFi"
+  },
+  "payloadCborBase64": "uQABal9fcHJlc2VuY2W5AAJkdHlwZWhzbmFwc2hvdGVzdGF0ZbkAAWZjdXJzb3K5AAJmYW5jaG9yYWFkaGVhZGFi"
+}

--- a/pkg/automerge/collaboration/testdata/ephemeral-update.json
+++ b/pkg/automerge/collaboration/testdata/ephemeral-update.json
@@ -1,0 +1,13 @@
+{
+  "description": "Ephemeral repo message wrapping a presence update",
+  "message": {
+    "type": "ephemeral",
+    "senderId": "peer-a",
+    "targetId": "peer-b",
+    "documentId": "4NMNnkMhL2wRfvHYuG1uxN",
+    "sessionId": "session-a",
+    "count": 1,
+    "data": "uQABal9fcHJlc2VuY2W5AANkdHlwZWZ1cGRhdGVnY2hhbm5lbGZjdXJzb3JldmFsdWW5AAJmYW5jaG9yYWFkaGVhZGFi"
+  },
+  "payloadCborBase64": "uQABal9fcHJlc2VuY2W5AANkdHlwZWZ1cGRhdGVnY2hhbm5lbGZjdXJzb3JldmFsdWW5AAJmYW5jaG9yYWFkaGVhZGFi"
+}

--- a/pkg/automerge/collaboration/testdata/presence-goodbye.json
+++ b/pkg/automerge/collaboration/testdata/presence-goodbye.json
@@ -1,0 +1,10 @@
+{
+  "description": "Presence goodbye envelope CBOR-encoded as an ephemeral payload",
+  "marker": "__presence",
+  "envelope": {
+    "__presence": {
+      "type": "goodbye"
+    }
+  },
+  "cborBase64": "uQABal9fcHJlc2VuY2W5AAFkdHlwZWdnb29kYnll"
+}

--- a/pkg/automerge/collaboration/testdata/presence-heartbeat.json
+++ b/pkg/automerge/collaboration/testdata/presence-heartbeat.json
@@ -1,0 +1,10 @@
+{
+  "description": "Presence heartbeat envelope CBOR-encoded as an ephemeral payload",
+  "marker": "__presence",
+  "envelope": {
+    "__presence": {
+      "type": "heartbeat"
+    }
+  },
+  "cborBase64": "uQABal9fcHJlc2VuY2W5AAFkdHlwZWloZWFydGJlYXQ="
+}

--- a/pkg/automerge/collaboration/testdata/presence-roundtrip.json
+++ b/pkg/automerge/collaboration/testdata/presence-roundtrip.json
@@ -1,0 +1,15 @@
+{
+  "description": "CBOR round-trip of a presence update envelope",
+  "envelope": {
+    "__presence": {
+      "type": "update",
+      "channel": "cursor",
+      "value": {
+        "anchor": "AAEC",
+        "head": "AwQF"
+      }
+    }
+  },
+  "cborBase64": "uQABal9fcHJlc2VuY2W5AANkdHlwZWZ1cGRhdGVnY2hhbm5lbGZjdXJzb3JldmFsdWW5AAJmYW5jaG9yZEFBRUNkaGVhZGRBd1FG",
+  "decodesEqual": true
+}

--- a/pkg/automerge/collaboration/testdata/presence-snapshot.json
+++ b/pkg/automerge/collaboration/testdata/presence-snapshot.json
@@ -1,0 +1,16 @@
+{
+  "description": "Presence snapshot envelope CBOR-encoded as an ephemeral payload",
+  "marker": "__presence",
+  "envelope": {
+    "__presence": {
+      "type": "snapshot",
+      "state": {
+        "cursor": {
+          "anchor": "a",
+          "head": "b"
+        }
+      }
+    }
+  },
+  "cborBase64": "uQABal9fcHJlc2VuY2W5AAJkdHlwZWhzbmFwc2hvdGVzdGF0ZbkAAWZjdXJzb3K5AAJmYW5jaG9yYWFkaGVhZGFi"
+}

--- a/pkg/automerge/collaboration/testdata/presence-update.json
+++ b/pkg/automerge/collaboration/testdata/presence-update.json
@@ -1,0 +1,15 @@
+{
+  "description": "Presence update envelope CBOR-encoded as an ephemeral payload",
+  "marker": "__presence",
+  "envelope": {
+    "__presence": {
+      "type": "update",
+      "channel": "cursor",
+      "value": {
+        "anchor": "a",
+        "head": "b"
+      }
+    }
+  },
+  "cborBase64": "uQABal9fcHJlc2VuY2W5AANkdHlwZWZ1cGRhdGVnY2hhbm5lbGZjdXJzb3JldmFsdWW5AAJmYW5jaG9yYWFkaGVhZGFi"
+}

--- a/pkg/automerge/collaboration/testdata/wire-ephemeral.json
+++ b/pkg/automerge/collaboration/testdata/wire-ephemeral.json
@@ -1,0 +1,13 @@
+{
+  "description": "Framed ephemeral message carrying a presence heartbeat payload",
+  "message": {
+    "type": "ephemeral",
+    "senderId": "peer-a",
+    "targetId": "server",
+    "documentId": "4NMNnkMhL2wRfvHYuG1uxN",
+    "sessionId": "session-a",
+    "count": 1,
+    "data": "uQABal9fcHJlc2VuY2W5AAFkdHlwZWloZWFydGJlYXQ="
+  },
+  "frameCborBase64": "uQAHZHR5cGVpZXBoZW1lcmFsaHNlbmRlcklkZnBlZXItYWh0YXJnZXRJZGZzZXJ2ZXJqZG9jdW1lbnRJZHY0Tk1ObmtNaEwyd1JmdkhZdUcxdXhOaXNlc3Npb25JZGlzZXNzaW9uLWFlY291bnQBZGRhdGFYILkAAWpfX3ByZXNlbmNluQABZHR5cGVpaGVhcnRiZWF0"
+}

--- a/pkg/automerge/collaboration/testdata/wire-error.json
+++ b/pkg/automerge/collaboration/testdata/wire-error.json
@@ -1,0 +1,10 @@
+{
+  "description": "Server error frame before closing the socket",
+  "message": {
+    "type": "error",
+    "senderId": "server",
+    "targetId": "peer-a",
+    "message": "unauthorized"
+  },
+  "frameCborBase64": "uQAEZHR5cGVlZXJyb3Joc2VuZGVySWRmc2VydmVyaHRhcmdldElkZnBlZXItYWdtZXNzYWdlbHVuYXV0aG9yaXplZA=="
+}

--- a/pkg/automerge/collaboration/testdata/wire-join.json
+++ b/pkg/automerge/collaboration/testdata/wire-join.json
@@ -1,0 +1,14 @@
+{
+  "description": "Client join handshake frame",
+  "message": {
+    "type": "join",
+    "senderId": "peer-a",
+    "peerMetadata": {
+      "isEphemeral": false
+    },
+    "supportedProtocolVersions": [
+      "1"
+    ]
+  },
+  "frameCborBase64": "uQAEZHR5cGVkam9pbmhzZW5kZXJJZGZwZWVyLWFscGVlck1ldGFkYXRhuQABa2lzRXBoZW1lcmFs9HgZc3VwcG9ydGVkUHJvdG9jb2xWZXJzaW9uc4FhMQ=="
+}

--- a/pkg/automerge/collaboration/testdata/wire-peer.json
+++ b/pkg/automerge/collaboration/testdata/wire-peer.json
@@ -1,0 +1,13 @@
+{
+  "description": "Server peer handshake reply frame",
+  "message": {
+    "type": "peer",
+    "senderId": "server",
+    "targetId": "peer-a",
+    "peerMetadata": {
+      "isEphemeral": false
+    },
+    "selectedProtocolVersion": "1"
+  },
+  "frameCborBase64": "uQAFZHR5cGVkcGVlcmhzZW5kZXJJZGZzZXJ2ZXJodGFyZ2V0SWRmcGVlci1hbHBlZXJNZXRhZGF0YbkAAWtpc0VwaGVtZXJhbPR3c2VsZWN0ZWRQcm90b2NvbFZlcnNpb25hMQ=="
+}

--- a/pkg/automerge/collaboration/testdata/wire-sync.json
+++ b/pkg/automerge/collaboration/testdata/wire-sync.json
@@ -1,0 +1,11 @@
+{
+  "description": "Framed sync message carrying opaque Automerge sync bytes",
+  "message": {
+    "type": "sync",
+    "senderId": "peer-a",
+    "targetId": "server",
+    "documentId": "4NMNnkMhL2wRfvHYuG1uxN",
+    "data": "AAECAw=="
+  },
+  "frameCborBase64": "uQAFZHR5cGVkc3luY2hzZW5kZXJJZGZwZWVyLWFodGFyZ2V0SWRmc2VydmVyamRvY3VtZW50SWR2NE5NTm5rTWhMMndSZnZIWXVHMXV4TmRkYXRhRAABAgM="
+}

--- a/pkg/automerge/collaboration/transport.go
+++ b/pkg/automerge/collaboration/transport.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import "fmt"
+
+// ProtocolV1 is the only automerge-repo WebSocket protocol version this package
+// speaks.
+const ProtocolV1 = "1"
+
+// Handshake frame types exchanged before document messages flow.
+const (
+	// FrameJoin is the client's first frame, announcing its peer id and the
+	// protocol versions it supports.
+	FrameJoin = "join"
+	// FramePeer is the server's reply, selecting a protocol version and
+	// advertising the server peer id.
+	FramePeer = "peer"
+	// FrameError is sent by either side to report a fatal error immediately
+	// before closing the socket.
+	FrameError = "error"
+)
+
+// PeerMetadata is the optional metadata a peer presents in the handshake. It is
+// not identity: the peer id and metadata are peer-chosen, so a gateway
+// authenticates the connection out of band and never trusts these as a user.
+type PeerMetadata struct {
+	StorageID   string `cbor:"storageId,omitempty"`
+	IsEphemeral bool   `cbor:"isEphemeral,omitempty"`
+}
+
+// JoinFrame is the client handshake frame. It has no target id because it is
+// sent before the client knows the server's peer id.
+type JoinFrame struct {
+	Type                      string       `cbor:"type"`
+	SenderID                  string       `cbor:"senderId"`
+	PeerMetadata              PeerMetadata `cbor:"peerMetadata"`
+	SupportedProtocolVersions []string     `cbor:"supportedProtocolVersions"`
+}
+
+// PeerFrame is the server's reply to a join frame.
+type PeerFrame struct {
+	Type                    string       `cbor:"type"`
+	SenderID                string       `cbor:"senderId"`
+	TargetID                string       `cbor:"targetId"`
+	PeerMetadata            PeerMetadata `cbor:"peerMetadata"`
+	SelectedProtocolVersion string       `cbor:"selectedProtocolVersion"`
+}
+
+// ErrorFrame reports a fatal error; the sender closes the socket after it.
+type ErrorFrame struct {
+	Type     string `cbor:"type"`
+	SenderID string `cbor:"senderId"`
+	TargetID string `cbor:"targetId"`
+	Message  string `cbor:"message"`
+}
+
+// NewJoinFrame builds a client join frame advertising ProtocolV1.
+func NewJoinFrame(senderID string, metadata PeerMetadata) JoinFrame {
+	return JoinFrame{
+		Type:                      FrameJoin,
+		SenderID:                  senderID,
+		PeerMetadata:              metadata,
+		SupportedProtocolVersions: []string{ProtocolV1},
+	}
+}
+
+// EncodeJoinFrame encodes a client join frame.
+func EncodeJoinFrame(frame JoinFrame) ([]byte, error) {
+	if frame.Type != FrameJoin {
+		return nil, fmt.Errorf("join frame has type %q", frame.Type)
+	}
+
+	if frame.SenderID == "" {
+		return nil, fmt.Errorf("join frame is missing a sender id")
+	}
+
+	if len(frame.SupportedProtocolVersions) == 0 {
+		return nil, fmt.Errorf("join frame lists no supported protocol versions")
+	}
+
+	return marshal(frame)
+}
+
+// EncodePeerFrame encodes a server peer reply frame.
+func EncodePeerFrame(frame PeerFrame) ([]byte, error) {
+	if frame.Type != FramePeer {
+		return nil, fmt.Errorf("peer frame has type %q", frame.Type)
+	}
+
+	if frame.SenderID == "" || frame.TargetID == "" {
+		return nil, fmt.Errorf("peer frame is missing a sender or target id")
+	}
+
+	if frame.SelectedProtocolVersion == "" {
+		return nil, fmt.Errorf("peer frame selected no protocol version")
+	}
+
+	return marshal(frame)
+}
+
+// EncodeErrorFrame encodes an error frame.
+func EncodeErrorFrame(frame ErrorFrame) ([]byte, error) {
+	if frame.Type != FrameError {
+		return nil, fmt.Errorf("error frame has type %q", frame.Type)
+	}
+
+	return marshal(frame)
+}
+
+// frameType peeks only the discriminator so a reader can route a frame to the
+// right decoder without decoding it twice into the wrong shape.
+type frameType struct {
+	Type string `cbor:"type"`
+}
+
+// FrameKind returns the type discriminator of a raw WebSocket frame.
+func FrameKind(data []byte) (string, error) {
+	var peek frameType
+	if err := unmarshal(data, &peek); err != nil {
+		return "", fmt.Errorf("cannot read frame type: %w", err)
+	}
+
+	if peek.Type == "" {
+		return "", fmt.Errorf("frame is missing a type")
+	}
+
+	return peek.Type, nil
+}
+
+// DecodeJoinFrame decodes and validates a client join frame, returning whether
+// it supports ProtocolV1.
+func DecodeJoinFrame(data []byte) (JoinFrame, error) {
+	var frame JoinFrame
+	if err := unmarshal(data, &frame); err != nil {
+		return JoinFrame{}, fmt.Errorf("cannot decode join frame: %w", err)
+	}
+
+	if frame.Type != FrameJoin {
+		return JoinFrame{}, fmt.Errorf("expected a join frame, got %q", frame.Type)
+	}
+
+	if frame.SenderID == "" {
+		return JoinFrame{}, fmt.Errorf("join frame is missing a sender id")
+	}
+
+	return frame, nil
+}
+
+// SupportsV1 reports whether the join frame offers ProtocolV1.
+func (f JoinFrame) SupportsV1() bool {
+	for _, version := range f.SupportedProtocolVersions {
+		if version == ProtocolV1 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// DecodePeerFrame decodes and validates a server peer frame.
+func DecodePeerFrame(data []byte) (PeerFrame, error) {
+	var frame PeerFrame
+	if err := unmarshal(data, &frame); err != nil {
+		return PeerFrame{}, fmt.Errorf("cannot decode peer frame: %w", err)
+	}
+
+	if frame.Type != FramePeer {
+		return PeerFrame{}, fmt.Errorf("expected a peer frame, got %q", frame.Type)
+	}
+
+	return frame, nil
+}
+
+// DecodeErrorFrame decodes an error frame.
+func DecodeErrorFrame(data []byte) (ErrorFrame, error) {
+	var frame ErrorFrame
+	if err := unmarshal(data, &frame); err != nil {
+		return ErrorFrame{}, fmt.Errorf("cannot decode error frame: %w", err)
+	}
+
+	if frame.Type != FrameError {
+		return ErrorFrame{}, fmt.Errorf("expected an error frame, got %q", frame.Type)
+	}
+
+	return frame, nil
+}

--- a/pkg/automerge/collaboration/transport_test.go
+++ b/pkg/automerge/collaboration/transport_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package collaboration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type wireFixture struct {
+	Description     string `json:"description"`
+	FrameCBORBase64 string `json:"frameCborBase64"`
+}
+
+// TestDecodeHandshakeFrames_MatchJavaScriptBytes decodes the exact handshake
+// frames the pinned WebSocket adapter emits.
+func TestDecodeHandshakeFrames_MatchJavaScriptBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("join", func(t *testing.T) {
+		t.Parallel()
+
+		data := decodeBase64(t, readFixture[wireFixture](t, "wire-join.json").FrameCBORBase64)
+
+		kind, err := FrameKind(data)
+		require.NoError(t, err)
+		assert.Equal(t, FrameJoin, kind)
+
+		frame, err := DecodeJoinFrame(data)
+		require.NoError(t, err)
+		assert.Equal(t, "peer-a", frame.SenderID)
+		assert.True(t, frame.SupportsV1())
+		assert.False(t, frame.PeerMetadata.IsEphemeral)
+	})
+
+	t.Run("peer", func(t *testing.T) {
+		t.Parallel()
+
+		data := decodeBase64(t, readFixture[wireFixture](t, "wire-peer.json").FrameCBORBase64)
+
+		frame, err := DecodePeerFrame(data)
+		require.NoError(t, err)
+		assert.Equal(t, "server", frame.SenderID)
+		assert.Equal(t, "peer-a", frame.TargetID)
+		assert.Equal(t, ProtocolV1, frame.SelectedProtocolVersion)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		data := decodeBase64(t, readFixture[wireFixture](t, "wire-error.json").FrameCBORBase64)
+
+		frame, err := DecodeErrorFrame(data)
+		require.NoError(t, err)
+		assert.Equal(t, "unauthorized", frame.Message)
+	})
+}
+
+// TestDecodeFramedMessages_MatchJavaScriptBytes decodes the framed document
+// messages the adapter emits and confirms the ephemeral frame carries a
+// presence payload our presence codec reads.
+func TestDecodeFramedMessages_MatchJavaScriptBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sync", func(t *testing.T) {
+		t.Parallel()
+
+		data := decodeBase64(t, readFixture[wireFixture](t, "wire-sync.json").FrameCBORBase64)
+
+		kind, err := FrameKind(data)
+		require.NoError(t, err)
+		assert.Equal(t, string(MessageSync), kind)
+
+		message, err := DecodeMessage(data)
+		require.NoError(t, err)
+		assert.Equal(t, MessageSync, message.Type)
+		assert.Equal(t, "4NMNnkMhL2wRfvHYuG1uxN", message.DocumentID)
+		assert.Equal(t, []byte{0, 1, 2, 3}, message.Data)
+	})
+
+	t.Run("ephemeral carries presence", func(t *testing.T) {
+		t.Parallel()
+
+		data := decodeBase64(t, readFixture[wireFixture](t, "wire-ephemeral.json").FrameCBORBase64)
+
+		message, err := DecodeMessage(data)
+		require.NoError(t, err)
+		assert.Equal(t, MessageEphemeral, message.Type)
+
+		presence, err := DecodePresence(message.Data)
+		require.NoError(t, err)
+		assert.Equal(t, PresenceHeartbeat, presence.Type)
+	})
+}
+
+// TestHandshakeFrames_RoundTrip encodes then decodes each handshake frame.
+func TestHandshakeFrames_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	join, err := EncodeJoinFrame(NewJoinFrame("peer-a", PeerMetadata{IsEphemeral: true}))
+	require.NoError(t, err)
+
+	decodedJoin, err := DecodeJoinFrame(join)
+	require.NoError(t, err)
+	assert.True(t, decodedJoin.SupportsV1())
+	assert.True(t, decodedJoin.PeerMetadata.IsEphemeral)
+
+	peer, err := EncodePeerFrame(PeerFrame{
+		Type:                    FramePeer,
+		SenderID:                "server",
+		TargetID:                "peer-a",
+		SelectedProtocolVersion: ProtocolV1,
+	})
+	require.NoError(t, err)
+
+	decodedPeer, err := DecodePeerFrame(peer)
+	require.NoError(t, err)
+	assert.Equal(t, ProtocolV1, decodedPeer.SelectedProtocolVersion)
+}
+
+// TestEncodeFrames_Validation rejects malformed handshake frames.
+func TestEncodeFrames_Validation(t *testing.T) {
+	t.Parallel()
+
+	_, err := EncodeJoinFrame(JoinFrame{Type: FrameJoin, SupportedProtocolVersions: []string{ProtocolV1}})
+	assert.Error(t, err, "join without a sender must be rejected")
+
+	_, err = EncodePeerFrame(PeerFrame{Type: FramePeer, SenderID: "s", TargetID: "c"})
+	assert.Error(t, err, "peer without a selected version must be rejected")
+}

--- a/pkg/automerge/prosemirror/parse.go
+++ b/pkg/automerge/prosemirror/parse.go
@@ -1,0 +1,357 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package prosemirror
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"go.probo.inc/probo/pkg/automerge"
+)
+
+// ToSpans converts a ProseMirror document (the JSON the editor stores) into the
+// Automerge rich-text spans that seed a collaboration document. It is the
+// forward counterpart of Render: writing the returned spans with
+// Text.UpdateSpans and then rendering the document reproduces the input, which
+// is what lets the server seed a document version's CRDT from its stored
+// ProseMirror content without a JavaScript build step.
+//
+// The traversal is the inverse of render.go: every block node emits a block
+// marker carrying its full ancestor path of Automerge block types; a container
+// block (blockquote, list item, table cell) folds its first paragraph's inline
+// content into itself, matching how @automerge/prosemirror flattens the tree;
+// list wrappers are transparent and only their items become blocks; and marks
+// map by the shared schema ledger. Unknown nodes and marks are dropped, mirroring
+// the renderer's tolerance for schema drift.
+func ToSpans(documentJSON string) ([]automerge.SpanInput, error) {
+	var document pmNode
+	if err := json.Unmarshal([]byte(documentJSON), &document); err != nil {
+		return nil, fmt.Errorf("cannot parse ProseMirror document: %w", err)
+	}
+
+	if document.Type != "doc" {
+		return nil, fmt.Errorf("expected a ProseMirror doc node, got %q", document.Type)
+	}
+
+	spans := make([]automerge.SpanInput, 0)
+	for _, child := range document.Content {
+		spans = emitBlock(spans, child, nil)
+	}
+
+	return spans, nil
+}
+
+// UpdateSpansConfig returns the span-writing configuration the seeder uses. Marks
+// expand after their range by default, matching the frontend adapter, so text
+// typed at a mark's trailing edge inherits it.
+func UpdateSpansConfig() automerge.UpdateSpansConfig {
+	return automerge.UpdateSpansConfig{DefaultExpand: automerge.MarkExpandAfter}
+}
+
+type (
+	pmNode struct {
+		Type    string         `json:"type"`
+		Attrs   map[string]any `json:"attrs,omitempty"`
+		Content []pmNode       `json:"content,omitempty"`
+		Text    string         `json:"text,omitempty"`
+		Marks   []pmMark       `json:"marks,omitempty"`
+	}
+
+	pmMark struct {
+		Type  string         `json:"type"`
+		Attrs map[string]any `json:"attrs,omitempty"`
+	}
+)
+
+// pmNodeToBlock maps a ProseMirror node name to its Automerge block type. List
+// items are absent because their type depends on the enclosing list wrapper.
+var pmNodeToBlock = map[string]string{
+	"paragraph":      blockTypeParagraph,
+	"heading":        blockTypeHeading,
+	"codeBlock":      blockTypeCode,
+	"blockquote":     blockTypeBlockquote,
+	"horizontalRule": blockTypeHorizontalRule,
+	"table":          blockTypeTable,
+	"tableRow":       blockTypeTableRow,
+	"tableCell":      blockTypeTableCell,
+	"tableHeader":    blockTypeTableHeader,
+}
+
+var pmMarkToAutomerge = map[string]string{}
+
+func init() {
+	for _, mapping := range markMappings {
+		pmMarkToAutomerge[mapping.ProseMirror] = mapping.Automerge
+	}
+}
+
+func emitBlock(spans []automerge.SpanInput, n pmNode, parents []string) []automerge.SpanInput {
+	switch n.Type {
+	case "bulletList", "orderedList":
+		itemType := blockTypeUnorderedListItem
+		if n.Type == "orderedList" {
+			itemType = blockTypeOrderedListItem
+		}
+
+		for _, item := range n.Content {
+			if item.Type != "listItem" {
+				continue
+			}
+
+			spans = append(spans, blockSpan(itemType, parents, nil))
+			// A list item always renders exactly one leading paragraph from its
+			// own content, so its first paragraph is always folded in.
+			spans = emitContainerChildren(spans, item.Content, childPath(parents, itemType), true)
+		}
+
+		return spans
+	case "paragraph", "heading", "codeBlock":
+		blockType := pmNodeToBlock[n.Type]
+		spans = append(spans, blockSpan(blockType, parents, blockAttributes(blockType, n.Attrs)))
+
+		return emitInline(spans, n.Content, childPath(parents, blockType))
+	case "blockquote", "tableCell", "tableHeader":
+		blockType := pmNodeToBlock[n.Type]
+		spans = append(spans, blockSpan(blockType, parents, blockAttributes(blockType, n.Attrs)))
+
+		// These containers only render a leading paragraph from their own content
+		// when it is non-empty (or they have no other children), so an empty
+		// first paragraph with siblings must stay an explicit block.
+		return emitContainerChildren(spans, n.Content, childPath(parents, blockType), false)
+	case "table", "tableRow":
+		blockType := pmNodeToBlock[n.Type]
+		spans = append(spans, blockSpan(blockType, parents, blockAttributes(blockType, n.Attrs)))
+
+		childParents := childPath(parents, blockType)
+		for _, child := range n.Content {
+			spans = emitBlock(spans, child, childParents)
+		}
+
+		return spans
+	case "horizontalRule":
+		return append(spans, blockSpan(blockTypeHorizontalRule, parents, map[string]any{}))
+	default:
+		// Unknown block node: drop it rather than abort, mirroring the renderer.
+		return spans
+	}
+}
+
+// emitContainerChildren writes the children of a container block. A container's
+// first paragraph may be folded into the container's own inline content (no
+// separate block marker), which is how list items, blockquotes, and table cells
+// carry their first line; any remaining children become nested blocks.
+//
+// Whether the fold happens matches how the renderer reconstructs the container.
+// A list item always renders one leading paragraph from its own content, so its
+// first paragraph is always folded (alwaysFoldFirstParagraph). A blockquote or
+// table cell only renders a leading paragraph when its own content is non-empty
+// or it has no other children, so an empty first paragraph that has siblings
+// must remain an explicit block or it would be lost on the round trip.
+func emitContainerChildren(
+	spans []automerge.SpanInput,
+	children []pmNode,
+	childParents []string,
+	alwaysFoldFirstParagraph bool,
+) []automerge.SpanInput {
+	if len(children) > 0 && children[0].Type == "paragraph" {
+		fold := alwaysFoldFirstParagraph ||
+			len(children) == 1 ||
+			len(children[0].Content) > 0
+		if fold {
+			spans = emitInline(spans, children[0].Content, childParents)
+
+			for _, child := range children[1:] {
+				spans = emitBlock(spans, child, childParents)
+			}
+
+			return spans
+		}
+	}
+
+	for _, child := range children {
+		spans = emitBlock(spans, child, childParents)
+	}
+
+	return spans
+}
+
+func emitInline(spans []automerge.SpanInput, inline []pmNode, blockParents []string) []automerge.SpanInput {
+	for _, child := range inline {
+		switch child.Type {
+		case "text":
+			if child.Text == "" {
+				continue
+			}
+
+			span := automerge.SpanInput{Text: child.Text}
+			if marks := convertMarks(child.Marks); len(marks) > 0 {
+				span.Marks = marks
+			}
+
+			spans = append(spans, span)
+		case "hardBreak":
+			spans = append(spans, hardBreakSpan(blockParents))
+		default:
+			continue
+		}
+	}
+
+	return spans
+}
+
+func convertMarks(marks []pmMark) map[string]automerge.Scalar {
+	if len(marks) == 0 {
+		return nil
+	}
+
+	result := make(map[string]automerge.Scalar, len(marks))
+
+	for _, mark := range marks {
+		name, ok := pmMarkToAutomerge[mark.Type]
+		if !ok {
+			continue
+		}
+
+		if name == "link" {
+			payload, err := json.Marshal(map[string]any{
+				"href":  stringAttribute(mark.Attrs, "href"),
+				"title": nullableStringAttribute(mark.Attrs, "title"),
+			})
+			if err != nil {
+				continue
+			}
+
+			result[name] = automerge.StringScalar(string(payload))
+
+			continue
+		}
+
+		result[name] = automerge.BoolScalar(true)
+	}
+
+	return result
+}
+
+func blockSpan(blockType string, parents []string, attrs map[string]any) automerge.SpanInput {
+	if attrs == nil {
+		attrs = map[string]any{}
+	}
+
+	return automerge.SpanInput{
+		Block: map[string]any{
+			"type":    blockType,
+			"parents": toAnySlice(parents),
+			"attrs":   attrs,
+			"isEmbed": false,
+		},
+	}
+}
+
+func hardBreakSpan(parents []string) automerge.SpanInput {
+	return automerge.SpanInput{
+		Block: map[string]any{
+			"type":    blockTypeHardBreak,
+			"parents": toAnySlice(parents),
+			"attrs":   map[string]any{},
+			"isEmbed": true,
+		},
+	}
+}
+
+func blockAttributes(blockType string, attrs map[string]any) map[string]any {
+	switch blockType {
+	case blockTypeHeading:
+		level := intAttribute(attrs, "level", 1)
+		if level < 1 || level > 6 {
+			level = 1
+		}
+
+		return map[string]any{"level": level}
+	case blockTypeCode:
+		if language, ok := attrs["language"].(string); ok {
+			return map[string]any{"language": language}
+		}
+
+		return map[string]any{}
+	case blockTypeTableCell, blockTypeTableHeader:
+		cellAttrs := map[string]any{
+			"colspan": intAttribute(attrs, "colspan", 1),
+			"rowspan": intAttribute(attrs, "rowspan", 1),
+		}
+
+		if colwidth := numberSliceAttribute(attrs, "colwidth"); colwidth != nil {
+			cellAttrs["colwidth"] = colwidth
+		}
+
+		return cellAttrs
+	default:
+		return map[string]any{}
+	}
+}
+
+func childPath(parents []string, blockType string) []string {
+	return append(slices.Clone(parents), blockType)
+}
+
+func toAnySlice(values []string) []any {
+	result := make([]any, len(values))
+	for i, value := range values {
+		result[i] = value
+	}
+
+	return result
+}
+
+func numberSliceAttribute(attrs map[string]any, name string) []any {
+	values, ok := attrs[name].([]any)
+	if !ok {
+		return nil
+	}
+
+	result := make([]any, 0, len(values))
+	for _, value := range values {
+		number, ok := value.(float64)
+		if !ok {
+			return nil
+		}
+
+		result = append(result, number)
+	}
+
+	return result
+}
+
+func stringAttribute(attrs map[string]any, name string) string {
+	if value, ok := attrs[name].(string); ok {
+		return value
+	}
+
+	return ""
+}
+
+func nullableStringAttribute(attrs map[string]any, name string) any {
+	if value, ok := attrs[name].(string); ok {
+		return value
+	}
+
+	return nil
+}

--- a/pkg/automerge/prosemirror/parse_test.go
+++ b/pkg/automerge/prosemirror/parse_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package prosemirror_test
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/automerge"
+	automergeprosemirror "go.probo.inc/probo/pkg/automerge/prosemirror"
+)
+
+// TestToSpans_RoundTripsCanonicalDocuments is the seeding-correctness gate: for
+// every document in the shared corpus, converting the canonical ProseMirror JSON
+// to spans, writing them into a fresh Automerge document, and rendering it back
+// must reproduce the same ProseMirror JSON. This is exactly what server-side
+// seeding does, so a green run means the server can bootstrap a document
+// version's CRDT from its stored content and materialize it unchanged.
+func TestToSpans_RoundTripsCanonicalDocuments(t *testing.T) {
+	t.Parallel()
+
+	file, err := os.Open("testdata/upstream-render.json.gz")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, file.Close()) })
+
+	reader, err := gzip.NewReader(file)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+
+	var fixtures []struct {
+		Name     string          `json:"name"`
+		Expected json.RawMessage `json:"expected"`
+	}
+	require.NoError(t, json.NewDecoder(reader).Decode(&fixtures))
+	require.NotEmpty(t, fixtures)
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.Name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			spans, err := automergeprosemirror.ToSpans(string(fixture.Expected))
+			require.NoError(t, err)
+
+			actorID, err := automerge.NewActorID()
+			require.NoError(t, err)
+
+			document, err := automerge.New(ctx, actorID)
+			require.NoError(t, err)
+
+			defer func() { _ = document.Close(ctx) }()
+
+			text, err := document.CreateText(ctx, "body")
+			require.NoError(t, err)
+
+			require.NoError(t, text.UpdateSpans(ctx, spans, automergeprosemirror.UpdateSpansConfig()))
+
+			readback, err := text.Spans(ctx)
+			require.NoError(t, err)
+
+			rendered, err := automergeprosemirror.Render(readback)
+			require.NoError(t, err)
+
+			assert.JSONEq(
+				t,
+				string(fixture.Expected),
+				rendered,
+				"seeding %s must round-trip through spans", fixture.Name,
+			)
+		})
+	}
+}

--- a/pkg/probo/document_collaboration_service.go
+++ b/pkg/probo/document_collaboration_service.go
@@ -214,6 +214,44 @@ func (s *DocumentService) OpenCollaboration(
 	}, nil
 }
 
+// NotifyCollaborationEphemeral relays an opaque automerge-repo gossip frame
+// (presence, cursors) to peers connected to other server instances, over the
+// same NOTIFY channel that carries persisted-change signals. The instanceID
+// identifies the publishing server so it can ignore its own echo. It is
+// fire-and-forget: it does not touch the document and runs outside any
+// transaction. An oversized frame returns an error and is not sent; the caller
+// still delivers it to its local peers.
+func (s *DocumentService) NotifyCollaborationEphemeral(
+	ctx context.Context,
+	documentVersionID gid.GID,
+	instanceID string,
+	frame []byte,
+) error {
+	payload, err := realtime.EncodeCollaborationEphemeral(realtime.CollaborationEphemeral{
+		VersionID:  documentVersionID.String(),
+		InstanceID: instanceID,
+		Frame:      frame,
+	})
+	if err != nil {
+		return fmt.Errorf("cannot encode collaboration ephemeral: %w", err)
+	}
+
+	return s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		if _, err := conn.Exec(
+			ctx,
+			`SELECT pg_notify(@channel, @payload)`,
+			pgx.StrictNamedArgs{
+				"channel": realtime.DocumentCollaborationChannel,
+				"payload": payload,
+			},
+		); err != nil {
+			return fmt.Errorf("cannot notify collaboration ephemeral: %w", err)
+		}
+
+		return nil
+	})
+}
+
 func (s *DocumentService) PersistCollaboration(
 	ctx context.Context,
 	scope coredata.Scoper,

--- a/pkg/realtime/ephemeral.go
+++ b/pkg/realtime/ephemeral.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package realtime
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// MaxCollaborationEphemeralBytes bounds the encoded NOTIFY payload for an
+// ephemeral gossip event. PostgreSQL caps a NOTIFY payload at 8000 bytes; this
+// leaves headroom for the JSON envelope and base64 expansion of the frame.
+// Presence and cursor frames are far smaller, so an oversized frame is dropped
+// from cross-instance gossip (local fan-out still delivers it) rather than
+// risking a failed NOTIFY.
+const MaxCollaborationEphemeralBytes = 7000
+
+// ephemeralKind marks a collaboration-changed NOTIFY payload as an ephemeral
+// envelope rather than the bare document-version id that signals a persisted
+// change. A bare id is not valid JSON, so the two never collide.
+const ephemeralKind = "ephemeral"
+
+// CollaborationEphemeral is an opaque automerge-repo gossip frame carried across
+// server instances over the collaboration NOTIFY channel, so presence and
+// cursors reach peers connected to other instances.
+type CollaborationEphemeral struct {
+	// VersionID is the document-version GID string the frame belongs to.
+	VersionID string
+	// InstanceID identifies the server instance that published the frame, so the
+	// publisher can ignore its own echo (it already delivered the frame to its
+	// local peers directly).
+	InstanceID string
+	// Frame is the opaque repo message to relay unchanged.
+	Frame []byte
+}
+
+type ephemeralEnvelope struct {
+	Kind       string `json:"k"`
+	VersionID  string `json:"v"`
+	InstanceID string `json:"i"`
+	Frame      []byte `json:"e"`
+}
+
+// EncodeCollaborationEphemeral encodes an ephemeral event into a NOTIFY payload.
+// It returns an error when the encoded payload would exceed the NOTIFY size
+// budget, so the caller can fall back to local-only fan-out.
+func EncodeCollaborationEphemeral(event CollaborationEphemeral) (string, error) {
+	payload, err := json.Marshal(ephemeralEnvelope{
+		Kind:       ephemeralKind,
+		VersionID:  event.VersionID,
+		InstanceID: event.InstanceID,
+		Frame:      event.Frame,
+	})
+	if err != nil {
+		return "", fmt.Errorf("cannot encode collaboration ephemeral: %w", err)
+	}
+
+	if len(payload) > MaxCollaborationEphemeralBytes {
+		return "", fmt.Errorf(
+			"collaboration ephemeral payload is %d bytes, over the %d-byte limit",
+			len(payload), MaxCollaborationEphemeralBytes,
+		)
+	}
+
+	return string(payload), nil
+}
+
+// DecodeCollaborationEphemeral decodes a NOTIFY payload as an ephemeral event. It
+// reports ok=false for a bare document-version id (the persisted-change signal)
+// or any payload that is not a well-formed ephemeral envelope, so callers can
+// treat the two payload kinds apart.
+func DecodeCollaborationEphemeral(payload string) (CollaborationEphemeral, bool) {
+	// A bare document-version id is base64url and never starts with '{', so this
+	// keeps the change-signal path free of a JSON decode.
+	if len(payload) == 0 || payload[0] != '{' {
+		return CollaborationEphemeral{}, false
+	}
+
+	var envelope ephemeralEnvelope
+	if err := json.Unmarshal([]byte(payload), &envelope); err != nil {
+		return CollaborationEphemeral{}, false
+	}
+
+	if envelope.Kind != ephemeralKind || envelope.VersionID == "" {
+		return CollaborationEphemeral{}, false
+	}
+
+	return CollaborationEphemeral{
+		VersionID:  envelope.VersionID,
+		InstanceID: envelope.InstanceID,
+		Frame:      envelope.Frame,
+	}, true
+}

--- a/pkg/realtime/ephemeral_test.go
+++ b/pkg/realtime/ephemeral_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package realtime_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/realtime"
+)
+
+func TestCollaborationEphemeral_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	event := realtime.CollaborationEphemeral{
+		VersionID:  "2AbcDocumentVersionGid",
+		InstanceID: "instance-7",
+		Frame:      []byte{0x00, 0x01, 0x02, 0xff, 0xfe},
+	}
+
+	payload, err := realtime.EncodeCollaborationEphemeral(event)
+	require.NoError(t, err)
+
+	decoded, ok := realtime.DecodeCollaborationEphemeral(payload)
+	require.True(t, ok)
+	assert.Equal(t, event, decoded)
+}
+
+func TestCollaborationEphemeral_BareIDIsNotEphemeral(t *testing.T) {
+	t.Parallel()
+
+	// A bare document-version id (the persisted-change signal) must not be
+	// mistaken for an ephemeral envelope.
+	_, ok := realtime.DecodeCollaborationEphemeral("q4Zx2Yt5gPJpq5RfXAkPfPcUj1rABCD")
+	assert.False(t, ok)
+
+	_, ok = realtime.DecodeCollaborationEphemeral("")
+	assert.False(t, ok)
+
+	// Well-formed JSON that is not our envelope is rejected.
+	_, ok = realtime.DecodeCollaborationEphemeral(`{"hello":"world"}`)
+	assert.False(t, ok)
+}
+
+func TestCollaborationEphemeral_RejectsOversizedFrame(t *testing.T) {
+	t.Parallel()
+
+	event := realtime.CollaborationEphemeral{
+		VersionID:  "version",
+		InstanceID: "instance",
+		Frame:      []byte(strings.Repeat("A", realtime.MaxCollaborationEphemeralBytes)),
+	}
+
+	_, err := realtime.EncodeCollaborationEphemeral(event)
+	assert.Error(t, err)
+}

--- a/pkg/server/api/console/v1/document_collaboration_hub.go
+++ b/pkg/server/api/console/v1/document_collaboration_hub.go
@@ -45,6 +45,13 @@ type (
 	documentCollaborationRoomPeer struct {
 		connectionID string
 		wake         chan documentCollaborationWake
+		// ephemeral carries opaque automerge-repo gossip frames (presence,
+		// cursors) destined for this peer. It is kept separate from wake so a
+		// dropped best-effort gossip frame never coalesces with, or masks, a
+		// sync refresh. Delivery is best-effort: a full buffer drops the
+		// oldest-style (the frame is skipped), which is acceptable for
+		// ephemeral state that the sender re-emits.
+		ephemeral chan []byte
 	}
 
 	documentCollaborationDocuments interface {
@@ -89,10 +96,13 @@ type (
 		room              *documentCollaborationRoom
 		peerID            uint64
 		Wake              <-chan documentCollaborationWake
+		Ephemeral         <-chan []byte
 		seedOwner         bool
 		once              sync.Once
 	}
 )
+
+const documentCollaborationEphemeralBuffer = 64
 
 const (
 	documentCollaborationPersistDebounce = 50 * time.Millisecond
@@ -180,9 +190,11 @@ func (h *documentCollaborationHub) addPeerLocked(
 	peerID := room.nextPeerID
 	room.nextPeerID++
 	wake := make(chan documentCollaborationWake, 8)
+	ephemeral := make(chan []byte, documentCollaborationEphemeralBuffer)
 	room.peers[peerID] = documentCollaborationRoomPeer{
 		connectionID: connectionID,
 		wake:         wake,
+		ephemeral:    ephemeral,
 	}
 	room.mu.Unlock()
 
@@ -192,6 +204,7 @@ func (h *documentCollaborationHub) addPeerLocked(
 		room:              room,
 		peerID:            peerID,
 		Wake:              wake,
+		Ephemeral:         ephemeral,
 	}
 }
 
@@ -222,6 +235,32 @@ func (l *documentCollaborationRoomLease) NotifyPeers() {
 
 		select {
 		case peer.wake <- documentCollaborationWake{}:
+		default:
+		}
+	}
+}
+
+// BroadcastEphemeral fans an opaque automerge-repo gossip frame out to every
+// other local peer in the room, leaving the originating peer untouched. It is
+// the repo-protocol counterpart of UpdatePresence: presence and cursor state
+// travel as opaque ephemeral frames rather than as the structured snapshots the
+// legacy protocol used. Delivery is best-effort; a peer whose buffer is full
+// skips the frame, relying on the sender to re-emit its ephemeral state.
+//
+// Fan-out is scoped to this server instance. Cross-instance gossip would require
+// carrying the payload through realtime.Events, which today only signals a
+// document changed; that remains a follow-up.
+func (l *documentCollaborationRoomLease) BroadcastEphemeral(frame []byte) {
+	l.room.mu.Lock()
+	defer l.room.mu.Unlock()
+
+	for peerID, peer := range l.room.peers {
+		if peerID == l.peerID {
+			continue
+		}
+
+		select {
+		case peer.ephemeral <- frame:
 		default:
 		}
 	}

--- a/pkg/server/api/console/v1/document_collaboration_hub.go
+++ b/pkg/server/api/console/v1/document_collaboration_hub.go
@@ -69,9 +69,10 @@ type (
 	}
 
 	documentCollaborationHub struct {
-		mu        sync.Mutex
-		documents documentCollaborationDocuments
-		rooms     map[gid.GID]*documentCollaborationRoom
+		mu         sync.Mutex
+		documents  documentCollaborationDocuments
+		rooms      map[gid.GID]*documentCollaborationRoom
+		instanceID string
 	}
 
 	documentCollaborationRoom struct {
@@ -113,9 +114,18 @@ func newDocumentCollaborationHub(
 	documents documentCollaborationDocuments,
 	events *realtime.Events,
 ) *documentCollaborationHub {
+	instanceID, err := newDocumentCollaborationConnectionID()
+	if err != nil {
+		// A random instance id only suppresses a server's own ephemeral echo; if
+		// generation ever fails, an empty id degrades to client-side dedup rather
+		// than breaking the hub.
+		instanceID = ""
+	}
+
 	hub := &documentCollaborationHub{
-		documents: documents,
-		rooms:     make(map[gid.GID]*documentCollaborationRoom),
+		documents:  documents,
+		rooms:      make(map[gid.GID]*documentCollaborationRoom),
+		instanceID: instanceID,
 	}
 	if events != nil {
 		events.Subscribe(hub.notifyExternal)
@@ -247,9 +257,10 @@ func (l *documentCollaborationRoomLease) NotifyPeers() {
 // legacy protocol used. Delivery is best-effort; a peer whose buffer is full
 // skips the frame, relying on the sender to re-emit its ephemeral state.
 //
-// Fan-out is scoped to this server instance. Cross-instance gossip would require
-// carrying the payload through realtime.Events, which today only signals a
-// document changed; that remains a follow-up.
+// This delivers only to peers on the current server instance. Peers on other
+// instances are reached separately, by publishing the frame over the
+// collaboration NOTIFY channel; the receiving instance delivers it with
+// fanoutEphemeral.
 func (l *documentCollaborationRoomLease) BroadcastEphemeral(frame []byte) {
 	l.room.mu.Lock()
 	defer l.room.mu.Unlock()
@@ -300,6 +311,13 @@ func (r *documentCollaborationRoom) notifyPresenceLocked() {
 }
 
 func (h *documentCollaborationHub) notifyExternal(payload string) {
+	// An ephemeral envelope carries opaque repo gossip (presence, cursors) from
+	// another instance; a bare document-version id signals a persisted change.
+	if ephemeral, ok := realtime.DecodeCollaborationEphemeral(payload); ok {
+		h.notifyExternalEphemeral(ephemeral)
+		return
+	}
+
 	documentVersionID, err := gid.ParseGID(payload)
 	if err != nil || documentVersionID.EntityType() != coredata.DocumentVersionEntityType {
 		return
@@ -319,6 +337,44 @@ func (h *documentCollaborationHub) notifyExternal(payload string) {
 	for _, peer := range room.peers {
 		select {
 		case peer.wake <- documentCollaborationWake{refresh: true}:
+		default:
+		}
+	}
+}
+
+func (h *documentCollaborationHub) notifyExternalEphemeral(ephemeral realtime.CollaborationEphemeral) {
+	// Our own echo: this instance already delivered the frame to its local peers
+	// when it published it, so re-delivering would surface a peer's own cursor.
+	if ephemeral.InstanceID != "" && ephemeral.InstanceID == h.instanceID {
+		return
+	}
+
+	documentVersionID, err := gid.ParseGID(ephemeral.VersionID)
+	if err != nil || documentVersionID.EntityType() != coredata.DocumentVersionEntityType {
+		return
+	}
+
+	h.mu.Lock()
+	room := h.rooms[documentVersionID]
+	h.mu.Unlock()
+
+	if room == nil {
+		return
+	}
+
+	room.fanoutEphemeral(ephemeral.Frame)
+}
+
+// fanoutEphemeral delivers a repo gossip frame that arrived from another server
+// instance to every local peer in the room. Unlike the lease's BroadcastEphemeral
+// there is no originating local peer to exclude.
+func (r *documentCollaborationRoom) fanoutEphemeral(frame []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, peer := range r.peers {
+		select {
+		case peer.ephemeral <- frame:
 		default:
 		}
 	}

--- a/pkg/server/api/console/v1/document_collaboration_hub_test.go
+++ b/pkg/server/api/console/v1/document_collaboration_hub_test.go
@@ -147,6 +147,86 @@ func TestDocumentCollaborationRoom_NotifiesOtherPeers(t *testing.T) {
 	assert.NotContains(t, hub.rooms, versionID)
 }
 
+func TestDocumentCollaborationRoom_BroadcastsEphemeralToOtherPeers(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	versionID := gid.New(tenantID, coredata.DocumentVersionEntityType)
+	document, err := automerge.New(context.Background(), automerge.ActorID{3})
+	require.NoError(t, err)
+
+	room := &documentCollaborationRoom{
+		collaboration: &probo.DocumentCollaboration{
+			Document: document,
+			Revision: 1,
+		},
+		peers:     make(map[uint64]documentCollaborationRoomPeer),
+		presences: make(map[string]documentCollaborationPresence),
+	}
+	room.revision.Store(1)
+	hub := &documentCollaborationHub{
+		rooms: map[gid.GID]*documentCollaborationRoom{
+			versionID: room,
+		},
+	}
+
+	hub.mu.Lock()
+	first := hub.addPeerLocked(versionID, room, "first")
+	second := hub.addPeerLocked(versionID, room, "second")
+	third := hub.addPeerLocked(versionID, room, "third")
+	hub.mu.Unlock()
+
+	frame := []byte{0x01, 0x02, 0x03}
+	first.BroadcastEphemeral(frame)
+
+	for _, lease := range []*documentCollaborationRoomLease{second, third} {
+		select {
+		case got := <-lease.Ephemeral:
+			assert.Equal(t, frame, got)
+		default:
+			require.Fail(t, "peer did not receive the ephemeral frame")
+		}
+	}
+
+	select {
+	case <-first.Ephemeral:
+		require.Fail(t, "originating peer must not receive its own ephemeral frame")
+	default:
+	}
+
+	require.NoError(t, document.Close(context.Background()))
+}
+
+func TestDocumentCollaborationRoom_DropsEphemeralWhenBufferFull(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	versionID := gid.New(tenantID, coredata.DocumentVersionEntityType)
+	document, err := automerge.New(context.Background(), automerge.ActorID{4})
+	require.NoError(t, err)
+
+	room := &documentCollaborationRoom{
+		collaboration: &probo.DocumentCollaboration{Document: document, Revision: 1},
+		peers:         make(map[uint64]documentCollaborationRoomPeer),
+		presences:     make(map[string]documentCollaborationPresence),
+	}
+	room.revision.Store(1)
+	hub := &documentCollaborationHub{
+		rooms: map[gid.GID]*documentCollaborationRoom{versionID: room},
+	}
+
+	hub.mu.Lock()
+	sender := hub.addPeerLocked(versionID, room, "sender")
+	_ = hub.addPeerLocked(versionID, room, "slow")
+	hub.mu.Unlock()
+
+	for range documentCollaborationEphemeralBuffer + 10 {
+		sender.BroadcastEphemeral([]byte{0xff})
+	}
+
+	require.NoError(t, document.Close(context.Background()))
+}
+
 func TestDocumentCollaborationRoom_DebouncesPersistence(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/server/api/console/v1/document_collaboration_hub_test.go
+++ b/pkg/server/api/console/v1/document_collaboration_hub_test.go
@@ -32,6 +32,7 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/probo"
+	"go.probo.inc/probo/pkg/realtime"
 )
 
 type fakeDocumentCollaborationDocuments struct {
@@ -191,6 +192,69 @@ func TestDocumentCollaborationRoom_BroadcastsEphemeralToOtherPeers(t *testing.T)
 	select {
 	case <-first.Ephemeral:
 		require.Fail(t, "originating peer must not receive its own ephemeral frame")
+	default:
+	}
+
+	require.NoError(t, document.Close(context.Background()))
+}
+
+func TestDocumentCollaborationHub_DeliversExternalEphemeral(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	versionID := gid.New(tenantID, coredata.DocumentVersionEntityType)
+	document, err := automerge.New(context.Background(), automerge.ActorID{5})
+	require.NoError(t, err)
+
+	room := &documentCollaborationRoom{
+		collaboration: &probo.DocumentCollaboration{Document: document, Revision: 1},
+		peers:         make(map[uint64]documentCollaborationRoomPeer),
+		presences:     make(map[string]documentCollaborationPresence),
+	}
+	room.revision.Store(1)
+	hub := &documentCollaborationHub{
+		rooms:      map[gid.GID]*documentCollaborationRoom{versionID: room},
+		instanceID: "local-instance",
+	}
+
+	hub.mu.Lock()
+	first := hub.addPeerLocked(versionID, room, "first")
+	second := hub.addPeerLocked(versionID, room, "second")
+	hub.mu.Unlock()
+
+	frame := []byte{0x0a, 0x0b, 0x0c}
+	remote, err := realtime.EncodeCollaborationEphemeral(realtime.CollaborationEphemeral{
+		VersionID:  versionID.String(),
+		InstanceID: "remote-instance",
+		Frame:      frame,
+	})
+	require.NoError(t, err)
+
+	hub.notifyExternal(remote)
+
+	// A frame from another instance reaches every local peer.
+	for _, lease := range []*documentCollaborationRoomLease{first, second} {
+		select {
+		case got := <-lease.Ephemeral:
+			assert.Equal(t, frame, got)
+		default:
+			require.Fail(t, "peer did not receive the external ephemeral frame")
+		}
+	}
+
+	// This instance's own echo is ignored: it already delivered locally.
+	own, err := realtime.EncodeCollaborationEphemeral(realtime.CollaborationEphemeral{
+		VersionID:  versionID.String(),
+		InstanceID: "local-instance",
+		Frame:      []byte{0xff},
+	})
+	require.NoError(t, err)
+
+	hub.notifyExternal(own)
+
+	select {
+	case <-first.Ephemeral:
+		require.Fail(t, "the hub must ignore its own ephemeral echo")
 	default:
 	}
 

--- a/pkg/server/api/console/v1/document_collaboration_repo_handler.go
+++ b/pkg/server/api/console/v1/document_collaboration_repo_handler.go
@@ -66,6 +66,9 @@ type repoCollaborationConfig struct {
 	documentVersionID gid.GID
 	logger            *log.Logger
 	shutdown          context.Context
+	// publishEphemeral relays a gossip frame to other server instances. It may be
+	// nil, which limits ephemeral fan-out to this instance.
+	publishEphemeral func(ctx context.Context, frame []byte) error
 }
 
 // handleRepo serves one document version over the automerge-repo protocol. It
@@ -152,6 +155,14 @@ func (h *documentCollaborationHandler) handleRepo(w http.ResponseWriter, r *http
 		documentVersionID: documentVersionID,
 		logger:            h.logger,
 		shutdown:          h.shutdown,
+		publishEphemeral: func(ctx context.Context, frame []byte) error {
+			return h.probo.Documents.NotifyCollaborationEphemeral(
+				ctx,
+				documentVersionID,
+				h.hub.instanceID,
+				frame,
+			)
+		},
 	}
 
 	if err := serveRepoCollaboration(r.Context(), connection, lease, syncState, config); err != nil {
@@ -293,6 +304,21 @@ func serveRepoCollaboration(
 
 			if fanout != nil {
 				lease.BroadcastEphemeral(fanout)
+
+				// Relay to peers on other instances. A failure here (including an
+				// oversized frame) must not drop the connection: local peers
+				// already have the frame and the sender re-emits its state.
+				if config.publishEphemeral != nil {
+					if err := config.publishEphemeral(ctx, fanout); err != nil && config.logger != nil {
+						config.logger.WarnCtx(
+							ctx,
+							"cannot relay collaboration ephemeral across instances",
+							log.Error(err),
+							log.String("document_version_id", config.documentVersionID.String()),
+						)
+					}
+				}
+
 				continue
 			}
 

--- a/pkg/server/api/console/v1/document_collaboration_repo_handler.go
+++ b/pkg/server/api/console/v1/document_collaboration_repo_handler.go
@@ -28,14 +28,18 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/go-chi/chi/v5"
-	"go.gearno.de/kit/httpserver"
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/automerge"
 	"go.probo.inc/probo/pkg/automerge/collaboration"
+	automergeprosemirror "go.probo.inc/probo/pkg/automerge/prosemirror"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/server/jsonx"
 )
+
+// emptyRichEditorDocument is the ProseMirror document a version with no stored
+// content seeds from, matching the frontend's default empty editor.
+const emptyRichEditorDocument = `{"type":"doc","content":[{"type":"paragraph"}]}`
 
 const documentCollaborationRepoRefreshInterval = 500 * time.Millisecond
 
@@ -99,18 +103,15 @@ func (h *documentCollaborationHandler) handleRepo(w http.ResponseWriter, r *http
 
 	defer lease.Close()
 
-	// The repo protocol has no seed handshake, so it cannot bootstrap an
-	// unseeded document; the server would otherwise serve an empty document as
-	// authoritative. Seeding the server-side document is a pending contract item
-	// (GATEWAY_CONTRACT.md), so refuse rather than risk clobbering content.
+	// The repo protocol has no seed handshake, so the server is authoritative for
+	// seeding: the connection that claimed the seed converts the version's stored
+	// ProseMirror content into the CRDT before serving it. The persist that
+	// follows marks the state seeded, so later connections skip this.
 	if lease.SeedOwner() {
-		httpserver.RenderError(
-			w,
-			http.StatusConflict,
-			fmt.Errorf("document is not initialized for the repo protocol"),
-		)
-
-		return
+		if err := seedRepoCollaboration(r.Context(), lease); err != nil {
+			h.renderServiceError(w, r, documentVersionIDString, err)
+			return
+		}
 	}
 
 	connection, err := websocket.Accept(
@@ -156,6 +157,45 @@ func (h *documentCollaborationHandler) handleRepo(w http.ResponseWriter, r *http
 	if err := serveRepoCollaboration(r.Context(), connection, lease, syncState, config); err != nil {
 		h.closeWithError(r.Context(), connection, documentVersionIDString, err)
 	}
+}
+
+// seedRepoCollaboration converts the version's stored ProseMirror content into
+// Automerge rich-text spans and writes them into the shared document, then
+// schedules a persist. It is called once per document, by the connection that
+// claimed the seed, and is safe if the body already exists (it reuses it rather
+// than recreating it).
+func seedRepoCollaboration(ctx context.Context, lease *documentCollaborationRoomLease) error {
+	content := lease.Collaboration().SeedContent
+	if content == "" {
+		content = emptyRichEditorDocument
+	}
+
+	spans, err := automergeprosemirror.ToSpans(content)
+	if err != nil {
+		return fmt.Errorf("cannot convert seed content to spans: %w", err)
+	}
+
+	document := lease.Collaboration().Document
+
+	text, err := document.Text(ctx, "body")
+	if err != nil {
+		text, err = document.CreateText(ctx, "body")
+		if err != nil {
+			return fmt.Errorf("cannot create seed text object: %w", err)
+		}
+	}
+
+	if err := text.UpdateSpans(ctx, spans, automergeprosemirror.UpdateSpansConfig()); err != nil {
+		return fmt.Errorf("cannot write seed spans: %w", err)
+	}
+
+	if _, err := document.Commit(ctx, "Seed collaboration document", time.Now()); err != nil {
+		return fmt.Errorf("cannot commit seed: %w", err)
+	}
+
+	lease.SchedulePersist()
+
+	return nil
 }
 
 // serveRepoCollaboration runs the automerge-repo protocol for one connection. It

--- a/pkg/server/api/console/v1/document_collaboration_repo_handler.go
+++ b/pkg/server/api/console/v1/document_collaboration_repo_handler.go
@@ -1,0 +1,366 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package console_v1
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/go-chi/chi/v5"
+	"go.gearno.de/kit/httpserver"
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/automerge"
+	"go.probo.inc/probo/pkg/automerge/collaboration"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/server/jsonx"
+)
+
+const documentCollaborationRepoRefreshInterval = 500 * time.Millisecond
+
+// repoCollaborationRefresher pulls changes another server instance persisted
+// into the shared in-memory document, so a NOTIFY-driven wake or the periodic
+// tick can re-sync connected peers. *probo.DocumentService satisfies it.
+type repoCollaborationRefresher interface {
+	RefreshCollaboration(
+		ctx context.Context,
+		scope coredata.Scoper,
+		documentVersionID gid.GID,
+		document *automerge.Document,
+		knownRevision int64,
+	) (int64, bool, error)
+}
+
+// repoCollaborationConfig carries the per-connection dependencies of the repo
+// collaboration loop. refresher may be nil, which disables cross-instance
+// refresh (used by the in-process convergence test that has no database).
+type repoCollaborationConfig struct {
+	serverPeerID      string
+	refresher         repoCollaborationRefresher
+	scope             coredata.Scoper
+	documentVersionID gid.GID
+	logger            *log.Logger
+	shutdown          context.Context
+}
+
+// handleRepo serves one document version over the automerge-repo protocol. It
+// mirrors handle (parse, authorize, acquire a room lease), then drives the
+// protocol with the transport-agnostic ServerConn and fans presence/sync out
+// through the shared hub. It is mounted alongside the custom /sync route so the
+// two protocols coexist during migration; see
+// pkg/automerge/collaboration/GATEWAY_CONTRACT.md.
+func (h *documentCollaborationHandler) handleRepo(w http.ResponseWriter, r *http.Request) {
+	documentVersionIDString := chi.URLParam(r, "documentVersionID")
+
+	documentVersionID, err := gid.ParseGID(documentVersionIDString)
+	if err != nil || documentVersionID.EntityType() != coredata.DocumentVersionEntityType {
+		jsonx.RenderNotFound(w, fmt.Errorf("document version not found"))
+		return
+	}
+
+	scope, err := h.authorize(r.Context(), documentVersionID)
+	if err != nil {
+		h.renderAuthorizationError(w, err)
+		return
+	}
+
+	connectionID, err := newDocumentCollaborationConnectionID()
+	if err != nil {
+		jsonx.RenderInternalServerError(w)
+		return
+	}
+
+	lease, err := h.hub.acquire(r.Context(), scope, documentVersionID, connectionID)
+	if err != nil {
+		h.renderServiceError(w, r, documentVersionIDString, err)
+		return
+	}
+
+	defer lease.Close()
+
+	// The repo protocol has no seed handshake, so it cannot bootstrap an
+	// unseeded document; the server would otherwise serve an empty document as
+	// authoritative. Seeding the server-side document is a pending contract item
+	// (GATEWAY_CONTRACT.md), so refuse rather than risk clobbering content.
+	if lease.SeedOwner() {
+		httpserver.RenderError(
+			w,
+			http.StatusConflict,
+			fmt.Errorf("document is not initialized for the repo protocol"),
+		)
+
+		return
+	}
+
+	connection, err := websocket.Accept(
+		w,
+		r,
+		&websocket.AcceptOptions{
+			OriginPatterns:  h.allowedOrigins,
+			CompressionMode: websocket.CompressionDisabled,
+		},
+	)
+	if err != nil {
+		h.logger.WarnCtx(
+			r.Context(),
+			"cannot accept document collaboration repo connection",
+			log.Error(err),
+			log.String("document_version_id", documentVersionIDString),
+		)
+
+		return
+	}
+
+	defer func() { _ = connection.Close(websocket.StatusNormalClosure, "") }()
+
+	connection.SetReadLimit(documentCollaborationMessageMaxBytes)
+
+	syncState, err := lease.Collaboration().Document.NewSyncState(r.Context())
+	if err != nil {
+		h.closeWithError(r.Context(), connection, documentVersionIDString, err)
+		return
+	}
+
+	defer func() { _ = syncState.Close(context.Background()) }()
+
+	config := repoCollaborationConfig{
+		serverPeerID:      "probo-gateway-" + connectionID,
+		refresher:         h.probo.Documents,
+		scope:             scope,
+		documentVersionID: documentVersionID,
+		logger:            h.logger,
+		shutdown:          h.shutdown,
+	}
+
+	if err := serveRepoCollaboration(r.Context(), connection, lease, syncState, config); err != nil {
+		h.closeWithError(r.Context(), connection, documentVersionIDString, err)
+	}
+}
+
+// serveRepoCollaboration runs the automerge-repo protocol for one connection. It
+// is transport-focused glue over the tested ServerConn driver and the hub's
+// fan-out primitives, kept as a standalone function so it can be driven by a
+// real ClientConn in tests without a database. It returns nil on a clean close
+// and an error only on an unexpected failure.
+func serveRepoCollaboration(
+	ctx context.Context,
+	connection *websocket.Conn,
+	lease *documentCollaborationRoomLease,
+	syncState *automerge.SyncState,
+	config repoCollaborationConfig,
+) error {
+	conn, err := collaboration.NewAdoptingServerConn(
+		collaboration.ServerConfig{ServerPeerID: config.serverPeerID},
+		syncState,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot create repo server connection: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	incoming := make(chan documentCollaborationIncoming, 1)
+	go readCollaborationMessages(ctx, connection, incoming)
+
+	// The first frame is the client's join.
+	var join documentCollaborationIncoming
+	select {
+	case join = <-incoming:
+	case <-ctx.Done():
+		return nil
+	}
+
+	if join.Err != nil {
+		return repoReadResult(join.Err)
+	}
+
+	if join.MessageType != websocket.MessageBinary {
+		_ = connection.Close(websocket.StatusUnsupportedData, "expected a binary join frame")
+		return nil
+	}
+
+	out, accepted, err := conn.Start(ctx, join.Data)
+	if err != nil {
+		return fmt.Errorf("cannot start repo server connection: %w", err)
+	}
+
+	if err := writeRepoFrames(ctx, connection, out); err != nil {
+		return err
+	}
+
+	if !accepted {
+		_ = connection.Close(websocket.StatusPolicyViolation, "unsupported protocol version")
+		return nil
+	}
+
+	revision := lease.Revision()
+
+	var tick <-chan time.Time
+	if config.refresher != nil {
+		ticker := time.NewTicker(documentCollaborationRepoRefreshInterval)
+		defer ticker.Stop()
+
+		tick = ticker.C
+	}
+
+	for {
+		select {
+		case <-config.shutdown.Done():
+			_ = connection.CloseNow()
+			return nil
+		case <-ctx.Done():
+			return nil
+		case message := <-incoming:
+			if message.Err != nil {
+				return repoReadResult(message.Err)
+			}
+
+			// automerge-repo frames are always binary; ignore anything else.
+			if message.MessageType != websocket.MessageBinary {
+				continue
+			}
+
+			reply, fanout, err := conn.Receive(ctx, message.Data)
+			if err != nil {
+				return fmt.Errorf("cannot process repo frame: %w", err)
+			}
+
+			if err := writeRepoFrames(ctx, connection, reply); err != nil {
+				return err
+			}
+
+			if fanout != nil {
+				lease.BroadcastEphemeral(fanout)
+				continue
+			}
+
+			// A sync frame may have advanced the shared document: wake the other
+			// peers so they re-sync, and schedule a debounced persist.
+			lease.NotifyPeers()
+
+			if err := lease.PersistError(); err != nil {
+				return fmt.Errorf("cannot persist repo collaboration: %w", err)
+			}
+
+			lease.SchedulePersist()
+		case frame := <-lease.Ephemeral:
+			if err := writeCollaborationMessage(ctx, connection, websocket.MessageBinary, frame); err != nil {
+				return err
+			}
+		case wake := <-lease.Wake:
+			// Legacy structured presence is not used by the repo protocol.
+			if wake.presence {
+				continue
+			}
+
+			if err := lease.PersistError(); err != nil {
+				return fmt.Errorf("cannot persist repo collaboration: %w", err)
+			}
+
+			if wake.refresh && config.refresher != nil {
+				var changed bool
+
+				revision, changed, err = config.refresher.RefreshCollaboration(
+					ctx,
+					config.scope,
+					config.documentVersionID,
+					lease.Collaboration().Document,
+					revision,
+				)
+				if err != nil {
+					return fmt.Errorf("cannot refresh repo collaboration: %w", err)
+				}
+
+				lease.SetRevision(revision)
+
+				if !changed {
+					continue
+				}
+			}
+
+			frames, err := conn.SyncChanged(ctx)
+			if err != nil {
+				return fmt.Errorf("cannot generate repo sync frames: %w", err)
+			}
+
+			if err := writeRepoFrames(ctx, connection, frames); err != nil {
+				return err
+			}
+		case <-tick:
+			if err := lease.PersistError(); err != nil {
+				return fmt.Errorf("cannot persist repo collaboration: %w", err)
+			}
+
+			var changed bool
+
+			revision, changed, err = config.refresher.RefreshCollaboration(
+				ctx,
+				config.scope,
+				config.documentVersionID,
+				lease.Collaboration().Document,
+				revision,
+			)
+			if err != nil {
+				return fmt.Errorf("cannot refresh repo collaboration: %w", err)
+			}
+
+			if !changed {
+				continue
+			}
+
+			lease.SetRevision(revision)
+
+			frames, err := conn.SyncChanged(ctx)
+			if err != nil {
+				return fmt.Errorf("cannot generate repo sync frames: %w", err)
+			}
+
+			if err := writeRepoFrames(ctx, connection, frames); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// repoReadResult maps a websocket read error to a loop result: a normal or
+// going-away close is a clean disconnect (nil), anything else is an error.
+func repoReadResult(err error) error {
+	switch websocket.CloseStatus(err) {
+	case websocket.StatusNormalClosure, websocket.StatusGoingAway:
+		return nil
+	default:
+		return fmt.Errorf("repo collaboration read failed: %w", err)
+	}
+}
+
+func writeRepoFrames(ctx context.Context, connection *websocket.Conn, frames [][]byte) error {
+	for _, frame := range frames {
+		if err := writeCollaborationMessage(ctx, connection, websocket.MessageBinary, frame); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/server/api/console/v1/document_collaboration_repo_handler_test.go
+++ b/pkg/server/api/console/v1/document_collaboration_repo_handler_test.go
@@ -1,0 +1,352 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package console_v1
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/automerge"
+	"go.probo.inc/probo/pkg/automerge/collaboration"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/probo"
+)
+
+// newRepoTestServer stands up an httptest WebSocket server that runs the repo
+// collaboration loop against a shared in-memory document, with no database. Each
+// connection acquires a lease from the hub, so sync and ephemeral fan-out go
+// through the real room machinery.
+func newRepoTestServer(
+	t *testing.T,
+	hub *documentCollaborationHub,
+	scope coredata.Scoper,
+	versionID gid.GID,
+) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connectionID, err := newDocumentCollaborationConnectionID()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		lease, err := hub.acquire(r.Context(), scope, versionID, connectionID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		defer lease.Close()
+
+		connection, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			InsecureSkipVerify: true, // test-only: no Origin from the Go client
+		})
+		if err != nil {
+			return
+		}
+
+		defer func() { _ = connection.Close(websocket.StatusNormalClosure, "") }()
+
+		connection.SetReadLimit(1 << 20)
+
+		syncState, err := lease.Collaboration().Document.NewSyncState(r.Context())
+		if err != nil {
+			return
+		}
+
+		defer func() { _ = syncState.Close(context.Background()) }()
+
+		_ = serveRepoCollaboration(r.Context(), connection, lease, syncState, repoCollaborationConfig{
+			serverPeerID: "probo-gateway-" + connectionID,
+			shutdown:     context.Background(),
+		})
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+// repoTestClient drives a real ClientConn over a WebSocket. A single reader
+// goroutine owns the connection: it reads server frames, feeds them to the
+// driver, and writes the driver's replies plus any ephemerals the test asks to
+// send, so there is never a concurrent writer.
+type repoTestClient struct {
+	document  *automerge.Document
+	conn      *websocket.Conn
+	ephemeral chan []byte
+	send      chan []byte
+	errs      chan error
+}
+
+func dialRepoClient(
+	t *testing.T,
+	ctx context.Context,
+	url string,
+	peerID string,
+	documentID string,
+) *repoTestClient {
+	t.Helper()
+
+	document, err := automerge.New(ctx, actorFromByte(len(peerID)))
+	require.NoError(t, err)
+
+	syncState, err := document.NewSyncState(ctx)
+	require.NoError(t, err)
+
+	driver, err := collaboration.NewClientConn(collaboration.ClientConfig{
+		ClientPeerID: peerID,
+		DocumentID:   documentID,
+		StartsEmpty:  true,
+	}, syncState)
+	require.NoError(t, err)
+
+	conn, _, err := websocket.Dial(ctx, url, nil)
+	require.NoError(t, err)
+
+	conn.SetReadLimit(1 << 20)
+
+	client := &repoTestClient{
+		document:  document,
+		conn:      conn,
+		ephemeral: make(chan []byte, 8),
+		send:      make(chan []byte, 8),
+		errs:      make(chan error, 1),
+	}
+
+	frames := make(chan []byte, 8)
+	go func() {
+		for {
+			kind, data, readErr := conn.Read(ctx)
+			if readErr != nil {
+				close(frames)
+				return
+			}
+
+			if kind != websocket.MessageBinary {
+				continue
+			}
+
+			select {
+			case frames <- data:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	write := func(payload []byte, messageType websocket.MessageType) error {
+		writeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		return conn.Write(writeCtx, messageType, payload)
+	}
+
+	go func() {
+		join, startErr := driver.Start()
+		if startErr != nil {
+			client.errs <- startErr
+			return
+		}
+
+		if err := write(join, websocket.MessageBinary); err != nil {
+			client.errs <- err
+			return
+		}
+
+		var count uint64
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case frame, ok := <-frames:
+				if !ok {
+					return
+				}
+
+				inbound, receiveErr := driver.Receive(ctx, frame)
+				if receiveErr != nil {
+					client.errs <- receiveErr
+					return
+				}
+
+				for _, outgoing := range inbound.Outgoing {
+					if err := write(outgoing, websocket.MessageBinary); err != nil {
+						client.errs <- err
+						return
+					}
+				}
+
+				if inbound.Ephemeral != nil {
+					select {
+					case client.ephemeral <- inbound.Ephemeral.Data:
+					default:
+					}
+				}
+			case payload := <-client.send:
+				count++
+
+				frame, ephemeralErr := driver.Ephemeral("session-"+peerID, count, payload)
+				if ephemeralErr != nil {
+					client.errs <- ephemeralErr
+					return
+				}
+
+				if err := write(frame, websocket.MessageBinary); err != nil {
+					client.errs <- err
+					return
+				}
+			}
+		}
+	}()
+
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
+
+	return client
+}
+
+func actorFromByte(value int) automerge.ActorID {
+	var actorID automerge.ActorID
+	actorID[0] = byte(value + 1)
+
+	return actorID
+}
+
+func (c *repoTestClient) waitForBody(t *testing.T, ctx context.Context, want string) {
+	t.Helper()
+
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case err := <-c.errs:
+			require.NoError(t, err)
+		case <-deadline:
+			require.Failf(t, "client did not converge", "wanted body %q", want)
+		default:
+		}
+
+		text, err := c.document.Text(ctx, "body")
+		if err == nil {
+			if value, err := text.String(ctx); err == nil && value == want {
+				return
+			}
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestServeRepoCollaboration_ConvergesRealDocument connects a real repo client to
+// the gateway loop and confirms it materializes the server's seeded document.
+// This exercises the whole server-side stack end to end without a database:
+// handshake, document-id adoption, and the sync loop over the hub lease.
+func TestServeRepoCollaboration_ConvergesRealDocument(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	tenantID := gid.NewTenantID()
+	versionID := gid.New(tenantID, coredata.DocumentVersionEntityType)
+
+	serverDocument, err := automerge.New(ctx, automerge.ActorID{200})
+	require.NoError(t, err)
+	defer func() { _ = serverDocument.Close(ctx) }()
+
+	text, err := serverDocument.CreateText(ctx, "body")
+	require.NoError(t, err)
+	require.NoError(t, text.Splice(ctx, 0, 0, "hello repo"))
+	_, err = serverDocument.Commit(ctx, "seed", time.Unix(1786147200, 0).UTC())
+	require.NoError(t, err)
+
+	documents := &fakeDocumentCollaborationDocuments{
+		collaboration: &probo.DocumentCollaboration{Document: serverDocument, Revision: 1},
+	}
+	hub := newDocumentCollaborationHub(documents, nil)
+	server := newRepoTestServer(t, hub, coredata.NewScope(tenantID), versionID)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	documentID := collaboration.DeriveDocumentID(versionID.String())
+
+	client := dialRepoClient(t, ctx, wsURL, "client-a", documentID)
+	client.waitForBody(t, ctx, "hello repo")
+}
+
+// TestServeRepoCollaboration_FansOutEphemeral connects two repo clients and
+// confirms an ephemeral one sends is gossiped to the other through the hub, which
+// is how repo presence and cursors travel.
+func TestServeRepoCollaboration_FansOutEphemeral(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	tenantID := gid.NewTenantID()
+	versionID := gid.New(tenantID, coredata.DocumentVersionEntityType)
+
+	serverDocument, err := automerge.New(ctx, automerge.ActorID{201})
+	require.NoError(t, err)
+	defer func() { _ = serverDocument.Close(ctx) }()
+
+	text, err := serverDocument.CreateText(ctx, "body")
+	require.NoError(t, err)
+	require.NoError(t, text.Splice(ctx, 0, 0, "shared"))
+	_, err = serverDocument.Commit(ctx, "seed", time.Unix(1786147200, 0).UTC())
+	require.NoError(t, err)
+
+	documents := &fakeDocumentCollaborationDocuments{
+		collaboration: &probo.DocumentCollaboration{Document: serverDocument, Revision: 1},
+	}
+	hub := newDocumentCollaborationHub(documents, nil)
+	server := newRepoTestServer(t, hub, coredata.NewScope(tenantID), versionID)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	documentID := collaboration.DeriveDocumentID(versionID.String())
+
+	// Both clients converge first, which guarantees both handshakes completed.
+	first := dialRepoClient(t, ctx, wsURL, "client-first", documentID)
+	first.waitForBody(t, ctx, "shared")
+
+	second := dialRepoClient(t, ctx, wsURL, "client-second", documentID)
+	second.waitForBody(t, ctx, "shared")
+
+	payload := []byte("cursor-at-3")
+	first.send <- payload
+
+	select {
+	case got := <-second.ephemeral:
+		assert.Equal(t, payload, got)
+	case err := <-second.errs:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "the second client did not receive the gossiped ephemeral")
+	}
+}

--- a/pkg/server/api/console/v1/document_collaboration_repo_handler_test.go
+++ b/pkg/server/api/console/v1/document_collaboration_repo_handler_test.go
@@ -47,6 +47,7 @@ func newRepoTestServer(
 	hub *documentCollaborationHub,
 	scope coredata.Scoper,
 	versionID gid.GID,
+	publishEphemeral func(ctx context.Context, frame []byte) error,
 ) *httptest.Server {
 	t.Helper()
 
@@ -91,8 +92,10 @@ func newRepoTestServer(
 		defer func() { _ = syncState.Close(context.Background()) }()
 
 		_ = serveRepoCollaboration(r.Context(), connection, lease, syncState, repoCollaborationConfig{
-			serverPeerID: "probo-gateway-" + connectionID,
-			shutdown:     context.Background(),
+			serverPeerID:      "probo-gateway-" + connectionID,
+			documentVersionID: versionID,
+			shutdown:          context.Background(),
+			publishEphemeral:  publishEphemeral,
 		})
 	}))
 
@@ -298,7 +301,7 @@ func TestServeRepoCollaboration_ConvergesRealDocument(t *testing.T) {
 		collaboration: &probo.DocumentCollaboration{Document: serverDocument, Revision: 1},
 	}
 	hub := newDocumentCollaborationHub(documents, nil)
-	server := newRepoTestServer(t, hub, coredata.NewScope(tenantID), versionID)
+	server := newRepoTestServer(t, hub, coredata.NewScope(tenantID), versionID, nil)
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
 	documentID := collaboration.DeriveDocumentID(versionID.String())
@@ -339,7 +342,7 @@ func TestServeRepoCollaboration_SeedsUnseededDocument(t *testing.T) {
 		},
 	}
 	hub := newDocumentCollaborationHub(documents, nil)
-	server := newRepoTestServer(t, hub, coredata.NewScope(tenantID), versionID)
+	server := newRepoTestServer(t, hub, coredata.NewScope(tenantID), versionID, nil)
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
 	documentID := collaboration.DeriveDocumentID(versionID.String())
@@ -375,7 +378,7 @@ func TestServeRepoCollaboration_FansOutEphemeral(t *testing.T) {
 		collaboration: &probo.DocumentCollaboration{Document: serverDocument, Revision: 1},
 	}
 	hub := newDocumentCollaborationHub(documents, nil)
-	server := newRepoTestServer(t, hub, coredata.NewScope(tenantID), versionID)
+	server := newRepoTestServer(t, hub, coredata.NewScope(tenantID), versionID, nil)
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
 	documentID := collaboration.DeriveDocumentID(versionID.String())
@@ -397,5 +400,64 @@ func TestServeRepoCollaboration_FansOutEphemeral(t *testing.T) {
 		require.NoError(t, err)
 	case <-time.After(10 * time.Second):
 		require.Fail(t, "the second client did not receive the gossiped ephemeral")
+	}
+}
+
+// TestServeRepoCollaboration_PublishesEphemeralCrossInstance confirms the loop
+// hands each gossiped frame to the cross-instance publisher, which is how
+// presence and cursors reach peers on other server instances.
+func TestServeRepoCollaboration_PublishesEphemeralCrossInstance(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	tenantID := gid.NewTenantID()
+	versionID := gid.New(tenantID, coredata.DocumentVersionEntityType)
+
+	serverDocument, err := automerge.New(ctx, automerge.ActorID{203})
+	require.NoError(t, err)
+	defer func() { _ = serverDocument.Close(ctx) }()
+
+	text, err := serverDocument.CreateText(ctx, "body")
+	require.NoError(t, err)
+	require.NoError(t, text.Splice(ctx, 0, 0, "shared"))
+	_, err = serverDocument.Commit(ctx, "seed", time.Unix(1786147200, 0).UTC())
+	require.NoError(t, err)
+
+	documents := &fakeDocumentCollaborationDocuments{
+		collaboration: &probo.DocumentCollaboration{Document: serverDocument, Revision: 1},
+	}
+	hub := newDocumentCollaborationHub(documents, nil)
+
+	published := make(chan []byte, 4)
+	publisher := func(_ context.Context, frame []byte) error {
+		select {
+		case published <- append([]byte(nil), frame...):
+		default:
+		}
+
+		return nil
+	}
+
+	server := newRepoTestServer(t, hub, coredata.NewScope(tenantID), versionID, publisher)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	documentID := collaboration.DeriveDocumentID(versionID.String())
+
+	client := dialRepoClient(t, ctx, wsURL, "client-a", documentID)
+	client.waitForBody(t, ctx, "shared")
+
+	payload := []byte("cursor-payload")
+	client.send <- payload
+
+	select {
+	case frame := <-published:
+		message, err := collaboration.DecodeMessage(frame)
+		require.NoError(t, err)
+		assert.Equal(t, collaboration.MessageEphemeral, message.Type)
+		assert.Equal(t, payload, message.Data)
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "the loop did not publish the ephemeral across instances")
 	}
 }

--- a/pkg/server/api/console/v1/document_collaboration_repo_handler_test.go
+++ b/pkg/server/api/console/v1/document_collaboration_repo_handler_test.go
@@ -65,6 +65,13 @@ func newRepoTestServer(
 
 		defer lease.Close()
 
+		if lease.SeedOwner() {
+			if err := seedRepoCollaboration(r.Context(), lease); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
 		connection, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 			InsecureSkipVerify: true, // test-only: no Origin from the Go client
 		})
@@ -298,6 +305,48 @@ func TestServeRepoCollaboration_ConvergesRealDocument(t *testing.T) {
 
 	client := dialRepoClient(t, ctx, wsURL, "client-a", documentID)
 	client.waitForBody(t, ctx, "hello repo")
+}
+
+// TestServeRepoCollaboration_SeedsUnseededDocument confirms the server seeds an
+// unseeded version from its stored ProseMirror content: the connection that
+// claims the seed converts the content to spans, and a repo client then
+// materializes it. This is the whole server-authoritative seeding path.
+func TestServeRepoCollaboration_SeedsUnseededDocument(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	tenantID := gid.NewTenantID()
+	versionID := gid.New(tenantID, coredata.DocumentVersionEntityType)
+
+	// A fresh, empty document with no body: exactly what OpenCollaboration
+	// returns for a version that has never been seeded.
+	serverDocument, err := automerge.New(ctx, automerge.ActorID{202})
+	require.NoError(t, err)
+	defer func() { _ = serverDocument.Close(ctx) }()
+
+	const seedContent = `{"type":"doc","content":[` +
+		`{"type":"heading","attrs":{"level":2},"content":[{"type":"text","text":"Seeded"}]},` +
+		`{"type":"paragraph","content":[{"type":"text","text":"body text"}]}]}`
+
+	documents := &fakeDocumentCollaborationDocuments{
+		collaboration: &probo.DocumentCollaboration{
+			Document:    serverDocument,
+			Revision:    1,
+			NeedsSeed:   true,
+			SeedContent: seedContent,
+		},
+	}
+	hub := newDocumentCollaborationHub(documents, nil)
+	server := newRepoTestServer(t, hub, coredata.NewScope(tenantID), versionID)
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	documentID := collaboration.DeriveDocumentID(versionID.String())
+
+	client := dialRepoClient(t, ctx, wsURL, "client-a", documentID)
+	// The flat text of the seeded document is the concatenation of its blocks.
+	client.waitForBody(t, ctx, "Seededbody text")
 }
 
 // TestServeRepoCollaboration_FansOutEphemeral connects two repo clients and

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -173,6 +173,10 @@ func NewMux(
 			"/document-versions/{documentVersionID}/sync",
 			collaborationHandler.handle,
 		)
+		r.Get(
+			"/document-versions/{documentVersionID}/repo",
+			collaborationHandler.handleRepo,
+		)
 
 		r.Get(
 			"/connectors/initiate",


### PR DESCRIPTION
Part of the split of #1657 ("CRDT for documents") into a review stack. Stack index: 5/6. Stacked on #1752.

## What this PR does
The architectural core of the migration: a new Go client/server codec and WebSocket transport for the real automerge-repo wire protocol, a session state machine, gateway wiring (opaque ephemeral fan-out through the collaboration hub, serving documents over the automerge-repo protocol, seeding repo documents from stored content server-side), document-id derivation kept in parity with the JS client, cross-instance ephemeral relay over Postgres NOTIFY, and cursor-based selection presence.

## Review lens
This is the "why we're doing this migration" PR and the largest one after stage 2. If it's too much in one pass, it splits cleanly at the "Pin the repo gateway integration contract" commit into protocol/gateway bring-up vs. cross-instance fan-out + selection cursors — flag in review if you'd like it broken up further and I'll split it.

## Stack
1. `automerge/1-prototype-bringup` (#1749): bring up Automerge-backed collaboration (prototype)
2. `automerge/2-engine-core-parity` (#1750): Automerge engine core + full upstream interop parity
3. `automerge/3-engine-hardening-refactor` (#1751): fuzzing, ProseMirror render parity, internal refactor
4. `automerge/4-api-cleanup-perf` (#1752): public API cleanup + save/load performance
5. **→ this PR**: migrate wire protocol to automerge-repo + cross-instance fan-out
6. `automerge/6-frontend-cutover-legacy-removal`: cut the frontend over, remove the legacy protocol