### PR TITLE
Share coredata order-field IsValid and UnmarshalText helpers

### DIFF
--- a/contrib/claude/coredata.md
+++ b/contrib/claude/coredata.md
@@ -405,7 +405,7 @@ Collection enum wrappers (`OAuth2Scopes`, `CountryCodes`, etc.) may keep custom 
 
 ## Order fields
 
-Order-field enums follow the same enum rules and additionally implement `Column()` and `page.OrderField`:
+Order-field enums follow the same enum rules and additionally implement `Column()` and `page.OrderField`. Shared `IsValid` / `UnmarshalText` logic lives in `order_field.go` — do not copy a validation switch into each file:
 
 ```go
 type XXXOrderField string
@@ -421,6 +421,29 @@ var (
     _ encoding.TextMarshaler   = XXXOrderField("")
     _ encoding.TextUnmarshaler = (*XXXOrderField)(nil)
 )
+
+func XXXOrderFields() []XXXOrderField {
+    return []XXXOrderField{
+        XXXOrderFieldCreatedAt,
+        XXXOrderFieldName,
+    }
+}
+
+func (v XXXOrderField) IsValid() bool {
+    return isValidOrderField(v, XXXOrderFields())
+}
+
+func (v XXXOrderField) String() string {
+    return string(v)
+}
+
+func (v XXXOrderField) MarshalText() ([]byte, error) {
+    return []byte(v.String()), nil
+}
+
+func (v *XXXOrderField) UnmarshalText(text []byte) error {
+    return unmarshalOrderField(v, text, XXXOrderFields())
+}
 
 func (f XXXOrderField) Column() string {
     return string(f)

--- a/pkg/coredata/access_review_campaign_order_field.go
+++ b/pkg/coredata/access_review_campaign_order_field.go
@@ -49,13 +49,7 @@ func AccessReviewCampaignOrderFields() []AccessReviewCampaignOrderField {
 }
 
 func (v AccessReviewCampaignOrderField) IsValid() bool {
-	switch v {
-	case
-		AccessReviewCampaignOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, AccessReviewCampaignOrderFields())
 }
 
 func (v AccessReviewCampaignOrderField) String() string {
@@ -67,14 +61,7 @@ func (v AccessReviewCampaignOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *AccessReviewCampaignOrderField) UnmarshalText(text []byte) error {
-	val := AccessReviewCampaignOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid AccessReviewCampaignOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, AccessReviewCampaignOrderFields())
 }
 
 func (p AccessReviewCampaignOrderField) Column() string {

--- a/pkg/coredata/access_review_campaign_source_fetch_attempt_order_field.go
+++ b/pkg/coredata/access_review_campaign_source_fetch_attempt_order_field.go
@@ -49,12 +49,7 @@ func AccessReviewCampaignSourceFetchAttemptOrderFields() []AccessReviewCampaignS
 }
 
 func (v AccessReviewCampaignSourceFetchAttemptOrderField) IsValid() bool {
-	switch v {
-	case AccessReviewCampaignSourceFetchAttemptOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, AccessReviewCampaignSourceFetchAttemptOrderFields())
 }
 
 func (v AccessReviewCampaignSourceFetchAttemptOrderField) String() string {
@@ -66,14 +61,7 @@ func (v AccessReviewCampaignSourceFetchAttemptOrderField) MarshalText() ([]byte,
 }
 
 func (v *AccessReviewCampaignSourceFetchAttemptOrderField) UnmarshalText(text []byte) error {
-	val := AccessReviewCampaignSourceFetchAttemptOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid AccessReviewCampaignSourceFetchAttemptOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, AccessReviewCampaignSourceFetchAttemptOrderFields())
 }
 
 func (p AccessReviewCampaignSourceFetchAttemptOrderField) Column() string {

--- a/pkg/coredata/access_review_entry_order_field.go
+++ b/pkg/coredata/access_review_entry_order_field.go
@@ -49,13 +49,7 @@ func AccessReviewEntryOrderFields() []AccessReviewEntryOrderField {
 }
 
 func (v AccessReviewEntryOrderField) IsValid() bool {
-	switch v {
-	case
-		AccessReviewEntryOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, AccessReviewEntryOrderFields())
 }
 
 func (v AccessReviewEntryOrderField) String() string {
@@ -67,14 +61,7 @@ func (v AccessReviewEntryOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *AccessReviewEntryOrderField) UnmarshalText(text []byte) error {
-	val := AccessReviewEntryOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid AccessReviewEntryOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, AccessReviewEntryOrderFields())
 }
 
 func (p AccessReviewEntryOrderField) Column() string {

--- a/pkg/coredata/access_review_source_order_field.go
+++ b/pkg/coredata/access_review_source_order_field.go
@@ -49,13 +49,7 @@ func AccessReviewSourceOrderFields() []AccessReviewSourceOrderField {
 }
 
 func (v AccessReviewSourceOrderField) IsValid() bool {
-	switch v {
-	case
-		AccessReviewSourceOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, AccessReviewSourceOrderFields())
 }
 
 func (v AccessReviewSourceOrderField) String() string {
@@ -67,14 +61,7 @@ func (v AccessReviewSourceOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *AccessReviewSourceOrderField) UnmarshalText(text []byte) error {
-	val := AccessReviewSourceOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid AccessReviewSourceOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, AccessReviewSourceOrderFields())
 }
 
 func (p AccessReviewSourceOrderField) Column() string {

--- a/pkg/coredata/agent_execution_order_field.go
+++ b/pkg/coredata/agent_execution_order_field.go
@@ -49,13 +49,7 @@ func AgentExecutionOrderFields() []AgentExecutionOrderField {
 }
 
 func (v AgentExecutionOrderField) IsValid() bool {
-	switch v {
-	case
-		AgentExecutionOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, AgentExecutionOrderFields())
 }
 
 func (v AgentExecutionOrderField) String() string {
@@ -67,14 +61,7 @@ func (v AgentExecutionOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *AgentExecutionOrderField) UnmarshalText(text []byte) error {
-	val := AgentExecutionOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid AgentExecutionOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, AgentExecutionOrderFields())
 }
 
 func (p AgentExecutionOrderField) Column() string {

--- a/pkg/coredata/ai_system_order_field.go
+++ b/pkg/coredata/ai_system_order_field.go
@@ -51,12 +51,7 @@ func AiSystemOrderFields() []AiSystemOrderField {
 }
 
 func (v AiSystemOrderField) IsValid() bool {
-	switch v {
-	case AiSystemOrderFieldCreatedAt, AiSystemOrderFieldName, AiSystemOrderFieldStatus:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, AiSystemOrderFields())
 }
 
 func (v AiSystemOrderField) String() string {
@@ -68,14 +63,7 @@ func (v AiSystemOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *AiSystemOrderField) UnmarshalText(text []byte) error {
-	val := AiSystemOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid AiSystemOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, AiSystemOrderFields())
 }
 
 func (p AiSystemOrderField) Column() string {

--- a/pkg/coredata/applicability_statement_order_field.go
+++ b/pkg/coredata/applicability_statement_order_field.go
@@ -49,14 +49,7 @@ func ApplicabilityStatementOrderFields() []ApplicabilityStatementOrderField {
 }
 
 func (v ApplicabilityStatementOrderField) IsValid() bool {
-	switch v {
-	case
-		ApplicabilityStatementOrderFieldCreatedAt,
-		ApplicabilityStatementOrderFieldControlSectionTitle:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ApplicabilityStatementOrderFields())
 }
 
 func (v ApplicabilityStatementOrderField) String() string {
@@ -68,14 +61,7 @@ func (v ApplicabilityStatementOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ApplicabilityStatementOrderField) UnmarshalText(text []byte) error {
-	val := ApplicabilityStatementOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ApplicabilityStatementOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ApplicabilityStatementOrderFields())
 }
 
 func (p ApplicabilityStatementOrderField) Column() string {

--- a/pkg/coredata/asset_order_field.go
+++ b/pkg/coredata/asset_order_field.go
@@ -51,15 +51,7 @@ func AssetOrderFields() []AssetOrderField {
 }
 
 func (v AssetOrderField) IsValid() bool {
-	switch v {
-	case
-		AssetOrderFieldCreatedAt,
-		AssetOrderFieldAmount,
-		AssetOrderFieldName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, AssetOrderFields())
 }
 
 func (v AssetOrderField) String() string {
@@ -71,14 +63,7 @@ func (v AssetOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *AssetOrderField) UnmarshalText(text []byte) error {
-	val := AssetOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid AssetOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, AssetOrderFields())
 }
 
 func (p AssetOrderField) Column() string {

--- a/pkg/coredata/audit_log_entry_order_field.go
+++ b/pkg/coredata/audit_log_entry_order_field.go
@@ -47,13 +47,7 @@ func AuditLogEntryOrderFields() []AuditLogEntryOrderField {
 }
 
 func (v AuditLogEntryOrderField) IsValid() bool {
-	switch v {
-	case
-		AuditLogEntryOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, AuditLogEntryOrderFields())
 }
 
 func (v AuditLogEntryOrderField) String() string {
@@ -65,14 +59,7 @@ func (v AuditLogEntryOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *AuditLogEntryOrderField) UnmarshalText(text []byte) error {
-	val := AuditLogEntryOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid AuditLogEntryOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, AuditLogEntryOrderFields())
 }
 
 func (p AuditLogEntryOrderField) Column() string {

--- a/pkg/coredata/audit_order_field.go
+++ b/pkg/coredata/audit_order_field.go
@@ -57,18 +57,7 @@ func AuditOrderFields() []AuditOrderField {
 }
 
 func (v AuditOrderField) IsValid() bool {
-	switch v {
-	case
-		AuditOrderFieldCreatedAt,
-		AuditOrderFieldValidFrom,
-		AuditOrderFieldValidUntil,
-		AuditOrderFieldAuditStartDate,
-		AuditOrderFieldAuditEndDate,
-		AuditOrderFieldState:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, AuditOrderFields())
 }
 
 func (v AuditOrderField) String() string {
@@ -80,14 +69,7 @@ func (v AuditOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *AuditOrderField) UnmarshalText(text []byte) error {
-	val := AuditOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid AuditOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, AuditOrderFields())
 }
 
 func (p AuditOrderField) Column() string {

--- a/pkg/coredata/business_function_order_field.go
+++ b/pkg/coredata/business_function_order_field.go
@@ -59,19 +59,7 @@ func BusinessFunctionOrderFields() []BusinessFunctionOrderField {
 }
 
 func (v BusinessFunctionOrderField) IsValid() bool {
-	switch v {
-	case
-		BusinessFunctionOrderFieldCreatedAt,
-		BusinessFunctionOrderFieldReferenceID,
-		BusinessFunctionOrderFieldName,
-		BusinessFunctionOrderFieldClassification,
-		BusinessFunctionOrderFieldMTDMinutes,
-		BusinessFunctionOrderFieldRTOMinutes,
-		BusinessFunctionOrderFieldRPOMinutes:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, BusinessFunctionOrderFields())
 }
 
 func (v BusinessFunctionOrderField) String() string {
@@ -83,14 +71,7 @@ func (v BusinessFunctionOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *BusinessFunctionOrderField) UnmarshalText(text []byte) error {
-	val := BusinessFunctionOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid BusinessFunctionOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, BusinessFunctionOrderFields())
 }
 
 func (p BusinessFunctionOrderField) Column() string {

--- a/pkg/coredata/common_third_party_order_field.go
+++ b/pkg/coredata/common_third_party_order_field.go
@@ -51,15 +51,7 @@ func CommonThirdPartyOrderFields() []CommonThirdPartyOrderField {
 }
 
 func (v CommonThirdPartyOrderField) IsValid() bool {
-	switch v {
-	case
-		CommonThirdPartyOrderFieldName,
-		CommonThirdPartyOrderFieldCreatedAt,
-		CommonThirdPartyOrderFieldUpdatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CommonThirdPartyOrderFields())
 }
 
 func (v CommonThirdPartyOrderField) String() string {
@@ -71,14 +63,7 @@ func (v CommonThirdPartyOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CommonThirdPartyOrderField) UnmarshalText(text []byte) error {
-	val := CommonThirdPartyOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CommonThirdPartyOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CommonThirdPartyOrderFields())
 }
 
 func (v CommonThirdPartyOrderField) Column() string {

--- a/pkg/coredata/common_tracker_pattern_order_field.go
+++ b/pkg/coredata/common_tracker_pattern_order_field.go
@@ -55,17 +55,7 @@ func CommonTrackerPatternOrderFields() []CommonTrackerPatternOrderField {
 }
 
 func (v CommonTrackerPatternOrderField) IsValid() bool {
-	switch v {
-	case
-		CommonTrackerPatternOrderFieldPattern,
-		CommonTrackerPatternOrderFieldConfidence,
-		CommonTrackerPatternOrderFieldCreatedAt,
-		CommonTrackerPatternOrderFieldUpdatedAt,
-		CommonTrackerPatternOrderFieldLastEnrichmentAttemptAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CommonTrackerPatternOrderFields())
 }
 
 func (v CommonTrackerPatternOrderField) String() string {
@@ -77,14 +67,7 @@ func (v CommonTrackerPatternOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CommonTrackerPatternOrderField) UnmarshalText(text []byte) error {
-	val := CommonTrackerPatternOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CommonTrackerPatternOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CommonTrackerPatternOrderFields())
 }
 
 func (v CommonTrackerPatternOrderField) Column() string {

--- a/pkg/coredata/compliance_custom_link_order_field.go
+++ b/pkg/coredata/compliance_custom_link_order_field.go
@@ -51,14 +51,7 @@ func ComplianceCustomLinkOrderFields() []ComplianceCustomLinkOrderField {
 }
 
 func (v ComplianceCustomLinkOrderField) IsValid() bool {
-	switch v {
-	case
-		ComplianceCustomLinkOrderFieldCreatedAt,
-		ComplianceCustomLinkOrderFieldRank:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ComplianceCustomLinkOrderFields())
 }
 
 func (v ComplianceCustomLinkOrderField) String() string {
@@ -70,14 +63,7 @@ func (v ComplianceCustomLinkOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ComplianceCustomLinkOrderField) UnmarshalText(text []byte) error {
-	val := ComplianceCustomLinkOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ComplianceCustomLinkOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ComplianceCustomLinkOrderFields())
 }
 
 func (p ComplianceCustomLinkOrderField) Column() string {

--- a/pkg/coredata/compliance_framework_order_field.go
+++ b/pkg/coredata/compliance_framework_order_field.go
@@ -51,14 +51,7 @@ func ComplianceFrameworkOrderFields() []ComplianceFrameworkOrderField {
 }
 
 func (v ComplianceFrameworkOrderField) IsValid() bool {
-	switch v {
-	case
-		ComplianceFrameworkOrderFieldCreatedAt,
-		ComplianceFrameworkOrderFieldRank:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ComplianceFrameworkOrderFields())
 }
 
 func (v ComplianceFrameworkOrderField) String() string {
@@ -70,14 +63,7 @@ func (v ComplianceFrameworkOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ComplianceFrameworkOrderField) UnmarshalText(text []byte) error {
-	val := ComplianceFrameworkOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ComplianceFrameworkOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ComplianceFrameworkOrderFields())
 }
 
 func (p ComplianceFrameworkOrderField) Column() string {

--- a/pkg/coredata/compliance_portal_access_order_field.go
+++ b/pkg/coredata/compliance_portal_access_order_field.go
@@ -47,13 +47,7 @@ func CompliancePortalAccessOrderFields() []CompliancePortalAccessOrderField {
 }
 
 func (v CompliancePortalAccessOrderField) IsValid() bool {
-	switch v {
-	case
-		CompliancePortalAccessOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CompliancePortalAccessOrderFields())
 }
 
 func (v CompliancePortalAccessOrderField) String() string {
@@ -65,14 +59,7 @@ func (v CompliancePortalAccessOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CompliancePortalAccessOrderField) UnmarshalText(text []byte) error {
-	val := CompliancePortalAccessOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CompliancePortalAccessOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CompliancePortalAccessOrderFields())
 }
 
 func (tcaof CompliancePortalAccessOrderField) Column() string {

--- a/pkg/coredata/compliance_portal_commitment_group_order_field.go
+++ b/pkg/coredata/compliance_portal_commitment_group_order_field.go
@@ -53,15 +53,7 @@ func CompliancePortalCommitmentGroupOrderFields() []CompliancePortalCommitmentGr
 }
 
 func (v CompliancePortalCommitmentGroupOrderField) IsValid() bool {
-	switch v {
-	case
-		CompliancePortalCommitmentGroupOrderFieldRank,
-		CompliancePortalCommitmentGroupOrderFieldCreatedAt,
-		CompliancePortalCommitmentGroupOrderFieldUpdatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CompliancePortalCommitmentGroupOrderFields())
 }
 
 func (v CompliancePortalCommitmentGroupOrderField) String() string {
@@ -73,14 +65,7 @@ func (v CompliancePortalCommitmentGroupOrderField) MarshalText() ([]byte, error)
 }
 
 func (v *CompliancePortalCommitmentGroupOrderField) UnmarshalText(text []byte) error {
-	val := CompliancePortalCommitmentGroupOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CompliancePortalCommitmentGroupOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CompliancePortalCommitmentGroupOrderFields())
 }
 
 func (p CompliancePortalCommitmentGroupOrderField) Column() string {

--- a/pkg/coredata/compliance_portal_commitment_order_field.go
+++ b/pkg/coredata/compliance_portal_commitment_order_field.go
@@ -53,15 +53,7 @@ func CompliancePortalCommitmentOrderFields() []CompliancePortalCommitmentOrderFi
 }
 
 func (v CompliancePortalCommitmentOrderField) IsValid() bool {
-	switch v {
-	case
-		CompliancePortalCommitmentOrderFieldRank,
-		CompliancePortalCommitmentOrderFieldCreatedAt,
-		CompliancePortalCommitmentOrderFieldUpdatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CompliancePortalCommitmentOrderFields())
 }
 
 func (v CompliancePortalCommitmentOrderField) String() string {
@@ -73,14 +65,7 @@ func (v CompliancePortalCommitmentOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CompliancePortalCommitmentOrderField) UnmarshalText(text []byte) error {
-	val := CompliancePortalCommitmentOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CompliancePortalCommitmentOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CompliancePortalCommitmentOrderFields())
 }
 
 func (p CompliancePortalCommitmentOrderField) Column() string {

--- a/pkg/coredata/compliance_portal_document_access_order_field.go
+++ b/pkg/coredata/compliance_portal_document_access_order_field.go
@@ -47,13 +47,7 @@ func CompliancePortalDocumentAccessOrderFields() []CompliancePortalDocumentAcces
 }
 
 func (v CompliancePortalDocumentAccessOrderField) IsValid() bool {
-	switch v {
-	case
-		CompliancePortalDocumentAccessOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CompliancePortalDocumentAccessOrderFields())
 }
 
 func (v CompliancePortalDocumentAccessOrderField) String() string {
@@ -65,14 +59,7 @@ func (v CompliancePortalDocumentAccessOrderField) MarshalText() ([]byte, error) 
 }
 
 func (v *CompliancePortalDocumentAccessOrderField) UnmarshalText(text []byte) error {
-	val := CompliancePortalDocumentAccessOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CompliancePortalDocumentAccessOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CompliancePortalDocumentAccessOrderFields())
 }
 
 func (tcdaof CompliancePortalDocumentAccessOrderField) Column() string {

--- a/pkg/coredata/compliance_portal_file_order_field.go
+++ b/pkg/coredata/compliance_portal_file_order_field.go
@@ -53,15 +53,7 @@ func CompliancePortalFileOrderFields() []CompliancePortalFileOrderField {
 }
 
 func (v CompliancePortalFileOrderField) IsValid() bool {
-	switch v {
-	case
-		CompliancePortalFileOrderFieldName,
-		CompliancePortalFileOrderFieldCreatedAt,
-		CompliancePortalFileOrderFieldUpdatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CompliancePortalFileOrderFields())
 }
 
 func (v CompliancePortalFileOrderField) String() string {
@@ -73,14 +65,7 @@ func (v CompliancePortalFileOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CompliancePortalFileOrderField) UnmarshalText(text []byte) error {
-	val := CompliancePortalFileOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CompliancePortalFileOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CompliancePortalFileOrderFields())
 }
 
 func (p CompliancePortalFileOrderField) Column() string {

--- a/pkg/coredata/compliance_portal_order_field.go
+++ b/pkg/coredata/compliance_portal_order_field.go
@@ -47,13 +47,7 @@ func CompliancePortalOrderFields() []CompliancePortalOrderField {
 }
 
 func (v CompliancePortalOrderField) IsValid() bool {
-	switch v {
-	case
-		CompliancePortalOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CompliancePortalOrderFields())
 }
 
 func (v CompliancePortalOrderField) String() string {
@@ -65,14 +59,7 @@ func (v CompliancePortalOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CompliancePortalOrderField) UnmarshalText(text []byte) error {
-	val := CompliancePortalOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CompliancePortalOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CompliancePortalOrderFields())
 }
 
 func (p CompliancePortalOrderField) Column() string {

--- a/pkg/coredata/compliance_portal_reference_order_field.go
+++ b/pkg/coredata/compliance_portal_reference_order_field.go
@@ -55,16 +55,7 @@ func CompliancePortalReferenceOrderFields() []CompliancePortalReferenceOrderFiel
 }
 
 func (v CompliancePortalReferenceOrderField) IsValid() bool {
-	switch v {
-	case
-		CompliancePortalReferenceOrderFieldRank,
-		CompliancePortalReferenceOrderFieldName,
-		CompliancePortalReferenceOrderFieldCreatedAt,
-		CompliancePortalReferenceOrderFieldUpdatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CompliancePortalReferenceOrderFields())
 }
 
 func (v CompliancePortalReferenceOrderField) String() string {
@@ -76,14 +67,7 @@ func (v CompliancePortalReferenceOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CompliancePortalReferenceOrderField) UnmarshalText(text []byte) error {
-	val := CompliancePortalReferenceOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CompliancePortalReferenceOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CompliancePortalReferenceOrderFields())
 }
 
 func (p CompliancePortalReferenceOrderField) Column() string {

--- a/pkg/coredata/connector_order_field.go
+++ b/pkg/coredata/connector_order_field.go
@@ -51,14 +51,7 @@ func ConnectorOrderFields() []ConnectorOrderField {
 }
 
 func (v ConnectorOrderField) IsValid() bool {
-	switch v {
-	case
-		ConnectorOrderFieldCreatedAt,
-		ConnectorOrderFieldProvider:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ConnectorOrderFields())
 }
 
 func (v ConnectorOrderField) String() string {
@@ -70,14 +63,7 @@ func (v ConnectorOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ConnectorOrderField) UnmarshalText(text []byte) error {
-	val := ConnectorOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ConnectorOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ConnectorOrderFields())
 }
 
 func (p ConnectorOrderField) Column() string {

--- a/pkg/coredata/control_order_field.go
+++ b/pkg/coredata/control_order_field.go
@@ -51,14 +51,7 @@ func ControlOrderFields() []ControlOrderField {
 }
 
 func (v ControlOrderField) IsValid() bool {
-	switch v {
-	case
-		ControlOrderFieldCreatedAt,
-		ControlOrderFieldSectionTitle:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ControlOrderFields())
 }
 
 func (v ControlOrderField) String() string {
@@ -70,14 +63,7 @@ func (v ControlOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ControlOrderField) UnmarshalText(text []byte) error {
-	val := ControlOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ControlOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ControlOrderFields())
 }
 
 func (p ControlOrderField) Column() string {

--- a/pkg/coredata/cookie_banner_order_field.go
+++ b/pkg/coredata/cookie_banner_order_field.go
@@ -47,13 +47,7 @@ func CookieBannerOrderFields() []CookieBannerOrderField {
 }
 
 func (v CookieBannerOrderField) IsValid() bool {
-	switch v {
-	case
-		CookieBannerOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CookieBannerOrderFields())
 }
 
 func (v CookieBannerOrderField) String() string {
@@ -65,14 +59,7 @@ func (v CookieBannerOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CookieBannerOrderField) UnmarshalText(text []byte) error {
-	val := CookieBannerOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CookieBannerOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CookieBannerOrderFields())
 }
 
 func (p CookieBannerOrderField) Column() string {

--- a/pkg/coredata/cookie_banner_translation_order_field.go
+++ b/pkg/coredata/cookie_banner_translation_order_field.go
@@ -51,14 +51,7 @@ func CookieBannerTranslationOrderFields() []CookieBannerTranslationOrderField {
 }
 
 func (v CookieBannerTranslationOrderField) IsValid() bool {
-	switch v {
-	case
-		CookieBannerTranslationOrderFieldLanguage,
-		CookieBannerTranslationOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CookieBannerTranslationOrderFields())
 }
 
 func (v CookieBannerTranslationOrderField) String() string {
@@ -70,14 +63,7 @@ func (v CookieBannerTranslationOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CookieBannerTranslationOrderField) UnmarshalText(text []byte) error {
-	val := CookieBannerTranslationOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CookieBannerTranslationOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CookieBannerTranslationOrderFields())
 }
 
 func (p CookieBannerTranslationOrderField) Column() string {

--- a/pkg/coredata/cookie_banner_version_order_field.go
+++ b/pkg/coredata/cookie_banner_version_order_field.go
@@ -47,13 +47,7 @@ func CookieBannerVersionOrderFields() []CookieBannerVersionOrderField {
 }
 
 func (v CookieBannerVersionOrderField) IsValid() bool {
-	switch v {
-	case
-		CookieBannerVersionOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CookieBannerVersionOrderFields())
 }
 
 func (v CookieBannerVersionOrderField) String() string {
@@ -65,14 +59,7 @@ func (v CookieBannerVersionOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CookieBannerVersionOrderField) UnmarshalText(text []byte) error {
-	val := CookieBannerVersionOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CookieBannerVersionOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CookieBannerVersionOrderFields())
 }
 
 func (p CookieBannerVersionOrderField) Column() string {

--- a/pkg/coredata/cookie_category_order_field.go
+++ b/pkg/coredata/cookie_category_order_field.go
@@ -47,13 +47,7 @@ func CookieCategoryOrderFields() []CookieCategoryOrderField {
 }
 
 func (v CookieCategoryOrderField) IsValid() bool {
-	switch v {
-	case
-		CookieCategoryOrderFieldRank:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CookieCategoryOrderFields())
 }
 
 func (v CookieCategoryOrderField) String() string {
@@ -65,14 +59,7 @@ func (v CookieCategoryOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CookieCategoryOrderField) UnmarshalText(text []byte) error {
-	val := CookieCategoryOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CookieCategoryOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CookieCategoryOrderFields())
 }
 
 func (p CookieCategoryOrderField) Column() string {

--- a/pkg/coredata/cookie_consent_record_order_field.go
+++ b/pkg/coredata/cookie_consent_record_order_field.go
@@ -47,13 +47,7 @@ func CookieConsentRecordOrderFields() []CookieConsentRecordOrderField {
 }
 
 func (v CookieConsentRecordOrderField) IsValid() bool {
-	switch v {
-	case
-		CookieConsentRecordOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CookieConsentRecordOrderFields())
 }
 
 func (v CookieConsentRecordOrderField) String() string {
@@ -65,14 +59,7 @@ func (v CookieConsentRecordOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CookieConsentRecordOrderField) UnmarshalText(text []byte) error {
-	val := CookieConsentRecordOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CookieConsentRecordOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CookieConsentRecordOrderFields())
 }
 
 func (p CookieConsentRecordOrderField) Column() string {

--- a/pkg/coredata/custom_domain_order_field.go
+++ b/pkg/coredata/custom_domain_order_field.go
@@ -51,15 +51,7 @@ func CustomDomainOrderFields() []CustomDomainOrderField {
 }
 
 func (v CustomDomainOrderField) IsValid() bool {
-	switch v {
-	case
-		CustomDomainOrderFieldCreatedAt,
-		CustomDomainOrderFieldDomain,
-		CustomDomainOrderFieldUpdatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, CustomDomainOrderFields())
 }
 
 func (v CustomDomainOrderField) String() string {
@@ -71,14 +63,7 @@ func (v CustomDomainOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *CustomDomainOrderField) UnmarshalText(text []byte) error {
-	val := CustomDomainOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid CustomDomainOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, CustomDomainOrderFields())
 }
 
 func (f CustomDomainOrderField) Column() string {

--- a/pkg/coredata/data_protection_impact_assessment_order_field.go
+++ b/pkg/coredata/data_protection_impact_assessment_order_field.go
@@ -47,13 +47,7 @@ func DataProtectionImpactAssessmentOrderFields() []DataProtectionImpactAssessmen
 }
 
 func (v DataProtectionImpactAssessmentOrderField) IsValid() bool {
-	switch v {
-	case
-		DataProtectionImpactAssessmentOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, DataProtectionImpactAssessmentOrderFields())
 }
 
 func (v DataProtectionImpactAssessmentOrderField) String() string {
@@ -65,14 +59,7 @@ func (v DataProtectionImpactAssessmentOrderField) MarshalText() ([]byte, error) 
 }
 
 func (v *DataProtectionImpactAssessmentOrderField) UnmarshalText(text []byte) error {
-	val := DataProtectionImpactAssessmentOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid DataProtectionImpactAssessmentOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, DataProtectionImpactAssessmentOrderFields())
 }
 
 func (p DataProtectionImpactAssessmentOrderField) Column() string {

--- a/pkg/coredata/datum_order_field.go
+++ b/pkg/coredata/datum_order_field.go
@@ -51,15 +51,7 @@ func DatumOrderFields() []DatumOrderField {
 }
 
 func (v DatumOrderField) IsValid() bool {
-	switch v {
-	case
-		DatumOrderFieldCreatedAt,
-		DatumOrderFieldName,
-		DatumOrderFieldDataClassification:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, DatumOrderFields())
 }
 
 func (v DatumOrderField) String() string {
@@ -71,14 +63,7 @@ func (v DatumOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *DatumOrderField) UnmarshalText(text []byte) error {
-	val := DatumOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid DatumOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, DatumOrderFields())
 }
 
 func (p DatumOrderField) Column() string {

--- a/pkg/coredata/detected_tracker_order_field.go
+++ b/pkg/coredata/detected_tracker_order_field.go
@@ -49,14 +49,7 @@ func DetectedTrackerOrderFields() []DetectedTrackerOrderField {
 }
 
 func (v DetectedTrackerOrderField) IsValid() bool {
-	switch v {
-	case
-		DetectedTrackerOrderFieldInitiatorURL,
-		DetectedTrackerOrderFieldLastDetectedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, DetectedTrackerOrderFields())
 }
 
 func (v DetectedTrackerOrderField) String() string {
@@ -68,14 +61,7 @@ func (v DetectedTrackerOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *DetectedTrackerOrderField) UnmarshalText(text []byte) error {
-	val := DetectedTrackerOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid DetectedTrackerOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, DetectedTrackerOrderFields())
 }
 
 func (p DetectedTrackerOrderField) Column() string {

--- a/pkg/coredata/device_order_field.go
+++ b/pkg/coredata/device_order_field.go
@@ -53,16 +53,7 @@ func DeviceOrderFields() []DeviceOrderField {
 }
 
 func (v DeviceOrderField) IsValid() bool {
-	switch v {
-	case
-		DeviceOrderFieldCreatedAt,
-		DeviceOrderFieldUpdatedAt,
-		DeviceOrderFieldHostname,
-		DeviceOrderFieldLastSeenAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, DeviceOrderFields())
 }
 
 func (v DeviceOrderField) String() string {
@@ -74,14 +65,7 @@ func (v DeviceOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *DeviceOrderField) UnmarshalText(text []byte) error {
-	val := DeviceOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid DeviceOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, DeviceOrderFields())
 }
 
 func (f DeviceOrderField) Column() string {

--- a/pkg/coredata/device_posture_order_field.go
+++ b/pkg/coredata/device_posture_order_field.go
@@ -47,12 +47,7 @@ func DevicePostureOrderFields() []DevicePostureOrderField {
 }
 
 func (v DevicePostureOrderField) IsValid() bool {
-	switch v {
-	case DevicePostureOrderFieldCheckKey:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, DevicePostureOrderFields())
 }
 
 func (v DevicePostureOrderField) String() string {
@@ -64,14 +59,7 @@ func (v DevicePostureOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *DevicePostureOrderField) UnmarshalText(text []byte) error {
-	val := DevicePostureOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid DevicePostureOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, DevicePostureOrderFields())
 }
 
 func (f DevicePostureOrderField) Column() string {

--- a/pkg/coredata/device_posture_report_order_field.go
+++ b/pkg/coredata/device_posture_report_order_field.go
@@ -47,12 +47,7 @@ func DevicePostureReportOrderFields() []DevicePostureReportOrderField {
 }
 
 func (v DevicePostureReportOrderField) IsValid() bool {
-	switch v {
-	case DevicePostureReportOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, DevicePostureReportOrderFields())
 }
 
 func (v DevicePostureReportOrderField) String() string {
@@ -64,14 +59,7 @@ func (v DevicePostureReportOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *DevicePostureReportOrderField) UnmarshalText(text []byte) error {
-	val := DevicePostureReportOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid DevicePostureReportOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, DevicePostureReportOrderFields())
 }
 
 func (f DevicePostureReportOrderField) Column() string {

--- a/pkg/coredata/document_order_field.go
+++ b/pkg/coredata/document_order_field.go
@@ -55,16 +55,7 @@ func DocumentOrderFields() []DocumentOrderField {
 }
 
 func (v DocumentOrderField) IsValid() bool {
-	switch v {
-	case
-		DocumentOrderFieldCreatedAt,
-		DocumentOrderFieldUpdatedAt,
-		DocumentOrderFieldTitle,
-		DocumentOrderFieldDocumentType:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, DocumentOrderFields())
 }
 
 func (v DocumentOrderField) String() string {
@@ -76,14 +67,7 @@ func (v DocumentOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *DocumentOrderField) UnmarshalText(text []byte) error {
-	val := DocumentOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid DocumentOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, DocumentOrderFields())
 }
 
 func (p DocumentOrderField) Column() string {

--- a/pkg/coredata/document_version_approval_decision_order_field.go
+++ b/pkg/coredata/document_version_approval_decision_order_field.go
@@ -49,13 +49,7 @@ func DocumentVersionApprovalDecisionOrderFields() []DocumentVersionApprovalDecis
 }
 
 func (v DocumentVersionApprovalDecisionOrderField) IsValid() bool {
-	switch v {
-	case
-		DocumentVersionApprovalDecisionOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, DocumentVersionApprovalDecisionOrderFields())
 }
 
 func (v DocumentVersionApprovalDecisionOrderField) String() string {
@@ -67,14 +61,7 @@ func (v DocumentVersionApprovalDecisionOrderField) MarshalText() ([]byte, error)
 }
 
 func (v *DocumentVersionApprovalDecisionOrderField) UnmarshalText(text []byte) error {
-	val := DocumentVersionApprovalDecisionOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid DocumentVersionApprovalDecisionOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, DocumentVersionApprovalDecisionOrderFields())
 }
 
 func (e DocumentVersionApprovalDecisionOrderField) Column() string {

--- a/pkg/coredata/document_version_approval_quorum_order_field.go
+++ b/pkg/coredata/document_version_approval_quorum_order_field.go
@@ -49,13 +49,7 @@ func DocumentVersionApprovalQuorumOrderFields() []DocumentVersionApprovalQuorumO
 }
 
 func (v DocumentVersionApprovalQuorumOrderField) IsValid() bool {
-	switch v {
-	case
-		DocumentVersionApprovalQuorumOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, DocumentVersionApprovalQuorumOrderFields())
 }
 
 func (v DocumentVersionApprovalQuorumOrderField) String() string {
@@ -67,14 +61,7 @@ func (v DocumentVersionApprovalQuorumOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *DocumentVersionApprovalQuorumOrderField) UnmarshalText(text []byte) error {
-	val := DocumentVersionApprovalQuorumOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid DocumentVersionApprovalQuorumOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, DocumentVersionApprovalQuorumOrderFields())
 }
 
 func (e DocumentVersionApprovalQuorumOrderField) Column() string {

--- a/pkg/coredata/document_version_order_field.go
+++ b/pkg/coredata/document_version_order_field.go
@@ -49,13 +49,7 @@ func DocumentVersionOrderFields() []DocumentVersionOrderField {
 }
 
 func (v DocumentVersionOrderField) IsValid() bool {
-	switch v {
-	case
-		DocumentVersionOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, DocumentVersionOrderFields())
 }
 
 func (v DocumentVersionOrderField) String() string {
@@ -67,14 +61,7 @@ func (v DocumentVersionOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *DocumentVersionOrderField) UnmarshalText(text []byte) error {
-	val := DocumentVersionOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid DocumentVersionOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, DocumentVersionOrderFields())
 }
 
 func (p DocumentVersionOrderField) Column() string {

--- a/pkg/coredata/document_version_signature_order_field.go
+++ b/pkg/coredata/document_version_signature_order_field.go
@@ -51,14 +51,7 @@ func DocumentVersionSignatureOrderFields() []DocumentVersionSignatureOrderField 
 }
 
 func (v DocumentVersionSignatureOrderField) IsValid() bool {
-	switch v {
-	case
-		DocumentVersionSignatureOrderFieldCreatedAt,
-		DocumentVersionSignatureOrderFieldSignedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, DocumentVersionSignatureOrderFields())
 }
 
 func (v DocumentVersionSignatureOrderField) String() string {
@@ -70,14 +63,7 @@ func (v DocumentVersionSignatureOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *DocumentVersionSignatureOrderField) UnmarshalText(text []byte) error {
-	val := DocumentVersionSignatureOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid DocumentVersionSignatureOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, DocumentVersionSignatureOrderFields())
 }
 
 func (p DocumentVersionSignatureOrderField) Column() string {

--- a/pkg/coredata/evidence_order_field.go
+++ b/pkg/coredata/evidence_order_field.go
@@ -49,13 +49,7 @@ func EvidenceOrderFields() []EvidenceOrderField {
 }
 
 func (v EvidenceOrderField) IsValid() bool {
-	switch v {
-	case
-		EvidenceOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, EvidenceOrderFields())
 }
 
 func (v EvidenceOrderField) String() string {
@@ -67,14 +61,7 @@ func (v EvidenceOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *EvidenceOrderField) UnmarshalText(text []byte) error {
-	val := EvidenceOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid EvidenceOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, EvidenceOrderFields())
 }
 
 func (p EvidenceOrderField) Column() string {

--- a/pkg/coredata/finding_order_field.go
+++ b/pkg/coredata/finding_order_field.go
@@ -59,19 +59,7 @@ func FindingOrderFields() []FindingOrderField {
 }
 
 func (v FindingOrderField) IsValid() bool {
-	switch v {
-	case
-		FindingOrderFieldCreatedAt,
-		FindingOrderFieldIdentifiedOn,
-		FindingOrderFieldDueDate,
-		FindingOrderFieldStatus,
-		FindingOrderFieldPriority,
-		FindingOrderFieldReferenceId,
-		FindingOrderFieldKind:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, FindingOrderFields())
 }
 
 func (v FindingOrderField) String() string {
@@ -83,14 +71,7 @@ func (v FindingOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *FindingOrderField) UnmarshalText(text []byte) error {
-	val := FindingOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid FindingOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, FindingOrderFields())
 }
 
 func (p FindingOrderField) Column() string {

--- a/pkg/coredata/framework_order_field.go
+++ b/pkg/coredata/framework_order_field.go
@@ -49,13 +49,7 @@ func FrameworkOrderFields() []FrameworkOrderField {
 }
 
 func (v FrameworkOrderField) IsValid() bool {
-	switch v {
-	case
-		FrameworkOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, FrameworkOrderFields())
 }
 
 func (v FrameworkOrderField) String() string {
@@ -67,14 +61,7 @@ func (v FrameworkOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *FrameworkOrderField) UnmarshalText(text []byte) error {
-	val := FrameworkOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid FrameworkOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, FrameworkOrderFields())
 }
 
 func (p FrameworkOrderField) Column() string {

--- a/pkg/coredata/invitation_order_field.go
+++ b/pkg/coredata/invitation_order_field.go
@@ -49,13 +49,7 @@ func InvitationOrderFields() []InvitationOrderField {
 }
 
 func (v InvitationOrderField) IsValid() bool {
-	switch v {
-	case
-		InvitationOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, InvitationOrderFields())
 }
 
 func (v InvitationOrderField) String() string {
@@ -67,14 +61,7 @@ func (v InvitationOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *InvitationOrderField) UnmarshalText(text []byte) error {
-	val := InvitationOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid InvitationOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, InvitationOrderFields())
 }
 
 func (p InvitationOrderField) Column() string {

--- a/pkg/coredata/mailing_list_subscriber_order_field.go
+++ b/pkg/coredata/mailing_list_subscriber_order_field.go
@@ -47,13 +47,7 @@ func MailingListSubscriberOrderFields() []MailingListSubscriberOrderField {
 }
 
 func (v MailingListSubscriberOrderField) IsValid() bool {
-	switch v {
-	case
-		MailingListSubscriberOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, MailingListSubscriberOrderFields())
 }
 
 func (v MailingListSubscriberOrderField) String() string {
@@ -65,14 +59,7 @@ func (v MailingListSubscriberOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *MailingListSubscriberOrderField) UnmarshalText(text []byte) error {
-	val := MailingListSubscriberOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid MailingListSubscriberOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, MailingListSubscriberOrderFields())
 }
 
 func (f MailingListSubscriberOrderField) Column() string {

--- a/pkg/coredata/mailing_list_update_order_field.go
+++ b/pkg/coredata/mailing_list_update_order_field.go
@@ -49,14 +49,7 @@ func MailingListUpdateOrderFields() []MailingListUpdateOrderField {
 }
 
 func (v MailingListUpdateOrderField) IsValid() bool {
-	switch v {
-	case
-		MailingListUpdateOrderFieldCreatedAt,
-		MailingListUpdateOrderFieldUpdatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, MailingListUpdateOrderFields())
 }
 
 func (v MailingListUpdateOrderField) String() string {
@@ -68,14 +61,7 @@ func (v MailingListUpdateOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *MailingListUpdateOrderField) UnmarshalText(text []byte) error {
-	val := MailingListUpdateOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid MailingListUpdateOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, MailingListUpdateOrderFields())
 }
 
 func (f MailingListUpdateOrderField) Column() string {

--- a/pkg/coredata/membership_order_field.go
+++ b/pkg/coredata/membership_order_field.go
@@ -57,17 +57,7 @@ func MembershipOrderFields() []MembershipOrderField {
 }
 
 func (v MembershipOrderField) IsValid() bool {
-	switch v {
-	case
-		MembershipOrderFieldOrganizationName,
-		MembershipOrderFieldFullName,
-		MembershipOrderFieldEmailAddress,
-		MembershipOrderFieldRole,
-		MembershipOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, MembershipOrderFields())
 }
 
 func (v MembershipOrderField) String() string {
@@ -79,14 +69,7 @@ func (v MembershipOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *MembershipOrderField) UnmarshalText(text []byte) error {
-	val := MembershipOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid MembershipOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, MembershipOrderFields())
 }
 
 func (p MembershipOrderField) Column() string {

--- a/pkg/coredata/membership_profile_order_field.go
+++ b/pkg/coredata/membership_profile_order_field.go
@@ -59,18 +59,7 @@ func MembershipProfileOrderFields() []MembershipProfileOrderField {
 }
 
 func (v MembershipProfileOrderField) IsValid() bool {
-	switch v {
-	case
-		MembershipProfileOrderFieldCreatedAt,
-		MembershipProfileOrderFieldFullName,
-		MembershipProfileOrderFieldEmailAddress,
-		MembershipProfileOrderFieldKind,
-		MembershipProfileOrderFieldOrganizationName,
-		MembershipProfileOrderFieldState:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, MembershipProfileOrderFields())
 }
 
 func (v MembershipProfileOrderField) String() string {
@@ -82,14 +71,7 @@ func (v MembershipProfileOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *MembershipProfileOrderField) UnmarshalText(text []byte) error {
-	val := MembershipProfileOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid MembershipProfileOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, MembershipProfileOrderFields())
 }
 
 func (p MembershipProfileOrderField) Column() string {

--- a/pkg/coredata/mesure_order_field.go
+++ b/pkg/coredata/mesure_order_field.go
@@ -51,14 +51,7 @@ func MeasureOrderFields() []MeasureOrderField {
 }
 
 func (v MeasureOrderField) IsValid() bool {
-	switch v {
-	case
-		MeasureOrderFieldCreatedAt,
-		MeasureOrderFieldName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, MeasureOrderFields())
 }
 
 func (v MeasureOrderField) String() string {
@@ -70,14 +63,7 @@ func (v MeasureOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *MeasureOrderField) UnmarshalText(text []byte) error {
-	val := MeasureOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid MeasureOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, MeasureOrderFields())
 }
 
 func (p MeasureOrderField) Column() string {

--- a/pkg/coredata/oauth2_access_token_order_field.go
+++ b/pkg/coredata/oauth2_access_token_order_field.go
@@ -47,12 +47,7 @@ func OAuth2AccessTokenOrderFields() []OAuth2AccessTokenOrderField {
 }
 
 func (v OAuth2AccessTokenOrderField) IsValid() bool {
-	switch v {
-	case OAuth2AccessTokenOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, OAuth2AccessTokenOrderFields())
 }
 
 func (v OAuth2AccessTokenOrderField) String() string {
@@ -64,14 +59,7 @@ func (v OAuth2AccessTokenOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *OAuth2AccessTokenOrderField) UnmarshalText(text []byte) error {
-	val := OAuth2AccessTokenOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid OAuth2AccessTokenOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, OAuth2AccessTokenOrderFields())
 }
 
 func (f OAuth2AccessTokenOrderField) Column() string {

--- a/pkg/coredata/oauth2_client_order_field.go
+++ b/pkg/coredata/oauth2_client_order_field.go
@@ -47,13 +47,7 @@ func OAuth2ClientOrderFields() []OAuth2ClientOrderField {
 }
 
 func (v OAuth2ClientOrderField) IsValid() bool {
-	switch v {
-	case
-		OAuth2ClientOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, OAuth2ClientOrderFields())
 }
 
 func (v OAuth2ClientOrderField) String() string {
@@ -65,14 +59,7 @@ func (v OAuth2ClientOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *OAuth2ClientOrderField) UnmarshalText(text []byte) error {
-	val := OAuth2ClientOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid OAuth2ClientOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, OAuth2ClientOrderFields())
 }
 
 func (f OAuth2ClientOrderField) Column() string {

--- a/pkg/coredata/oauth2_consent_order_field.go
+++ b/pkg/coredata/oauth2_consent_order_field.go
@@ -47,13 +47,7 @@ func OAuth2ConsentOrderFields() []OAuth2ConsentOrderField {
 }
 
 func (v OAuth2ConsentOrderField) IsValid() bool {
-	switch v {
-	case
-		OAuth2ConsentOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, OAuth2ConsentOrderFields())
 }
 
 func (v OAuth2ConsentOrderField) String() string {
@@ -65,14 +59,7 @@ func (v OAuth2ConsentOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *OAuth2ConsentOrderField) UnmarshalText(text []byte) error {
-	val := OAuth2ConsentOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid OAuth2ConsentOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, OAuth2ConsentOrderFields())
 }
 
 func (f OAuth2ConsentOrderField) Column() string {

--- a/pkg/coredata/obligation_order_field.go
+++ b/pkg/coredata/obligation_order_field.go
@@ -53,16 +53,7 @@ func ObligationOrderFields() []ObligationOrderField {
 }
 
 func (v ObligationOrderField) IsValid() bool {
-	switch v {
-	case
-		ObligationOrderFieldCreatedAt,
-		ObligationOrderFieldLastReviewDate,
-		ObligationOrderFieldDueDate,
-		ObligationOrderFieldStatus:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ObligationOrderFields())
 }
 
 func (v ObligationOrderField) String() string {
@@ -74,14 +65,7 @@ func (v ObligationOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ObligationOrderField) UnmarshalText(text []byte) error {
-	val := ObligationOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ObligationOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ObligationOrderFields())
 }
 
 func (p ObligationOrderField) Column() string {

--- a/pkg/coredata/order_field.go
+++ b/pkg/coredata/order_field.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,49 +21,35 @@
 package coredata
 
 import (
-	"encoding"
 	"fmt"
-
-	"go.probo.inc/probo/pkg/page"
+	"slices"
+	"strings"
 )
 
-type (
-	IdentityOrderField string
-)
+func isValidOrderField[T ~string](v T, values []T) bool {
+	return slices.Contains(values, v)
+}
 
-const (
-	IdentityOrderFieldCreatedAt IdentityOrderField = "CREATED_AT"
-)
-
-var (
-	_ page.OrderField          = IdentityOrderField("")
-	_ fmt.Stringer             = IdentityOrderField("")
-	_ encoding.TextMarshaler   = IdentityOrderField("")
-	_ encoding.TextUnmarshaler = (*IdentityOrderField)(nil)
-)
-
-func IdentityOrderFields() []IdentityOrderField {
-	return []IdentityOrderField{
-		IdentityOrderFieldCreatedAt,
+func unmarshalOrderField[T ~string](dst *T, text []byte, values []T) error {
+	val := T(text)
+	if !isValidOrderField(val, values) {
+		return fmt.Errorf("invalid %s value: %q", orderFieldTypeName[T](), string(text))
 	}
+
+	*dst = val
+
+	return nil
 }
 
-func (v IdentityOrderField) IsValid() bool {
-	return isValidOrderField(v, IdentityOrderFields())
-}
+func orderFieldTypeName[T any]() string {
+	var zero T
 
-func (v IdentityOrderField) String() string {
-	return string(v)
-}
+	name := fmt.Sprintf("%T", zero)
+	_, after, ok := strings.Cut(name, ".")
 
-func (v IdentityOrderField) MarshalText() ([]byte, error) {
-	return []byte(v.String()), nil
-}
+	if ok {
+		return after
+	}
 
-func (v *IdentityOrderField) UnmarshalText(text []byte) error {
-	return unmarshalOrderField(v, text, IdentityOrderFields())
-}
-
-func (p IdentityOrderField) Column() string {
-	return string(p)
+	return name
 }

--- a/pkg/coredata/order_field_test.go
+++ b/pkg/coredata/order_field_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,49 +21,28 @@
 package coredata
 
 import (
-	"encoding"
-	"fmt"
+	"testing"
 
-	"go.probo.inc/probo/pkg/page"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-type (
-	IdentityOrderField string
-)
+func TestIsValidOrderField(t *testing.T) {
+	t.Parallel()
 
-const (
-	IdentityOrderFieldCreatedAt IdentityOrderField = "CREATED_AT"
-)
-
-var (
-	_ page.OrderField          = IdentityOrderField("")
-	_ fmt.Stringer             = IdentityOrderField("")
-	_ encoding.TextMarshaler   = IdentityOrderField("")
-	_ encoding.TextUnmarshaler = (*IdentityOrderField)(nil)
-)
-
-func IdentityOrderFields() []IdentityOrderField {
-	return []IdentityOrderField{
-		IdentityOrderFieldCreatedAt,
-	}
+	assert.True(t, isValidOrderField(DocumentOrderFieldCreatedAt, DocumentOrderFields()))
+	assert.False(t, isValidOrderField(DocumentOrderField("NOPE"), DocumentOrderFields()))
 }
 
-func (v IdentityOrderField) IsValid() bool {
-	return isValidOrderField(v, IdentityOrderFields())
-}
+func TestUnmarshalOrderField(t *testing.T) {
+	t.Parallel()
 
-func (v IdentityOrderField) String() string {
-	return string(v)
-}
+	var field DocumentOrderField
 
-func (v IdentityOrderField) MarshalText() ([]byte, error) {
-	return []byte(v.String()), nil
-}
+	err := unmarshalOrderField(&field, []byte("TITLE"), DocumentOrderFields())
+	require.NoError(t, err)
+	assert.Equal(t, DocumentOrderFieldTitle, field)
 
-func (v *IdentityOrderField) UnmarshalText(text []byte) error {
-	return unmarshalOrderField(v, text, IdentityOrderFields())
-}
-
-func (p IdentityOrderField) Column() string {
-	return string(p)
+	err = unmarshalOrderField(&field, []byte("NOPE"), DocumentOrderFields())
+	require.EqualError(t, err, `invalid DocumentOrderField value: "NOPE"`)
 }

--- a/pkg/coredata/organization_order_field.go
+++ b/pkg/coredata/organization_order_field.go
@@ -53,15 +53,7 @@ func OrganizationOrderFields() []OrganizationOrderField {
 }
 
 func (v OrganizationOrderField) IsValid() bool {
-	switch v {
-	case
-		OrganizationOrderFieldName,
-		OrganizationOrderFieldCreatedAt,
-		OrganizationOrderFieldUpdatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, OrganizationOrderFields())
 }
 
 func (v OrganizationOrderField) String() string {
@@ -73,14 +65,7 @@ func (v OrganizationOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *OrganizationOrderField) UnmarshalText(text []byte) error {
-	val := OrganizationOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid OrganizationOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, OrganizationOrderFields())
 }
 
 func (p OrganizationOrderField) Column() string {

--- a/pkg/coredata/personal_api_key_order_field.go
+++ b/pkg/coredata/personal_api_key_order_field.go
@@ -49,13 +49,7 @@ func PersonalAPIKeyOrderFields() []PersonalAPIKeyOrderField {
 }
 
 func (v PersonalAPIKeyOrderField) IsValid() bool {
-	switch v {
-	case
-		PersonalAPIKeyOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, PersonalAPIKeyOrderFields())
 }
 
 func (v PersonalAPIKeyOrderField) String() string {
@@ -67,14 +61,7 @@ func (v PersonalAPIKeyOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *PersonalAPIKeyOrderField) UnmarshalText(text []byte) error {
-	val := PersonalAPIKeyOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid PersonalAPIKeyOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, PersonalAPIKeyOrderFields())
 }
 
 func (p PersonalAPIKeyOrderField) Column() string {

--- a/pkg/coredata/processing_activity_order_field.go
+++ b/pkg/coredata/processing_activity_order_field.go
@@ -49,14 +49,7 @@ func ProcessingActivityOrderFields() []ProcessingActivityOrderField {
 }
 
 func (v ProcessingActivityOrderField) IsValid() bool {
-	switch v {
-	case
-		ProcessingActivityOrderFieldCreatedAt,
-		ProcessingActivityOrderFieldName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ProcessingActivityOrderFields())
 }
 
 func (v ProcessingActivityOrderField) String() string {
@@ -68,14 +61,7 @@ func (v ProcessingActivityOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ProcessingActivityOrderField) UnmarshalText(text []byte) error {
-	val := ProcessingActivityOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ProcessingActivityOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ProcessingActivityOrderFields())
 }
 
 func (p ProcessingActivityOrderField) Column() string {

--- a/pkg/coredata/report_order_field.go
+++ b/pkg/coredata/report_order_field.go
@@ -49,13 +49,7 @@ func ReportOrderFields() []ReportOrderField {
 }
 
 func (v ReportOrderField) IsValid() bool {
-	switch v {
-	case
-		ReportOrderFieldID:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ReportOrderFields())
 }
 
 func (v ReportOrderField) String() string {
@@ -67,14 +61,7 @@ func (v ReportOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ReportOrderField) UnmarshalText(text []byte) error {
-	val := ReportOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ReportOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ReportOrderFields())
 }
 
 func (p ReportOrderField) Column() string {

--- a/pkg/coredata/rights_request_order_field.go
+++ b/pkg/coredata/rights_request_order_field.go
@@ -53,16 +53,7 @@ func RightsRequestOrderFields() []RightsRequestOrderField {
 }
 
 func (v RightsRequestOrderField) IsValid() bool {
-	switch v {
-	case
-		RightsRequestOrderFieldCreatedAt,
-		RightsRequestOrderFieldDeadline,
-		RightsRequestOrderFieldState,
-		RightsRequestOrderFieldType:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, RightsRequestOrderFields())
 }
 
 func (v RightsRequestOrderField) String() string {
@@ -74,14 +65,7 @@ func (v RightsRequestOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *RightsRequestOrderField) UnmarshalText(text []byte) error {
-	val := RightsRequestOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid RightsRequestOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, RightsRequestOrderFields())
 }
 
 func (p RightsRequestOrderField) Column() string {

--- a/pkg/coredata/risk_analysis_boundary_order_field.go
+++ b/pkg/coredata/risk_analysis_boundary_order_field.go
@@ -49,14 +49,7 @@ func RiskAnalysisBoundaryOrderFields() []RiskAnalysisBoundaryOrderField {
 }
 
 func (v RiskAnalysisBoundaryOrderField) IsValid() bool {
-	switch v {
-	case
-		RiskAnalysisBoundaryOrderFieldCreatedAt,
-		RiskAnalysisBoundaryOrderFieldName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, RiskAnalysisBoundaryOrderFields())
 }
 
 func (v RiskAnalysisBoundaryOrderField) String() string {
@@ -68,14 +61,7 @@ func (v RiskAnalysisBoundaryOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *RiskAnalysisBoundaryOrderField) UnmarshalText(text []byte) error {
-	val := RiskAnalysisBoundaryOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid RiskAnalysisBoundaryOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, RiskAnalysisBoundaryOrderFields())
 }
 
 func (p RiskAnalysisBoundaryOrderField) Column() string { return string(p) }

--- a/pkg/coredata/risk_analysis_diagram_order_field.go
+++ b/pkg/coredata/risk_analysis_diagram_order_field.go
@@ -49,14 +49,7 @@ func RiskAnalysisDiagramOrderFields() []RiskAnalysisDiagramOrderField {
 }
 
 func (v RiskAnalysisDiagramOrderField) IsValid() bool {
-	switch v {
-	case
-		RiskAnalysisDiagramOrderFieldCreatedAt,
-		RiskAnalysisDiagramOrderFieldName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, RiskAnalysisDiagramOrderFields())
 }
 
 func (v RiskAnalysisDiagramOrderField) String() string {
@@ -68,14 +61,7 @@ func (v RiskAnalysisDiagramOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *RiskAnalysisDiagramOrderField) UnmarshalText(text []byte) error {
-	val := RiskAnalysisDiagramOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid RiskAnalysisDiagramOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, RiskAnalysisDiagramOrderFields())
 }
 
 func (p RiskAnalysisDiagramOrderField) Column() string { return string(p) }

--- a/pkg/coredata/risk_analysis_node_order_field.go
+++ b/pkg/coredata/risk_analysis_node_order_field.go
@@ -49,14 +49,7 @@ func RiskAnalysisNodeOrderFields() []RiskAnalysisNodeOrderField {
 }
 
 func (v RiskAnalysisNodeOrderField) IsValid() bool {
-	switch v {
-	case
-		RiskAnalysisNodeOrderFieldCreatedAt,
-		RiskAnalysisNodeOrderFieldName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, RiskAnalysisNodeOrderFields())
 }
 
 func (v RiskAnalysisNodeOrderField) String() string {
@@ -68,14 +61,7 @@ func (v RiskAnalysisNodeOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *RiskAnalysisNodeOrderField) UnmarshalText(text []byte) error {
-	val := RiskAnalysisNodeOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid RiskAnalysisNodeOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, RiskAnalysisNodeOrderFields())
 }
 
 func (p RiskAnalysisNodeOrderField) Column() string { return string(p) }

--- a/pkg/coredata/risk_analysis_order_field.go
+++ b/pkg/coredata/risk_analysis_order_field.go
@@ -49,14 +49,7 @@ func RiskAnalysisOrderFields() []RiskAnalysisOrderField {
 }
 
 func (v RiskAnalysisOrderField) IsValid() bool {
-	switch v {
-	case
-		RiskAnalysisOrderFieldCreatedAt,
-		RiskAnalysisOrderFieldName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, RiskAnalysisOrderFields())
 }
 
 func (v RiskAnalysisOrderField) String() string {
@@ -68,14 +61,7 @@ func (v RiskAnalysisOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *RiskAnalysisOrderField) UnmarshalText(text []byte) error {
-	val := RiskAnalysisOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid RiskAnalysisOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, RiskAnalysisOrderFields())
 }
 
 func (p RiskAnalysisOrderField) Column() string {

--- a/pkg/coredata/risk_analysis_process_order_field.go
+++ b/pkg/coredata/risk_analysis_process_order_field.go
@@ -49,14 +49,7 @@ func RiskAnalysisProcessOrderFields() []RiskAnalysisProcessOrderField {
 }
 
 func (v RiskAnalysisProcessOrderField) IsValid() bool {
-	switch v {
-	case
-		RiskAnalysisProcessOrderFieldCreatedAt,
-		RiskAnalysisProcessOrderFieldName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, RiskAnalysisProcessOrderFields())
 }
 
 func (v RiskAnalysisProcessOrderField) String() string {
@@ -68,14 +61,7 @@ func (v RiskAnalysisProcessOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *RiskAnalysisProcessOrderField) UnmarshalText(text []byte) error {
-	val := RiskAnalysisProcessOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid RiskAnalysisProcessOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, RiskAnalysisProcessOrderFields())
 }
 
 func (p RiskAnalysisProcessOrderField) Column() string { return string(p) }

--- a/pkg/coredata/risk_analysis_scenario_order_field.go
+++ b/pkg/coredata/risk_analysis_scenario_order_field.go
@@ -49,14 +49,7 @@ func RiskAnalysisScenarioOrderFields() []RiskAnalysisScenarioOrderField {
 }
 
 func (v RiskAnalysisScenarioOrderField) IsValid() bool {
-	switch v {
-	case
-		RiskAnalysisScenarioOrderFieldCreatedAt,
-		RiskAnalysisScenarioOrderFieldName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, RiskAnalysisScenarioOrderFields())
 }
 
 func (v RiskAnalysisScenarioOrderField) String() string {
@@ -68,14 +61,7 @@ func (v RiskAnalysisScenarioOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *RiskAnalysisScenarioOrderField) UnmarshalText(text []byte) error {
-	val := RiskAnalysisScenarioOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid RiskAnalysisScenarioOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, RiskAnalysisScenarioOrderFields())
 }
 
 func (p RiskAnalysisScenarioOrderField) Column() string { return string(p) }

--- a/pkg/coredata/risk_analysis_threat_order_field.go
+++ b/pkg/coredata/risk_analysis_threat_order_field.go
@@ -49,14 +49,7 @@ func RiskAnalysisThreatOrderFields() []RiskAnalysisThreatOrderField {
 }
 
 func (v RiskAnalysisThreatOrderField) IsValid() bool {
-	switch v {
-	case
-		RiskAnalysisThreatOrderFieldCreatedAt,
-		RiskAnalysisThreatOrderFieldName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, RiskAnalysisThreatOrderFields())
 }
 
 func (v RiskAnalysisThreatOrderField) String() string {
@@ -68,14 +61,7 @@ func (v RiskAnalysisThreatOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *RiskAnalysisThreatOrderField) UnmarshalText(text []byte) error {
-	val := RiskAnalysisThreatOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid RiskAnalysisThreatOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, RiskAnalysisThreatOrderFields())
 }
 
 func (p RiskAnalysisThreatOrderField) Column() string { return string(p) }

--- a/pkg/coredata/risk_order_field.go
+++ b/pkg/coredata/risk_order_field.go
@@ -63,20 +63,7 @@ func RiskOrderFields() []RiskOrderField {
 }
 
 func (v RiskOrderField) IsValid() bool {
-	switch v {
-	case
-		RiskOrderFieldCreatedAt,
-		RiskOrderFieldUpdatedAt,
-		RiskOrderFieldName,
-		RiskOrderFieldCategory,
-		RiskOrderFieldTreatment,
-		RiskOrderFieldInherentRiskScore,
-		RiskOrderFieldResidualRiskScore,
-		RiskOrderFieldOwnerFullName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, RiskOrderFields())
 }
 
 func (v RiskOrderField) String() string {
@@ -88,14 +75,7 @@ func (v RiskOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *RiskOrderField) UnmarshalText(text []byte) error {
-	val := RiskOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid RiskOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, RiskOrderFields())
 }
 
 func (p RiskOrderField) Column() string {

--- a/pkg/coredata/saml_configuration_order_field.go
+++ b/pkg/coredata/saml_configuration_order_field.go
@@ -49,13 +49,7 @@ func SAMLConfigurationOrderFields() []SAMLConfigurationOrderField {
 }
 
 func (v SAMLConfigurationOrderField) IsValid() bool {
-	switch v {
-	case
-		SAMLConfigurationOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, SAMLConfigurationOrderFields())
 }
 
 func (v SAMLConfigurationOrderField) String() string {
@@ -67,14 +61,7 @@ func (v SAMLConfigurationOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *SAMLConfigurationOrderField) UnmarshalText(text []byte) error {
-	val := SAMLConfigurationOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid SAMLConfigurationOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, SAMLConfigurationOrderFields())
 }
 
 func (p SAMLConfigurationOrderField) Column() string {

--- a/pkg/coredata/scim_bridge_order_field.go
+++ b/pkg/coredata/scim_bridge_order_field.go
@@ -49,13 +49,7 @@ func SCIMBridgeOrderFields() []SCIMBridgeOrderField {
 }
 
 func (v SCIMBridgeOrderField) IsValid() bool {
-	switch v {
-	case
-		SCIMBridgeOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, SCIMBridgeOrderFields())
 }
 
 func (v SCIMBridgeOrderField) String() string {
@@ -67,14 +61,7 @@ func (v SCIMBridgeOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *SCIMBridgeOrderField) UnmarshalText(text []byte) error {
-	val := SCIMBridgeOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid SCIMBridgeOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, SCIMBridgeOrderFields())
 }
 
 func (p SCIMBridgeOrderField) Column() string {

--- a/pkg/coredata/scim_configuration_order_field.go
+++ b/pkg/coredata/scim_configuration_order_field.go
@@ -49,13 +49,7 @@ func SCIMConfigurationOrderFields() []SCIMConfigurationOrderField {
 }
 
 func (v SCIMConfigurationOrderField) IsValid() bool {
-	switch v {
-	case
-		SCIMConfigurationOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, SCIMConfigurationOrderFields())
 }
 
 func (v SCIMConfigurationOrderField) String() string {
@@ -67,14 +61,7 @@ func (v SCIMConfigurationOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *SCIMConfigurationOrderField) UnmarshalText(text []byte) error {
-	val := SCIMConfigurationOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid SCIMConfigurationOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, SCIMConfigurationOrderFields())
 }
 
 func (p SCIMConfigurationOrderField) Column() string {

--- a/pkg/coredata/scim_event_order_field.go
+++ b/pkg/coredata/scim_event_order_field.go
@@ -49,13 +49,7 @@ func SCIMEventOrderFields() []SCIMEventOrderField {
 }
 
 func (v SCIMEventOrderField) IsValid() bool {
-	switch v {
-	case
-		SCIMEventOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, SCIMEventOrderFields())
 }
 
 func (v SCIMEventOrderField) String() string {
@@ -67,14 +61,7 @@ func (v SCIMEventOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *SCIMEventOrderField) UnmarshalText(text []byte) error {
-	val := SCIMEventOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid SCIMEventOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, SCIMEventOrderFields())
 }
 
 func (p SCIMEventOrderField) Column() string {

--- a/pkg/coredata/session_order_field.go
+++ b/pkg/coredata/session_order_field.go
@@ -53,15 +53,7 @@ func SessionOrderFields() []SessionOrderField {
 }
 
 func (v SessionOrderField) IsValid() bool {
-	switch v {
-	case
-		SessionOrderFieldCreatedAt,
-		SessionOrderFieldExpiredAt,
-		SessionOrderFieldUpdatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, SessionOrderFields())
 }
 
 func (v SessionOrderField) String() string {
@@ -73,14 +65,7 @@ func (v SessionOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *SessionOrderField) UnmarshalText(text []byte) error {
-	val := SessionOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid SessionOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, SessionOrderFields())
 }
 
 func (p SessionOrderField) Column() string {

--- a/pkg/coredata/statement_of_applicability_order_field.go
+++ b/pkg/coredata/statement_of_applicability_order_field.go
@@ -51,14 +51,7 @@ func StatementOfApplicabilityOrderFields() []StatementOfApplicabilityOrderField 
 }
 
 func (v StatementOfApplicabilityOrderField) IsValid() bool {
-	switch v {
-	case
-		StatementOfApplicabilityOrderFieldName,
-		StatementOfApplicabilityOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, StatementOfApplicabilityOrderFields())
 }
 
 func (v StatementOfApplicabilityOrderField) String() string {
@@ -70,14 +63,7 @@ func (v StatementOfApplicabilityOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *StatementOfApplicabilityOrderField) UnmarshalText(text []byte) error {
-	val := StatementOfApplicabilityOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid StatementOfApplicabilityOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, StatementOfApplicabilityOrderFields())
 }
 
 func (s StatementOfApplicabilityOrderField) Column() string {

--- a/pkg/coredata/task_order_field.go
+++ b/pkg/coredata/task_order_field.go
@@ -51,14 +51,7 @@ func TaskOrderFields() []TaskOrderField {
 }
 
 func (v TaskOrderField) IsValid() bool {
-	switch v {
-	case
-		TaskOrderFieldPriorityRank,
-		TaskOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, TaskOrderFields())
 }
 
 func (v TaskOrderField) String() string {
@@ -70,14 +63,7 @@ func (v TaskOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *TaskOrderField) UnmarshalText(text []byte) error {
-	val := TaskOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid TaskOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, TaskOrderFields())
 }
 
 func (p TaskOrderField) Column() string {

--- a/pkg/coredata/third_party_business_associate_agreement_order_field.go
+++ b/pkg/coredata/third_party_business_associate_agreement_order_field.go
@@ -51,14 +51,7 @@ func ThirdPartyBusinessAssociateAgreementOrderFields() []ThirdPartyBusinessAssoc
 }
 
 func (v ThirdPartyBusinessAssociateAgreementOrderField) IsValid() bool {
-	switch v {
-	case
-		ThirdPartyBusinessAssociateAgreementOrderFieldValidFrom,
-		ThirdPartyBusinessAssociateAgreementOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ThirdPartyBusinessAssociateAgreementOrderFields())
 }
 
 func (v ThirdPartyBusinessAssociateAgreementOrderField) String() string {
@@ -70,14 +63,7 @@ func (v ThirdPartyBusinessAssociateAgreementOrderField) MarshalText() ([]byte, e
 }
 
 func (v *ThirdPartyBusinessAssociateAgreementOrderField) UnmarshalText(text []byte) error {
-	val := ThirdPartyBusinessAssociateAgreementOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ThirdPartyBusinessAssociateAgreementOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ThirdPartyBusinessAssociateAgreementOrderFields())
 }
 
 func (p ThirdPartyBusinessAssociateAgreementOrderField) Column() string {

--- a/pkg/coredata/third_party_compliance_report_order_field.go
+++ b/pkg/coredata/third_party_compliance_report_order_field.go
@@ -51,14 +51,7 @@ func ThirdPartyComplianceReportOrderFields() []ThirdPartyComplianceReportOrderFi
 }
 
 func (v ThirdPartyComplianceReportOrderField) IsValid() bool {
-	switch v {
-	case
-		ThirdPartyComplianceReportOrderFieldReportDate,
-		ThirdPartyComplianceReportOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ThirdPartyComplianceReportOrderFields())
 }
 
 func (v ThirdPartyComplianceReportOrderField) String() string {
@@ -70,14 +63,7 @@ func (v ThirdPartyComplianceReportOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ThirdPartyComplianceReportOrderField) UnmarshalText(text []byte) error {
-	val := ThirdPartyComplianceReportOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ThirdPartyComplianceReportOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ThirdPartyComplianceReportOrderFields())
 }
 
 func (p ThirdPartyComplianceReportOrderField) Column() string {

--- a/pkg/coredata/third_party_contact_order_field.go
+++ b/pkg/coredata/third_party_contact_order_field.go
@@ -53,15 +53,7 @@ func ThirdPartyContactOrderFields() []ThirdPartyContactOrderField {
 }
 
 func (v ThirdPartyContactOrderField) IsValid() bool {
-	switch v {
-	case
-		ThirdPartyContactOrderFieldCreatedAt,
-		ThirdPartyContactOrderFieldFullName,
-		ThirdPartyContactOrderFieldEmail:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ThirdPartyContactOrderFields())
 }
 
 func (v ThirdPartyContactOrderField) String() string {
@@ -73,14 +65,7 @@ func (v ThirdPartyContactOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ThirdPartyContactOrderField) UnmarshalText(text []byte) error {
-	val := ThirdPartyContactOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ThirdPartyContactOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ThirdPartyContactOrderFields())
 }
 
 func (p ThirdPartyContactOrderField) Column() string {

--- a/pkg/coredata/third_party_data_privacy_agreement_order_field.go
+++ b/pkg/coredata/third_party_data_privacy_agreement_order_field.go
@@ -51,14 +51,7 @@ func ThirdPartyDataPrivacyAgreementOrderFields() []ThirdPartyDataPrivacyAgreemen
 }
 
 func (v ThirdPartyDataPrivacyAgreementOrderField) IsValid() bool {
-	switch v {
-	case
-		ThirdPartyDataPrivacyAgreementOrderFieldValidFrom,
-		ThirdPartyDataPrivacyAgreementOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ThirdPartyDataPrivacyAgreementOrderFields())
 }
 
 func (v ThirdPartyDataPrivacyAgreementOrderField) String() string {
@@ -70,14 +63,7 @@ func (v ThirdPartyDataPrivacyAgreementOrderField) MarshalText() ([]byte, error) 
 }
 
 func (v *ThirdPartyDataPrivacyAgreementOrderField) UnmarshalText(text []byte) error {
-	val := ThirdPartyDataPrivacyAgreementOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ThirdPartyDataPrivacyAgreementOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ThirdPartyDataPrivacyAgreementOrderFields())
 }
 
 func (p ThirdPartyDataPrivacyAgreementOrderField) Column() string {

--- a/pkg/coredata/third_party_order_field.go
+++ b/pkg/coredata/third_party_order_field.go
@@ -53,15 +53,7 @@ func ThirdPartyOrderFields() []ThirdPartyOrderField {
 }
 
 func (v ThirdPartyOrderField) IsValid() bool {
-	switch v {
-	case
-		ThirdPartyOrderFieldCreatedAt,
-		ThirdPartyOrderFieldUpdatedAt,
-		ThirdPartyOrderFieldName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ThirdPartyOrderFields())
 }
 
 func (v ThirdPartyOrderField) String() string {
@@ -73,14 +65,7 @@ func (v ThirdPartyOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ThirdPartyOrderField) UnmarshalText(text []byte) error {
-	val := ThirdPartyOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ThirdPartyOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ThirdPartyOrderFields())
 }
 
 func (p ThirdPartyOrderField) Column() string {

--- a/pkg/coredata/third_party_risk_assessment_order_field.go
+++ b/pkg/coredata/third_party_risk_assessment_order_field.go
@@ -51,14 +51,7 @@ func ThirdPartyRiskAssessmentOrderFields() []ThirdPartyRiskAssessmentOrderField 
 }
 
 func (v ThirdPartyRiskAssessmentOrderField) IsValid() bool {
-	switch v {
-	case
-		ThirdPartyRiskAssessmentOrderFieldCreatedAt,
-		ThirdPartyRiskAssessmentOrderFieldExpiresAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ThirdPartyRiskAssessmentOrderFields())
 }
 
 func (v ThirdPartyRiskAssessmentOrderField) String() string {
@@ -70,14 +63,7 @@ func (v ThirdPartyRiskAssessmentOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ThirdPartyRiskAssessmentOrderField) UnmarshalText(text []byte) error {
-	val := ThirdPartyRiskAssessmentOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ThirdPartyRiskAssessmentOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ThirdPartyRiskAssessmentOrderFields())
 }
 
 func (p ThirdPartyRiskAssessmentOrderField) Column() string {

--- a/pkg/coredata/third_party_service_order_field.go
+++ b/pkg/coredata/third_party_service_order_field.go
@@ -51,14 +51,7 @@ func ThirdPartyServiceOrderFields() []ThirdPartyServiceOrderField {
 }
 
 func (v ThirdPartyServiceOrderField) IsValid() bool {
-	switch v {
-	case
-		ThirdPartyServiceOrderFieldCreatedAt,
-		ThirdPartyServiceOrderFieldName:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, ThirdPartyServiceOrderFields())
 }
 
 func (v ThirdPartyServiceOrderField) String() string {
@@ -70,14 +63,7 @@ func (v ThirdPartyServiceOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *ThirdPartyServiceOrderField) UnmarshalText(text []byte) error {
-	val := ThirdPartyServiceOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid ThirdPartyServiceOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, ThirdPartyServiceOrderFields())
 }
 
 func (p ThirdPartyServiceOrderField) Column() string {

--- a/pkg/coredata/tracker_pattern_order_field.go
+++ b/pkg/coredata/tracker_pattern_order_field.go
@@ -55,17 +55,7 @@ func TrackerPatternOrderFields() []TrackerPatternOrderField {
 }
 
 func (v TrackerPatternOrderField) IsValid() bool {
-	switch v {
-	case
-		TrackerPatternOrderFieldCreatedAt,
-		TrackerPatternOrderFieldName,
-		TrackerPatternOrderFieldLastMatchedAt,
-		TrackerPatternOrderFieldUpdatedAt,
-		TrackerPatternOrderFieldSource:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, TrackerPatternOrderFields())
 }
 
 func (v TrackerPatternOrderField) String() string {
@@ -77,14 +67,7 @@ func (v TrackerPatternOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *TrackerPatternOrderField) UnmarshalText(text []byte) error {
-	val := TrackerPatternOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid TrackerPatternOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, TrackerPatternOrderFields())
 }
 
 func (p TrackerPatternOrderField) Column() string {

--- a/pkg/coredata/tracker_resource_order_field.go
+++ b/pkg/coredata/tracker_resource_order_field.go
@@ -53,16 +53,7 @@ func TrackerResourceOrderFields() []TrackerResourceOrderField {
 }
 
 func (v TrackerResourceOrderField) IsValid() bool {
-	switch v {
-	case
-		TrackerResourceOrderFieldCreatedAt,
-		TrackerResourceOrderFieldLastDetectedAt,
-		TrackerResourceOrderFieldOrigin,
-		TrackerResourceOrderFieldUpdatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, TrackerResourceOrderFields())
 }
 
 func (v TrackerResourceOrderField) String() string {
@@ -74,14 +65,7 @@ func (v TrackerResourceOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *TrackerResourceOrderField) UnmarshalText(text []byte) error {
-	val := TrackerResourceOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid TrackerResourceOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, TrackerResourceOrderFields())
 }
 
 func (p TrackerResourceOrderField) Column() string {

--- a/pkg/coredata/transfer_impact_assessment_order_field.go
+++ b/pkg/coredata/transfer_impact_assessment_order_field.go
@@ -47,13 +47,7 @@ func TransferImpactAssessmentOrderFields() []TransferImpactAssessmentOrderField 
 }
 
 func (v TransferImpactAssessmentOrderField) IsValid() bool {
-	switch v {
-	case
-		TransferImpactAssessmentOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, TransferImpactAssessmentOrderFields())
 }
 
 func (v TransferImpactAssessmentOrderField) String() string {
@@ -65,14 +59,7 @@ func (v TransferImpactAssessmentOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *TransferImpactAssessmentOrderField) UnmarshalText(text []byte) error {
-	val := TransferImpactAssessmentOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid TransferImpactAssessmentOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, TransferImpactAssessmentOrderFields())
 }
 
 func (p TransferImpactAssessmentOrderField) Column() string {

--- a/pkg/coredata/treatment_plan_order_field.go
+++ b/pkg/coredata/treatment_plan_order_field.go
@@ -55,17 +55,7 @@ func TreatmentPlanOrderFields() []TreatmentPlanOrderField {
 }
 
 func (v TreatmentPlanOrderField) IsValid() bool {
-	switch v {
-	case
-		TreatmentPlanOrderFieldCreatedAt,
-		TreatmentPlanOrderFieldTreatment,
-		TreatmentPlanOrderFieldCategory,
-		TreatmentPlanOrderFieldInherentRiskScore,
-		TreatmentPlanOrderFieldResidualRiskScore:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, TreatmentPlanOrderFields())
 }
 
 func (v TreatmentPlanOrderField) String() string {
@@ -77,14 +67,7 @@ func (v TreatmentPlanOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *TreatmentPlanOrderField) UnmarshalText(text []byte) error {
-	val := TreatmentPlanOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid TreatmentPlanOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, TreatmentPlanOrderFields())
 }
 
 func (p TreatmentPlanOrderField) Column() string {

--- a/pkg/coredata/webhook_event_order_field.go
+++ b/pkg/coredata/webhook_event_order_field.go
@@ -49,13 +49,7 @@ func WebhookEventOrderFields() []WebhookEventOrderField {
 }
 
 func (v WebhookEventOrderField) IsValid() bool {
-	switch v {
-	case
-		WebhookEventOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, WebhookEventOrderFields())
 }
 
 func (v WebhookEventOrderField) String() string {
@@ -67,14 +61,7 @@ func (v WebhookEventOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *WebhookEventOrderField) UnmarshalText(text []byte) error {
-	val := WebhookEventOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid WebhookEventOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, WebhookEventOrderFields())
 }
 
 func (p WebhookEventOrderField) Column() string {

--- a/pkg/coredata/webhook_subscription_order_field.go
+++ b/pkg/coredata/webhook_subscription_order_field.go
@@ -49,13 +49,7 @@ func WebhookSubscriptionOrderFields() []WebhookSubscriptionOrderField {
 }
 
 func (v WebhookSubscriptionOrderField) IsValid() bool {
-	switch v {
-	case
-		WebhookSubscriptionOrderFieldCreatedAt:
-		return true
-	}
-
-	return false
+	return isValidOrderField(v, WebhookSubscriptionOrderFields())
 }
 
 func (v WebhookSubscriptionOrderField) String() string {
@@ -67,14 +61,7 @@ func (v WebhookSubscriptionOrderField) MarshalText() ([]byte, error) {
 }
 
 func (v *WebhookSubscriptionOrderField) UnmarshalText(text []byte) error {
-	val := WebhookSubscriptionOrderField(text)
-	if !val.IsValid() {
-		return fmt.Errorf("invalid WebhookSubscriptionOrderField value: %q", string(text))
-	}
-
-	*v = val
-
-	return nil
+	return unmarshalOrderField(v, text, WebhookSubscriptionOrderFields())
 }
 
 func (p WebhookSubscriptionOrderField) Column() string {


### PR DESCRIPTION
Keep Column() per type and drop the copied validation switch from every order-field file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares order-field enum validation and text (un)marshaling in `pkg/coredata` via shared helpers to remove duplicated switches and standardize error messages. Old behavior: per-type `IsValid` switches and manual `UnmarshalText`; new behavior: enums call `isValidOrderField`/`unmarshalOrderField` and `MarshalText` uses `String()` for consistent output.

### Coredata **`+314`** **`-1493`**
- Add `order_field.go` with `isValidOrderField`, `unmarshalOrderField`, and `orderFieldTypeName`.
- Replace per-type `IsValid` and `UnmarshalText` across all `*OrderField` enums.
- Make `MarshalText()` delegate to `String()` for uniform behavior.
- Review: ensure each `XXXOrderFields()` list is exhaustive; validation relies on it.

### Tests **`+48`** **`-0`**
- Add `order_field_test.go` covering helper validation, unmarshaling, and error text.

### Agents **`+24`** **`-1`**
- Update `contrib/claude/coredata.md` to document the shared helpers and `MarshalText()` via `String()`.

<sup>Written for commit e9cc54c6f94a2927404b6cc9f3420ac7b2d9ff80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

