### PR TITLE
Redirect cookie-banner SDK to probo.com

### DIFF
--- a/packages/cookie-banner/CHANGELOG.md
+++ b/packages/cookie-banner/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `@probo/cookie-banner` SDK will be documented in this
 
 ## Unreleased
 
+### Changed
+
+- API calls to the retired hosted console hosts (`eu.console.getprobo.com`, `us.console.getprobo.com`) are rewritten to `eu.probo.com` and `us.probo.com` so existing snippets keep working after the domain migration. Self-hosted and already-migrated base URLs are unchanged.
+
 ## [0.16.0] - 2026-08-19
 
 ### Added

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -34,6 +34,7 @@ import {
   StorageDetector,
 } from "./detectors";
 import { NotFoundError } from "./errors";
+import { rewriteLegacyConsoleHost } from "./hosted-url";
 import { fetchJSON } from "./http";
 import { detectLanguage } from "./i18n";
 import type { ConsentIntegration } from "./integrations";
@@ -91,7 +92,7 @@ export class CookieBannerClient {
     if (!base.endsWith("/")) {
       base += "/";
     }
-    this.baseUrl = new URL(base);
+    this.baseUrl = rewriteLegacyConsoleHost(new URL(base));
     this.bannerId = config.bannerId;
     this.visitorId = getVisitorId(config.bannerId);
     this.lang = detectLanguage(config.lang);

--- a/packages/cookie-banner/src/hosted-url.test.ts
+++ b/packages/cookie-banner/src/hosted-url.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { describe, expect, it } from "vitest";
+
+import { rewriteLegacyConsoleHost } from "./hosted-url";
+
+describe("rewriteLegacyConsoleHost", () => {
+  it("rewrites the EU console host", () => {
+    const url = new URL("https://eu.console.getprobo.com/api/cookie-banner/v1/");
+    expect(rewriteLegacyConsoleHost(url).href).toBe(
+      "https://eu.probo.com/api/cookie-banner/v1/",
+    );
+  });
+
+  it("rewrites the US console host", () => {
+    const url = new URL("https://us.console.getprobo.com/api/cookie-banner/v1/");
+    expect(rewriteLegacyConsoleHost(url).href).toBe(
+      "https://us.probo.com/api/cookie-banner/v1/",
+    );
+  });
+
+  it("matches the host case-insensitively", () => {
+    const url = new URL("https://EU.CONSOLE.GETPROBO.COM/api/cookie-banner/v1/");
+    expect(rewriteLegacyConsoleHost(url).href).toBe(
+      "https://eu.probo.com/api/cookie-banner/v1/",
+    );
+  });
+
+  it("preserves path and query", () => {
+    const url = new URL(
+      "https://us.console.getprobo.com/api/cookie-banner/v1/banner/consents?lang=fr",
+    );
+    expect(rewriteLegacyConsoleHost(url).href).toBe(
+      "https://us.probo.com/api/cookie-banner/v1/banner/consents?lang=fr",
+    );
+  });
+
+  it("leaves already-migrated hosted URLs unchanged", () => {
+    const url = new URL("https://eu.probo.com/api/cookie-banner/v1/");
+    expect(rewriteLegacyConsoleHost(url)).toBe(url);
+  });
+
+  it("leaves self-hosted URLs unchanged", () => {
+    const url = new URL("https://privacy.example.com/api/cookie-banner/v1/");
+    expect(rewriteLegacyConsoleHost(url)).toBe(url);
+  });
+
+  it("does not rewrite suffix hosts", () => {
+    const url = new URL("https://foo.eu.console.getprobo.com/api/cookie-banner/v1/");
+    expect(rewriteLegacyConsoleHost(url)).toBe(url);
+  });
+});

--- a/packages/cookie-banner/src/hosted-url.ts
+++ b/packages/cookie-banner/src/hosted-url.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+const LEGACY_CONSOLE_HOSTS: Record<string, string> = {
+  "eu.console.getprobo.com": "eu.probo.com",
+  "us.console.getprobo.com": "us.probo.com",
+};
+
+// Snippets copied while the console lived on *.console.getprobo.com still
+// pass that host as baseUrl. Rewrite so API calls hit the current hosted
+// domains; self-hosted and already-migrated URLs are left alone.
+export function rewriteLegacyConsoleHost(url: URL): URL {
+  const next = LEGACY_CONSOLE_HOSTS[url.hostname.toLowerCase()];
+  if (!next) {
+    return url;
+  }
+  const rewritten = new URL(url.href);
+  rewritten.hostname = next;
+  return rewritten;
+}

--- a/packages/cookie-banner/src/queue.ts
+++ b/packages/cookie-banner/src/queue.ts
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 import { COOKIE_NAME } from "./cookie";
+import { rewriteLegacyConsoleHost } from "./hosted-url";
 import { fetchJSON } from "./http";
 const MAX_QUEUE_SIZE = 10;
 const MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
@@ -91,7 +92,10 @@ export async function flush(bannerId: string): Promise<void> {
 
   for (const entry of queue) {
     try {
-      await fetchJSON(entry.url, { method: "POST", body: entry.body });
+      await fetchJSON(rewriteLegacyConsoleHost(new URL(entry.url)), {
+        method: "POST",
+        body: entry.body,
+      });
       sentTimestamps.push(entry.timestamp);
     } catch {
       // will remain in queue


### PR DESCRIPTION
Closes https://linear.app/probo/issue/ENG-684/cb-rewrite-endpoint-url-to-point-to-probocom

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rewrites requests from the retired hosted console domains to probo.com so existing `@probo/cookie-banner` snippets keep working after the domain migration. Previously the SDK used the provided baseUrl as-is; now it rewrites `eu.console.getprobo.com`/`us.console.getprobo.com` to `eu.probo.com`/`us.probo.com`, leaving self-hosted and already-migrated URLs unchanged.

### Tests **`+70`** **`-0`**
Covers `rewriteLegacyConsoleHost` for EU/US rewrites, case-insensitive hosts, path/query preservation, no-op on migrated/self-hosted URLs, and avoiding suffix host rewrites.

### Package: cookie-banner **`+48`** **`-2`**
Introduces `rewriteLegacyConsoleHost` and applies it when initializing the client baseUrl and when flushing the queue so queued and live requests hit `eu/us.probo.com` if snippets still pass legacy hosts. Updates the `@probo/cookie-banner` changelog to document the redirect behavior.

<sup>Written for commit 50e672b3092b56d447fef188ec99ce9b9336e27d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

