### PR TITLE
Let MCP clients request business-function scope

### DIFF
--- a/pkg/bearertoken/bearer_challenge.go
+++ b/pkg/bearertoken/bearer_challenge.go
@@ -40,7 +40,7 @@ func protectedResourceMetadataURL(baseURL *baseurl.BaseURL) string {
 
 // BearerChallenge builds the WWW-Authenticate header value per RFC 6750 and RFC 9728.
 // Pass errorCode == "" for discovery-only (401, no Bearer attempt).
-// Pass scopes only when errorCode == BearerErrInsufficientScope.
+// Optional scopes tell the client which access scopes to request.
 func BearerChallenge(
 	baseURL *baseurl.BaseURL,
 	errorCode string,
@@ -54,7 +54,7 @@ func BearerChallenge(
 		parts = append(parts, fmt.Sprintf(`error="%s"`, errorCode))
 	}
 
-	if errorCode == BearerErrInsufficientScope && len(scopes) > 0 {
+	if len(scopes) > 0 {
 		scopeValues := make([]string, len(scopes))
 		for i, scope := range scopes {
 			scopeValues[i] = string(scope)
@@ -78,8 +78,9 @@ func SetBearerChallenge(
 }
 
 // SetBearerUnauthenticated sets a discovery-only challenge (RFC 9728 resource_metadata).
-func SetBearerUnauthenticated(w http.ResponseWriter, baseURL *baseurl.BaseURL) {
-	SetBearerChallenge(w, baseURL, "")
+// Pass scopes so MCP clients such as Claude request them on connect.
+func SetBearerUnauthenticated(w http.ResponseWriter, baseURL *baseurl.BaseURL, scopes ...coredata.OAuth2Scope) {
+	SetBearerChallenge(w, baseURL, "", scopes...)
 }
 
 func SetBearerInvalidToken(w http.ResponseWriter, baseURL *baseurl.BaseURL) {

--- a/pkg/bearertoken/bearer_challenge_test.go
+++ b/pkg/bearertoken/bearer_challenge_test.go
@@ -46,6 +46,12 @@ func TestBearerChallenge(t *testing.T) {
 			want:      `Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"`,
 		},
 		{
+			name:      "discovery with scopes",
+			errorCode: "",
+			scopes:    []coredata.OAuth2Scope{"v1:asset", "v1:business-function"},
+			want:      `Bearer scope="v1:asset v1:business-function", resource_metadata="https://example.com/.well-known/oauth-protected-resource"`,
+		},
+		{
 			name:      "invalid token",
 			errorCode: BearerErrInvalidToken,
 			want:      `Bearer error="invalid_token", resource_metadata="https://example.com/.well-known/oauth-protected-resource"`,

--- a/pkg/coredata/oauth2_scope.go
+++ b/pkg/coredata/oauth2_scope.go
@@ -79,6 +79,39 @@ func (s OAuth2Scopes) ContainsAll(seq iter.Seq[OAuth2Scope]) bool {
 	return true
 }
 
+func (s OAuth2Scopes) Union(other OAuth2Scopes) OAuth2Scopes {
+	if len(other) == 0 {
+		return slices.Clone(s)
+	}
+
+	if len(s) == 0 {
+		return slices.Clone(other)
+	}
+
+	seen := make(map[OAuth2Scope]struct{}, len(s)+len(other))
+	out := make(OAuth2Scopes, 0, len(s)+len(other))
+
+	for _, scope := range s {
+		if _, ok := seen[scope]; ok {
+			continue
+		}
+
+		seen[scope] = struct{}{}
+		out = append(out, scope)
+	}
+
+	for _, scope := range other {
+		if _, ok := seen[scope]; ok {
+			continue
+		}
+
+		seen[scope] = struct{}{}
+		out = append(out, scope)
+	}
+
+	return out
+}
+
 func (s OAuth2Scopes) String() string {
 	ss := make([]string, len(s))
 	for i, scope := range s {

--- a/pkg/iam/oauth2/cimd_authorization_scopes.go
+++ b/pkg/iam/oauth2/cimd_authorization_scopes.go
@@ -18,58 +18,40 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package coredata_test
+package oauth2
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
 	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/iam/oauth2scope"
 )
 
-func TestOAuth2Scope_IsRead(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		scope coredata.OAuth2Scope
-		want  bool
-	}{
-		{scope: "v1:org:read", want: true},
-		{scope: "v1:document:read", want: true},
-		{scope: "v1:org", want: false},
-		{scope: "v1:privacy", want: false},
-		{scope: "openid", want: false},
-		{scope: "offline_access", want: false},
+func advertisedWriteScopes(registry *oauth2scope.Registry) coredata.OAuth2Scopes {
+	if registry == nil {
+		return nil
 	}
 
-	for _, tt := range tests {
-		t.Run(
-			tt.scope.String(),
-			func(t *testing.T) {
-				t.Parallel()
-
-				assert.Equal(t, tt.want, tt.scope.IsRead())
-			},
-		)
-	}
+	return authorizationServerScopes(registry.AllWriteScopes())
 }
 
-func TestOAuth2Scopes_Union(t *testing.T) {
-	t.Parallel()
+func resolveCIMDAuthorizationScopes(
+	client *coredata.OAuth2Client,
+	requested coredata.OAuth2Scopes,
+	registry *oauth2scope.Registry,
+) (coredata.OAuth2Scopes, coredata.OAuth2Scopes) {
+	if client == nil {
+		return nil, requested
+	}
 
-	t.Run(
-		"keeps left order and appends new scopes",
-		func(t *testing.T) {
-			t.Parallel()
+	allowed := client.Scopes
+	resolved := requested.OrDefault(allowed)
 
-			left := coredata.OAuth2Scopes{"openid", "v1:asset"}
-			right := coredata.OAuth2Scopes{"v1:asset", "v1:business-function"}
+	if client.ExternalClientID == "" {
+		return allowed, resolved
+	}
 
-			assert.Equal(
-				t,
-				coredata.OAuth2Scopes{"openid", "v1:asset", "v1:business-function"},
-				left.Union(right),
-			)
-		},
-	)
+	advertised := advertisedWriteScopes(registry)
+	allowed = allowed.Union(advertised)
+	resolved = resolved.Union(advertised)
+
+	return allowed, resolved
 }

--- a/pkg/iam/oauth2/cimd_authorization_scopes_test.go
+++ b/pkg/iam/oauth2/cimd_authorization_scopes_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package oauth2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/iam/oauth2scope"
+)
+
+func testCIMDScopeRegistry() *oauth2scope.Registry {
+	return oauth2scope.NewRegistry().Register(
+		map[coredata.OAuth2Scope][]string{
+			"v1:asset":             {"core:asset:list"},
+			"v1:business-function": {"core:business-function:list"},
+		},
+	)
+}
+
+func TestResolveCIMDAuthorizationScopes(t *testing.T) {
+	t.Parallel()
+
+	reg := testCIMDScopeRegistry()
+
+	t.Run(
+		"cimd stale request still offers advertised write scopes",
+		func(t *testing.T) {
+			t.Parallel()
+
+			client := &coredata.OAuth2Client{
+				ExternalClientID: "https://claude.ai/oauth/mcp-oauth-client-metadata",
+				Scopes:           coredata.OAuth2Scopes{ScopeOpenID, "v1:asset"},
+			}
+
+			allowed, requested := resolveCIMDAuthorizationScopes(
+				client,
+				coredata.OAuth2Scopes{ScopeOpenID, "v1:asset"},
+				reg,
+			)
+
+			require.True(t, allowed.ContainsAll(requested.Values()))
+			assert.True(t, requested.Contains("v1:business-function"))
+			assert.True(t, requested.Contains("v1:asset"))
+		},
+	)
+
+	t.Run(
+		"cimd omitted request uses advertised write scopes",
+		func(t *testing.T) {
+			t.Parallel()
+
+			client := &coredata.OAuth2Client{
+				ExternalClientID: "https://claude.ai/oauth/mcp-oauth-client-metadata",
+				Scopes:           coredata.OAuth2Scopes{ScopeOpenID, "v1:asset"},
+			}
+
+			allowed, requested := resolveCIMDAuthorizationScopes(
+				client,
+				nil,
+				reg,
+			)
+
+			require.True(t, allowed.ContainsAll(requested.Values()))
+			assert.True(t, requested.Contains("v1:business-function"))
+			assert.True(t, requested.Contains("v1:asset"))
+			assert.True(t, requested.Contains(ScopeOpenID))
+		},
+	)
+
+	t.Run(
+		"public dcr client keeps explicit request",
+		func(t *testing.T) {
+			t.Parallel()
+
+			client := &coredata.OAuth2Client{
+				TokenEndpointAuthMethod: coredata.OAuth2ClientTokenEndpointAuthMethodNone,
+				Scopes:                  coredata.OAuth2Scopes{ScopeOpenID, "v1:asset"},
+			}
+
+			allowed, requested := resolveCIMDAuthorizationScopes(
+				client,
+				coredata.OAuth2Scopes{ScopeOpenID, "v1:asset"},
+				reg,
+			)
+
+			assert.Equal(t, client.Scopes, allowed)
+			assert.Equal(t, coredata.OAuth2Scopes{ScopeOpenID, "v1:asset"}, requested)
+			assert.False(t, requested.Contains("v1:business-function"))
+		},
+	)
+}

--- a/pkg/iam/oauth2/service.go
+++ b/pkg/iam/oauth2/service.go
@@ -693,8 +693,13 @@ func (s *Service) CreateDeviceCode(
 				)
 			}
 
-			requestedScopes := scopes.OrDefault(client.Scopes)
-			if !client.AreScopesAllowed(requestedScopes) {
+			allowed, requestedScopes := resolveCIMDAuthorizationScopes(
+				&client,
+				scopes,
+				s.registry,
+			)
+
+			if !allowed.ContainsAll(requestedScopes.Values()) {
 				return NewError(
 					ErrInvalidScope,
 					WithDescription("requested scope exceeds client registration"),
@@ -1469,8 +1474,13 @@ func (s *Service) Authorize(
 				return fmt.Errorf("cannot authorize: unsupported response_type")
 			}
 
-			requestedScopes := req.Scopes.OrDefault(client.Scopes)
-			if !client.AreScopesAllowed(requestedScopes) {
+			allowed, requestedScopes := resolveCIMDAuthorizationScopes(
+				client,
+				req.Scopes,
+				s.registry,
+			)
+
+			if !allowed.ContainsAll(requestedScopes.Values()) {
 				return fmt.Errorf("cannot authorize: requested scope exceeds client registration")
 			}
 

--- a/pkg/server/api/authn/identity_presence_middleware.go
+++ b/pkg/server/api/authn/identity_presence_middleware.go
@@ -28,10 +28,11 @@ import (
 	"go.gearno.de/kit/httpserver"
 	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/bearertoken"
+	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/server/gqlutils"
 )
 
-func NewIdentityPresenceMiddleware(baseURL *baseurl.BaseURL) func(next http.Handler) http.Handler {
+func NewIdentityPresenceMiddleware(baseURL *baseurl.BaseURL, scopes ...coredata.OAuth2Scope) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +43,7 @@ func NewIdentityPresenceMiddleware(baseURL *baseurl.BaseURL) func(next http.Hand
 					if bearertoken.IsAttempt(r.Header.Get("Authorization")) {
 						bearertoken.SetBearerInvalidToken(w, baseURL)
 					} else {
-						bearertoken.SetBearerUnauthenticated(w, baseURL)
+						bearertoken.SetBearerUnauthenticated(w, baseURL, scopes...)
 					}
 
 					httpserver.RenderJSON(

--- a/pkg/server/api/mcp/v1/v1_handler.go
+++ b/pkg/server/api/mcp/v1/v1_handler.go
@@ -106,7 +106,7 @@ func NewMux(
 	r := chi.NewMux()
 	r.Use(authn.NewAPIKeyMiddleware(iamSvc, tokenSecret))
 	r.Use(authn.NewOAuth2AccessTokenMiddleware(iamSvc))
-	r.Use(authn.NewIdentityPresenceMiddleware(baseURL))
+	r.Use(authn.NewIdentityPresenceMiddleware(baseURL, iamSvc.OAuth2ScopeRegistry.AllWriteScopes()...))
 	r.Handle("/", protectedHandler)
 
 	logger.Info("MCP server initialized successfully")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [ENG-769](https://linear.app/probo/issue/ENG-769/enable-business-function-registration-through-mcp).

Claude reconnects with CIMD and often a stale `scope=` list. Consent showed only that request, so `v1:business-function` never appeared after it shipped. Public DCR clients (Cursor) still freeze scopes at registration and are unchanged here.

This change:

- Puts current write scopes on the unauthenticated MCP `401 WWW-Authenticate` `scope=` parameter so Claude can request them
- Unions the current write catalog into CIMD authorize allowed and requested scopes so a stale request still offers **Manage business functions**

Reconnect after deploy and grant **Manage business functions** on the Probo consent page. Existing tokens do not pick up the scope automatically.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-769](https://linear.app/probo/issue/ENG-769/enable-business-function-registration-through-mcp)

<div><a href="https://cursor.com/agents/bc-705959b8-e767-40aa-ac0f-c1fae6dbe967?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-705959b8-e767-40aa-ac0f-c1fae6dbe967&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advertises current write scopes to CIMD MCP clients and unions them during authorize/device flows so reconnect can grant v1:business-function without re-registration. Previously reconnect reused a stale scope request that hid new scopes; public DCR clients remain restricted to explicit requests. Action: reconnect MCP/CIMD clients and grant “Manage business functions” to issue updated tokens. Addresses Linear ENG-769.

### Service **`+76`** **`-8`**
- Includes optional scopes in Bearer discovery challenges and allows `SetBearerUnauthenticated` to carry scopes.
- Resolves CIMD authorization scopes by unioning the registry’s current write scopes for clients with an external client ID; uses this in device and authorize flows to validate requested scopes without weakening public DCR checks.

### GraphQL API **`+3`** **`-2`**
- `NewIdentityPresenceMiddleware` accepts scopes and forwards them to discovery challenges, guiding clients on which scopes to request.

### MCP **`+1`** **`-1`**
- MCP v1 handler injects the IAM registry’s current write scopes into the identity middleware so 401s advertise them.

### Coredata **`+33`** **`-0`**
- Adds `OAuth2Scopes.Union` to merge scope sets while preserving order and de-duplicating entries.

### Tests **`+138`** **`-0`**
- Covers Bearer discovery with scopes, `OAuth2Scopes.Union`, and CIMD scope resolution behavior (CIMD unions advertised scopes; public DCR clients keep explicit requests).

<sup>Written for commit 4245099ff99221f08ba892b2017821c068fab0f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

