### PR TITLE
Use document classification in PDF watermarks

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -524,7 +524,7 @@
     },
     "watermark": {
       "label": "Add watermark",
-      "description": "Add a confidential watermark with custom text and a timestamp to all PDFs",
+      "description": "Add a watermark with custom text and a timestamp to all PDFs",
       "textLabel": "Watermark text",
       "textPlaceholder": "Enter watermark text"
     },
@@ -565,7 +565,7 @@
     },
     "watermark": {
       "label": "Add watermark",
-      "description": "Add a confidential watermark with custom text and a timestamp",
+      "description": "Add a watermark with custom text and a timestamp",
       "textLabel": "Watermark text",
       "textPlaceholder": "Enter watermark text"
     },

--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -524,7 +524,7 @@
     },
     "watermark": {
       "label": "Add watermark",
-      "description": "Add a watermark with custom text and a timestamp to all PDFs",
+      "description": "Add a watermark with each document's classification, custom text, and a timestamp to all PDFs",
       "textLabel": "Watermark text",
       "textPlaceholder": "Enter watermark text"
     },
@@ -565,7 +565,7 @@
     },
     "watermark": {
       "label": "Add watermark",
-      "description": "Add a watermark with custom text and a timestamp",
+      "description": "Add a watermark with the document classification, custom text, and a timestamp",
       "textLabel": "Watermark text",
       "textPlaceholder": "Enter watermark text"
     },

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -1003,7 +1003,7 @@
     },
     "watermark": {
       "label": "Ajouter un filigrane",
-      "description": "Ajouter un filigrane avec un texte personnalisé et un horodatage à tous les PDF",
+      "description": "Ajouter à tous les PDF un filigrane avec la classification de chaque document, un texte personnalisé et un horodatage",
       "textLabel": "Texte du filigrane",
       "textPlaceholder": "Saisissez le texte du filigrane"
     },
@@ -1044,7 +1044,7 @@
     },
     "watermark": {
       "label": "Ajouter un filigrane",
-      "description": "Ajouter un filigrane avec un texte personnalisé et un horodatage",
+      "description": "Ajouter un filigrane avec la classification du document, un texte personnalisé et un horodatage",
       "textLabel": "Texte du filigrane",
       "textPlaceholder": "Saisissez le texte du filigrane"
     },

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -1003,7 +1003,7 @@
     },
     "watermark": {
       "label": "Ajouter un filigrane",
-      "description": "Ajouter un filigrane confidentiel avec un texte personnalisé et un horodatage à tous les PDF",
+      "description": "Ajouter un filigrane avec un texte personnalisé et un horodatage à tous les PDF",
       "textLabel": "Texte du filigrane",
       "textPlaceholder": "Saisissez le texte du filigrane"
     },
@@ -1044,7 +1044,7 @@
     },
     "watermark": {
       "label": "Ajouter un filigrane",
-      "description": "Ajouter un filigrane confidentiel avec un texte personnalisé et un horodatage",
+      "description": "Ajouter un filigrane avec un texte personnalisé et un horodatage",
       "textLabel": "Texte du filigrane",
       "textPlaceholder": "Saisissez le texte du filigrane"
     },

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -1003,7 +1003,7 @@
     },
     "watermark": {
       "label": "Watermerk toevoegen",
-      "description": "Voeg een vertrouwelijk watermerk met aangepaste tekst en een tijdstempel toe aan alle PDF's",
+      "description": "Voeg een watermerk met aangepaste tekst en een tijdstempel toe aan alle PDF's",
       "textLabel": "Watermerktekst",
       "textPlaceholder": "Voer watermerktekst in"
     },
@@ -1044,7 +1044,7 @@
     },
     "watermark": {
       "label": "Watermerk toevoegen",
-      "description": "Voeg een vertrouwelijk watermerk met aangepaste tekst en een tijdstempel toe",
+      "description": "Voeg een watermerk met aangepaste tekst en een tijdstempel toe",
       "textLabel": "Watermerktekst",
       "textPlaceholder": "Voer watermerktekst in"
     },

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -1003,7 +1003,7 @@
     },
     "watermark": {
       "label": "Watermerk toevoegen",
-      "description": "Voeg een watermerk met aangepaste tekst en een tijdstempel toe aan alle PDF's",
+      "description": "Voeg aan alle PDF's een watermerk toe met de classificatie van elk document, aangepaste tekst en een tijdstempel",
       "textLabel": "Watermerktekst",
       "textPlaceholder": "Voer watermerktekst in"
     },
@@ -1044,7 +1044,7 @@
     },
     "watermark": {
       "label": "Watermerk toevoegen",
-      "description": "Voeg een watermerk met aangepaste tekst en een tijdstempel toe",
+      "description": "Voeg een watermerk toe met de documentclassificatie, aangepaste tekst en een tijdstempel",
       "textLabel": "Watermerktekst",
       "textPlaceholder": "Voer watermerktekst in"
     },

--- a/pkg/complianceportal/visitor/document_service.go
+++ b/pkg/complianceportal/visitor/document_service.go
@@ -85,14 +85,18 @@ func (s *Service) ExportDocumentPDF(
 	documentID gid.GID,
 	email mail.Addr,
 ) ([]byte, error) {
-	pdfData, err := s.exportDocumentPDFData(ctx, scope, compliancePortalID, documentID)
+	pdfData, classification, err := s.exportDocumentPDFData(ctx, scope, compliancePortalID, documentID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot export document PDF: %w", err)
 	}
 
 	watermarkText := pdfutils.TruncateWatermarkText(email.String())
 
-	watermarkedPDF, err := pdfutils.AddWatermarkWithTimestamp(pdfData, watermarkText)
+	watermarkedPDF, err := pdfutils.AddWatermarkWithTimestamp(
+		pdfData,
+		classification.String(),
+		watermarkText,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 	}
@@ -106,7 +110,12 @@ func (s *Service) ExportDocumentPDFWithoutWatermark(
 	compliancePortalID gid.GID,
 	documentID gid.GID,
 ) ([]byte, error) {
-	return s.exportDocumentPDFData(ctx, scope, compliancePortalID, documentID)
+	pdfData, _, err := s.exportDocumentPDFData(ctx, scope, compliancePortalID, documentID)
+	if err != nil {
+		return nil, err
+	}
+
+	return pdfData, nil
 }
 
 // GetDocument loads a document and its association with the given compliance
@@ -160,7 +169,7 @@ func (s *Service) exportDocumentPDFData(
 	scope coredata.Scoper,
 	compliancePortalID gid.GID,
 	documentID gid.GID,
-) ([]byte, error) {
+) ([]byte, coredata.DocumentClassification, error) {
 	document := &coredata.Document{}
 	portalDocument := &coredata.CompliancePortalDocument{}
 	compliancePortal := &coredata.CompliancePortal{}
@@ -207,25 +216,25 @@ func (s *Service) exportDocumentPDFData(
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if version.FileID != nil {
 		pdfData, err := s.fileManager.GetFileBytes(ctx, fileRecord)
 		if err != nil {
-			return nil, fmt.Errorf("cannot fetch document PDF file: %w", err)
+			return nil, "", fmt.Errorf("cannot fetch document PDF file: %w", err)
 		}
 
-		return pdfData, nil
+		return pdfData, version.Classification, nil
 	}
 
 	// TODO: remove on-the-fly fallback once all published versions have a stored PDF.
 	pdfData, err := s.generateDocumentPDFOnTheFly(ctx, scope, document, version)
 	if err != nil {
-		return nil, fmt.Errorf("cannot generate PDF on the fly: %w", err)
+		return nil, "", fmt.Errorf("cannot generate PDF on the fly: %w", err)
 	}
 
-	return pdfData, nil
+	return pdfData, version.Classification, nil
 }
 
 // generatePDFOnTheFly generates a PDF from scratch for versions that don't have

--- a/pkg/complianceportal/visitor/document_service.go
+++ b/pkg/complianceportal/visitor/document_service.go
@@ -92,7 +92,7 @@ func (s *Service) ExportDocumentPDF(
 
 	watermarkText := pdfutils.TruncateWatermarkText(email.String())
 
-	watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, watermarkText)
+	watermarkedPDF, err := pdfutils.AddWatermarkWithTimestamp(pdfData, watermarkText)
 	if err != nil {
 		return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 	}

--- a/pkg/complianceportal/visitor/portal_file_service.go
+++ b/pkg/complianceportal/visitor/portal_file_service.go
@@ -121,7 +121,7 @@ func (s *Service) ExportPortalFile(
 	if mimeType == "application/pdf" {
 		watermarkText := pdfutils.TruncateWatermarkText(email.String())
 
-		watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(fileData, watermarkText)
+		watermarkedPDF, err := pdfutils.AddWatermarkWithTimestamp(fileData, watermarkText)
 		if err != nil {
 			return nil, "", fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}

--- a/pkg/complianceportal/visitor/portal_file_service.go
+++ b/pkg/complianceportal/visitor/portal_file_service.go
@@ -121,7 +121,11 @@ func (s *Service) ExportPortalFile(
 	if mimeType == "application/pdf" {
 		watermarkText := pdfutils.TruncateWatermarkText(email.String())
 
-		watermarkedPDF, err := pdfutils.AddWatermarkWithTimestamp(fileData, watermarkText)
+		watermarkedPDF, err := pdfutils.AddWatermarkWithTimestamp(
+			fileData,
+			coredata.DocumentClassificationConfidential.String(),
+			watermarkText,
+		)
 		if err != nil {
 			return nil, "", fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}

--- a/pkg/complianceportal/visitor/report_service.go
+++ b/pkg/complianceportal/visitor/report_service.go
@@ -104,7 +104,11 @@ func (s *Service) ExportReportPDF(
 
 	watermarkText := pdfutils.TruncateWatermarkText(email.String())
 
-	watermarkedPDF, err := pdfutils.AddWatermarkWithTimestamp(pdfData, watermarkText)
+	watermarkedPDF, err := pdfutils.AddWatermarkWithTimestamp(
+		pdfData,
+		coredata.DocumentClassificationConfidential.String(),
+		watermarkText,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 	}

--- a/pkg/complianceportal/visitor/report_service.go
+++ b/pkg/complianceportal/visitor/report_service.go
@@ -104,7 +104,7 @@ func (s *Service) ExportReportPDF(
 
 	watermarkText := pdfutils.TruncateWatermarkText(email.String())
 
-	watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, watermarkText)
+	watermarkedPDF, err := pdfutils.AddWatermarkWithTimestamp(pdfData, watermarkText)
 	if err != nil {
 		return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 	}

--- a/pkg/pdfutils/pdfutils.go
+++ b/pkg/pdfutils/pdfutils.go
@@ -70,14 +70,14 @@ func MergePDFs(pdfs ...[]byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func AddWatermarkWithTimestamp(pdfData []byte, watermarkText string) ([]byte, error) {
+func AddWatermarkWithTimestamp(pdfData []byte, classification string, watermarkText string) ([]byte, error) {
 	if err := ValidateWatermarkText(watermarkText); err != nil {
 		return nil, fmt.Errorf("cannot validate watermark text: %w", err)
 	}
 
 	reader := bytes.NewReader(pdfData)
 
-	textImage, err := generateTextImage(buildWatermarkLines(watermarkText, time.Now()))
+	textImage, err := generateTextImage(buildWatermarkLines(classification, watermarkText, time.Now()))
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate watermark image: %w", err)
 	}
@@ -111,8 +111,9 @@ func AddWatermarkWithTimestamp(pdfData []byte, watermarkText string) ([]byte, er
 	return buf.Bytes(), nil
 }
 
-func buildWatermarkLines(watermarkText string, timestamp time.Time) []string {
+func buildWatermarkLines(classification string, watermarkText string, timestamp time.Time) []string {
 	return []string{
+		classification,
 		watermarkText,
 		timestamp.Format("2006-01-02"),
 	}

--- a/pkg/pdfutils/pdfutils.go
+++ b/pkg/pdfutils/pdfutils.go
@@ -70,20 +70,14 @@ func MergePDFs(pdfs ...[]byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func AddConfidentialWithTimestamp(pdfData []byte, watermarkText string) ([]byte, error) {
+func AddWatermarkWithTimestamp(pdfData []byte, watermarkText string) ([]byte, error) {
 	if err := ValidateWatermarkText(watermarkText); err != nil {
 		return nil, fmt.Errorf("cannot validate watermark text: %w", err)
 	}
 
 	reader := bytes.NewReader(pdfData)
 
-	watermarkLines := []string{
-		"Confidential",
-		watermarkText,
-		time.Now().Format("2006-01-02"),
-	}
-
-	textImage, err := generateTextImage(watermarkLines)
+	textImage, err := generateTextImage(buildWatermarkLines(watermarkText, time.Now()))
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate watermark image: %w", err)
 	}
@@ -115,6 +109,13 @@ func AddConfidentialWithTimestamp(pdfData []byte, watermarkText string) ([]byte,
 	}
 
 	return buf.Bytes(), nil
+}
+
+func buildWatermarkLines(watermarkText string, timestamp time.Time) []string {
+	return []string{
+		watermarkText,
+		timestamp.Format("2006-01-02"),
+	}
 }
 
 func ValidateWatermarkText(watermarkText string) error {

--- a/pkg/pdfutils/pdfutils_test.go
+++ b/pkg/pdfutils/pdfutils_test.go
@@ -34,7 +34,7 @@ func TestAddWatermarkWithTimestamp_WatermarkTextTooLong(t *testing.T) {
 
 	watermarkText := strings.Repeat("a", MaxWatermarkTextLength+1)
 
-	pdf, err := AddWatermarkWithTimestamp(nil, watermarkText)
+	pdf, err := AddWatermarkWithTimestamp(nil, "PUBLIC", watermarkText)
 
 	require.Error(t, err)
 	assert.Nil(t, pdf)
@@ -56,7 +56,7 @@ func TestAddWatermarkWithTimestamp_WatermarkTextEmpty(t *testing.T) {
 			func(t *testing.T) {
 				t.Parallel()
 
-				pdf, err := AddWatermarkWithTimestamp(nil, watermarkText)
+				pdf, err := AddWatermarkWithTimestamp(nil, "PUBLIC", watermarkText)
 
 				require.Error(t, err)
 				assert.Nil(t, pdf)
@@ -66,15 +66,16 @@ func TestAddWatermarkWithTimestamp_WatermarkTextEmpty(t *testing.T) {
 	}
 }
 
-func TestBuildWatermarkLines_DoesNotAddClassification(t *testing.T) {
+func TestBuildWatermarkLines_UsesDocumentClassification(t *testing.T) {
 	t.Parallel()
 
 	lines := buildWatermarkLines(
+		"PUBLIC",
 		"recipient@example.com",
 		time.Date(2026, time.August, 24, 10, 43, 0, 0, time.UTC),
 	)
 
-	assert.Equal(t, []string{"recipient@example.com", "2026-08-24"}, lines)
+	assert.Equal(t, []string{"PUBLIC", "recipient@example.com", "2026-08-24"}, lines)
 }
 
 func TestTruncateWatermarkText(t *testing.T) {

--- a/pkg/pdfutils/pdfutils_test.go
+++ b/pkg/pdfutils/pdfutils_test.go
@@ -18,30 +18,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package pdfutils_test
+package pdfutils
 
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.probo.inc/probo/pkg/pdfutils"
 )
 
-func TestAddConfidentialWithTimestamp_WatermarkTextTooLong(t *testing.T) {
+func TestAddWatermarkWithTimestamp_WatermarkTextTooLong(t *testing.T) {
 	t.Parallel()
 
-	watermarkText := strings.Repeat("a", pdfutils.MaxWatermarkTextLength+1)
+	watermarkText := strings.Repeat("a", MaxWatermarkTextLength+1)
 
-	pdf, err := pdfutils.AddConfidentialWithTimestamp(nil, watermarkText)
+	pdf, err := AddWatermarkWithTimestamp(nil, watermarkText)
 
 	require.Error(t, err)
 	assert.Nil(t, pdf)
 	assert.ErrorContains(t, err, "watermark text must not exceed 64 bytes")
 }
 
-func TestAddConfidentialWithTimestamp_WatermarkTextEmpty(t *testing.T) {
+func TestAddWatermarkWithTimestamp_WatermarkTextEmpty(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]string{
@@ -56,7 +56,7 @@ func TestAddConfidentialWithTimestamp_WatermarkTextEmpty(t *testing.T) {
 			func(t *testing.T) {
 				t.Parallel()
 
-				pdf, err := pdfutils.AddConfidentialWithTimestamp(nil, watermarkText)
+				pdf, err := AddWatermarkWithTimestamp(nil, watermarkText)
 
 				require.Error(t, err)
 				assert.Nil(t, pdf)
@@ -64,6 +64,17 @@ func TestAddConfidentialWithTimestamp_WatermarkTextEmpty(t *testing.T) {
 			},
 		)
 	}
+}
+
+func TestBuildWatermarkLines_DoesNotAddClassification(t *testing.T) {
+	t.Parallel()
+
+	lines := buildWatermarkLines(
+		"recipient@example.com",
+		time.Date(2026, time.August, 24, 10, 43, 0, 0, time.UTC),
+	)
+
+	assert.Equal(t, []string{"recipient@example.com", "2026-08-24"}, lines)
 }
 
 func TestTruncateWatermarkText(t *testing.T) {
@@ -78,12 +89,12 @@ func TestTruncateWatermarkText(t *testing.T) {
 			expected: "recipient@example.com",
 		},
 		"ASCII over limit": {
-			input:    strings.Repeat("a", pdfutils.MaxWatermarkTextLength+1),
-			expected: strings.Repeat("a", pdfutils.MaxWatermarkTextLength),
+			input:    strings.Repeat("a", MaxWatermarkTextLength+1),
+			expected: strings.Repeat("a", MaxWatermarkTextLength),
 		},
 		"multibyte rune at boundary": {
-			input:    strings.Repeat("a", pdfutils.MaxWatermarkTextLength-1) + "é",
-			expected: strings.Repeat("a", pdfutils.MaxWatermarkTextLength-1),
+			input:    strings.Repeat("a", MaxWatermarkTextLength-1) + "é",
+			expected: strings.Repeat("a", MaxWatermarkTextLength-1),
 		},
 	}
 
@@ -93,7 +104,7 @@ func TestTruncateWatermarkText(t *testing.T) {
 			func(t *testing.T) {
 				t.Parallel()
 
-				actual := pdfutils.TruncateWatermarkText(testCase.input)
+				actual := TruncateWatermarkText(testCase.input)
 
 				assert.Equal(t, testCase.expected, actual)
 			},

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -2748,7 +2748,11 @@ func exportDocumentPDF(
 			return nil, fmt.Errorf("watermark text is required with watermark enabled")
 		}
 
-		pdfData, err = pdfutils.AddWatermarkWithTimestamp(pdfData, *options.WatermarkText)
+		pdfData, err = pdfutils.AddWatermarkWithTimestamp(
+			pdfData,
+			version.Classification.String(),
+			*options.WatermarkText,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}
@@ -2795,7 +2799,11 @@ func exportStoredPDF(
 			return nil, fmt.Errorf("watermark text is required with watermark enabled")
 		}
 
-		pdfData, err = pdfutils.AddWatermarkWithTimestamp(pdfData, *options.WatermarkText)
+		pdfData, err = pdfutils.AddWatermarkWithTimestamp(
+			pdfData,
+			version.Classification.String(),
+			*options.WatermarkText,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}
@@ -3017,7 +3025,11 @@ func generateDocumentPDF(
 			return nil, fmt.Errorf("watermark text is required with watermark enabled")
 		}
 
-		watermarkedPDF, err := pdfutils.AddWatermarkWithTimestamp(pdfData, *options.WatermarkText)
+		watermarkedPDF, err := pdfutils.AddWatermarkWithTimestamp(
+			pdfData,
+			version.Classification.String(),
+			*options.WatermarkText,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -2748,7 +2748,7 @@ func exportDocumentPDF(
 			return nil, fmt.Errorf("watermark text is required with watermark enabled")
 		}
 
-		pdfData, err = pdfutils.AddConfidentialWithTimestamp(pdfData, *options.WatermarkText)
+		pdfData, err = pdfutils.AddWatermarkWithTimestamp(pdfData, *options.WatermarkText)
 		if err != nil {
 			return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}
@@ -2795,7 +2795,7 @@ func exportStoredPDF(
 			return nil, fmt.Errorf("watermark text is required with watermark enabled")
 		}
 
-		pdfData, err = pdfutils.AddConfidentialWithTimestamp(pdfData, *options.WatermarkText)
+		pdfData, err = pdfutils.AddWatermarkWithTimestamp(pdfData, *options.WatermarkText)
 		if err != nil {
 			return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}
@@ -3017,7 +3017,7 @@ func generateDocumentPDF(
 			return nil, fmt.Errorf("watermark text is required with watermark enabled")
 		}
 
-		watermarkedPDF, err := pdfutils.AddConfidentialWithTimestamp(pdfData, *options.WatermarkText)
+		watermarkedPDF, err := pdfutils.AddWatermarkWithTimestamp(pdfData, *options.WatermarkText)
 		if err != nil {
 			return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- replace the hard-coded `Confidential` watermark label with each document version's stored classification
- preserve the existing confidential label for reports and standalone portal files, which have no document classification
- clarify the localized console descriptions to explain that document classification is included
- add regression coverage for classification-aware watermark lines

## Testing

- `go test ./pkg/pdfutils ./pkg/complianceportal/visitor ./pkg/probo`
- `npm run check --workspace @probo/console`
- parsed all modified locale catalogs with `JSON.parse`

Resolves ENG-761.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-761](https://linear.app/probo/issue/ENG-761/all-wattermark-document-is-classify-as-confidential)

<div><a href="https://cursor.com/agents/bc-7b4e6098-c0e3-4834-b844-74b590bbf27d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b4e6098-c0e3-4834-b844-74b590bbf27d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the hard-coded "Confidential" PDF watermark with each document’s classification. Previously the watermark was "Confidential" + custom text + date; now it is classification + custom text + date, aligning UI copy and addressing ENG-761.

### Service **`+53`** **`-22`**
Renames the `pkg/pdfutils` helper to AddWatermarkWithTimestamp(classification, text), builds watermark lines via a new internal buildWatermarkLines, and propagates classification from version metadata in `pkg/complianceportal/visitor` and `pkg/probo`. `ExportDocumentPDFData` now returns PDF bytes and the version’s classification; portal/report exports default to `Confidential`. Migration: replace all AddConfidentialWithTimestamp calls with AddWatermarkWithTimestamp and pass a classification string.

### Tests **`+24`** **`-12`**
Moves tests into `pkg/pdfutils` to cover buildWatermarkLines and the new helper signature. Adds a regression ensuring the classification appears in watermark lines.

### App: console **`+6`** **`-6`**
Updates `apps/console` (`@probo/console`) locale copy to describe watermarks as classification + custom text + timestamp.

<sup>Written for commit db78f46c463ed2d858b7683443660d6696d12845. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

