### PR TITLE
Run database-backed tests in CI

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -461,6 +461,23 @@ jobs:
           submodules: recursive
       - uses: "runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc" # v2
       - uses: "./.github/actions/setup"
+      - name: "Configure Docker image source"
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "Fork pull request: pulling images from their origin registries, not the artifact.probo.inc mirror"
+            echo "COMPOSE_FILE=compose.yaml" >> "$GITHUB_ENV"
+          else
+            echo "COMPOSE_FILE=compose.yaml:compose.github-action.yaml" >> "$GITHUB_ENV"
+          fi
+      - uses: "docker/setup-compose-action@4eb059ff7f16592f9c84d5ca339c53cb7c5064e2" # v2.3.0
+      - uses: "docker/login-action@dbcb813823bdd20940b903addbd779551569679f" # v4.6.0
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          registry: artifact.probo.inc
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+      - name: "Start test database"
+        run: "docker compose up --detach --wait postgres"
       - name: "Create placeholder dist files"
         run: |
           mkdir -p apps/console/dist apps/compliance-portal/dist
@@ -470,6 +487,7 @@ jobs:
       - run: "make test"
         env:
           GOTESTSUM_JUNITFILE: "junit.xml"
+          PROBO_TEST_PG_URL: "postgres://probod:probod@localhost:5432/probod_test"
       - name: "Race-test e2e harness packages"
         run: "CGO_ENABLED=1 go test -race -count=1 ./e2e/internal/..."
       - name: "Upload test results"

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -488,6 +488,7 @@ jobs:
         env:
           GOTESTSUM_JUNITFILE: "junit.xml"
           PROBO_TEST_PG_URL: "postgres://probod:probod@localhost:5432/probod_test"
+          TEST_FLAGS: "-count=1 -race -cover -coverprofile=coverage.out"
       - name: "Race-test e2e harness packages"
         run: "CGO_ENABLED=1 go test -race -count=1 ./e2e/internal/..."
       - name: "Upload test results"

--- a/internal/test/pg.go
+++ b/internal/test/pg.go
@@ -48,9 +48,7 @@ const (
 	pgURLEnvVar = "PROBO_TEST_PG_URL"
 
 	// defaultPGURL targets the local compose Postgres so tests run with zero
-	// configuration against a developer's stack. When the database is not
-	// reachable (e.g. in CI, where `make test` runs without Postgres) the
-	// connection check fails and the test is skipped.
+	// configuration against a developer's stack.
 	defaultPGURL = "postgres://probod:probod@localhost:5432/probod_test"
 )
 
@@ -65,10 +63,12 @@ var (
 // PGClient returns a process-wide shared pg.Client connected to the test
 // database described by the PROBO_TEST_PG_URL environment variable (falling
 // back to a local compose Postgres), applying the agent_executions migrations on
-// first use. The test is skipped when no database is reachable so `make test`
-// stays a pure unit-test run.
+// first use. The test is skipped when the default local database is unreachable,
+// but fails when an explicitly configured database is unreachable.
 func PGClient(t *testing.T) *pg.Client {
 	t.Helper()
+
+	pgURLConfigured := os.Getenv(pgURLEnvVar) != ""
 
 	pgOnce.Do(
 		func() {
@@ -124,6 +124,10 @@ func PGClient(t *testing.T) *pg.Client {
 	)
 
 	if pgInitErr != nil {
+		if pgURLConfigured {
+			t.Fatalf("cannot connect to configured test database: %v", pgInitErr)
+		}
+
 		t.Skipf("cannot connect to test database: %v", pgInitErr)
 	}
 

--- a/pkg/agentexecution/helpers_test.go
+++ b/pkg/agentexecution/helpers_test.go
@@ -37,6 +37,7 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/llm"
+	"go.probo.inc/probo/pkg/mail"
 )
 
 func testLogger() *log.Logger {
@@ -409,7 +410,6 @@ func enqueueAgentInput(
 			},
 		),
 	)
-
 	return input
 }
 
@@ -427,6 +427,8 @@ func enqueueAgentInputWithIdentity(
 	require.NoError(t, err)
 
 	now := time.Now()
+	emailAddress, err := mail.ParseAddr(identityID.String() + "@example.com")
+	require.NoError(t, err)
 	input := coredata.AgentInput{
 		ID:               gid.New(execution.ID.TenantID(), coredata.AgentInputEntityType),
 		OrganizationID:   execution.OrganizationID,
@@ -444,6 +446,18 @@ func enqueueAgentInputWithIdentity(
 		client.WithTx(
 			context.Background(),
 			func(ctx context.Context, tx pg.Tx) error {
+				identity := coredata.Identity{
+					ID:                   identityID,
+					EmailAddress:         emailAddress,
+					FullName:             "Agent Input Test",
+					EmailAddressVerified: true,
+					CreatedAt:            now,
+					UpdatedAt:            now,
+				}
+				if err := identity.Insert(ctx, tx); err != nil {
+					return err
+				}
+
 				_, err := input.EnqueueIdempotently(
 					ctx,
 					tx,
@@ -453,6 +467,16 @@ func enqueueAgentInputWithIdentity(
 				return err
 			},
 		),
+	)
+	t.Cleanup(
+		func() {
+			_ = client.WithTx(
+				context.Background(),
+				func(ctx context.Context, tx pg.Tx) error {
+					return (&coredata.Identity{ID: identityID}).Delete(ctx, tx)
+				},
+			)
+		},
 	)
 
 	return input

--- a/pkg/agentexecution/helpers_test.go
+++ b/pkg/agentexecution/helpers_test.go
@@ -410,6 +410,7 @@ func enqueueAgentInput(
 			},
 		),
 	)
+
 	return input
 }
 
@@ -429,6 +430,7 @@ func enqueueAgentInputWithIdentity(
 	now := time.Now()
 	emailAddress, err := mail.ParseAddr(identityID.String() + "@example.com")
 	require.NoError(t, err)
+
 	input := coredata.AgentInput{
 		ID:               gid.New(execution.ID.TenantID(), coredata.AgentInputEntityType),
 		OrganizationID:   execution.OrganizationID,

--- a/pkg/agentexecution/worker_test.go
+++ b/pkg/agentexecution/worker_test.go
@@ -44,6 +44,23 @@ import (
 	"go.probo.inc/probo/pkg/llm"
 )
 
+type cancellationObservedTool struct {
+	agent.Tool
+	canceled chan<- struct{}
+	once     sync.Once
+}
+
+func (t *cancellationObservedTool) Execute(ctx context.Context, arguments string) (agent.ToolResult, error) {
+	stop := context.AfterFunc(ctx, func() {
+		t.once.Do(func() { close(t.canceled) })
+	})
+	defer stop()
+
+	return t.Tool.Execute(ctx, arguments)
+}
+
+func (*cancellationObservedTool) Suspendable() {}
+
 func TestWorker_PicksUpAndCompletes(t *testing.T) {
 	client := test.PGClient(t)
 	ag := newDummyAgent(
@@ -570,6 +587,7 @@ func TestWorker_StopAndResumeNestedSubAgent(t *testing.T) {
 	client := test.PGClient(t)
 
 	toolReady := make(chan struct{})
+	innerCanceled := make(chan struct{})
 	toolRelease := make(chan struct{})
 
 	var readyOnce sync.Once
@@ -610,7 +628,10 @@ func TestWorker_StopAndResumeNestedSubAgent(t *testing.T) {
 			),
 			stopResponse("outer done"),
 		},
-		innerAgent.AsTool("call_inner", "Call inner"),
+		&cancellationObservedTool{
+			Tool:     innerAgent.AsTool("call_inner", "Call inner"),
+			canceled: innerCanceled,
+		},
 	)
 
 	registry := &simpleRegistry{
@@ -641,6 +662,12 @@ func TestWorker_StopAndResumeNestedSubAgent(t *testing.T) {
 	case <-runWorker.ShutdownBroadcast():
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for worker shutdown broadcast")
+	}
+
+	select {
+	case <-innerCanceled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for cancellation to reach inner agent")
 	}
 
 	close(toolRelease)
@@ -696,6 +723,7 @@ func TestWorker_StopAndResumeNestedSubAgentMultiLevel(t *testing.T) {
 	client := test.PGClient(t)
 
 	toolReady := make(chan struct{})
+	grandchildCanceled := make(chan struct{})
 	toolRelease := make(chan struct{})
 
 	var readyOnce sync.Once
@@ -736,7 +764,10 @@ func TestWorker_StopAndResumeNestedSubAgentMultiLevel(t *testing.T) {
 			),
 			stopResponse("child done"),
 		},
-		grandchildAgent.AsTool("call_grandchild", "Call grandchild"),
+		&cancellationObservedTool{
+			Tool:     grandchildAgent.AsTool("call_grandchild", "Call grandchild"),
+			canceled: grandchildCanceled,
+		},
 	)
 
 	outerAgent := newDummyAgent(
@@ -782,6 +813,12 @@ func TestWorker_StopAndResumeNestedSubAgentMultiLevel(t *testing.T) {
 	case <-runWorker.ShutdownBroadcast():
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for worker shutdown broadcast")
+	}
+
+	select {
+	case <-grandchildCanceled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for cancellation to reach grandchild agent")
 	}
 
 	close(toolRelease)

--- a/pkg/probot/channel/slack/event_worker_test.go
+++ b/pkg/probot/channel/slack/event_worker_test.go
@@ -182,7 +182,7 @@ func TestEventWorkerHandler_RetriesTransientFailure(t *testing.T) {
 	assert.Nil(t, failed.ProcessedAt)
 	assert.NotNil(t, failed.LastError)
 	require.NotNil(t, failed.NextAttemptAt)
-	assert.True(t, failed.NextAttemptAt.Equal(now.Add(time.Second)))
+	assert.WithinDuration(t, now.Add(time.Second), *failed.NextAttemptAt, time.Microsecond)
 
 	_, err = handler.Claim(t.Context())
 	require.ErrorIs(t, err, worker.ErrNoTask)
@@ -257,7 +257,7 @@ func TestEventWorkerHandler_RecoversStaleClaim(t *testing.T) {
 	recovered := fixture.load(t, queued.EventID)
 	assert.Nil(t, recovered.ProcessingStartedAt)
 	require.NotNil(t, recovered.NextAttemptAt)
-	assert.True(t, recovered.NextAttemptAt.Equal(recoveryTime))
+	assert.WithinDuration(t, recoveryTime, *recovered.NextAttemptAt, time.Microsecond)
 	assert.NotNil(t, recovered.LastError)
 }
 

--- a/pkg/probot/channel/slack/execution_ingress_test.go
+++ b/pkg/probot/channel/slack/execution_ingress_test.go
@@ -42,6 +42,7 @@ func TestExecutionIngressCreatesIdleDirectConversationAndDeduplicatesEvent(t *te
 	handler := &Service{pg: pgClient}
 	identityID := gid.New(scope.GetTenantID(), coredata.IdentityEntityType)
 	insertTestIdentity(t, pgClient, identityID)
+
 	event := EventBody{
 		Type:        EventTypeAppMention,
 		User:        "U123",
@@ -221,8 +222,10 @@ func TestExecutionIngressReusesThreadSessionAndStoresPerInputCoordinates(t *test
 	handler := &Service{pg: pgClient}
 	aliceID := gid.New(scope.GetTenantID(), coredata.IdentityEntityType)
 	bobID := gid.New(scope.GetTenantID(), coredata.IdentityEntityType)
+
 	insertTestIdentity(t, pgClient, aliceID)
 	insertTestIdentity(t, pgClient, bobID)
+
 	transcript := "Thread:\n<@U1>: we should grant it\n<@U2>: @probot grant it"
 
 	require.NoError(

--- a/pkg/probot/channel/slack/execution_ingress_test.go
+++ b/pkg/probot/channel/slack/execution_ingress_test.go
@@ -41,6 +41,7 @@ func TestExecutionIngressCreatesIdleDirectConversationAndDeduplicatesEvent(t *te
 	pgClient, scope, organizationID := executionIngressDatabase(t)
 	handler := &Service{pg: pgClient}
 	identityID := gid.New(scope.GetTenantID(), coredata.IdentityEntityType)
+	insertTestIdentity(t, pgClient, identityID)
 	event := EventBody{
 		Type:        EventTypeAppMention,
 		User:        "U123",
@@ -220,6 +221,8 @@ func TestExecutionIngressReusesThreadSessionAndStoresPerInputCoordinates(t *test
 	handler := &Service{pg: pgClient}
 	aliceID := gid.New(scope.GetTenantID(), coredata.IdentityEntityType)
 	bobID := gid.New(scope.GetTenantID(), coredata.IdentityEntityType)
+	insertTestIdentity(t, pgClient, aliceID)
+	insertTestIdentity(t, pgClient, bobID)
 	transcript := "Thread:\n<@U1>: we should grant it\n<@U2>: @probot grant it"
 
 	require.NoError(
@@ -398,6 +401,8 @@ func TestExecutionIngressRoutesAnchoredReplyWithoutChangingDomainSession(t *test
 
 	domainSessionKey := *execution.SessionKey
 	handler := &Service{pg: pgClient}
+	identityID := gid.New(scope.GetTenantID(), coredata.IdentityEntityType)
+	insertTestIdentity(t, pgClient, identityID)
 	require.NoError(
 		t,
 		handler.enqueueExecutionInput(
@@ -406,7 +411,7 @@ func TestExecutionIngressRoutesAnchoredReplyWithoutChangingDomainSession(t *test
 			"T999",
 			"T999",
 			organizationID,
-			gid.New(scope.GetTenantID(), coredata.IdentityEntityType),
+			identityID,
 			EventBody{
 				Type:        EventTypeMessage,
 				User:        "U999",

--- a/pkg/probot/channel/slack/install_credentials.go
+++ b/pkg/probot/channel/slack/install_credentials.go
@@ -112,7 +112,7 @@ func (s *InstallationService) loadUsableCredentials(
 		)
 	}
 
-	installation.UpdatedAt = time.Now()
+	installation.UpdatedAt = time.Now().Round(time.Microsecond)
 
 	var persistErr error
 	for range credentialPersistAttempts {

--- a/pkg/probot/channel/slack/service_binding_test.go
+++ b/pkg/probot/channel/slack/service_binding_test.go
@@ -231,13 +231,15 @@ func TestService_HandleInteraction_BoundMentionSetsAssistantStatus(t *testing.T)
 
 	slackAPI := newRecordingSlackAPI(t, nil)
 	pgClient, organizationID, teamID := executionAdapterDatabase(t)
+	identityID := gid.New(organizationID.TenantID(), coredata.IdentityEntityType)
+	insertTestIdentity(t, pgClient, identityID)
 	handler := newInteractionService(
 		t,
 		pgClient,
 		slackAPI.URL,
 		&stubBindingGate{
 			binding: &identitybinding.Binding{
-				IdentityID: gid.New(organizationID.TenantID(), coredata.IdentityEntityType),
+				IdentityID: identityID,
 			},
 		},
 	)
@@ -371,13 +373,15 @@ func TestService_HandleInteraction_BoundDMSetsAssistantStatus(t *testing.T) {
 
 	slackAPI := newRecordingSlackAPI(t, nil)
 	pgClient, organizationID, teamID := executionAdapterDatabase(t)
+	identityID := gid.New(organizationID.TenantID(), coredata.IdentityEntityType)
+	insertTestIdentity(t, pgClient, identityID)
 	handler := newInteractionService(
 		t,
 		pgClient,
 		slackAPI.URL,
 		&stubBindingGate{
 			binding: &identitybinding.Binding{
-				IdentityID: gid.New(organizationID.TenantID(), coredata.IdentityEntityType),
+				IdentityID: identityID,
 			},
 		},
 	)

--- a/pkg/probot/channel/slack/test_helpers_test.go
+++ b/pkg/probot/channel/slack/test_helpers_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.gearno.de/kit/httpclient"
@@ -34,6 +35,7 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/crypto/cipher"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/mail"
 	"go.probo.inc/probo/pkg/probot"
 )
 
@@ -141,4 +143,40 @@ func uniqueSlackTeamID(t *testing.T) string {
 	t.Helper()
 
 	return "T-" + gid.New(gid.NilTenant, coredata.SlackbotInstallationEntityType).String()
+}
+
+func insertTestIdentity(t *testing.T, pgClient *pg.Client, identityID gid.GID) {
+	t.Helper()
+
+	now := time.Now()
+	emailAddress, err := mail.ParseAddr(identityID.String() + "@example.com")
+	require.NoError(t, err)
+	identity := coredata.Identity{
+		ID:                   identityID,
+		EmailAddress:         emailAddress,
+		FullName:             "Slack Test",
+		EmailAddressVerified: true,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+
+	require.NoError(
+		t,
+		pgClient.WithTx(
+			t.Context(),
+			func(ctx context.Context, tx pg.Tx) error {
+				return identity.Insert(ctx, tx)
+			},
+		),
+	)
+	t.Cleanup(
+		func() {
+			_ = pgClient.WithTx(
+				context.Background(),
+				func(ctx context.Context, tx pg.Tx) error {
+					return identity.Delete(ctx, tx)
+				},
+			)
+		},
+	)
 }

--- a/pkg/probot/channel/slack/test_helpers_test.go
+++ b/pkg/probot/channel/slack/test_helpers_test.go
@@ -151,6 +151,7 @@ func insertTestIdentity(t *testing.T, pgClient *pg.Client, identityID gid.GID) {
 	now := time.Now()
 	emailAddress, err := mail.ParseAddr(identityID.String() + "@example.com")
 	require.NoError(t, err)
+
 	identity := coredata.Identity{
 		ID:                   identityID,
 		EmailAddress:         emailAddress,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- start the initialized Compose PostgreSQL service in the Go test job
- use the Harbor mirror for trusted branches and Docker Hub for forks
- fail rather than skip when the explicitly configured CI database is unavailable
- run CI tests uncached and repair fixtures, precision assertions, and synchronization exposed by enabling database-backed tests

## Testing

- full uncached race/coverage suite: 5,177 passed, 5 environment-dependent skips, 0 failures
- targeted third-party and webhook database tests passed
- unreachable configured database produced a test failure rather than a skip
- workflow YAML parsed successfully

[full_uncached_race_suite.log](https://cursor.com/agents/bc-3d8c49b2-e336-44dd-b14b-1eb8c97e8aa9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffull_uncached_race_suite.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d8c49b2-e336-44dd-b14b-1eb8c97e8aa9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d8c49b2-e336-44dd-b14b-1eb8c97e8aa9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs database-backed tests in CI by starting a PostgreSQL service and enforcing consistent behavior. The default local DB still skips when absent, but a configured PROBO_TEST_PG_URL fails fast if unreachable.

### Tests **`+121`** **`-7`**
- Add identity insertion helpers for DB-backed agent and Slack tests.
- Make time assertions microsecond-tolerant and observe nested agent cancellation.
- Complete whitespace lint fixes in database tests.

### Service **`+3`** **`-3`**
- Round Slack installation UpdatedAt to microsecond precision.
- Update GitHub access-review fixture to match the formatted GraphQL query body.

### Other **`+28`** **`-5`**
- Choose compose files per fork vs trusted branches and log in to the Harbor mirror on trusted.
- Start Compose Postgres; run tests uncached with -race and coverage while exporting PROBO_TEST_PG_URL.

<sup>Written for commit 9c43724767f5fefaf0049235c8e413826d943865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

