### PR TITLE
Add CIMD support for Resend

### DIFF
--- a/pkg/connector/provider/apply_test.go
+++ b/pkg/connector/provider/apply_test.go
@@ -97,7 +97,7 @@ func TestApplyOAuth2Defaults_AuthURLFromSlug(t *testing.T) {
 func TestApplyOAuth2Defaults_PKCEDefaults(t *testing.T) {
 	t.Parallel()
 
-	for _, p := range []string{"PAGERDUTY", "POSTHOG"} {
+	for _, p := range []string{"PAGERDUTY", "POSTHOG", "RESEND"} {
 		t.Run(p, func(t *testing.T) {
 			t.Parallel()
 
@@ -110,19 +110,44 @@ func TestApplyOAuth2Defaults_PKCEDefaults(t *testing.T) {
 	}
 }
 
-// TestApplyOAuth2Defaults_PublicClientTokenAuth verifies that PostHog, a
-// public (CIMD) client, propagates token_endpoint_auth_method "none" so the
-// token exchange omits a client_secret.
+// TestApplyOAuth2Defaults_PublicClientTokenAuth verifies that CIMD clients
+// propagate token_endpoint_auth_method "none" so token exchanges omit a
+// client_secret.
 func TestApplyOAuth2Defaults_PublicClientTokenAuth(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range []string{"POSTHOG", "RESEND"} {
+		t.Run(p, func(t *testing.T) {
+			t.Parallel()
+
+			r := provider.NewBuiltinRegistry()
+			c := &connector.OAuth2Connector{}
+			require.NoError(t, r.ApplyOAuth2Defaults(p, "https://example.com/cb", c))
+
+			assert.Equal(t, "none", c.TokenEndpointAuth,
+				"provider %s must use token_endpoint_auth_method none (public client)", p)
+			assert.True(t, c.RequiresPKCE, "provider %s public client must require PKCE", p)
+		})
+	}
+}
+
+func TestApplyOAuth2Defaults_ResendCIMD(t *testing.T) {
 	t.Parallel()
 
 	r := provider.NewBuiltinRegistry()
 	c := &connector.OAuth2Connector{}
-	require.NoError(t, r.ApplyOAuth2Defaults("POSTHOG", "https://example.com/cb", c))
+	require.NoError(t, r.ApplyOAuth2Defaults("RESEND", "https://example.com/cb", c))
 
-	assert.Equal(t, "none", c.TokenEndpointAuth,
-		"PostHog must use token_endpoint_auth_method none (public client)")
-	assert.True(t, c.RequiresPKCE, "PostHog public client must require PKCE")
+	assert.Equal(t, "https://api.resend.com/oauth/authorize", c.AuthURL)
+	assert.Equal(t, "https://api.resend.com/oauth/token", c.TokenURL)
+	assert.Equal(t, []string{"full_access"}, c.RegisteredScopes)
+
+	publicProviders := make(map[coredata.ConnectorProvider]bool)
+	for _, reg := range r.PublicClients() {
+		publicProviders[reg.Provider] = true
+	}
+
+	assert.True(t, publicProviders[coredata.ConnectorProviderResend])
 }
 
 // TestApplyOAuth2Defaults_CopiesSiteClosures verifies the multi-site

--- a/pkg/connector/provider/resend.go
+++ b/pkg/connector/provider/resend.go
@@ -34,11 +34,17 @@ func resendRegistration() *Registration {
 		Provider:         coredata.ConnectorProviderResend,
 		DisplayName:      "Resend",
 		DocumentationURL: accessReviewDocsURL("resend"),
+		PublicClient:     true,
 		Endpoints: Endpoints{
 			APIBase: "https://api.resend.com",
+			Auth:    "https://api.resend.com/oauth/authorize",
+			Token:   "https://api.resend.com/oauth/token",
 			Probe:   "https://api.resend.com/domains",
 		},
-		SupportsAPIKey: true,
+		TokenEndpointAuth: "none",
+		RequiresPKCE:      true,
+		OAuth2Scopes:      []string{"full_access"},
+		SupportsAPIKey:    true,
 		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
 			return drivers.NewResendDriver(c, ep.APIBase), nil
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- register Resend as a public CIMD OAuth client
- configure Resend authorization and token endpoints with PKCE
- request `full_access` for access-review API key enumeration
- retain API-key authentication as an alternative

## Testing

- `go test ./pkg/connector/provider ./pkg/connector`
- `go test ./pkg/server/api/console/v1 -run 'TestHandleConnectorOAuth2ClientMetadata'`
- `go test ./pkg/probod -run 'Test'`
- `make go-fmt`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d0901a5-7a48-45a4-a9f4-e3017e14319c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d0901a5-7a48-45a4-a9f4-e3017e14319c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CIMD OAuth for Resend as a public client with PKCE. Previously Resend required API keys only; now PKCE-based OAuth uses token exchanges without a client_secret, requests the full_access scope, and still supports API-key auth.

### Service **`+7`** **`-1`**
Registers Resend as a public CIMD OAuth client and configures endpoints: Auth https://api.resend.com/oauth/authorize and Token https://api.resend.com/oauth/token. Sets token_endpoint_auth_method to "none", requires PKCE, and registers the "full_access" scope while retaining API-key support.

### Tests **`+33`** **`-8`**
Expands PKCE default coverage to include RESEND and generalizes the public-client token auth test to POSTHOG and RESEND. Adds a Resend-specific test that validates the OAuth endpoints, required scope, PKCE requirement, and inclusion in the public-clients registry.

<sup>Written for commit 5d717eaefbf631119dcb1fd405537dacd4cde93a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

