### PR TITLE
Console cp ux refactor integrations

### DIFF
--- a/apps/console/src/pages/organizations/compliance-portals/_locales/en-US.json
+++ b/apps/console/src/pages/organizations/compliance-portals/_locales/en-US.json
@@ -435,10 +435,10 @@
     "notInstalled": "Install the Probo Slack app from organization settings before choosing a channel.",
     "channel": {
       "label": "Channel",
-      "placeholder": "Choose a channel",
+      "placeholder": "Select channel",
       "help": "Invite @Probo to a channel before selecting it.",
       "emptyTitle": "No Slack channel yet",
-      "emptyDescription": "In Slack, invite @Probo to a channel, then refresh this list."
+      "emptyDescription": "In Slack, invite @Probo to a channel, then open this list again."
     },
     "actions": {
       "clear": "Clear",

--- a/apps/console/src/pages/organizations/compliance-portals/_locales/en-US.json
+++ b/apps/console/src/pages/organizations/compliance-portals/_locales/en-US.json
@@ -444,7 +444,6 @@
       "clear": "Clear",
       "install": "Install",
       "refresh": "Refresh",
-      "loadMore": "Load more",
       "loadingMore": "Loading…"
     }
   },

--- a/apps/console/src/pages/organizations/compliance-portals/_locales/fr-FR.json
+++ b/apps/console/src/pages/organizations/compliance-portals/_locales/fr-FR.json
@@ -435,10 +435,10 @@
     "notInstalled": "Installez l’application Slack Probo depuis les paramètres de l’organisation avant de choisir un canal.",
     "channel": {
       "label": "Canal",
-      "placeholder": "Choisir un canal",
+      "placeholder": "Sélectionner un canal",
       "help": "Invitez @Probo dans un canal avant de le sélectionner.",
       "emptyTitle": "Aucun canal Slack pour le moment",
-      "emptyDescription": "Dans Slack, invitez @Probo dans un canal, puis actualisez cette liste."
+      "emptyDescription": "Dans Slack, invitez @Probo dans un canal, puis rouvrez cette liste."
     },
     "actions": {
       "clear": "Effacer",

--- a/apps/console/src/pages/organizations/compliance-portals/_locales/fr-FR.json
+++ b/apps/console/src/pages/organizations/compliance-portals/_locales/fr-FR.json
@@ -444,7 +444,6 @@
       "clear": "Effacer",
       "install": "Installer",
       "refresh": "Actualiser",
-      "loadMore": "Charger plus",
       "loadingMore": "Chargement…"
     }
   },

--- a/apps/console/src/pages/organizations/compliance-portals/_locales/nl-NL.json
+++ b/apps/console/src/pages/organizations/compliance-portals/_locales/nl-NL.json
@@ -196,7 +196,6 @@
       "clear": "Wissen",
       "install": "Installeren",
       "refresh": "Vernieuwen",
-      "loadMore": "Meer laden",
       "loadingMore": "Laden…"
     }
   },

--- a/apps/console/src/pages/organizations/compliance-portals/_locales/nl-NL.json
+++ b/apps/console/src/pages/organizations/compliance-portals/_locales/nl-NL.json
@@ -187,10 +187,10 @@
     "notInstalled": "Installeer de Probo Slack-app via de organisatie-instellingen voordat u een kanaal kiest.",
     "channel": {
       "label": "Kanaal",
-      "placeholder": "Kies een kanaal",
+      "placeholder": "Selecteer kanaal",
       "help": "Nodig @Probo uit in een kanaal voordat u het selecteert.",
       "emptyTitle": "Nog geen Slack-kanaal",
-      "emptyDescription": "Nodig @Probo in Slack uit in een kanaal en vernieuw daarna deze lijst."
+      "emptyDescription": "Nodig @Probo in Slack uit in een kanaal en open daarna deze lijst opnieuw."
     },
     "actions": {
       "clear": "Wissen",

--- a/apps/console/src/pages/organizations/compliance-portals/integrations/CompliancePortalIntegrationsPage.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/integrations/CompliancePortalIntegrationsPage.tsx
@@ -24,6 +24,7 @@ import { graphql } from "relay-runtime";
 import type { CompliancePortalIntegrationsPageQuery } from "#/__generated__/core/CompliancePortalIntegrationsPageQuery.graphql";
 
 import { CompliancePortalSlackSection } from "./_components/CompliancePortalSlackSection";
+import { integrationsPage } from "./variants";
 
 export const compliancePortalIntegrationsPageQuery = graphql`
   query CompliancePortalIntegrationsPageQuery($compliancePortalId: ID!) {
@@ -50,7 +51,7 @@ export function CompliancePortalIntegrationsPage({ queryRef }: CompliancePortalI
   }
 
   return (
-    <div className="space-y-6">
+    <div className={integrationsPage()}>
       <CompliancePortalSlackSection compliancePortalKey={compliancePortal} />
     </div>
   );

--- a/apps/console/src/pages/organizations/compliance-portals/integrations/CompliancePortalIntegrationsPageSkeleton.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/integrations/CompliancePortalIntegrationsPageSkeleton.tsx
@@ -18,37 +18,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { Suspense, useEffect } from "react";
-import { useQueryLoader } from "react-relay";
-import { useParams } from "react-router";
+import { CardSkeleton } from "@probo/ui/src/v2/Card/CardSkeleton";
+import { HeadingSkeleton } from "@probo/ui/src/v2/typography/HeadingSkeleton";
 
-import type { CompliancePortalIntegrationsPageQuery } from "#/__generated__/core/CompliancePortalIntegrationsPageQuery.graphql";
+import { integrationsPageSkeleton } from "./variants";
 
-import {
-  CompliancePortalIntegrationsPage,
-  compliancePortalIntegrationsPageQuery,
-} from "./CompliancePortalIntegrationsPage";
-import { CompliancePortalIntegrationsPageSkeleton } from "./CompliancePortalIntegrationsPageSkeleton";
-
-export default function CompliancePortalIntegrationsPageLoader() {
-  const { compliancePortalId } = useParams<{ compliancePortalId: string }>();
-  const [queryRef, loadQuery] = useQueryLoader<CompliancePortalIntegrationsPageQuery>(
-    compliancePortalIntegrationsPageQuery,
-  );
-
-  useEffect(() => {
-    if (compliancePortalId) {
-      loadQuery({ compliancePortalId });
-    }
-  }, [loadQuery, compliancePortalId]);
-
-  if (!queryRef) {
-    return <CompliancePortalIntegrationsPageSkeleton />;
-  }
+export function CompliancePortalIntegrationsPageSkeleton() {
+  const { root, section, intro } = integrationsPageSkeleton();
 
   return (
-    <Suspense fallback={<CompliancePortalIntegrationsPageSkeleton />}>
-      <CompliancePortalIntegrationsPage queryRef={queryRef} />
-    </Suspense>
+    <div className={root()}>
+      <div className={section()}>
+        <div className={intro()}>
+          <HeadingSkeleton size={4} className="w-40" />
+        </div>
+        <CardSkeleton size={4} />
+      </div>
+    </div>
   );
 }

--- a/apps/console/src/pages/organizations/compliance-portals/integrations/CompliancePortalIntegrationsPageSkeleton.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/integrations/CompliancePortalIntegrationsPageSkeleton.tsx
@@ -24,7 +24,7 @@ import { HeadingSkeleton } from "@probo/ui/src/v2/typography/HeadingSkeleton";
 import { integrationsPageSkeleton } from "./variants";
 
 export function CompliancePortalIntegrationsPageSkeleton() {
-  const { root, section, intro } = integrationsPageSkeleton();
+  const { root, section, intro, grid, card } = integrationsPageSkeleton();
 
   return (
     <div className={root()}>
@@ -32,7 +32,9 @@ export function CompliancePortalIntegrationsPageSkeleton() {
         <div className={intro()}>
           <HeadingSkeleton size={4} className="w-40" />
         </div>
-        <CardSkeleton size={4} />
+        <div className={grid()}>
+          <CardSkeleton size={3} className={card()} />
+        </div>
       </div>
     </div>
   );

--- a/apps/console/src/pages/organizations/compliance-portals/integrations/_components/CompliancePortalSlackSection.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/integrations/_components/CompliancePortalSlackSection.tsx
@@ -18,7 +18,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { Button, Card, Option, Select, Slack } from "@probo/ui";
+import { SlackLogoIcon } from "@phosphor-icons/react";
+import { Button } from "@probo/ui/src/v2/Button/Button";
+import { ButtonAnchor } from "@probo/ui/src/v2/Button/ButtonAnchor";
+import { Callout } from "@probo/ui/src/v2/Callout/Callout";
+import { Card } from "@probo/ui/src/v2/Card/Card";
+import { Field } from "@probo/ui/src/v2/form/Field";
+import { Select } from "@probo/ui/src/v2/Select/Select";
+import { SelectItem } from "@probo/ui/src/v2/Select/SelectItem";
+import { SelectPopup } from "@probo/ui/src/v2/Select/SelectPopup";
+import { SelectTrigger } from "@probo/ui/src/v2/Select/SelectTrigger";
+import { Heading } from "@probo/ui/src/v2/typography/Heading";
+import { Text } from "@probo/ui/src/v2/typography/Text";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { fetchQuery, useRefetchableFragment, useRelayEnvironment } from "react-relay";
@@ -31,6 +42,9 @@ import type { CompliancePortalSlackSectionRefetchQuery } from "#/__generated__/c
 import type { CompliancePortalSlackSectionSetMutation } from "#/__generated__/core/CompliancePortalSlackSectionSetMutation.graphql";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 import { useMutation } from "#/lib/relay/useMutation";
+
+import { hostingCard } from "../../hosting/variants";
+import { slackSection } from "../variants";
 
 const fragment = graphql`
   fragment CompliancePortalSlackSection_compliancePortal on CompliancePortal
@@ -179,6 +193,13 @@ export function CompliancePortalSlackSection({
   const loadMoreCursor = extraChannels.length > 0
     ? nextCursor
     : firstPage.nextCursor;
+  const channelNames = Object.fromEntries(
+    channels.map(channel => [channel.id, `#${channel.name}`]),
+  );
+  const showInstall = !isInstalled
+    && compliancePortal.organization.canInstallSlackbot
+    && compliancePortal.organization.slackbotAvailable;
+  const showChannelConfig = isInstalled === true && compliancePortal.canConfigureSlack;
 
   const refreshChannels = () => {
     setExtraChannels([]);
@@ -219,99 +240,125 @@ export function CompliancePortalSlackSection({
     });
   };
 
+  const { root, intro, lead, copy, channel, channelRow, channelField, empty, emptyCopy, emptyCallout }
+    = slackSection();
+  const { frame, header, wash, fade, icon: iconSlot, control, body } = hostingCard({
+    tone: "sand",
+    wide: true,
+  });
+
   return (
-    <div className="space-y-4">
-      <h2 className="text-base font-medium">{t("slackSection.title")}</h2>
-      <Card padded className="space-y-4">
-        <div className="flex items-center gap-3">
-          <div className="h-10 w-10 flex items-center justify-center bg-subtle rounded">
-            <Slack className="h-6 w-6" />
+    <section className={root()}>
+      <div className={intro()}>
+        <Heading level={2} size={4} weight="medium" highContrast>
+          {t("slackSection.title")}
+        </Heading>
+      </div>
+      <Card variant="ghost" size={2} padding="none" className={frame()}>
+        <div className={header()}>
+          <div className={wash()} />
+          <div className={fade()} />
+          <div className={lead()}>
+            <div className={iconSlot()}>
+              <SlackLogoIcon size={24} weight="duotone" />
+            </div>
+            <div className={copy()}>
+              <Text size={3} weight="medium" highContrast>
+                {isInstalled
+                  ? t("slackSection.connectionTitle")
+                  : t("slackSection.notInstalledTitle")}
+              </Text>
+              <Text size={2} color="neutral">
+                {isInstalled
+                  ? t("slackSection.description")
+                  : t("slackSection.notInstalled")}
+              </Text>
+            </div>
           </div>
-          <div className="mr-auto">
-            <h3 className="text-base font-semibold">
-              {isInstalled
-                ? t("slackSection.connectionTitle")
-                : t("slackSection.notInstalledTitle")}
-            </h3>
-            <p className="text-sm text-txt-tertiary">
-              {isInstalled
-                ? t("slackSection.description")
-                : t("slackSection.notInstalled")}
-            </p>
-          </div>
-          {!isInstalled
-            && compliancePortal.organization.canInstallSlackbot
-            && compliancePortal.organization.slackbotAvailable && (
-            <Button variant="secondary" asChild>
-              <a href={getSlackInstallUrl(organizationId)}>
+          {showInstall && (
+            <div className={control()}>
+              <ButtonAnchor
+                href={getSlackInstallUrl(organizationId)}
+                variant="solid"
+                color="neutral"
+                highContrast
+              >
                 {t("slackSection.actions.install")}
-              </a>
-            </Button>
+              </ButtonAnchor>
+            </div>
           )}
         </div>
-
-        {isInstalled && compliancePortal.canConfigureSlack && (
-          <div className="space-y-1.5">
+        {showChannelConfig && (
+          <div className={body()}>
             {hasChannels
               ? (
-                  <>
-                    <label className="text-sm font-medium">
-                      {t("slackSection.channel.label")}
-                    </label>
-                    <div className="flex items-center gap-2">
-                      <div className="grow">
-                        <Select
-                          value={
-                            compliancePortal.slackbotNotificationChannel
-                              ?.channelId ?? ""
-                          }
-                          onValueChange={setNotificationChannel}
-                          placeholder={t("slackSection.channel.placeholder")}
-                          disabled={isSettingChannel || isClearingChannel}
+                  <Select
+                    value={configuredChannel?.channelId ?? null}
+                    onValueChange={(channelId) => {
+                      if (channelId != null) {
+                        setNotificationChannel(channelId);
+                      }
+                    }}
+                    disabled={isSettingChannel || isClearingChannel}
+                  >
+                    <div className={channel()}>
+                      <div className={channelRow()}>
+                        <Field
+                          label={t("slackSection.channel.label")}
+                          className={channelField()}
                         >
-                          {channels.map(channel => (
-                            <Option key={channel.id} value={channel.id}>
-                              #
-                              {channel.name}
-                            </Option>
-                          ))}
-                        </Select>
+                          <SelectTrigger placeholder={t("slackSection.channel.placeholder")}>
+                            {(value: string | null) => (value ? channelNames[value] : null)}
+                          </SelectTrigger>
+                        </Field>
+                        {configuredChannel && (
+                          <Button
+                            variant="surface"
+                            color="neutral"
+                            loading={isClearingChannel}
+                            onClick={clearNotificationChannel}
+                          >
+                            {t("slackSection.actions.clear")}
+                          </Button>
+                        )}
                       </div>
-                      {compliancePortal.slackbotNotificationChannel && (
+                      <Text size={1} color="faint">
+                        {t("slackSection.channel.help")}
+                      </Text>
+                      {listedChannels.length === 0 && (
                         <Button
-                          variant="secondary"
-                          onClick={clearNotificationChannel}
-                          disabled={isClearingChannel}
+                          variant="surface"
+                          color="neutral"
+                          onClick={refreshChannels}
                         >
-                          {t("slackSection.actions.clear")}
+                          {t("slackSection.actions.refresh")}
                         </Button>
                       )}
                     </div>
-                    <p className="text-xs text-txt-tertiary">
-                      {t("slackSection.channel.help")}
-                    </p>
-                    {listedChannels.length === 0 && (
-                      <Button
-                        variant="secondary"
-                        onClick={refreshChannels}
-                      >
-                        {t("slackSection.actions.refresh")}
-                      </Button>
-                    )}
-                  </>
+                    <SelectPopup>
+                      {channels.map(listedChannel => (
+                        <SelectItem key={listedChannel.id} value={listedChannel.id}>
+                          {`#${listedChannel.name}`}
+                        </SelectItem>
+                      ))}
+                    </SelectPopup>
+                  </Select>
                 )
               : (
-                  <div className="flex items-center gap-3 rounded-lg border border-border-low bg-level-1 px-4 py-3">
-                    <div className="grow">
-                      <p className="text-sm font-medium">
-                        {t("slackSection.channel.emptyTitle")}
-                      </p>
-                      <p className="text-sm text-txt-tertiary">
-                        {t("slackSection.channel.emptyDescription")}
-                      </p>
-                    </div>
+                  <div className={empty()}>
+                    <Callout variant="surface" color="neutral" className={emptyCallout()}>
+                      <div className={emptyCopy()}>
+                        <Text size={2} weight="medium" highContrast>
+                          {t("slackSection.channel.emptyTitle")}
+                        </Text>
+                        <Text size={2}>
+                          {t("slackSection.channel.emptyDescription")}
+                        </Text>
+                      </div>
+                    </Callout>
                     <Button
-                      variant="secondary"
+                      variant="surface"
+                      color="neutral"
                       onClick={refreshChannels}
                     >
                       {t("slackSection.actions.refresh")}
@@ -320,19 +367,18 @@ export function CompliancePortalSlackSection({
                 )}
             {loadMoreCursor && (
               <Button
-                variant="secondary"
+                variant="surface"
+                color="neutral"
+                loading={isLoadingMore}
                 onClick={loadMoreChannels}
-                disabled={isLoadingMore}
               >
-                {isLoadingMore
-                  ? t("slackSection.actions.loadingMore")
-                  : t("slackSection.actions.loadMore")}
+                {t("slackSection.actions.loadMore")}
               </Button>
             )}
           </div>
         )}
       </Card>
-    </div>
+    </section>
   );
 }
 

--- a/apps/console/src/pages/organizations/compliance-portals/integrations/_components/CompliancePortalSlackSection.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/integrations/_components/CompliancePortalSlackSection.tsx
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { SlackLogoIcon } from "@phosphor-icons/react";
 import { Button } from "@probo/ui/src/v2/Button/Button";
 import { ButtonAnchor } from "@probo/ui/src/v2/Button/ButtonAnchor";
 import { Callout } from "@probo/ui/src/v2/Callout/Callout";
@@ -28,6 +27,7 @@ import { Select } from "@probo/ui/src/v2/Select/Select";
 import { SelectItem } from "@probo/ui/src/v2/Select/SelectItem";
 import { SelectPopup } from "@probo/ui/src/v2/Select/SelectPopup";
 import { SelectTrigger } from "@probo/ui/src/v2/Select/SelectTrigger";
+import { SlackLogo } from "@probo/ui/src/v2/SlackLogo/SlackLogo";
 import { Heading } from "@probo/ui/src/v2/typography/Heading";
 import { Text } from "@probo/ui/src/v2/typography/Text";
 import { useState } from "react";
@@ -240,11 +240,12 @@ export function CompliancePortalSlackSection({
     });
   };
 
-  const { root, intro, lead, copy, channel, channelRow, channelField, empty, emptyCopy, emptyCallout }
-    = slackSection();
+  const {
+    root, intro, grid, card, lead, copy, channel, channelRow, channelField,
+    empty, emptyCopy, emptyCallout,
+  } = slackSection();
   const { frame, header, wash, fade, icon: iconSlot, control, body } = hostingCard({
     tone: "sand",
-    wide: true,
   });
 
   return (
@@ -254,130 +255,132 @@ export function CompliancePortalSlackSection({
           {t("slackSection.title")}
         </Heading>
       </div>
-      <Card variant="ghost" size={2} padding="none" className={frame()}>
-        <div className={header()}>
-          <div className={wash()} />
-          <div className={fade()} />
-          <div className={lead()}>
-            <div className={iconSlot()}>
-              <SlackLogoIcon size={24} weight="duotone" />
+      <div className={grid()}>
+        <Card variant="ghost" size={2} padding="none" className={frame({ className: card() })}>
+          <div className={header()}>
+            <div className={wash()} />
+            <div className={fade()} />
+            <div className={lead()}>
+              <div className={iconSlot()}>
+                <SlackLogo className="size-6" aria-hidden />
+              </div>
+              <div className={copy()}>
+                <Text size={3} weight="medium" highContrast>
+                  {isInstalled
+                    ? t("slackSection.connectionTitle")
+                    : t("slackSection.notInstalledTitle")}
+                </Text>
+                <Text size={2} color="neutral">
+                  {isInstalled
+                    ? t("slackSection.description")
+                    : t("slackSection.notInstalled")}
+                </Text>
+              </div>
             </div>
-            <div className={copy()}>
-              <Text size={3} weight="medium" highContrast>
-                {isInstalled
-                  ? t("slackSection.connectionTitle")
-                  : t("slackSection.notInstalledTitle")}
-              </Text>
-              <Text size={2} color="neutral">
-                {isInstalled
-                  ? t("slackSection.description")
-                  : t("slackSection.notInstalled")}
-              </Text>
-            </div>
+            {showInstall && (
+              <div className={control()}>
+                <ButtonAnchor
+                  href={getSlackInstallUrl(organizationId)}
+                  variant="solid"
+                  color="neutral"
+                  highContrast
+                >
+                  {t("slackSection.actions.install")}
+                </ButtonAnchor>
+              </div>
+            )}
           </div>
-          {showInstall && (
-            <div className={control()}>
-              <ButtonAnchor
-                href={getSlackInstallUrl(organizationId)}
-                variant="solid"
-                color="neutral"
-                highContrast
-              >
-                {t("slackSection.actions.install")}
-              </ButtonAnchor>
-            </div>
-          )}
-        </div>
-        {showChannelConfig && (
-          <div className={body()}>
-            {hasChannels
-              ? (
-                  <Select
-                    value={configuredChannel?.channelId ?? null}
-                    onValueChange={(channelId) => {
-                      if (channelId != null) {
-                        setNotificationChannel(channelId);
-                      }
-                    }}
-                    disabled={isSettingChannel || isClearingChannel}
-                  >
-                    <div className={channel()}>
-                      <div className={channelRow()}>
-                        <Field
-                          label={t("slackSection.channel.label")}
-                          className={channelField()}
-                        >
-                          <SelectTrigger placeholder={t("slackSection.channel.placeholder")}>
-                            {(value: string | null) => (value ? channelNames[value] : null)}
-                          </SelectTrigger>
-                        </Field>
-                        {configuredChannel && (
+          {showChannelConfig && (
+            <div className={body()}>
+              {hasChannels
+                ? (
+                    <Select
+                      value={configuredChannel?.channelId ?? null}
+                      onValueChange={(channelId) => {
+                        if (channelId != null) {
+                          setNotificationChannel(channelId);
+                        }
+                      }}
+                      disabled={isSettingChannel || isClearingChannel}
+                    >
+                      <div className={channel()}>
+                        <div className={channelRow()}>
+                          <Field
+                            label={t("slackSection.channel.label")}
+                            className={channelField()}
+                          >
+                            <SelectTrigger placeholder={t("slackSection.channel.placeholder")}>
+                              {(value: string | null) => (value ? channelNames[value] : null)}
+                            </SelectTrigger>
+                          </Field>
+                          {configuredChannel && (
+                            <Button
+                              variant="surface"
+                              color="neutral"
+                              loading={isClearingChannel}
+                              onClick={clearNotificationChannel}
+                            >
+                              {t("slackSection.actions.clear")}
+                            </Button>
+                          )}
+                        </div>
+                        <Text size={1} color="faint">
+                          {t("slackSection.channel.help")}
+                        </Text>
+                        {listedChannels.length === 0 && (
                           <Button
                             variant="surface"
                             color="neutral"
-                            loading={isClearingChannel}
-                            onClick={clearNotificationChannel}
+                            onClick={refreshChannels}
                           >
-                            {t("slackSection.actions.clear")}
+                            {t("slackSection.actions.refresh")}
                           </Button>
                         )}
                       </div>
-                      <Text size={1} color="faint">
-                        {t("slackSection.channel.help")}
-                      </Text>
-                      {listedChannels.length === 0 && (
-                        <Button
-                          variant="surface"
-                          color="neutral"
-                          onClick={refreshChannels}
-                        >
-                          {t("slackSection.actions.refresh")}
-                        </Button>
-                      )}
+                      <SelectPopup>
+                        {channels.map(listedChannel => (
+                          <SelectItem key={listedChannel.id} value={listedChannel.id}>
+                            {`#${listedChannel.name}`}
+                          </SelectItem>
+                        ))}
+                      </SelectPopup>
+                    </Select>
+                  )
+                : (
+                    <div className={empty()}>
+                      <Callout variant="surface" color="neutral" className={emptyCallout()}>
+                        <div className={emptyCopy()}>
+                          <Text size={2} weight="medium" highContrast>
+                            {t("slackSection.channel.emptyTitle")}
+                          </Text>
+                          <Text size={2}>
+                            {t("slackSection.channel.emptyDescription")}
+                          </Text>
+                        </div>
+                      </Callout>
+                      <Button
+                        variant="surface"
+                        color="neutral"
+                        onClick={refreshChannels}
+                      >
+                        {t("slackSection.actions.refresh")}
+                      </Button>
                     </div>
-                    <SelectPopup>
-                      {channels.map(listedChannel => (
-                        <SelectItem key={listedChannel.id} value={listedChannel.id}>
-                          {`#${listedChannel.name}`}
-                        </SelectItem>
-                      ))}
-                    </SelectPopup>
-                  </Select>
-                )
-              : (
-                  <div className={empty()}>
-                    <Callout variant="surface" color="neutral" className={emptyCallout()}>
-                      <div className={emptyCopy()}>
-                        <Text size={2} weight="medium" highContrast>
-                          {t("slackSection.channel.emptyTitle")}
-                        </Text>
-                        <Text size={2}>
-                          {t("slackSection.channel.emptyDescription")}
-                        </Text>
-                      </div>
-                    </Callout>
-                    <Button
-                      variant="surface"
-                      color="neutral"
-                      onClick={refreshChannels}
-                    >
-                      {t("slackSection.actions.refresh")}
-                    </Button>
-                  </div>
-                )}
-            {loadMoreCursor && (
-              <Button
-                variant="surface"
-                color="neutral"
-                loading={isLoadingMore}
-                onClick={loadMoreChannels}
-              >
-                {t("slackSection.actions.loadMore")}
-              </Button>
-            )}
-          </div>
-        )}
-      </Card>
+                  )}
+              {loadMoreCursor && (
+                <Button
+                  variant="surface"
+                  color="neutral"
+                  loading={isLoadingMore}
+                  onClick={loadMoreChannels}
+                >
+                  {t("slackSection.actions.loadMore")}
+                </Button>
+              )}
+            </div>
+          )}
+        </Card>
+      </div>
     </section>
   );
 }

--- a/apps/console/src/pages/organizations/compliance-portals/integrations/_components/CompliancePortalSlackSection.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/integrations/_components/CompliancePortalSlackSection.tsx
@@ -30,7 +30,7 @@ import { SelectTrigger } from "@probo/ui/src/v2/Select/SelectTrigger";
 import { SlackLogo } from "@probo/ui/src/v2/SlackLogo/SlackLogo";
 import { Heading } from "@probo/ui/src/v2/typography/Heading";
 import { Text } from "@probo/ui/src/v2/typography/Text";
-import { useState } from "react";
+import { useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { fetchQuery, useRefetchableFragment, useRelayEnvironment } from "react-relay";
 import { graphql } from "relay-runtime";
@@ -167,11 +167,13 @@ export function CompliancePortalSlackSection({
   };
 
   const environment = useRelayEnvironment();
+  const [, startTransition] = useTransition();
   const [extraChannels, setExtraChannels] = useState<
     { id: string; name: string }[]
   >([]);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   const isInstalled = compliancePortal.organization.slackbotInstallation?.active;
   const firstPage = compliancePortal.organization.slackbotChannels;
@@ -189,7 +191,8 @@ export function CompliancePortalSlackSection({
         ...listedChannels,
       ]
     : listedChannels;
-  const hasChannels = channels.length > 0;
+  const slackListEmpty = listedChannels.length === 0;
+  const showEmptyCallout = slackListEmpty && !isRefreshing;
   const loadMoreCursor = extraChannels.length > 0
     ? nextCursor
     : firstPage.nextCursor;
@@ -204,7 +207,15 @@ export function CompliancePortalSlackSection({
   const refreshChannels = () => {
     setExtraChannels([]);
     setNextCursor(null);
-    refetch({}, { fetchPolicy: "network-only" });
+    setIsRefreshing(true);
+    startTransition(() => {
+      refetch({}, {
+        fetchPolicy: "network-only",
+        onComplete() {
+          setIsRefreshing(false);
+        },
+      });
+    });
   };
 
   const loadMoreChannels = () => {
@@ -242,7 +253,7 @@ export function CompliancePortalSlackSection({
 
   const {
     root, intro, grid, card, lead, copy, channel, channelRow, channelField,
-    empty, emptyCopy, emptyCallout,
+    empty, emptyCopy, emptyCallout, popupEmpty, popupLoadMore,
   } = slackSection();
   const { frame, header, wash, fade, icon: iconSlot, control, body } = hostingCard({
     tone: "sand",
@@ -292,91 +303,103 @@ export function CompliancePortalSlackSection({
           </div>
           {showChannelConfig && (
             <div className={body()}>
-              {hasChannels
-                ? (
-                    <Select
-                      value={configuredChannel?.channelId ?? null}
-                      onValueChange={(channelId) => {
-                        if (channelId != null) {
-                          setNotificationChannel(channelId);
-                        }
-                      }}
-                      disabled={isSettingChannel || isClearingChannel}
+              {showEmptyCallout && (
+                <div className={empty()}>
+                  <Callout variant="surface" color="neutral" className={emptyCallout()}>
+                    <div className={emptyCopy()}>
+                      <Text size={2} weight="medium" highContrast>
+                        {t("slackSection.channel.emptyTitle")}
+                      </Text>
+                      <Text size={2}>
+                        {t("slackSection.channel.emptyDescription")}
+                      </Text>
+                    </div>
+                  </Callout>
+                </div>
+              )}
+              <Select
+                value={configuredChannel?.channelId ?? null}
+                onOpenChange={(open) => {
+                  if (open) {
+                    refreshChannels();
+                  }
+                }}
+                onValueChange={(channelId) => {
+                  if (channelId != null) {
+                    setNotificationChannel(channelId);
+                  }
+                }}
+                disabled={isSettingChannel || isClearingChannel}
+              >
+                <div className={channel()}>
+                  <div className={channelRow()}>
+                    <Field
+                      label={t("slackSection.channel.label")}
+                      className={channelField()}
                     >
-                      <div className={channel()}>
-                        <div className={channelRow()}>
-                          <Field
-                            label={t("slackSection.channel.label")}
-                            className={channelField()}
-                          >
-                            <SelectTrigger placeholder={t("slackSection.channel.placeholder")}>
-                              {(value: string | null) => (value ? channelNames[value] : null)}
-                            </SelectTrigger>
-                          </Field>
-                          {configuredChannel && (
-                            <Button
-                              variant="surface"
-                              color="neutral"
-                              loading={isClearingChannel}
-                              onClick={clearNotificationChannel}
-                            >
-                              {t("slackSection.actions.clear")}
-                            </Button>
-                          )}
-                        </div>
-                        <Text size={1} color="faint">
-                          {t("slackSection.channel.help")}
-                        </Text>
-                        {listedChannels.length === 0 && (
-                          <Button
-                            variant="surface"
-                            color="neutral"
-                            onClick={refreshChannels}
-                          >
-                            {t("slackSection.actions.refresh")}
-                          </Button>
+                      <SelectTrigger placeholder={t("slackSection.channel.placeholder")}>
+                        {(value: string | null) => (
+                          value
+                            ? (channelNames[value] ?? `#${value}`)
+                            : t("slackSection.channel.placeholder")
                         )}
-                      </div>
-                      <SelectPopup>
-                        {channels.map(listedChannel => (
+                      </SelectTrigger>
+                    </Field>
+                    {configuredChannel && (
+                      <Button
+                        variant="surface"
+                        color="neutral"
+                        loading={isClearingChannel}
+                        onClick={clearNotificationChannel}
+                      >
+                        {t("slackSection.actions.clear")}
+                      </Button>
+                    )}
+                  </div>
+                  <Text size={1} color="faint">
+                    {t("slackSection.channel.help")}
+                  </Text>
+                </div>
+                <SelectPopup>
+                  {isRefreshing && slackListEmpty
+                    ? (
+                        <Text size={2} color="faint" className={popupEmpty()}>
+                          {t("slackSection.actions.loadingMore")}
+                        </Text>
+                      )
+                    : slackListEmpty
+                      ? (
+                          <div className={popupEmpty()}>
+                            <Text size={2} weight="medium" highContrast>
+                              {t("slackSection.channel.emptyTitle")}
+                            </Text>
+                            <Text size={1} color="faint">
+                              {t("slackSection.channel.emptyDescription")}
+                            </Text>
+                          </div>
+                        )
+                      : channels.map(listedChannel => (
                           <SelectItem key={listedChannel.id} value={listedChannel.id}>
                             {`#${listedChannel.name}`}
                           </SelectItem>
                         ))}
-                      </SelectPopup>
-                    </Select>
-                  )
-                : (
-                    <div className={empty()}>
-                      <Callout variant="surface" color="neutral" className={emptyCallout()}>
-                        <div className={emptyCopy()}>
-                          <Text size={2} weight="medium" highContrast>
-                            {t("slackSection.channel.emptyTitle")}
-                          </Text>
-                          <Text size={2}>
-                            {t("slackSection.channel.emptyDescription")}
-                          </Text>
-                        </div>
-                      </Callout>
+                  {loadMoreCursor && (
+                    <div className={popupLoadMore()}>
                       <Button
-                        variant="surface"
+                        variant="ghost"
                         color="neutral"
-                        onClick={refreshChannels}
+                        loading={isLoadingMore}
+                        onPointerDown={(event) => {
+                          event.preventDefault();
+                        }}
+                        onClick={loadMoreChannels}
                       >
-                        {t("slackSection.actions.refresh")}
+                        {t("slackSection.actions.loadMore")}
                       </Button>
                     </div>
                   )}
-              {loadMoreCursor && (
-                <Button
-                  variant="surface"
-                  color="neutral"
-                  loading={isLoadingMore}
-                  onClick={loadMoreChannels}
-                >
-                  {t("slackSection.actions.loadMore")}
-                </Button>
-              )}
+                </SelectPopup>
+              </Select>
             </div>
           )}
         </Card>

--- a/apps/console/src/pages/organizations/compliance-portals/integrations/_components/CompliancePortalSlackSection.tsx
+++ b/apps/console/src/pages/organizations/compliance-portals/integrations/_components/CompliancePortalSlackSection.tsx
@@ -32,11 +32,10 @@ import { Heading } from "@probo/ui/src/v2/typography/Heading";
 import { Text } from "@probo/ui/src/v2/typography/Text";
 import { useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
-import { fetchQuery, useRefetchableFragment, useRelayEnvironment } from "react-relay";
+import { useRefetchableFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
 import type { CompliancePortalSlackSection_compliancePortal$key } from "#/__generated__/core/CompliancePortalSlackSection_compliancePortal.graphql";
-import type { CompliancePortalSlackSectionChannelsQuery } from "#/__generated__/core/CompliancePortalSlackSectionChannelsQuery.graphql";
 import type { CompliancePortalSlackSectionClearMutation } from "#/__generated__/core/CompliancePortalSlackSectionClearMutation.graphql";
 import type { CompliancePortalSlackSectionRefetchQuery } from "#/__generated__/core/CompliancePortalSlackSectionRefetchQuery.graphql";
 import type { CompliancePortalSlackSectionSetMutation } from "#/__generated__/core/CompliancePortalSlackSectionSetMutation.graphql";
@@ -56,7 +55,6 @@ const fragment = graphql`
       channelName
     }
     organization {
-      id
       canInstallSlackbot: permission(action: "core:connector:initiate")
       slackbotAvailable
       slackbotInstallation {
@@ -66,26 +64,6 @@ const fragment = graphql`
         channels {
           id
           name
-        }
-        nextCursor
-      }
-    }
-  }
-`;
-
-const loadMoreChannelsQuery = graphql`
-  query CompliancePortalSlackSectionChannelsQuery(
-    $organizationId: ID!
-    $cursor: String
-  ) {
-    organization: node(id: $organizationId) @required(action: THROW) {
-      ... on Organization {
-        slackbotChannels(cursor: $cursor) {
-          channels {
-            id
-            name
-          }
-          nextCursor
         }
       }
     }
@@ -166,20 +144,11 @@ export function CompliancePortalSlackSection({
     });
   };
 
-  const environment = useRelayEnvironment();
   const [, startTransition] = useTransition();
-  const [extraChannels, setExtraChannels] = useState<
-    { id: string; name: string }[]
-  >([]);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const isInstalled = compliancePortal.organization.slackbotInstallation?.active;
-  const firstPage = compliancePortal.organization.slackbotChannels;
-  const listedChannels = extraChannels.length > 0
-    ? [...firstPage.channels, ...extraChannels]
-    : firstPage.channels;
+  const listedChannels = compliancePortal.organization.slackbotChannels.channels;
   const configuredChannel = compliancePortal.slackbotNotificationChannel;
   const channels = configuredChannel
     && !listedChannels.some(channel => channel.id === configuredChannel.channelId)
@@ -193,9 +162,6 @@ export function CompliancePortalSlackSection({
     : listedChannels;
   const slackListEmpty = listedChannels.length === 0;
   const showEmptyCallout = slackListEmpty && !isRefreshing;
-  const loadMoreCursor = extraChannels.length > 0
-    ? nextCursor
-    : firstPage.nextCursor;
   const channelNames = Object.fromEntries(
     channels.map(channel => [channel.id, `#${channel.name}`]),
   );
@@ -205,8 +171,6 @@ export function CompliancePortalSlackSection({
   const showChannelConfig = isInstalled === true && compliancePortal.canConfigureSlack;
 
   const refreshChannels = () => {
-    setExtraChannels([]);
-    setNextCursor(null);
     setIsRefreshing(true);
     startTransition(() => {
       refetch({}, {
@@ -218,42 +182,9 @@ export function CompliancePortalSlackSection({
     });
   };
 
-  const loadMoreChannels = () => {
-    if (!loadMoreCursor || isLoadingMore) {
-      return;
-    }
-
-    setIsLoadingMore(true);
-    fetchQuery<CompliancePortalSlackSectionChannelsQuery>(
-      environment,
-      loadMoreChannelsQuery,
-      {
-        organizationId: compliancePortal.organization.id,
-        cursor: loadMoreCursor,
-      },
-      { fetchPolicy: "network-only" },
-    ).subscribe({
-      next(data) {
-        const page = data.organization.slackbotChannels;
-        if (!page) {
-          return;
-        }
-
-        setExtraChannels(current => [...current, ...page.channels]);
-        setNextCursor(page.nextCursor ?? null);
-      },
-      complete() {
-        setIsLoadingMore(false);
-      },
-      error() {
-        setIsLoadingMore(false);
-      },
-    });
-  };
-
   const {
     root, intro, grid, card, lead, copy, channel, channelRow, channelField,
-    empty, emptyCopy, emptyCallout, popupEmpty, popupLoadMore,
+    empty, emptyCopy, emptyCallout, popupEmpty,
   } = slackSection();
   const { frame, header, wash, fade, icon: iconSlot, control, body } = hostingCard({
     tone: "sand",
@@ -383,21 +314,6 @@ export function CompliancePortalSlackSection({
                             {`#${listedChannel.name}`}
                           </SelectItem>
                         ))}
-                  {loadMoreCursor && (
-                    <div className={popupLoadMore()}>
-                      <Button
-                        variant="ghost"
-                        color="neutral"
-                        loading={isLoadingMore}
-                        onPointerDown={(event) => {
-                          event.preventDefault();
-                        }}
-                        onClick={loadMoreChannels}
-                      >
-                        {t("slackSection.actions.loadMore")}
-                      </Button>
-                    </div>
-                  )}
                 </SelectPopup>
               </Select>
             </div>

--- a/apps/console/src/pages/organizations/compliance-portals/integrations/variants.ts
+++ b/apps/console/src/pages/organizations/compliance-portals/integrations/variants.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { tv } from "tailwind-variants/lite";
+
+export const integrationsPage = tv({
+  base: "flex flex-col gap-6",
+});
+
+export const integrationsPageSkeleton = tv({
+  slots: {
+    root: "flex flex-col gap-6",
+    section: "flex flex-col gap-4",
+    intro: "flex flex-col gap-1",
+  },
+});
+
+export const slackSection = tv({
+  slots: {
+    root: "flex flex-col gap-4",
+    intro: "flex flex-col gap-1",
+    lead: "relative z-1 flex min-w-0 flex-1 items-center gap-3",
+    copy: "flex min-w-0 flex-1 flex-col gap-0.5",
+    channel: "flex flex-col gap-1.5",
+    channelRow: "flex items-end gap-2",
+    channelField: "min-w-0 flex-1",
+    empty: "flex items-start gap-3",
+    emptyCopy: "flex flex-col gap-0.5",
+    emptyCallout: "min-w-0 flex-1",
+  },
+});

--- a/apps/console/src/pages/organizations/compliance-portals/integrations/variants.ts
+++ b/apps/console/src/pages/organizations/compliance-portals/integrations/variants.ts
@@ -48,5 +48,7 @@ export const slackSection = tv({
     empty: "flex items-start gap-3",
     emptyCopy: "flex flex-col gap-0.5",
     emptyCallout: "min-w-0 flex-1",
+    popupEmpty: "flex flex-col gap-0.5 px-3 py-2",
+    popupLoadMore: "w-full px-1 py-1 [&_button]:w-full",
   },
 });

--- a/apps/console/src/pages/organizations/compliance-portals/integrations/variants.ts
+++ b/apps/console/src/pages/organizations/compliance-portals/integrations/variants.ts
@@ -49,6 +49,5 @@ export const slackSection = tv({
     emptyCopy: "flex flex-col gap-0.5",
     emptyCallout: "min-w-0 flex-1",
     popupEmpty: "flex flex-col gap-0.5 px-3 py-2",
-    popupLoadMore: "w-full px-1 py-1 [&_button]:w-full",
   },
 });

--- a/apps/console/src/pages/organizations/compliance-portals/routes.ts
+++ b/apps/console/src/pages/organizations/compliance-portals/routes.ts
@@ -26,6 +26,7 @@ import { PageSkeleton } from "#/components/skeletons/PageSkeleton";
 
 import { CompliancePortalLayoutSkeleton } from "./CompliancePortalLayoutSkeleton";
 import { CompliancePortalHostingPageSkeleton } from "./hosting/CompliancePortalHostingPageSkeleton";
+import { CompliancePortalIntegrationsPageSkeleton } from "./integrations/CompliancePortalIntegrationsPageSkeleton";
 
 export const compliancePortalRoutes = [
   {
@@ -55,7 +56,7 @@ export const compliancePortalRoutes = [
       },
       {
         path: "integrations",
-        Fallback: LinkCardSkeleton,
+        Fallback: CompliancePortalIntegrationsPageSkeleton,
         Component: lazy(() => import("#/pages/organizations/compliance-portals/integrations/CompliancePortalIntegrationsPageLoader")),
       },
       {

--- a/packages/ui/src/v2/SlackLogo/SlackLogo.stories.tsx
+++ b/packages/ui/src/v2/SlackLogo/SlackLogo.stories.tsx
@@ -18,35 +18,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { tv } from "tailwind-variants/lite";
+import type { Meta, StoryObj } from "@storybook/react";
 
-export const integrationsPage = tv({
-  base: "flex flex-col gap-6",
-});
+import { SlackLogo } from "./SlackLogo";
 
-export const integrationsPageSkeleton = tv({
-  slots: {
-    root: "flex flex-col gap-6",
-    section: "flex flex-col gap-4",
-    intro: "flex flex-col gap-1",
-    grid: "grid grid-cols-3 gap-3 max-lg:grid-cols-2 max-sm:grid-cols-1",
-    card: "col-span-2 max-sm:col-span-1",
+export default {
+  title: "v2/SlackLogo",
+  component: SlackLogo,
+  args: {
+    className: "size-6",
   },
-});
+  render: args => <SlackLogo {...args} />,
+} satisfies Meta<typeof SlackLogo>;
 
-export const slackSection = tv({
-  slots: {
-    root: "flex flex-col gap-4",
-    intro: "flex flex-col gap-1",
-    grid: "grid grid-cols-3 gap-3 max-lg:grid-cols-2 max-sm:grid-cols-1",
-    card: "col-span-2 max-sm:col-span-1",
-    lead: "relative z-1 flex min-w-0 flex-1 items-center gap-3",
-    copy: "flex min-w-0 flex-1 flex-col gap-0.5",
-    channel: "flex flex-col gap-1.5",
-    channelRow: "flex items-end gap-2",
-    channelField: "min-w-0 flex-1",
-    empty: "flex items-start gap-3",
-    emptyCopy: "flex flex-col gap-0.5",
-    emptyCallout: "min-w-0 flex-1",
-  },
-});
+type Story = StoryObj<typeof SlackLogo>;
+
+export const Playground: Story = {};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-6">
+      <SlackLogo className="size-4" />
+      <SlackLogo className="size-6" />
+      <SlackLogo className="size-10" />
+    </div>
+  ),
+};

--- a/packages/ui/src/v2/SlackLogo/SlackLogo.tsx
+++ b/packages/ui/src/v2/SlackLogo/SlackLogo.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import type { ComponentProps } from "react";
+
+export type SlackLogoProps = ComponentProps<"svg">;
+
+// Official Slack brand mark. Fills are Slack's four-color palette and do not
+// follow currentColor — size it with width/height or a size class.
+export function SlackLogo(props: SlackLogoProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 2447.6 2452.5"
+      {...props}
+    >
+      <g clipRule="evenodd" fillRule="evenodd">
+        <path
+          d="m897.4 0c-135.3.1-244.8 109.9-244.7 245.2-.1 135.3 109.5 245.1 244.8 245.2h244.8v-245.1c.1-135.3-109.5-245.1-244.9-245.3.1 0 .1 0 0 0m0 654h-652.6c-135.3.1-244.9 109.9-244.8 245.2-.2 135.3 109.4 245.1 244.7 245.3h652.7c135.3-.1 244.9-109.9 244.8-245.2.1-135.4-109.5-245.2-244.8-245.3z"
+          fill="#36c5f0"
+        />
+        <path
+          d="m2447.6 899.2c.1-135.3-109.5-245.1-244.8-245.2-135.3.1-244.9 109.9-244.8 245.2v245.3h244.8c135.3-.1 244.9-109.9 244.8-245.3zm-652.7 0v-654c.1-135.2-109.4-245-244.7-245.2-135.3.1-244.9 109.9-244.8 245.2v654c-.2 135.3 109.4 245.1 244.7 245.3 135.3-.1 244.9-109.9 244.8-245.3z"
+          fill="#2eb67d"
+        />
+        <path
+          d="m1550.1 2452.5c135.3-.1 244.9-109.9 244.8-245.2.1-135.3-109.5-245.1-244.8-245.2h-244.8v245.2c-.1 135.2 109.5 245 244.8 245.2zm0-654.1h652.7c135.3-.1 244.9-109.9 244.8-245.2.2-135.3-109.4-245.1-244.7-245.3h-652.7c-135.3.1-244.9 109.9-244.8 245.2-.1 135.4 109.4 245.2 244.7 245.3z"
+          fill="#ecb22e"
+        />
+        <path
+          d="m0 1553.2c-.1 135.3 109.5 245.1 244.8 245.2 135.3-.1 244.9-109.9 244.8-245.2v-245.2h-244.8c-135.3.1-244.9 109.9-244.8 245.2zm652.7 0v654c-.2 135.3 109.4 245.1 244.7 245.3 135.3-.1 244.9-109.9 244.8-245.2v-653.9c.2-135.3-109.4-245.1-244.7-245.3-135.4 0-244.9 109.8-244.8 245.1 0 0 0 .1 0 0"
+          fill="#e01e5a"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/pkg/probot/channel/slack/client.go
+++ b/pkg/probot/channel/slack/client.go
@@ -47,7 +47,9 @@ const (
 	slackMethodReactionsAdd         = "reactions.add"
 	slackMethodUpdateMessage        = "chat.update"
 
-	conversationsPageSize = 200
+	// Slack conversations.list max page size. One request is enough for
+	// typical workspaces; the picker does not page further in the UI.
+	conversationsPageSize = 1000
 	threadRepliesPageSize = 200
 	slackHTTPTimeout      = 30 * time.Second
 )

--- a/pkg/probot/channel/slack/client_test.go
+++ b/pkg/probot/channel/slack/client_test.go
@@ -184,7 +184,7 @@ func TestClientListConversations(t *testing.T) {
 							assert.Equal(t, "/api/conversations.list", r.URL.Path)
 							assert.Equal(t, tt.wantCursor, r.URL.Query().Get("cursor"))
 							assert.Equal(t, "true", r.URL.Query().Get("exclude_archived"))
-							assert.Equal(t, "200", r.URL.Query().Get("limit"))
+							assert.Equal(t, "1000", r.URL.Query().Get("limit"))
 							assert.Equal(t, "public_channel,private_channel", r.URL.Query().Get("types"))
 							assert.Equal(t, "Bearer "+testBotToken, r.Header.Get("Authorization"))
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrates the Compliance Portal Integrations page to UI v2 and makes the Slack channel picker live and predictable. Previously it cached the first page and showed a “Load more” button; now it refetches on open, removes pagination by requesting Slack’s max page, and keeps a usable empty state. Also widens the Slack card to two columns, adds an official Slack logo to `@probo/ui`, and swaps in a page-specific skeleton.

### App: console **`+275`** **`-194`**
- Rebuilds the Slack section with UI v2 primitives and hosting card chrome using new `variants.ts`.
- Refetches channels when the picker opens and removes in-UI pagination; keeps inline empty and loading states.
- Tightens install/config gating and switches the install CTA to a link-style button; updates en/fr/nl copy and placeholders.
- Adds a page-specific skeleton and sets it as the route fallback; Slack card spans two columns.

### Package: ui **`+100`** **`-0`**
- Adds `SlackLogo` (official four-color SVG) with Storybook stories to `@probo/ui/src/v2/SlackLogo/`.
- No breaking changes.

### Service **`+3`** **`-1`**
- Requests Slack conversations.list with limit 1000 to avoid UI pagination.

### Tests **`+1`** **`-1`**
- Updates Slack client test to expect limit 1000.

<sup>Written for commit afe3da1e1428e2b56e4ea44d27d2e7aabaac8bef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

