### PR TITLE
Add structured logging to MCP transport

### DIFF
--- a/pkg/server/api/mcp/mcputils/logger.go
+++ b/pkg/server/api/mcp/mcputils/logger.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package mcputils
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+
+	"go.gearno.de/kit/log"
+)
+
+type (
+	slogHandler struct {
+		logger *log.Logger
+		attrs  []slog.Attr
+		groups []slogGroup
+	}
+
+	slogGroup struct {
+		name  string
+		attrs []slog.Attr
+	}
+)
+
+// NewSlogLogger adapts the application logger for dependencies that use slog.
+func NewSlogLogger(logger *log.Logger) *slog.Logger {
+	return slog.New(&slogHandler{logger: logger})
+}
+
+func (h *slogHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *slogHandler) Handle(ctx context.Context, record slog.Record) error {
+	attrs := slices.Clone(h.attrs)
+	groupedAttrs := make([]slog.Attr, 0, record.NumAttrs())
+	record.Attrs(func(attr slog.Attr) bool {
+		groupedAttrs = append(groupedAttrs, attr)
+		return true
+	})
+
+	for i := len(h.groups) - 1; i >= 0; i-- {
+		groupAttrs := append(slices.Clone(h.groups[i].attrs), groupedAttrs...)
+		groupedAttrs = []slog.Attr{
+			slog.Group(h.groups[i].name, attrsToAny(groupAttrs)...),
+		}
+	}
+
+	h.logger.Log(ctx, record.Level, record.Message, append(attrs, groupedAttrs...)...)
+
+	return nil
+}
+
+func (h *slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	child := h.clone()
+	if len(child.groups) == 0 {
+		child.attrs = append(child.attrs, attrs...)
+	} else {
+		i := len(child.groups) - 1
+		child.groups[i].attrs = append(child.groups[i].attrs, attrs...)
+	}
+
+	return child
+}
+
+func (h *slogHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+
+	child := h.clone()
+	child.groups = append(child.groups, slogGroup{name: name})
+
+	return child
+}
+
+func (h *slogHandler) clone() *slogHandler {
+	child := &slogHandler{
+		logger: h.logger,
+		attrs:  slices.Clone(h.attrs),
+		groups: slices.Clone(h.groups),
+	}
+	for i := range child.groups {
+		child.groups[i].attrs = slices.Clone(child.groups[i].attrs)
+	}
+
+	return child
+}
+
+func attrsToAny(attrs []slog.Attr) []any {
+	values := make([]any, len(attrs))
+	for i, attr := range attrs {
+		values[i] = attr
+	}
+
+	return values
+}

--- a/pkg/server/api/mcp/mcputils/logger_test.go
+++ b/pkg/server/api/mcp/mcputils/logger_test.go
@@ -21,10 +21,12 @@
 package mcputils_test
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"testing"
+	"testing/slogtest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,4 +69,33 @@ func TestNewSlogLogger_PreservesRecord(t *testing.T) {
 		},
 		entry["request"],
 	)
+}
+
+func TestNewSlogLogger_ConformsToSlogHandler(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	logger := log.NewLogger(
+		log.WithLevel(log.LevelDebug),
+		log.WithOutput(&output),
+	)
+
+	err := slogtest.TestHandler(
+		mcputils.NewSlogLogger(logger).Handler(),
+		func() []map[string]any {
+			entries := make([]map[string]any, 0)
+			scanner := bufio.NewScanner(bytes.NewReader(output.Bytes()))
+			for scanner.Scan() {
+				var entry map[string]any
+				unmarshalErr := json.Unmarshal(scanner.Bytes(), &entry)
+				require.NoError(t, unmarshalErr)
+				entries = append(entries, entry)
+			}
+			require.NoError(t, scanner.Err())
+
+			return entries
+		},
+	)
+
+	assert.NoError(t, err)
 }

--- a/pkg/server/api/mcp/mcputils/logger_test.go
+++ b/pkg/server/api/mcp/mcputils/logger_test.go
@@ -21,12 +21,10 @@
 package mcputils_test
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"testing"
-	"testing/slogtest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,33 +67,4 @@ func TestNewSlogLogger_PreservesRecord(t *testing.T) {
 		},
 		entry["request"],
 	)
-}
-
-func TestNewSlogLogger_ConformsToSlogHandler(t *testing.T) {
-	t.Parallel()
-
-	var output bytes.Buffer
-	logger := log.NewLogger(
-		log.WithLevel(log.LevelDebug),
-		log.WithOutput(&output),
-	)
-
-	err := slogtest.TestHandler(
-		mcputils.NewSlogLogger(logger).Handler(),
-		func() []map[string]any {
-			entries := make([]map[string]any, 0)
-			scanner := bufio.NewScanner(bytes.NewReader(output.Bytes()))
-			for scanner.Scan() {
-				var entry map[string]any
-				unmarshalErr := json.Unmarshal(scanner.Bytes(), &entry)
-				require.NoError(t, unmarshalErr)
-				entries = append(entries, entry)
-			}
-			require.NoError(t, scanner.Err())
-
-			return entries
-		},
-	)
-
-	assert.NoError(t, err)
 }

--- a/pkg/server/api/mcp/mcputils/logger_test.go
+++ b/pkg/server/api/mcp/mcputils/logger_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package mcputils_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/server/api/mcp/mcputils"
+)
+
+func TestNewSlogLogger_PreservesRecord(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	logger := log.NewLogger(
+		log.WithLevel(log.LevelDebug),
+		log.WithName("mcp.transport"),
+		log.WithOutput(&output),
+	)
+	slogLogger := mcputils.NewSlogLogger(logger).
+		With("component", "streamable").
+		WithGroup("request").
+		With("method", "POST").
+		WithGroup("details")
+
+	slogLogger.ErrorContext(context.Background(), "transport failed", "retryable", true)
+
+	var entry map[string]any
+	err := json.Unmarshal(output.Bytes(), &entry)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ERROR", entry["level"])
+	assert.Equal(t, "transport failed", entry["msg"])
+	assert.Equal(t, "mcp.transport", entry["name"])
+	assert.Equal(t, "streamable", entry["component"])
+	assert.Equal(
+		t,
+		map[string]any{
+			"method": "POST",
+			"details": map[string]any{
+				"retryable": true,
+			},
+		},
+		entry["request"],
+	)
+}

--- a/pkg/server/api/mcp/v1/v1_handler.go
+++ b/pkg/server/api/mcp/v1/v1_handler.go
@@ -98,7 +98,7 @@ func NewMux(
 			Stateless: true,
 			// SessionTimeout: 30 * time.Minute,
 			EventStore: eventStore,
-			Logger:     nil, // TODO put logger here
+			Logger:     mcputils.NewSlogLogger(logger.Named("transport")),
 		},
 	)
 	protectedHandler := http.NewCrossOriginProtection().Handler(handler)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- adapt the application logger to the standard `slog` API used by the MCP SDK
- wire a named transport logger into the streamable HTTP handler
- preserve log levels, attributes, nested groups, and request contexts through the adapter
- cover the transport logging behavior with a focused unit test

## Testing
- `go test ./pkg/server/api/mcp/mcputils ./pkg/server/api/mcp/v1`
- `go vet ./pkg/server/api/mcp/mcputils ./pkg/server/api/mcp/v1`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-772](https://linear.app/probo/issue/ENG-772/add-logger-to-mcp)

<div><a href="https://cursor.com/agents/bc-33aae98b-dc19-4810-9d81-c6ebb07b388c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33aae98b-dc19-4810-9d81-c6ebb07b388c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured logging to the MCP transport so SDK logs flow through our standard logger instead of being dropped. Old behavior: `nil` logger; new behavior: a named `transport` logger using `slog` preserves levels, attrs, and nested groups; no change to request handling. Addresses ENG-772.

### MCP **`+117`** **`-1`**
- Adds `mcputils.NewSlogLogger`, adapting `go.gearno.de/kit/log` to `slog` with `WithAttrs` and nested `WithGroup`.
- Wires `logger.Named("transport")` into the MCP v1 streamable HTTP handler.
- Preserves context, attributes, and group structure when forwarding records.

### Tests **`+70`** **`-0`**
- Adds a unit test that asserts level, message, logger name, attributes, and nested groups are preserved and encoded.
- Focuses the adapter test on MCP behavior and drops `testing/slogtest` usage.

<sup>Written for commit 1b6dbf79c9dcd94925dc3ff1fa8e706a9a73d913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

