### PR TITLE
Add Attio access review support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,6 +216,9 @@
 # Calendly OAuth.
 # PROBOD_CONNECTOR_CALENDLY_CLIENT_ID=
 # PROBOD_CONNECTOR_CALENDLY_CLIENT_SECRET=
+# Attio OAuth.
+# PROBOD_CONNECTOR_ATTIO_CLIENT_ID=
+# PROBOD_CONNECTOR_ATTIO_CLIENT_SECRET=
 # PostHog Cloud (US + EU) OAuth needs NO config: it uses the CIMD public-client
 # flow (no app registration, no client_secret), auto-enabled when this
 # deployment is publicly reachable at PROBOD_BASE_URL. Self-hosted PostHog uses

--- a/e2e/console/connector_test.go
+++ b/e2e/console/connector_test.go
@@ -102,6 +102,7 @@ func TestAccessReviewDrivers(t *testing.T) {
 
 	assert.True(t, providerNames["BREX"], "expected BREX provider to be present")
 	assert.True(t, providerNames["HUBSPOT"], "expected HUBSPOT provider to be present")
+	assert.True(t, providerNames["ATTIO"], "expected ATTIO provider to be present")
 
 	// 1Password is the only provider offering both connect paths, and each path
 	// needs different settings: the SCIM-bridge driver behind the API key, the

--- a/packages/ui/src/Atoms/ThirdParties/Attio.tsx
+++ b/packages/ui/src/Atoms/ThirdParties/Attio.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import type { ComponentProps } from "react";
+
+export function Attio(props: ComponentProps<"svg">) {
+  return (
+    <svg
+      viewBox="0 0 32 28"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M31.669 19.1747 28.9957 14.8963l-.0159-.0258-.2108-.3362c-.3978-.6384-1.086-1.0203-1.8379-1.0223l-4.3062-.014-.3004.4814-5.1456 8.2346-.2844.4555 2.1561 3.445c.3978.6405 1.086 1.0223 1.8438 1.0223h6.0347c.7439 0 1.448-.3918 1.8419-1.0203l.2128-.3401.01-.014 2.6772-4.2844c.4396-.7001.4396-1.6051 0-2.3033h-.002Zm-.8155 1.7922-2.6772 4.2843-.0378.0518a.362.362 0 0 1-.2686.1193.3577.3577 0 0 1-.3102-.173l-2.6773-4.2844a1.1946 1.1946 0 0 1-.0795-.1512 1.2864 1.2864 0 0 1-.0577-.1571 1.2428 1.2428 0 0 1 0-.6604c.0298-.1054.0756-.2108.1352-.3063l2.6733-4.2804.006-.0099a.3788.3788 0 0 1 .2128-.1532l.0716-.0139.0298-.002a.357.357 0 0 1 .3103.175l2.6733 4.2784c.2446.3899.2446.8911 0 1.281h-.004Z"
+        fill="#2E3238"
+      />
+      <path
+        d="M23.7582 8.8234c.4376-.7021.4376-1.6051 0-2.3033L21.085 2.2417l-.2228-.36C20.4624 1.2432 19.7742.8613 19.0184.8613h-6.0347c-.7539 0-1.4421.3819-1.8439 1.0224L.3334 19.1783A2.176 2.176 0 0 0-.0007 20.33c0 .4058.1154.8055.3321 1.1496l2.898 4.6405c.3999.6404 1.0881 1.0203 1.842 1.0203h6.0346c.7578 0 1.446-.3819 1.8439-1.0223l.2207-.3501v-.004l.004-.008 2.1541-3.445 6.3848-10.2177 2.0408-3.2679.004-.002Zm-.6305-1.1516c0 .2208-.0616.4435-.1869.6404L12.3551 25.2548a.357.357 0 0 1-.3103.1711.3576.3576 0 0 1-.3102-.1711l-2.6753-4.2863c-.2427-.3879-.2427-.8871 0-1.279L19.6449 2.7509a.357.357 0 0 1 .3103-.173.3578.3578 0 0 1 .3123.175l2.6733 4.2784c.1253.1969.1869.4197.1869.6405Z"
+        fill="#2E3238"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/Atoms/ThirdParties/ThirdPartyLogo.tsx
+++ b/packages/ui/src/Atoms/ThirdParties/ThirdPartyLogo.tsx
@@ -23,6 +23,7 @@ import type { ComponentProps, FC } from "react";
 import { Anthropic } from "./Anthropic";
 import { Apollo } from "./Apollo";
 import { Asana } from "./Asana";
+import { Attio } from "./Attio";
 import { Authentik } from "./Authentik";
 import { BetterStack } from "./BetterStack";
 import { Bitbucket } from "./Bitbucket";
@@ -91,6 +92,7 @@ const thirdParties: Record<string, FC<ComponentProps<"svg">>> = {
   APOLLO: Apollo,
   ASANA: Asana,
   AUTHENTIK: Authentik,
+  ATTIO: Attio,
   BETTER_STACK: BetterStack,
   BITBUCKET: Bitbucket,
   BREVO: Brevo,

--- a/packages/ui/src/Atoms/ThirdParties/index.ts
+++ b/packages/ui/src/Atoms/ThirdParties/index.ts
@@ -2,6 +2,7 @@ export { Anthropic } from "./Anthropic";
 export { Apollo } from "./Apollo";
 export { Asana } from "./Asana";
 export { Authentik } from "./Authentik";
+export { Attio } from "./Attio";
 export { BetterStack } from "./BetterStack";
 export { Bitbucket } from "./Bitbucket";
 export { Brevo } from "./Brevo";

--- a/pkg/accessreview/drivers/attio.go
+++ b/pkg/accessreview/drivers/attio.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+const (
+	attioWorkspaceMembersPath = "/v2/workspace_members"
+	attioIdentityPath         = "/v2/self"
+)
+
+type (
+	AttioDriver struct {
+		httpClient *http.Client
+		baseURL    string
+	}
+
+	attioWorkspaceMember struct {
+		ID struct {
+			WorkspaceMemberID string `json:"workspace_member_id"`
+		} `json:"id"`
+		FirstName    string `json:"first_name"`
+		LastName     string `json:"last_name"`
+		EmailAddress string `json:"email_address"`
+		CreatedAt    string `json:"created_at"`
+		AccessLevel  string `json:"access_level"`
+	}
+
+	attioWorkspaceMembersResponse struct {
+		Data []attioWorkspaceMember `json:"data"`
+	}
+
+	attioNameResolver struct {
+		httpClient *http.Client
+		baseURL    string
+	}
+
+	attioIdentityResponse struct {
+		Active        bool   `json:"active"`
+		WorkspaceName string `json:"workspace_name"`
+	}
+)
+
+var (
+	_ Driver       = (*AttioDriver)(nil)
+	_ NameResolver = (*attioNameResolver)(nil)
+)
+
+func NewAttioDriver(httpClient *http.Client, baseURL string) *AttioDriver {
+	return &AttioDriver{httpClient: httpClient, baseURL: baseURL}
+}
+
+func (d *AttioDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
+	endpoint, err := url.JoinPath(d.baseURL, attioWorkspaceMembersPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build attio workspace members URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create attio workspace members request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	httpResp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot execute attio workspace members request: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return nil, fmt.Errorf("cannot fetch attio workspace members: unexpected status %d", httpResp.StatusCode)
+	}
+
+	var resp attioWorkspaceMembersResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("cannot decode attio workspace members response: %w", err)
+	}
+
+	records := make([]AccountRecord, 0, len(resp.Data))
+	for _, member := range resp.Data {
+		email := strings.TrimSpace(member.EmailAddress)
+		if email == "" {
+			continue
+		}
+
+		accessLevel := strings.ToLower(strings.TrimSpace(member.AccessLevel))
+		records = append(records, AccountRecord{
+			Email:       email,
+			FullName:    strings.TrimSpace(strings.Join([]string{member.FirstName, member.LastName}, " ")),
+			Roles:       attioRoles(accessLevel),
+			Active:      new(accessLevel != "suspended"),
+			IsAdmin:     new(accessLevel == "admin"),
+			MFAStatus:   coredata.MFAStatusUnknown,
+			AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
+			AccountType: coredata.AccessReviewEntryAccountTypeUser,
+			ExternalID:  strings.TrimSpace(member.ID.WorkspaceMemberID),
+			CreatedAt:   parseRFC3339Ptr(member.CreatedAt),
+		})
+	}
+
+	return records, nil
+}
+
+func NewAttioNameResolver(httpClient *http.Client, baseURL string) NameResolver {
+	return &attioNameResolver{httpClient: httpClient, baseURL: baseURL}
+}
+
+func (r *attioNameResolver) ResolveInstanceName(ctx context.Context) (string, error) {
+	endpoint, err := url.JoinPath(r.baseURL, attioIdentityPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot build attio identity URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("cannot create attio identity request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	httpResp, err := r.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("cannot execute attio identity request: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return "", nameStatusError("attio identity", httpResp.StatusCode)
+	}
+
+	var resp attioIdentityResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return "", fmt.Errorf("cannot decode attio identity response: %w", err)
+	}
+
+	if !resp.Active {
+		return "", fmt.Errorf("cannot resolve attio workspace name: inactive token: %w", ErrTerminalNameResolution)
+	}
+
+	return strings.TrimSpace(resp.WorkspaceName), nil
+}
+
+func attioRoles(accessLevel string) []string {
+	switch accessLevel {
+	case "admin":
+		return []string{"Admin"}
+	case "member":
+		return []string{"Member"}
+	case "suspended":
+		return []string{"Suspended"}
+	case "":
+		return []string{}
+	default:
+		return []string{accessLevel}
+	}
+}

--- a/pkg/accessreview/drivers/attio_test.go
+++ b/pkg/accessreview/drivers/attio_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestAttioDriver(t *testing.T) {
+	t.Parallel()
+
+	rec := newRecorder(t, "testdata/attio", "ATTIO_TOKEN")
+	client := newVCRClient(rec, bearerAuth(os.Getenv("ATTIO_TOKEN")))
+
+	records, err := NewAttioDriver(client, "https://api.attio.com").ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 3)
+
+	createdAt := time.Date(2022, time.November, 21, 13, 22, 49, 61281000, time.UTC)
+	assert.Equal(t, AccountRecord{
+		Email:       "ada@example.com",
+		FullName:    "Ada Lovelace",
+		Roles:       []string{"Admin"},
+		Active:      new(true),
+		IsAdmin:     new(true),
+		MFAStatus:   coredata.MFAStatusUnknown,
+		AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
+		AccountType: coredata.AccessReviewEntryAccountTypeUser,
+		ExternalID:  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+		CreatedAt:   new(createdAt),
+	}, records[0])
+	assert.Equal(t, []string{"Member"}, records[1].Roles)
+	assert.Equal(t, new(true), records[1].Active)
+	assert.Equal(t, new(false), records[1].IsAdmin)
+	assert.Equal(t, []string{"Suspended"}, records[2].Roles)
+	assert.Equal(t, new(false), records[2].Active)
+	assert.Equal(t, new(false), records[2].IsAdmin)
+}
+
+func TestAttioNameResolver_ResolveInstanceName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("active token", func(t *testing.T) {
+		t.Parallel()
+
+		rec := newRecorder(t, "testdata/attio_identity", "ATTIO_TOKEN")
+		client := newVCRClient(rec, bearerAuth(os.Getenv("ATTIO_TOKEN")))
+
+		resolver := NewAttioNameResolver(client, "https://api.attio.com")
+		name, err := resolver.ResolveInstanceName(context.Background())
+
+		require.NoError(t, err)
+		assert.Equal(t, "Acme", name)
+	})
+
+	t.Run("inactive token", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"active":false}`))
+		}))
+		t.Cleanup(server.Close)
+
+		resolver := NewAttioNameResolver(server.Client(), server.URL)
+		name, err := resolver.ResolveInstanceName(context.Background())
+
+		require.Error(t, err)
+		assert.Empty(t, name)
+		assert.ErrorIs(t, err, ErrTerminalNameResolution)
+	})
+
+	t.Run("server error remains retryable", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+		}))
+		t.Cleanup(server.Close)
+
+		resolver := NewAttioNameResolver(server.Client(), server.URL)
+		_, err := resolver.ResolveInstanceName(context.Background())
+
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, ErrTerminalNameResolution))
+	})
+}

--- a/pkg/accessreview/drivers/testdata/attio.yaml
+++ b/pkg/accessreview/drivers/testdata/attio.yaml
@@ -1,0 +1,31 @@
+---
+# Hand-authored K7 fixture matching Attio's published v2 workspace-member schema.
+# Synthetic resource IDs and identities only.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.attio.com
+        form: {}
+        headers:
+            Accept:
+                - application/json
+        url: https://api.attio.com/v2/workspace_members
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"data":[{"id":{"workspace_id":"11111111-1111-4111-8111-111111111111","workspace_member_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"},"first_name":"Ada","last_name":"Lovelace","avatar_url":null,"email_address":"ada@example.com","created_at":"2022-11-21T13:22:49.061281Z","access_level":"admin"},{"id":{"workspace_id":"11111111-1111-4111-8111-111111111111","workspace_member_id":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"},"first_name":"Grace","last_name":"Hopper","avatar_url":null,"email_address":"grace@example.com","created_at":"2023-01-02T03:04:05Z","access_level":"member"},{"id":{"workspace_id":"11111111-1111-4111-8111-111111111111","workspace_member_id":"cccccccc-cccc-4ccc-8ccc-cccccccccccc"},"first_name":"Suspended","last_name":"User","avatar_url":null,"email_address":"suspended@example.com","created_at":"2024-02-03T04:05:06Z","access_level":"suspended"}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms

--- a/pkg/accessreview/drivers/testdata/attio_identity.yaml
+++ b/pkg/accessreview/drivers/testdata/attio_identity.yaml
@@ -1,0 +1,31 @@
+---
+# Hand-authored K7 fixture matching Attio's published v2 token identity schema.
+# Synthetic resource IDs and workspace details only.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.attio.com
+        form: {}
+        headers:
+            Accept:
+                - application/json
+        url: https://api.attio.com/v2/self
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        uncompressed: true
+        body: '{"active":true,"scope":"user_management:read","client_id":"22222222-2222-4222-8222-222222222222","token_type":"Bearer","exp":null,"iat":1669017769,"sub":"11111111-1111-4111-8111-111111111111","aud":"22222222-2222-4222-8222-222222222222","iss":"attio.com","workspace_id":"11111111-1111-4111-8111-111111111111","workspace_name":"Acme","workspace_slug":"acme","workspace_logo_url":null}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 50ms

--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -556,6 +556,7 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 		"SQUARE",
 		"CAL_COM",
 		"CALENDLY",
+		"ATTIO",
 	} {
 		clientID := b.resolver.getEnv("PROBOD_CONNECTOR_" + provider + "_CLIENT_ID")
 		if clientID == "" {
@@ -745,6 +746,7 @@ func (b *Builder) validateRequired() error {
 		{"CONNECTOR_SQUARE", []string{"CLIENT_SECRET"}},
 		{"CONNECTOR_CAL_COM", []string{"CLIENT_SECRET"}},
 		{"CONNECTOR_CALENDLY", []string{"CLIENT_SECRET"}},
+		{"CONNECTOR_ATTIO", []string{"CLIENT_SECRET"}},
 		{"CONNECTOR_VERCEL", []string{"CLIENT_SECRET", "INTEGRATION_SLUG"}},
 	}
 

--- a/pkg/bootstrap/builder_test.go
+++ b/pkg/bootstrap/builder_test.go
@@ -764,7 +764,7 @@ func TestBuilder_Build_AccessReviewConnectors(t *testing.T) {
 		"GITLAB", "BITBUCKET", "HEROKU", "PAGERDUTY",
 		"ASANA", "NETLIFY", "CLICKUP", "MONDAY", "DATADOG",
 		"ZENDESK", "LINEAR", "GOOGLE_ANALYTICS", "SQUARE",
-		"CAL_COM", "CALENDLY",
+		"CAL_COM", "CALENDLY", "ATTIO",
 	}
 
 	env := requiredEnv()

--- a/pkg/connector/provider/attio.go
+++ b/pkg/connector/provider/attio.go
@@ -18,36 +18,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { Meta, StoryObj } from "@storybook/react";
+package provider
 
-import { ThirdPartyLogo } from "./ThirdPartyLogo";
+import (
+	"context"
+	"net/http"
 
-const meta = {
-  title: "Atoms/ThirdParties/ThirdPartyLogo",
-  component: ThirdPartyLogo,
-  args: {
-    height: 48,
-    width: 48,
-  },
-} satisfies Meta<typeof ThirdPartyLogo>;
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/accessreview/drivers"
+	"go.probo.inc/probo/pkg/coredata"
+)
 
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Attio: Story = {
-  args: {
-    thirdParty: "ATTIO",
-  },
-};
-
-export const CalCom: Story = {
-  args: {
-    thirdParty: "CAL_COM",
-  },
-};
-
-export const Calendly: Story = {
-  args: {
-    thirdParty: "CALENDLY",
-  },
-};
+func attioRegistration() *Registration {
+	return &Registration{
+		Provider:       coredata.ConnectorProviderAttio,
+		DisplayName:    "Attio",
+		SupportsAPIKey: true,
+		Endpoints: Endpoints{
+			Auth:    "https://app.attio.com/authorize",
+			Token:   "https://app.attio.com/oauth/token",
+			APIBase: "https://api.attio.com",
+			Probe:   "https://api.attio.com/v2/workspace_members",
+		},
+		OAuth2Scopes: []string{"user_management:read"},
+		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
+			return drivers.NewAttioDriver(c, ep.APIBase), nil
+		},
+		NewNameResolver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) drivers.NameResolver {
+			return drivers.NewAttioNameResolver(c, ep.APIBase)
+		},
+	}
+}

--- a/pkg/connector/provider/attio_test.go
+++ b/pkg/connector/provider/attio_test.go
@@ -18,36 +18,39 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { Meta, StoryObj } from "@storybook/react";
+package provider_test
 
-import { ThirdPartyLogo } from "./ThirdPartyLogo";
+import (
+	"testing"
 
-const meta = {
-  title: "Atoms/ThirdParties/ThirdPartyLogo",
-  component: ThirdPartyLogo,
-  args: {
-    height: 48,
-    width: 48,
-  },
-} satisfies Meta<typeof ThirdPartyLogo>;
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/connector"
+	"go.probo.inc/probo/pkg/connector/provider"
+	"go.probo.inc/probo/pkg/coredata"
+)
 
-export default meta;
-type Story = StoryObj<typeof meta>;
+func TestAttioRegistration(t *testing.T) {
+	t.Parallel()
 
-export const Attio: Story = {
-  args: {
-    thirdParty: "ATTIO",
-  },
-};
+	r := provider.NewBuiltinRegistry()
+	reg, ok := r.Get(coredata.ConnectorProviderAttio)
+	require.True(t, ok)
 
-export const CalCom: Story = {
-  args: {
-    thirdParty: "CAL_COM",
-  },
-};
+	assert.True(t, reg.SupportsAPIKey)
+	assert.Equal(t, []string{"user_management:read"}, reg.OAuth2Scopes)
+	assert.Equal(t, "https://api.attio.com/v2/workspace_members", reg.Endpoints.Probe)
+	assert.NotNil(t, reg.NewDriver)
+	assert.NotNil(t, reg.NewNameResolver)
 
-export const Calendly: Story = {
-  args: {
-    thirdParty: "CALENDLY",
-  },
-};
+	oauthConnector := &connector.OAuth2Connector{}
+	require.NoError(t, r.ApplyOAuth2Defaults(
+		string(coredata.ConnectorProviderAttio),
+		"https://example.com/callback",
+		oauthConnector,
+	))
+
+	assert.Equal(t, "https://app.attio.com/authorize", oauthConnector.AuthURL)
+	assert.Equal(t, "https://app.attio.com/oauth/token", oauthConnector.TokenURL)
+	assert.Equal(t, []string{"user_management:read"}, oauthConnector.RegisteredScopes)
+}

--- a/pkg/connector/provider/builtin.go
+++ b/pkg/connector/provider/builtin.go
@@ -61,6 +61,7 @@ func NewBuiltinRegistryWith(opts ...Option) (*Registry, error) {
 		apolloRegistration(),
 		authentikRegistration(),
 		asanaRegistration(),
+		attioRegistration(),
 		betterStackRegistration(),
 		bitbucketRegistration(),
 		brevoRegistration(),

--- a/pkg/coredata/connector_provider.go
+++ b/pkg/coredata/connector_provider.go
@@ -95,6 +95,7 @@ const (
 	ConnectorProviderAuthentik       ConnectorProvider = "AUTHENTIK"
 	ConnectorProviderCalCom          ConnectorProvider = "CAL_COM"
 	ConnectorProviderCalendly        ConnectorProvider = "CALENDLY"
+	ConnectorProviderAttio           ConnectorProvider = "ATTIO"
 )
 
 var (
@@ -168,6 +169,7 @@ func ConnectorProviders() []ConnectorProvider {
 		ConnectorProviderAuthentik,
 		ConnectorProviderCalCom,
 		ConnectorProviderCalendly,
+		ConnectorProviderAttio,
 	}
 }
 
@@ -237,7 +239,8 @@ func (v ConnectorProvider) IsValid() bool {
 		ConnectorProviderNuki,
 		ConnectorProviderAuthentik,
 		ConnectorProviderCalCom,
-		ConnectorProviderCalendly:
+		ConnectorProviderCalendly,
+		ConnectorProviderAttio:
 		return true
 	}
 

--- a/pkg/coredata/migrations/20260821T160700Z.sql
+++ b/pkg/coredata/migrations/20260821T160700Z.sql
@@ -1,0 +1,21 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TYPE connector_provider ADD VALUE IF NOT EXISTS 'ATTIO';

--- a/pkg/server/api/console/v1/graphql/connector.graphql
+++ b/pkg/server/api/console/v1/graphql/connector.graphql
@@ -118,6 +118,7 @@ enum ConnectorProvider
     CAL_COM @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderCalCom")
     CALENDLY
         @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderCalendly")
+    ATTIO @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderAttio")
 }
 
 type ConnectorProviderInfo {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- register Attio as an OAuth and API-key access-review provider
- map Attio workspace members and resolve workspace names
- add the PostgreSQL `connector_provider` migration for `ATTIO`
- add Attio branding, bootstrap configuration, and GraphQL exposure
- cover Attio API behavior with deterministic K7 cassettes

## Testing
- `go test ./pkg/accessreview/drivers -run 'TestAttio' -count=1`
- `make test MODULE=./pkg/accessreview/drivers`
- `make test MODULE=./pkg/connector/provider`
- `go test ./pkg/bootstrap ./pkg/coredata ./pkg/server/api/console/v1`
- `go test ./pkg/coredata -run '^TestDevice_DeleteOrphans$' -count=1`
- verified `ATTIO` exists in the migrated PostgreSQL `connector_provider` enum
- `go test -c -o /tmp/probo-console-e2e.test ./e2e/console`
- `npm -w @probo/ui run check`
- ESLint on changed UI files
- `make relay`

## Manual testing
Storybook visual verification is currently blocked by an existing Tailwind build error: `Cannot apply unknown utility class my-2`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ff463f5-555c-45b5-99e0-cf27c651e37f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ff463f5-555c-45b5-99e0-cf27c651e37f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Attio as an access-review provider via OAuth or API key so campaigns can review Attio workspace members and show a human-friendly workspace name. Previously Attio was unsupported; now ATTIO is available in GraphQL and UI, and a DB enum migration enables persistence.

### Service **`+301`** **`-0`**
- Registers Attio in the connector registry with OAuth endpoints, probe, `user_management:read` scope, and API-key flow.
- Adds a driver that lists `/v2/workspace_members`, maps Admin/Member/Suspended, sets active/admin flags, and captures IDs and timestamps.
- Adds a name resolver using `/v2/self` that returns the workspace name; treats inactive tokens as terminal.
- Wires bootstrap to read `PROBOD_CONNECTOR_ATTIO_CLIENT_ID`/`PROBOD_CONNECTOR_ATTIO_CLIENT_SECRET` and validates required secrets.

### Coredata **`+25`** **`-1`**
- Introduces `ATTIO` as a `ConnectorProvider`, adds it to providers and validity checks.
- Migration required: run `20260821T160700Z.sql` to extend the `connector_provider` enum with `ATTIO` before enabling the provider.

### GraphQL API **`+1`** **`-0`**
- Exposes `ATTIO` in the Console GraphQL `ConnectorProvider` enum.

### Package: ui **`+50`** **`-0`**
- Adds an Attio logo in `packages/ui` and wires it into `ThirdPartyLogo` and Storybook.

### Tests **`+173`** **`-1`**
- Covers the Attio driver and name resolver with deterministic K7 fixtures.
- Verifies provider registration defaults and updates e2e to assert the `ATTIO` provider is present.

### Other **`+3`** **`-0`**
- Documents new env vars in `.env.example` for Attio OAuth.

<sup>Written for commit e745590edc4d3b85614ac49888fa37bf65db28df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

