### PR TITLE
Ctp3 cleaning improvements

### DIFF
--- a/apps/console/src/pages/organizations/cookie-banners/_locales/en-US.json
+++ b/apps/console/src/pages/organizations/cookie-banners/_locales/en-US.json
@@ -57,7 +57,7 @@
   "trackerAttribution": {
     "firstParty": "First party",
     "visitorSoftware": "Visitor software",
-    "identifying": "Identifying…"
+    "undetermined": "Undetermined"
   },
   "trackerPatternRowEdit": {
     "fields": { "description": "Description", "descriptionPlaceholder": "Description", "maxAge": "Max age" },

--- a/apps/console/src/pages/organizations/cookie-banners/_locales/en-US.json
+++ b/apps/console/src/pages/organizations/cookie-banners/_locales/en-US.json
@@ -56,6 +56,7 @@
   },
   "trackerAttribution": {
     "firstParty": "First party",
+    "thirdParty": "Third party",
     "visitorSoftware": "Visitor software",
     "undetermined": "Undetermined"
   },

--- a/apps/console/src/pages/organizations/cookie-banners/_locales/en-US.json
+++ b/apps/console/src/pages/organizations/cookie-banners/_locales/en-US.json
@@ -54,6 +54,11 @@
     "languageDefault": "{{language}} (default)",
     "defaultLanguageDescription": "This is the default language. These translations are shown when a visitor's language is not available."
   },
+  "trackerAttribution": {
+    "firstParty": "First party",
+    "visitorSoftware": "Visitor software",
+    "identifying": "Identifying…"
+  },
   "trackerPatternRowEdit": {
     "fields": { "description": "Description", "descriptionPlaceholder": "Description", "maxAge": "Max age" },
     "actions": { "save": "Save", "cancel": "Cancel" }

--- a/apps/console/src/pages/organizations/cookie-banners/_locales/fr-FR.json
+++ b/apps/console/src/pages/organizations/cookie-banners/_locales/fr-FR.json
@@ -56,6 +56,7 @@
   },
   "trackerAttribution": {
     "firstParty": "Première partie",
+    "thirdParty": "Tierce partie",
     "visitorSoftware": "Logiciel du visiteur",
     "undetermined": "Indéterminé"
   },

--- a/apps/console/src/pages/organizations/cookie-banners/_locales/fr-FR.json
+++ b/apps/console/src/pages/organizations/cookie-banners/_locales/fr-FR.json
@@ -57,7 +57,7 @@
   "trackerAttribution": {
     "firstParty": "Première partie",
     "visitorSoftware": "Logiciel du visiteur",
-    "identifying": "Identification…"
+    "undetermined": "Indéterminé"
   },
   "trackerPatternRowEdit": {
     "fields": { "description": "Description", "descriptionPlaceholder": "Description", "maxAge": "Âge maximal" },

--- a/apps/console/src/pages/organizations/cookie-banners/_locales/fr-FR.json
+++ b/apps/console/src/pages/organizations/cookie-banners/_locales/fr-FR.json
@@ -54,6 +54,11 @@
     "languageDefault": "{{language}} (par défaut)",
     "defaultLanguageDescription": "Il s’agit de la langue par défaut. Ces traductions sont affichées lorsque la langue d’un visiteur n’est pas disponible."
   },
+  "trackerAttribution": {
+    "firstParty": "Première partie",
+    "visitorSoftware": "Logiciel du visiteur",
+    "identifying": "Identification…"
+  },
   "trackerPatternRowEdit": {
     "fields": { "description": "Description", "descriptionPlaceholder": "Description", "maxAge": "Âge maximal" },
     "actions": { "save": "Enregistrer", "cancel": "Annuler" }

--- a/apps/console/src/pages/organizations/cookie-banners/_locales/nl-NL.json
+++ b/apps/console/src/pages/organizations/cookie-banners/_locales/nl-NL.json
@@ -54,6 +54,11 @@
     "languageDefault": "{{language}} (standaard)",
     "defaultLanguageDescription": "Dit is de standaardtaal. Deze vertalingen worden getoond wanneer de taal van een bezoeker niet beschikbaar is."
   },
+  "trackerAttribution": {
+    "firstParty": "Eerste partij",
+    "visitorSoftware": "Bezoekerssoftware",
+    "identifying": "Bezig met identificeren…"
+  },
   "trackerPatternRowEdit": {
     "fields": { "description": "Beschrijving", "descriptionPlaceholder": "Beschrijving", "maxAge": "Maximale leeftijd" },
     "actions": { "save": "Opslaan", "cancel": "Annuleren" }

--- a/apps/console/src/pages/organizations/cookie-banners/_locales/nl-NL.json
+++ b/apps/console/src/pages/organizations/cookie-banners/_locales/nl-NL.json
@@ -57,7 +57,7 @@
   "trackerAttribution": {
     "firstParty": "Eerste partij",
     "visitorSoftware": "Bezoekerssoftware",
-    "identifying": "Bezig met identificeren…"
+    "undetermined": "Onbepaald"
   },
   "trackerPatternRowEdit": {
     "fields": { "description": "Beschrijving", "descriptionPlaceholder": "Beschrijving", "maxAge": "Maximale leeftijd" },

--- a/apps/console/src/pages/organizations/cookie-banners/_locales/nl-NL.json
+++ b/apps/console/src/pages/organizations/cookie-banners/_locales/nl-NL.json
@@ -56,6 +56,7 @@
   },
   "trackerAttribution": {
     "firstParty": "Eerste partij",
+    "thirdParty": "Derde partij",
     "visitorSoftware": "Bezoekerssoftware",
     "undetermined": "Onbepaald"
   },

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerAttributionLabel.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerAttributionLabel.tsx
@@ -38,7 +38,7 @@ export function TrackerAttributionLabel({ attribution }: TrackerAttributionLabel
     case "UNDETERMINED":
       return (
         <span className="text-txt-tertiary text-sm">
-          {t("trackerAttribution.identifying")}
+          {t("trackerAttribution.undetermined")}
         </span>
       );
     default:

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerAttributionLabel.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerAttributionLabel.tsx
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 import { Badge } from "@probo/ui";
+import type { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { CommonTrackerPatternAttribution } from "#/__generated__/core/TrackerPatternRowFragment.graphql";
@@ -27,12 +28,25 @@ interface TrackerAttributionLabelProps {
   attribution: CommonTrackerPatternAttribution | null | undefined;
 }
 
-export function TrackerAttributionLabel({ attribution }: TrackerAttributionLabelProps) {
+// The explicit ReactElement return is what makes the switch below exhaustive:
+// without it a missing case falls out of the function as undefined and still
+// compiles, which is how THIRD_PARTY silently rendered as a dash.
+export function TrackerAttributionLabel({
+  attribution,
+}: TrackerAttributionLabelProps): ReactElement {
   const { t } = useTranslation("organizations/cookie-banners");
+
+  // A null attribution is a pattern with no catalog link at all, which is the
+  // only case with nothing to say.
+  if (attribution == null) {
+    return <span className="text-txt-tertiary text-sm">-</span>;
+  }
 
   switch (attribution) {
     case "FIRST_PARTY":
       return <Badge variant="success">{t("trackerAttribution.firstParty")}</Badge>;
+    case "THIRD_PARTY":
+      return <Badge variant="info">{t("trackerAttribution.thirdParty")}</Badge>;
     case "NOT_ATTRIBUTABLE":
       return <Badge variant="warning">{t("trackerAttribution.visitorSoftware")}</Badge>;
     case "UNDETERMINED":
@@ -41,7 +55,5 @@ export function TrackerAttributionLabel({ attribution }: TrackerAttributionLabel
           {t("trackerAttribution.undetermined")}
         </span>
       );
-    default:
-      return <span className="text-txt-tertiary text-sm">-</span>;
   }
 }

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerAttributionLabel.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerAttributionLabel.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { Badge } from "@probo/ui";
+import { useTranslation } from "react-i18next";
+
+import type { CommonTrackerPatternAttribution } from "#/__generated__/core/TrackerPatternRowFragment.graphql";
+
+interface TrackerAttributionLabelProps {
+  attribution: CommonTrackerPatternAttribution | null | undefined;
+}
+
+export function TrackerAttributionLabel({ attribution }: TrackerAttributionLabelProps) {
+  const { t } = useTranslation("organizations/cookie-banners");
+
+  switch (attribution) {
+    case "FIRST_PARTY":
+      return <Badge variant="success">{t("trackerAttribution.firstParty")}</Badge>;
+    case "NOT_ATTRIBUTABLE":
+      return <Badge variant="warning">{t("trackerAttribution.visitorSoftware")}</Badge>;
+    case "UNDETERMINED":
+      return (
+        <span className="text-txt-tertiary text-sm">
+          {t("trackerAttribution.identifying")}
+        </span>
+      );
+    default:
+      return <span className="text-txt-tertiary text-sm">-</span>;
+  }
+}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
@@ -28,6 +28,7 @@ import type { TrackerPatternPropertiesSection_trackerPattern$key } from "#/__gen
 import type { TrackerPatternPropertiesSectionMoveMutation } from "#/__generated__/core/TrackerPatternPropertiesSectionMoveMutation.graphql";
 
 import { MoveToCategorySelect } from "./MoveToCategorySelect";
+import { TrackerAttributionLabel } from "./TrackerAttributionLabel";
 
 const trackerPatternPropertiesSectionFragment = graphql`
   fragment TrackerPatternPropertiesSection_trackerPattern on TrackerPattern {
@@ -53,6 +54,7 @@ const trackerPatternPropertiesSectionFragment = graphql`
     commonThirdParty {
       name
     }
+    attribution
   }
 `;
 
@@ -182,7 +184,7 @@ export function TrackerPatternPropertiesSection({
                   <span className="text-sm">{pattern.commonThirdParty.name}</span>
                 </div>
               )
-            : <span className="text-txt-tertiary text-sm">-</span>}
+            : <TrackerAttributionLabel attribution={pattern.attribution} />}
       </PropertyRow>
       <PropertyRow label={t("trackerProperties.properties.maxAge")}>
         <span className="text-sm">

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
@@ -45,6 +45,7 @@ import type { TrackerPatternRowUpdateMutation } from "#/__generated__/core/Track
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 
 import { MoveToCategorySelect } from "./MoveToCategorySelect";
+import { TrackerAttributionLabel } from "./TrackerAttributionLabel";
 import { TrackerPatternRowEdit } from "./TrackerPatternRowEdit";
 
 const trackerPatternFragment = graphql`
@@ -70,6 +71,7 @@ const trackerPatternFragment = graphql`
       id
       name
     }
+    attribution
   }
 `;
 
@@ -400,7 +402,7 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
                   <span className="truncate">{pattern.commonThirdParty.name}</span>
                 </div>
               )
-            : <span className="text-txt-tertiary">-</span>}
+            : <TrackerAttributionLabel attribution={pattern.attribution} />}
       </Td>
       <Td>
         {srcBadge

--- a/e2e/console/tracker_pattern_test.go
+++ b/e2e/console/tracker_pattern_test.go
@@ -620,6 +620,73 @@ func TestTrackerPattern_List(t *testing.T) {
 	})
 }
 
+func TestTrackerPattern_Attribution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("is null without a catalog link", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+		patternID := factory.CreateTrackerPattern(owner, categoryID)
+
+		const query = `
+			query($id: ID!) {
+				node(id: $id) {
+					... on TrackerPattern {
+						id
+						attribution
+					}
+				}
+			}
+		`
+
+		var result struct {
+			Node struct {
+				ID          string  `json:"id"`
+				Attribution *string `json:"attribution"`
+			} `json:"node"`
+		}
+
+		require.NoError(t, owner.Execute(query, map[string]any{"id": patternID}, &result))
+		assert.Nil(t, result.Node.Attribution, "a freshly created pattern has no catalog verdict")
+	})
+
+	t.Run("inherits the catalog verdict", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+		patternID := factory.CreateTrackerPattern(owner, categoryID)
+		commonID := seedCommonTrackerPatternWithAttribution(t, coredata.CommonTrackerPatternAttributionFirstParty)
+		linkTrackerPatternToCommon(t, patternID, commonID)
+
+		const query = `
+			query($id: ID!) {
+				node(id: $id) {
+					... on TrackerPattern {
+						id
+						attribution
+					}
+				}
+			}
+		`
+
+		var result struct {
+			Node struct {
+				ID          string  `json:"id"`
+				Attribution *string `json:"attribution"`
+			} `json:"node"`
+		}
+
+		require.NoError(t, owner.Execute(query, map[string]any{"id": patternID}, &result))
+		require.NotNil(t, result.Node.Attribution, "a catalog-linked pattern must expose the inherited verdict")
+		assert.Equal(t, string(coredata.CommonTrackerPatternAttributionFirstParty), *result.Node.Attribution)
+	})
+}
+
 func TestTrackerPattern_CommonTrackerPatternID(t *testing.T) {
 	t.Parallel()
 
@@ -664,6 +731,15 @@ func TestTrackerPattern_CommonTrackerPatternID(t *testing.T) {
 func seedCommonTrackerPattern(t *testing.T) gid.GID {
 	t.Helper()
 
+	return seedCommonTrackerPatternWithAttribution(t, coredata.CommonTrackerPatternAttributionUndetermined)
+}
+
+func seedCommonTrackerPatternWithAttribution(
+	t *testing.T,
+	attribution coredata.CommonTrackerPatternAttribution,
+) gid.GID {
+	t.Helper()
+
 	ctx := context.Background()
 	conn := dialTestPg(t, ctx)
 	t.Cleanup(func() { _ = conn.Close(ctx) })
@@ -677,7 +753,7 @@ func seedCommonTrackerPattern(t *testing.T) gid.GID {
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10
 		)
-	`, id, "COOKIE", "e2e_common_"+id.String(), "EXACT", "Seeded catalog description", 1.0, coredata.CommonTrackerPatternAttributionUndetermined, 0, now, now)
+	`, id, "COOKIE", "e2e_common_"+id.String(), "EXACT", "Seeded catalog description", 1.0, attribution, 0, now, now)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/examples/cookie-banner-react/package.json
+++ b/examples/cookie-banner-react/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@probo/cookie-banner": "*",
+    "loglevel": "^1.9.2",
     "posthog-js": "^1.413.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.8"

--- a/examples/cookie-banner-react/src/App.tsx
+++ b/examples/cookie-banner-react/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { appLogger } from "./lib/logger";
 import { ConfigTab } from "./tabs/ConfigTab";
 import { ThemedBannerTab } from "./tabs/ThemedBannerTab";
 import { HeadlessTab } from "./tabs/HeadlessTab";
@@ -58,7 +59,10 @@ export function App() {
         {tabs.map((tab) => (
           <button
             key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
+            onClick={() => {
+              appLogger.debug("[app] tab", tab.id);
+              setActiveTab(tab.id);
+            }}
             style={{
               padding: "8px 16px",
               border: "none",

--- a/examples/cookie-banner-react/src/lib/logger.ts
+++ b/examples/cookie-banner-react/src/lib/logger.ts
@@ -1,0 +1,15 @@
+import log from "loglevel";
+
+function named(name: string) {
+  const logger = log.getLogger(name);
+  logger.setLevel("debug");
+  return logger;
+}
+
+log.setLevel("debug");
+
+export const appLogger = named("probo:example:app");
+export const configLogger = named("probo:example:config");
+export const themedLogger = named("probo:example:themed");
+export const headlessLogger = named("probo:example:headless");
+export const debugLogger = named("probo:example:debug");

--- a/examples/cookie-banner-react/src/lib/logger.ts
+++ b/examples/cookie-banner-react/src/lib/logger.ts
@@ -1,15 +1,31 @@
 import log from "loglevel";
 
 function named(name: string) {
-  const logger = log.getLogger(name);
-  logger.setLevel("debug");
-  return logger;
+  return log.getLogger(name);
 }
 
 log.setLevel("debug");
 
-export const appLogger = named("probo:example:app");
-export const configLogger = named("probo:example:config");
-export const themedLogger = named("probo:example:themed");
-export const headlessLogger = named("probo:example:headless");
-export const debugLogger = named("probo:example:debug");
+const namedLoggers = {
+  "probo:example:app": named("probo:example:app"),
+  "probo:example:config": named("probo:example:config"),
+  "probo:example:themed": named("probo:example:themed"),
+  "probo:example:headless": named("probo:example:headless"),
+  "probo:example:debug": named("probo:example:debug"),
+} as const;
+
+export const appLogger = namedLoggers["probo:example:app"];
+export const configLogger = namedLoggers["probo:example:config"];
+export const themedLogger = namedLoggers["probo:example:themed"];
+export const headlessLogger = namedLoggers["probo:example:headless"];
+export const debugLogger = namedLoggers["probo:example:debug"];
+
+export function enableNamedLoggers(): void {
+  for (const [name, logger] of Object.entries(namedLoggers)) {
+    logger.setLevel("debug");
+    // loglevel persists via property assignment, which the SDK does not
+    // hook. Replay the same key through setItem so a live write is
+    // observed as SCRIPT after the detector has wrapped Storage.
+    localStorage.setItem(`loglevel:${name}`, "DEBUG");
+  }
+}

--- a/examples/cookie-banner-react/src/tabs/ConfigTab.tsx
+++ b/examples/cookie-banner-react/src/tabs/ConfigTab.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useConfig } from "../hooks/useConfig";
+import { configLogger } from "../lib/logger";
 
 export function ConfigTab() {
   const [config, setConfig] = useConfig();
@@ -13,6 +14,7 @@ export function ConfigTab() {
     gcmEnabled !== config.gcmEnabled;
 
   const save = () => {
+    configLogger.debug("[config] save", { bannerId, baseUrl, gcmEnabled });
     setConfig({ bannerId, baseUrl, gcmEnabled });
   };
 

--- a/examples/cookie-banner-react/src/tabs/DebugTab.tsx
+++ b/examples/cookie-banner-react/src/tabs/DebugTab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { getConsent } from "@probo/cookie-banner/consent";
 import type { ConsentData } from "@probo/cookie-banner/consent";
 import { useConfig } from "../hooks/useConfig";
+import { debugLogger } from "../lib/logger";
 
 interface ConsentSnapshot {
   ready: boolean;
@@ -67,7 +68,9 @@ export function DebugTab() {
   useEffect(() => {
     const mgr = getConsent();
     return mgr.subscribe(() => {
-      setSnapshot(readSnapshot());
+      const next = readSnapshot();
+      debugLogger.debug("[debug] consent", next);
+      setSnapshot(next);
       setVisitorId(readVisitorId(config.bannerId));
       setCookie(readCookie());
       setDataLayer(readDataLayer());

--- a/examples/cookie-banner-react/src/tabs/HeadlessTab.tsx
+++ b/examples/cookie-banner-react/src/tabs/HeadlessTab.tsx
@@ -6,7 +6,7 @@ import {
   type BannerConfig,
 } from "@probo/cookie-banner/headless";
 import { useConfig } from "../hooks/useConfig";
-import { headlessLogger } from "../lib/logger";
+import { enableNamedLoggers, headlessLogger } from "../lib/logger";
 import type { EventEntry } from "../App";
 
 const headlessActions: Record<string, string> = {
@@ -140,6 +140,7 @@ export function HeadlessTab({ events, pushEvent }: HeadlessTabProps) {
           config?: BannerConfig;
         };
         const bannerConfig = detail?.config;
+        enableNamedLoggers();
         headlessLogger.debug("[headless] probo-ready", detail);
         pushEvent("probo-ready", {
           ...detail,

--- a/examples/cookie-banner-react/src/tabs/HeadlessTab.tsx
+++ b/examples/cookie-banner-react/src/tabs/HeadlessTab.tsx
@@ -6,7 +6,36 @@ import {
   type BannerConfig,
 } from "@probo/cookie-banner/headless";
 import { useConfig } from "../hooks/useConfig";
+import { headlessLogger } from "../lib/logger";
 import type { EventEntry } from "../App";
+
+const headlessActions: Record<string, string> = {
+  "PROBO-ACKNOWLEDGE-BUTTON": "Acknowledge",
+  "PROBO-ACCEPT-BUTTON": "Accept All",
+  "PROBO-REJECT-BUTTON": "Reject All",
+  "PROBO-CUSTOMIZE-BUTTON": "Customize",
+  "PROBO-SAVE-BUTTON": "Save Preferences",
+  "PROBO-SETTINGS-LINK": "Cookie settings",
+};
+
+function headlessActionLabel(target: EventTarget | null): string | null {
+  if (!(target instanceof Element)) {
+    return null;
+  }
+
+  const host = target.closest(
+    "probo-acknowledge-button, probo-accept-button, probo-reject-button, probo-customize-button, probo-save-button, probo-settings-link",
+  );
+  if (!host) {
+    return null;
+  }
+
+  if (host.tagName === "PROBO-REJECT-BUTTON" && host.closest("probo-privacy-choices")) {
+    return "Do Not Sell";
+  }
+
+  return headlessActions[host.tagName] ?? null;
+}
 
 let registered = false;
 
@@ -21,6 +50,7 @@ export function HeadlessTab({ events, pushEvent }: HeadlessTabProps) {
 
   useEffect(() => {
     if (!registered) {
+      headlessLogger.debug("[headless] registerHeadlessComponents");
       registerHeadlessComponents();
       registered = true;
     }
@@ -95,6 +125,14 @@ export function HeadlessTab({ events, pushEvent }: HeadlessTabProps) {
       </p>
     `;
 
+    const onClick = (e: Event) => {
+      const label = headlessActionLabel(e.target);
+      if (label) {
+        headlessLogger.debug("[headless] click", label);
+      }
+    };
+    container.addEventListener("click", onClick);
+
     const root = container.querySelector("probo-cookie-banner-root");
     if (root) {
       root.addEventListener("probo-ready", (e: Event) => {
@@ -102,18 +140,21 @@ export function HeadlessTab({ events, pushEvent }: HeadlessTabProps) {
           config?: BannerConfig;
         };
         const bannerConfig = detail?.config;
+        headlessLogger.debug("[headless] probo-ready", detail);
         pushEvent("probo-ready", {
           ...detail,
           layout: bannerConfig ? resolveLayout(bannerConfig) : null,
           bannerText: bannerConfig ? resolveBannerText(bannerConfig) : null,
         });
       });
-      root.addEventListener("probo-consent", (e: Event) =>
-        pushEvent("probo-consent", (e as CustomEvent).detail),
-      );
+      root.addEventListener("probo-consent", (e: Event) => {
+        headlessLogger.debug("[headless] probo-consent", (e as CustomEvent).detail);
+        pushEvent("probo-consent", (e as CustomEvent).detail);
+      });
     }
 
     return () => {
+      container.removeEventListener("click", onClick);
       container.innerHTML = "";
     };
   }, [config.bannerId, config.baseUrl, config.gcmEnabled, pushEvent]);

--- a/examples/cookie-banner-react/src/tabs/ThemedBannerTab.tsx
+++ b/examples/cookie-banner-react/src/tabs/ThemedBannerTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "
 import posthog from "posthog-js";
 import { registerCookieBanner, type BannerConfig } from "@probo/cookie-banner";
 import { useConfig } from "../hooks/useConfig";
+import { themedLogger } from "../lib/logger";
 import {
   configurePosthogFromBanner,
   getPosthogStatus,
@@ -27,6 +28,7 @@ export function ThemedBannerTab({ events, pushEvent }: ThemedBannerTabProps) {
 
   useEffect(() => {
     if (!registered) {
+      themedLogger.debug("[themed] registerCookieBanner");
       registerCookieBanner();
       registered = true;
     }
@@ -45,11 +47,13 @@ export function ThemedBannerTab({ events, pushEvent }: ThemedBannerTabProps) {
         if (detail?.config) {
           configurePosthogFromBanner(detail.config);
         }
+        themedLogger.debug("[themed] probo-ready", (e as CustomEvent).detail);
         pushEvent("probo-ready", (e as CustomEvent).detail);
       });
-      el.addEventListener("probo-consent", (e: Event) =>
-        pushEvent("probo-consent", (e as CustomEvent).detail),
-      );
+      el.addEventListener("probo-consent", (e: Event) => {
+        themedLogger.debug("[themed] probo-consent", (e as CustomEvent).detail);
+        pushEvent("probo-consent", (e as CustomEvent).detail);
+      });
     },
     [pushEvent],
   );
@@ -64,6 +68,7 @@ export function ThemedBannerTab({ events, pushEvent }: ThemedBannerTabProps) {
     // make the example fail closed if the panel is reused without its
     // disabled-state wiring.
     if (posthog.has_opted_out_capturing()) return;
+    themedLogger.debug("[themed] posthog ping");
     posthog.capture("themed_tab_manual_ping", { source: "example" });
     setManualPing(new Date().toISOString());
   }, []);
@@ -122,7 +127,10 @@ export function ThemedBannerTab({ events, pushEvent }: ThemedBannerTabProps) {
         gcm-enabled={config.gcmEnabled ? "true" : "false"}
       />
 
-      <p style={{ marginTop: 16 }}>
+      <p
+        style={{ marginTop: 16 }}
+        onClick={() => themedLogger.debug("[themed] cookie settings")}
+      >
         <probo-settings-link>Cookie settings</probo-settings-link>
       </p>
 

--- a/examples/cookie-banner-react/src/tabs/ThemedBannerTab.tsx
+++ b/examples/cookie-banner-react/src/tabs/ThemedBannerTab.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "
 import posthog from "posthog-js";
 import { registerCookieBanner, type BannerConfig } from "@probo/cookie-banner";
 import { useConfig } from "../hooks/useConfig";
-import { themedLogger } from "../lib/logger";
+import { enableNamedLoggers, themedLogger } from "../lib/logger";
 import {
   configurePosthogFromBanner,
   getPosthogStatus,
@@ -47,6 +47,7 @@ export function ThemedBannerTab({ events, pushEvent }: ThemedBannerTabProps) {
         if (detail?.config) {
           configurePosthogFromBanner(detail.config);
         }
+        enableNamedLoggers();
         themedLogger.debug("[themed] probo-ready", (e as CustomEvent).detail);
         pushEvent("probo-ready", (e as CustomEvent).detail);
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -781,6 +781,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@probo/cookie-banner": "*",
+        "loglevel": "^1.9.2",
         "posthog-js": "^1.413.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.8"
@@ -15649,6 +15650,19 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/longest-streak": {

--- a/packages/n8n-node/CHANGELOG.md
+++ b/packages/n8n-node/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `@probo/n8n-nodes-probo` package will be documented i
 
 ## Unreleased
 
+### Added
+
+- Tracker Pattern `Get` / `Get Many`: `attribution` catalog verdict inherited from the linked common tracker pattern
+
 ## [0.220.0] - 2026-08-14
 
 ### Added

--- a/packages/n8n-node/nodes/Probo/actions/trackerPattern/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/trackerPattern/get.operation.ts
@@ -58,6 +58,7 @@ export async function execute(
 					excluded
 					lastMatchedAt
 					commonTrackerPatternId
+					attribution
 					createdAt
 					updatedAt
 				}

--- a/packages/n8n-node/nodes/Probo/actions/trackerPattern/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/trackerPattern/getAll.operation.ts
@@ -93,6 +93,7 @@ export async function execute(
 								excluded
 								lastMatchedAt
 								commonTrackerPatternId
+								attribution
 								createdAt
 								updatedAt
 							}

--- a/pkg/cmd/tracker-pattern/list/list.go
+++ b/pkg/cmd/tracker-pattern/list/list.go
@@ -47,6 +47,7 @@ query($id: ID!, $first: Int, $after: CursorKey) {
             excluded
             lastMatchedAt
             commonTrackerPatternId
+            attribution
           }
         }
         pageInfo {
@@ -69,6 +70,7 @@ type trackerPattern struct {
 	Excluded               bool    `json:"excluded"`
 	LastMatchedAt          *string `json:"lastMatchedAt"`
 	CommonTrackerPatternID *string `json:"commonTrackerPatternId"`
+	Attribution            *string `json:"attribution"`
 }
 
 func NewCmdList(f *cmdutil.Factory) *cobra.Command {
@@ -170,10 +172,15 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 					commonPatternID = *p.CommonTrackerPatternID
 				}
 
-				rows = append(rows, []string{p.ID, p.Pattern, p.MatchType, p.TrackerType, p.DisplayName, source, excluded, lastMatched, commonPatternID})
+				attribution := ""
+				if p.Attribution != nil {
+					attribution = *p.Attribution
+				}
+
+				rows = append(rows, []string{p.ID, p.Pattern, p.MatchType, p.TrackerType, p.DisplayName, source, excluded, lastMatched, commonPatternID, attribution})
 			}
 
-			t := cmdutil.NewTable("ID", "PATTERN", "MATCH TYPE", "TRACKER TYPE", "DISPLAY NAME", "SOURCE", "EXCLUDED", "LAST MATCHED", "COMMON PATTERN ID").Rows(rows...)
+			t := cmdutil.NewTable("ID", "PATTERN", "MATCH TYPE", "TRACKER TYPE", "DISPLAY NAME", "SOURCE", "EXCLUDED", "LAST MATCHED", "COMMON PATTERN ID", "ATTRIBUTION").Rows(rows...)
 			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
 
 			if totalCount > len(patterns) {

--- a/pkg/cmd/tracker-pattern/view/view.go
+++ b/pkg/cmd/tracker-pattern/view/view.go
@@ -46,6 +46,7 @@ query($id: ID!) {
       excluded
       lastMatchedAt
       commonTrackerPatternId
+      attribution
       createdAt
       updatedAt
     }
@@ -67,6 +68,7 @@ type viewResponse struct {
 		Excluded               bool    `json:"excluded"`
 		LastMatchedAt          *string `json:"lastMatchedAt"`
 		CommonTrackerPatternID *string `json:"commonTrackerPatternId"`
+		Attribution            *string `json:"attribution"`
 		CreatedAt              string  `json:"createdAt"`
 		UpdatedAt              string  `json:"updatedAt"`
 	} `json:"node"`
@@ -150,6 +152,10 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Common Pattern:"), *v.CommonTrackerPatternID)
 			} else {
 				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Origin:"), "Manual (no catalog link)")
+			}
+
+			if v.Attribution != nil && *v.Attribution != "" {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Attribution:"), *v.Attribution)
 			}
 
 			_, _ = fmt.Fprintln(out)

--- a/pkg/coredata/common_third_party_domain.go
+++ b/pkg/coredata/common_third_party_domain.go
@@ -45,6 +45,13 @@ type (
 	CommonThirdPartyDomains []*CommonThirdPartyDomain
 )
 
+// LoadByDomain resolves a host to the catalog entry that owns it.
+//
+// A domain is unique per catalog entry, not globally: two entries for the same
+// vendor each carry it until one is merged away. The ordering makes the choice
+// deterministic in that window, so attribution cannot flip between two calls
+// or after a vacuum. Collapsing the duplicate is `proboctl common-third-party
+// merge`; this only keeps the answer stable until it runs.
 func (d *CommonThirdPartyDomain) LoadByDomain(
 	ctx context.Context,
 	conn pg.Querier,
@@ -61,6 +68,8 @@ FROM
     common_third_party_domains
 WHERE
     domain = @domain
+ORDER BY
+    created_at, id
 LIMIT 1;
 `
 

--- a/pkg/coredata/common_tracker_pattern.go
+++ b/pkg/coredata/common_tracker_pattern.go
@@ -562,6 +562,83 @@ LIMIT @limit;
 	return results, nil
 }
 
+// PatternSummary is the part of a pattern a reviewer reads to judge what the
+// software actually did: the key, where it was stored, and the verdict already
+// on it. The description is deliberately absent — it is agent prose that names
+// a vendor, which is what a review is meant to check rather than trust.
+type PatternSummary struct {
+	Pattern     string
+	TrackerType string
+	Attribution CommonTrackerPatternAttribution
+	Confidence  float32
+}
+
+// LoadSummariesGroupedByCommonThirdPartyID returns a short pattern summary for
+// every catalog entry in one round trip, keyed by the entry that owns it.
+//
+// Judging a row means reading its keys — a device id means a vendor, a theme
+// preference means local state — and doing that per row is one query each. A
+// backlog of a hundred rows makes the correct method slow enough that batching
+// by name becomes tempting, which is where misjudgements come from. Loading
+// them together removes the reason to guess.
+//
+// Capped per entry by the caller: a handful of keys is enough to classify a
+// row, and loglevel-style namespaces run to dozens.
+func (ps *CommonTrackerPatterns) LoadSummariesGroupedByCommonThirdPartyID(
+	ctx context.Context,
+	conn pg.Querier,
+) (map[gid.GID][]PatternSummary, error) {
+	q := `
+SELECT
+    common_third_party_id,
+    pattern,
+    tracker_type,
+    attribution,
+    confidence
+FROM
+    common_tracker_patterns
+WHERE
+    common_third_party_id IS NOT NULL
+ORDER BY
+    common_third_party_id,
+    confidence DESC,
+    pattern
+`
+
+	rows, err := conn.Query(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query common tracker pattern summaries: %w", err)
+	}
+	defer rows.Close()
+
+	byParty := make(map[gid.GID][]PatternSummary)
+
+	for rows.Next() {
+		var (
+			partyID gid.GID
+			summary PatternSummary
+		)
+
+		if err := rows.Scan(
+			&partyID,
+			&summary.Pattern,
+			&summary.TrackerType,
+			&summary.Attribution,
+			&summary.Confidence,
+		); err != nil {
+			return nil, fmt.Errorf("cannot scan common tracker pattern summary: %w", err)
+		}
+
+		byParty[partyID] = append(byParty[partyID], summary)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate common tracker pattern summaries: %w", err)
+	}
+
+	return byParty, nil
+}
+
 func (ps *CommonTrackerPatterns) LoadByCommonThirdPartyID(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/coredata/common_tracker_pattern.go
+++ b/pkg/coredata/common_tracker_pattern.go
@@ -568,7 +568,7 @@ LIMIT @limit;
 // a vendor, which is what a review is meant to check rather than trust.
 type PatternSummary struct {
 	Pattern     string
-	TrackerType string
+	TrackerType TrackerType
 	Attribution CommonTrackerPatternAttribution
 	Confidence  float32
 }

--- a/pkg/coredata/common_tracker_pattern_summary_test.go
+++ b/pkg/coredata/common_tracker_pattern_summary_test.go
@@ -100,7 +100,7 @@ func TestLoadSummariesGroupedByCommonThirdPartyID(t *testing.T) {
 	assert.Equal(t, "aaa-high-confidence", mine[0].Pattern,
 		"highest confidence first, since the caller shows only the first few")
 	assert.Equal(t, "zzz-low-confidence", mine[1].Pattern)
-	assert.Equal(t, "COOKIE", mine[0].TrackerType,
+	assert.Equal(t, coredata.TrackerTypeCookie, mine[0].TrackerType,
 		"the storage kind is what separates an egressing cookie from local state")
 
 	require.Len(t, byParty[other.ID], 1, "grouping must not leak across entries")

--- a/pkg/coredata/common_tracker_pattern_summary_test.go
+++ b/pkg/coredata/common_tracker_pattern_summary_test.go
@@ -88,6 +88,7 @@ func TestLoadSummariesGroupedByCommonThirdPartyID(t *testing.T) {
 		var patterns coredata.CommonTrackerPatterns
 
 		var err error
+
 		byParty, err = patterns.LoadSummariesGroupedByCommonThirdPartyID(ctx, conn)
 
 		return err

--- a/pkg/coredata/common_tracker_pattern_summary_test.go
+++ b/pkg/coredata/common_tracker_pattern_summary_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/internal/test"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+// The grouped loader exists so a reviewer can read every row's keys in one
+// round trip: doing it per row is what makes reading the evidence slower than
+// guessing from the name. Pin the grouping, the confidence ordering the
+// caller's cap relies on, and that unlinked patterns stay out.
+func TestLoadSummariesGroupedByCommonThirdPartyID(t *testing.T) {
+	t.Parallel()
+
+	client := test.PGClient(t)
+	ctx := context.Background()
+
+	party := seedCommonThirdParty(t, ctx, client)
+	other := seedCommonThirdParty(t, ctx, client)
+
+	insert := func(owner *coredata.CommonThirdParty, key string, confidence float32) {
+		t.Helper()
+
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		pattern := coredata.CommonTrackerPattern{
+			ID:          gid.New(gid.NilTenant, coredata.CommonTrackerPatternEntityType),
+			TrackerType: coredata.TrackerTypeCookie,
+			Pattern:     key,
+			MatchType:   coredata.TrackerPatternMatchTypeExact,
+			Confidence:  confidence,
+			Attribution: coredata.CommonTrackerPatternAttributionThirdParty,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+
+		if owner != nil {
+			pattern.CommonThirdPartyID = &owner.ID
+		}
+
+		require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+			return pattern.Insert(ctx, tx)
+		}))
+
+		t.Cleanup(func() {
+			_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
+				_, err := tx.Exec(ctx, `DELETE FROM common_tracker_patterns WHERE id = $1`, pattern.ID)
+				return err
+			})
+		})
+	}
+
+	insert(&party, "zzz-low-confidence", 0.20)
+	insert(&party, "aaa-high-confidence", 0.90)
+	insert(&other, "other-party-key", 0.80)
+	insert(nil, "unlinked-key", 0.70)
+
+	var byParty map[gid.GID][]coredata.PatternSummary
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		var patterns coredata.CommonTrackerPatterns
+
+		var err error
+		byParty, err = patterns.LoadSummariesGroupedByCommonThirdPartyID(ctx, conn)
+
+		return err
+	}))
+
+	mine := byParty[party.ID]
+	require.Len(t, mine, 2, "only this entry's patterns")
+
+	assert.Equal(t, "aaa-high-confidence", mine[0].Pattern,
+		"highest confidence first, since the caller shows only the first few")
+	assert.Equal(t, "zzz-low-confidence", mine[1].Pattern)
+	assert.Equal(t, "COOKIE", mine[0].TrackerType,
+		"the storage kind is what separates an egressing cookie from local state")
+
+	require.Len(t, byParty[other.ID], 1, "grouping must not leak across entries")
+
+	for owner, summaries := range byParty {
+		for _, s := range summaries {
+			assert.NotEqual(t, "unlinked-key", s.Pattern,
+				"a pattern with no vendor has no entry to group under (owner %s)", owner)
+		}
+	}
+}

--- a/pkg/proboctl/commonthirdparty/list.go
+++ b/pkg/proboctl/commonthirdparty/list.go
@@ -184,6 +184,7 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 					var patterns coredata.CommonTrackerPatterns
 
 					var err error
+
 					byParty, err = patterns.LoadSummariesGroupedByCommonThirdPartyID(ctx, conn)
 
 					return err

--- a/pkg/proboctl/commonthirdparty/list.go
+++ b/pkg/proboctl/commonthirdparty/list.go
@@ -166,7 +166,7 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 			return nil
 		}
 
-		table := clicmdutil.NewTable("ID", "NAME", "SLUG", "CATEGORY", "STATE", "STATUS", "LAST ATTEMPT", "UPDATED")
+		table := clicmdutil.NewTable("ID", "NAME", "SLUG", "CATEGORY", "REVIEW", "STATE", "STATUS", "LAST ATTEMPT", "UPDATED")
 
 		for _, p := range parties {
 			lastAttempt := ""
@@ -179,6 +179,7 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 				p.Name,
 				p.Slug,
 				string(p.Category),
+				reviewSummary(p),
 				enrichmentState(p),
 				enrichmentStatus(p),
 				lastAttempt,

--- a/pkg/proboctl/commonthirdparty/list.go
+++ b/pkg/proboctl/commonthirdparty/list.go
@@ -23,11 +23,13 @@ package commonthirdparty
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.gearno.de/kit/pg"
 	clicmdutil "go.probo.inc/probo/pkg/cmd/cmdutil"
 	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/proboctl/cmdutil"
 )
@@ -40,6 +42,7 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 		flagState    string
 		flagStatus   string
 		flagReview   string
+		flagPatterns bool
 		flagSort     string
 		flagOrder    string
 	)
@@ -58,6 +61,7 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagState, "state", "", "Filter by enrichment state (queued, enriched, unenriched)")
 	cmd.Flags().StringVar(&flagStatus, "status", "", "Filter by last enrichment status (done, partial, failed)")
 	cmd.Flags().StringVar(&flagReview, "review", "", "Filter by review state (unreviewed, validated, rejected)")
+	cmd.Flags().BoolVar(&flagPatterns, "with-patterns", false, "Show each entry's tracker pattern keys, so a review can be judged from the listing instead of one lookup per row")
 	cmd.Flags().StringVar(&flagSort, "sort", "name", "Sort field: name, created, updated")
 	cmd.Flags().StringVar(&flagOrder, "order", "", "Sort order: asc, desc (default depends on field)")
 
@@ -166,6 +170,47 @@ func newCmdList(f *cmdutil.Factory) *cobra.Command {
 			return nil
 		}
 
+		// The pattern keys are what a review is judged on, so with
+		// --with-patterns they replace the enrichment columns rather than
+		// widening an already wide table. One grouped query serves the whole
+		// page: per-row lookups are what make reading the evidence slower
+		// than guessing from the name.
+		if flagPatterns {
+			var byParty map[gid.GID][]coredata.PatternSummary
+
+			if err := pgClient.WithConn(
+				cmd.Context(),
+				func(ctx context.Context, conn pg.Querier) error {
+					var patterns coredata.CommonTrackerPatterns
+
+					var err error
+					byParty, err = patterns.LoadSummariesGroupedByCommonThirdPartyID(ctx, conn)
+
+					return err
+				},
+			); err != nil {
+				return fmt.Errorf("cannot load pattern summaries: %w", err)
+			}
+
+			table := clicmdutil.NewTable("NAME", "SLUG", "CATEGORY", "REVIEW", "PATTERNS")
+
+			for _, p := range parties {
+				table.Row(
+					p.Name,
+					p.Slug,
+					string(p.Category),
+					reviewSummary(p),
+					summarisePatterns(byParty[p.ID]),
+				)
+			}
+
+			_, _ = fmt.Fprintln(f.IOStreams.Out, table.Render())
+			cmdutil.PrintPageInfo(f.IOStreams.Out, pageInfo)
+			_, _ = fmt.Fprintf(f.IOStreams.ErrOut, "Showing %d common third parties.\n", len(parties))
+
+			return nil
+		}
+
 		table := clicmdutil.NewTable("ID", "NAME", "SLUG", "CATEGORY", "REVIEW", "STATE", "STATUS", "LAST ATTEMPT", "UPDATED")
 
 		for _, p := range parties {
@@ -203,4 +248,46 @@ func optionalString(s string) *string {
 	}
 
 	return &s
+}
+
+// summarisePatterns renders the few keys that decide a verdict. Highest
+// confidence first (the loader orders them), capped because a handful is
+// enough to classify a row and a shared-library namespace runs to dozens.
+func summarisePatterns(summaries []coredata.PatternSummary) string {
+	const shown = 4
+
+	if len(summaries) == 0 {
+		return "(none)"
+	}
+
+	parts := make([]string, 0, shown+1)
+
+	for i, s := range summaries {
+		if i == shown {
+			parts = append(parts, fmt.Sprintf("+%d more", len(summaries)-shown))
+			break
+		}
+
+		parts = append(parts, fmt.Sprintf("%s [%s]", s.Pattern, storageAbbrev(s.TrackerType)))
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// storageAbbrev keeps the storage kind visible without the column dominating
+// the row: where a key lives distinguishes a cookie sent to a vendor from
+// local state that never leaves the browser.
+func storageAbbrev(trackerType string) string {
+	switch trackerType {
+	case "COOKIE":
+		return "ck"
+	case "LOCAL_STORAGE":
+		return "ls"
+	case "SESSION_STORAGE":
+		return "ss"
+	case "INDEXED_DB":
+		return "idb"
+	}
+
+	return strings.ToLower(trackerType)
 }

--- a/pkg/proboctl/commonthirdparty/list.go
+++ b/pkg/proboctl/commonthirdparty/list.go
@@ -278,17 +278,19 @@ func summarisePatterns(summaries []coredata.PatternSummary) string {
 // storageAbbrev keeps the storage kind visible without the column dominating
 // the row: where a key lives distinguishes a cookie sent to a vendor from
 // local state that never leaves the browser.
-func storageAbbrev(trackerType string) string {
+func storageAbbrev(trackerType coredata.TrackerType) string {
 	switch trackerType {
-	case "COOKIE":
+	case coredata.TrackerTypeCookie:
 		return "ck"
-	case "LOCAL_STORAGE":
+	case coredata.TrackerTypeLocalStorage:
 		return "ls"
-	case "SESSION_STORAGE":
+	case coredata.TrackerTypeSessionStorage:
 		return "ss"
-	case "INDEXED_DB":
+	case coredata.TrackerTypeIndexedDB:
 		return "idb"
+	case coredata.TrackerTypeCacheStorage:
+		return "cs"
 	}
 
-	return strings.ToLower(trackerType)
+	return strings.ToLower(string(trackerType))
 }

--- a/pkg/proboctl/commonthirdparty/prune.go
+++ b/pkg/proboctl/commonthirdparty/prune.go
@@ -61,7 +61,11 @@ func newCmdPrune(f *cmdutil.Factory) *cobra.Command {
 			"vendor that nothing ever linked. They are not duplicates of anything, so " +
 			"`merge` cannot clean them up.\n\n" +
 			"Curated seed entries are always excluded, with no override: the next seed " +
-			"run would recreate them anyway.\n\n" +
+			"run would recreate them anyway. Reviewed entries are excluded for the same " +
+			"reason: a rejection is what the mapping pipeline reads to settle future " +
+			"patterns, and a validation is a confirmation that the entry belongs here — " +
+			"both are decisions worth keeping even with nothing referencing them. Use " +
+			"`review <slug> unreviewed` first if an entry really should go.\n\n" +
 			"Entries younger than --older-than are kept, because an entry is created " +
 			"before enrichment fills it in and before its triggering pattern is " +
 			"linked, so a young unreferenced entry is usually still in flight.",
@@ -129,6 +133,19 @@ func newCmdPrune(f *cmdutil.Factory) *cobra.Command {
 					// Curated entries are never pruned: the seed recreates
 					// them, so deleting one is churn at best.
 					if _, seeded := seededSlugs[party.Slug]; seeded {
+						continue
+					}
+
+					// A reviewed row carries a human decision, which is the
+					// thing worth keeping even when nothing references it.
+					// Deleting a rejected row loses the verdict the mapping
+					// pipeline reads, so the next matching pattern is
+					// adjudicated from scratch — the recurrence this state
+					// exists to stop. Deleting a validated one discards a
+					// confirmation that a real vendor belongs in the catalog,
+					// and it is precisely the vendors whose misattributed
+					// patterns were just detached that end up unreferenced.
+					if party.Review != nil && *party.Review != coredata.CommonThirdPartyReviewUnreviewed {
 						continue
 					}
 

--- a/pkg/proboctl/commonthirdparty/prune_review_test.go
+++ b/pkg/proboctl/commonthirdparty/prune_review_test.go
@@ -83,10 +83,12 @@ func TestPruneSkipsReviewedRows(t *testing.T) {
 	// LoadAllUnreferencedIDs is what prune selects from; all three qualify,
 	// so the review check is the only thing that can separate them.
 	var ids []gid.GID
+
 	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
 		var parties coredata.CommonThirdParties
 
 		var err error
+
 		ids, err = parties.LoadAllUnreferencedIDs(ctx, conn, time.Now().Add(-24*time.Hour), false)
 
 		return err

--- a/pkg/proboctl/commonthirdparty/prune_review_test.go
+++ b/pkg/proboctl/commonthirdparty/prune_review_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package commonthirdparty
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/internal/test"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+// A reviewed row carries a decision, so prune must leave it alone even when
+// nothing references it — which is exactly the state a row lands in once its
+// misattributed patterns are detached.
+func TestPruneSkipsReviewedRows(t *testing.T) {
+	t.Parallel()
+
+	client := test.PGClient(t)
+	ctx := context.Background()
+
+	insert := func(review coredata.CommonThirdPartyReview, verdict *coredata.CommonTrackerPatternAttribution) coredata.CommonThirdParty {
+		t.Helper()
+
+		// Older than the 24h guard so age is not what keeps it.
+		created := time.Now().Add(-72 * time.Hour)
+		id := gid.New(gid.NilTenant, coredata.CommonThirdPartyEntityType)
+		party := coredata.CommonThirdParty{
+			ID:              id,
+			Name:            "Prune " + id.String(),
+			Slug:            "prune-" + id.String(),
+			Category:        coredata.ThirdPartyCategoryOther,
+			Certifications:  []string{},
+			Review:          &review,
+			RejectedVerdict: verdict,
+			CreatedAt:       created,
+			UpdatedAt:       created,
+		}
+
+		require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+			return party.Insert(ctx, tx)
+		}))
+
+		t.Cleanup(func() {
+			_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
+				_, err := tx.Exec(ctx, `DELETE FROM common_third_parties WHERE id = $1`, id)
+				return err
+			})
+		})
+
+		return party
+	}
+
+	firstParty := coredata.CommonTrackerPatternAttributionFirstParty
+
+	validated := insert(coredata.CommonThirdPartyReviewValidated, nil)
+	rejected := insert(coredata.CommonThirdPartyReviewRejected, &firstParty)
+	unreviewed := insert(coredata.CommonThirdPartyReviewUnreviewed, nil)
+
+	// LoadAllUnreferencedIDs is what prune selects from; all three qualify,
+	// so the review check is the only thing that can separate them.
+	var ids []gid.GID
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		var parties coredata.CommonThirdParties
+
+		var err error
+		ids, err = parties.LoadAllUnreferencedIDs(ctx, conn, time.Now().Add(-24*time.Hour), false)
+
+		return err
+	}))
+
+	found := map[gid.GID]bool{}
+	for _, id := range ids {
+		found[id] = true
+	}
+
+	assert.True(t, found[validated.ID], "the query itself must see all three as unreferenced")
+	assert.True(t, found[rejected.ID])
+	assert.True(t, found[unreviewed.ID])
+
+	// And the reviewed ones must carry a state prune can filter on.
+	require.NotNil(t, validated.Review)
+	assert.NotEqual(t, coredata.CommonThirdPartyReviewUnreviewed, *validated.Review)
+	require.NotNil(t, rejected.Review)
+	assert.NotEqual(t, coredata.CommonThirdPartyReviewUnreviewed, *rejected.Review)
+	require.NotNil(t, unreviewed.Review)
+	assert.Equal(t, coredata.CommonThirdPartyReviewUnreviewed, *unreviewed.Review)
+}

--- a/pkg/proboctl/commonthirdparty/show.go
+++ b/pkg/proboctl/commonthirdparty/show.go
@@ -130,6 +130,7 @@ func newCmdShow(f *cmdutil.Factory) *cobra.Command {
 		row("Name:", party.Name)
 		row("Slug:", party.Slug)
 		row("Category:", string(party.Category))
+		row("Review:", reviewSummary(&party))
 
 		if party.WebsiteURL != nil {
 			row("Website:", *party.WebsiteURL)
@@ -231,4 +232,24 @@ func printEnrichmentDetails(out io.Writer, label lipgloss.Style, party coredata.
 
 		_, _ = fmt.Fprintln(out, table.Render())
 	}
+}
+
+// reviewSummary renders the review state, appending the terminal verdict a
+// rejection carries: the state alone does not say what patterns resolving to
+// this row will be attributed, which is the reason to look.
+func reviewSummary(party *coredata.CommonThirdParty) string {
+	if party.Review == nil {
+		return "(unknown)"
+	}
+
+	if *party.Review != coredata.CommonThirdPartyReviewRejected {
+		return string(*party.Review)
+	}
+
+	verdict := "(no verdict)"
+	if party.RejectedVerdict != nil {
+		verdict = string(*party.RejectedVerdict)
+	}
+
+	return fmt.Sprintf("%s -> %s", *party.Review, verdict)
 }

--- a/pkg/proboctl/seed/common-third-parties/data/data.json
+++ b/pkg/proboctl/seed/common-third-parties/data/data.json
@@ -6393,17 +6393,7 @@
     "name": "PowerLinks",
     "category": "MARKETING",
     "domains": [
-      "powerlinks.com"
-    ],
-    "legalName": "PowerLinks Media Ltd.",
-    "headquarterAddress": "London, United Kingdom",
-    "websiteUrl": "https://www.powerlinks.com",
-    "privacyPolicyUrl": "https://www.powerlinks.com/privacy-policy/"
-  },
-  {
-    "name": "PowerLinks Media",
-    "category": "MARKETING",
-    "domains": [
+      "powerlinks.com",
       "px.powerlinks.com"
     ],
     "legalName": "PowerLinks Media Ltd.",

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -1519,6 +1519,33 @@ func (r *trackerPatternResolver) CommonThirdParty(ctx context.Context, obj *type
 	return types.NewCommonThirdParty(party), nil
 }
 
+// Attribution is the resolver for the attribution field.
+//
+// The verdict lives on the linked common catalog row, not the org
+// pattern. A missing catalog link is a real null, not UNDETERMINED.
+func (r *trackerPatternResolver) Attribution(ctx context.Context, obj *types.TrackerPattern) (*coredata.CommonTrackerPatternAttribution, error) {
+	if obj.CommonTrackerPatternID == nil {
+		return nil, nil
+	}
+
+	loaders := dataloader.FromContext(ctx)
+
+	pattern, err := loaders.CommonTrackerPattern.Load(ctx, *obj.CommonTrackerPatternID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) || errors.Is(err, dataloadgen.ErrNotFound) {
+			return nil, nil
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot get common tracker pattern", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	attribution := pattern.Attribution
+
+	return &attribution, nil
+}
+
 // DetectedTrackers is the resolver for the detectedTrackers field.
 func (r *trackerPatternResolver) DetectedTrackers(ctx context.Context, obj *types.TrackerPattern, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DetectedTrackerOrderBy) (*types.DetectedTrackerConnection, error) {
 	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternGet)

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -1528,6 +1528,14 @@ func (r *trackerPatternResolver) Attribution(ctx context.Context, obj *types.Tra
 		return nil, nil
 	}
 
+	// Same catalog row, same gate as the sibling commonThirdParty resolver:
+	// the verdict is global catalog data, so a role denied it there must not
+	// be able to read it here instead.
+	identity := authn.IdentityFromContext(ctx)
+	if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyGet); err != nil {
+		return nil, err
+	}
+
 	loaders := dataloader.FromContext(ctx)
 
 	pattern, err := loaders.CommonTrackerPattern.Load(ctx, *obj.CommonTrackerPatternID)

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -246,6 +246,28 @@ type CookieCategory implements Node {
     permission(action: String!): Boolean! @goField(forceResolver: true)
 }
 
+enum CommonTrackerPatternAttribution
+    @goModel(
+        model: "go.probo.inc/probo/pkg/coredata.CommonTrackerPatternAttribution"
+    ) {
+    UNDETERMINED
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.CommonTrackerPatternAttributionUndetermined"
+        )
+    THIRD_PARTY
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.CommonTrackerPatternAttributionThirdParty"
+        )
+    FIRST_PARTY
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.CommonTrackerPatternAttributionFirstParty"
+        )
+    NOT_ATTRIBUTABLE
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.CommonTrackerPatternAttributionNotAttributable"
+        )
+}
+
 enum TrackerPatternMatchType
     @goModel(
         model: "go.probo.inc/probo/pkg/coredata.TrackerPatternMatchType"
@@ -330,6 +352,13 @@ type TrackerPattern implements Node
     debugging agent-generated descriptions.
     """
     commonTrackerPatternId: ID
+
+    """
+    Catalog verdict inherited from the linked common tracker pattern.
+    Null when the org pattern has no catalog link.
+    """
+    attribution: CommonTrackerPatternAttribution
+        @goField(forceResolver: true)
 
     detectedTrackers(
         first: Int

--- a/pkg/server/api/console/v1/types/tracker_pattern.go
+++ b/pkg/server/api/console/v1/types/tracker_pattern.go
@@ -35,7 +35,7 @@ type (
 	// type via @goModel. The first block contains the fields gqlgen
 	// fulfills directly from the model; resolver-only fields
 	// (cookieCategory, detectedTrackers, thirdParty, commonThirdParty,
-	// detectedCount, permission) are populated by the resolver.
+	// attribution, detectedCount, permission) are populated by the resolver.
 	//
 	// ThirdPartyID is not exposed in GraphQL — it is a foreign-key
 	// handle the resolver uses to load the linked org-scoped third

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5883,7 +5883,12 @@ func (r *Resolver) ListTrackerPatternsTool(ctx context.Context, req *mcp.CallToo
 
 	p := page.NewPage(patterns, cursor)
 
-	return nil, types.NewListTrackerPatternsOutput(p), nil
+	attributions, err := r.trackerPatternAttributions(ctx, patterns...)
+	if err != nil {
+		panic(fmt.Errorf("cannot load tracker pattern attributions: %w", err))
+	}
+
+	return nil, types.NewListTrackerPatternsOutput(p, attributions), nil
 }
 
 func (r *Resolver) GetTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTrackerPatternInput) (*mcp.CallToolResult, types.GetTrackerPatternOutput, error) {
@@ -5897,7 +5902,12 @@ func (r *Resolver) GetTrackerPatternTool(ctx context.Context, req *mcp.CallToolR
 		return nil, types.GetTrackerPatternOutput{}, fmt.Errorf("cannot get tracker pattern: %w", err)
 	}
 
-	return nil, types.GetTrackerPatternOutput{TrackerPattern: types.NewTrackerPattern(pattern)}, nil
+	mapped, err := r.newTrackerPattern(ctx, pattern)
+	if err != nil {
+		return nil, types.GetTrackerPatternOutput{}, fmt.Errorf("cannot load tracker pattern attribution: %w", err)
+	}
+
+	return nil, types.GetTrackerPatternOutput{TrackerPattern: mapped}, nil
 }
 
 func (r *Resolver) AddTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTrackerPatternInput) (*mcp.CallToolResult, types.AddTrackerPatternOutput, error) {
@@ -5922,7 +5932,12 @@ func (r *Resolver) AddTrackerPatternTool(ctx context.Context, req *mcp.CallToolR
 		return nil, types.AddTrackerPatternOutput{}, fmt.Errorf("cannot create tracker pattern: %w", err)
 	}
 
-	return nil, types.AddTrackerPatternOutput{TrackerPattern: types.NewTrackerPattern(pattern)}, nil
+	mapped, err := r.newTrackerPattern(ctx, pattern)
+	if err != nil {
+		return nil, types.AddTrackerPatternOutput{}, fmt.Errorf("cannot load tracker pattern attribution: %w", err)
+	}
+
+	return nil, types.AddTrackerPatternOutput{TrackerPattern: mapped}, nil
 }
 
 func (r *Resolver) UpdateTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrackerPatternInput) (*mcp.CallToolResult, types.UpdateTrackerPatternOutput, error) {
@@ -5950,7 +5965,12 @@ func (r *Resolver) UpdateTrackerPatternTool(ctx context.Context, req *mcp.CallTo
 		return nil, types.UpdateTrackerPatternOutput{}, fmt.Errorf("cannot update tracker pattern: %w", err)
 	}
 
-	return nil, types.UpdateTrackerPatternOutput{TrackerPattern: types.NewTrackerPattern(pattern)}, nil
+	mapped, err := r.newTrackerPattern(ctx, pattern)
+	if err != nil {
+		return nil, types.UpdateTrackerPatternOutput{}, fmt.Errorf("cannot load tracker pattern attribution: %w", err)
+	}
+
+	return nil, types.UpdateTrackerPatternOutput{TrackerPattern: mapped}, nil
 }
 
 func (r *Resolver) DeleteTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTrackerPatternInput) (*mcp.CallToolResult, types.DeleteTrackerPatternOutput, error) {
@@ -5984,7 +6004,12 @@ func (r *Resolver) MoveTrackerPatternToCategoryTool(ctx context.Context, req *mc
 		return nil, types.MoveTrackerPatternToCategoryOutput{}, fmt.Errorf("cannot move tracker pattern: %w", err)
 	}
 
-	return nil, types.MoveTrackerPatternToCategoryOutput{TrackerPattern: types.NewTrackerPattern(result.TrackerPattern)}, nil
+	mapped, err := r.newTrackerPattern(ctx, result.TrackerPattern)
+	if err != nil {
+		return nil, types.MoveTrackerPatternToCategoryOutput{}, fmt.Errorf("cannot load tracker pattern attribution: %w", err)
+	}
+
+	return nil, types.MoveTrackerPatternToCategoryOutput{TrackerPattern: mapped}, nil
 }
 
 func (r *Resolver) PublishCookieBannerVersionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishCookieBannerVersionInput) (*mcp.CallToolResult, types.PublishCookieBannerVersionOutput, error) {

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -11870,6 +11870,12 @@ components:
             - $ref: "#/components/schemas/GID"
             - type: "null"
           description: Linked common tracker-pattern catalog ID, if any. Non-null indicates the pattern was matched to the global catalog (description may originate from the seed or agents); null means no catalog link.
+        attribution:
+          anyOf:
+            - type: string
+              enum: [UNDETERMINED, THIRD_PARTY, FIRST_PARTY, NOT_ATTRIBUTABLE]
+            - type: "null"
+          description: Catalog verdict inherited from the linked common tracker pattern. Null when the org pattern has no catalog link.
         created_at:
           type: string
           format: date-time

--- a/pkg/server/api/mcp/v1/tracker_pattern.go
+++ b/pkg/server/api/mcp/v1/tracker_pattern.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package mcp_v1
+
+import (
+	"context"
+	"fmt"
+
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/server/api/mcp/v1/types"
+)
+
+func (r *Resolver) trackerPatternAttributions(
+	ctx context.Context,
+	patterns ...*coredata.TrackerPattern,
+) (map[gid.GID]coredata.CommonTrackerPatternAttribution, error) {
+	ids := make([]gid.GID, 0, len(patterns))
+	seen := make(map[gid.GID]struct{}, len(patterns))
+	for _, pattern := range patterns {
+		if pattern == nil || pattern.CommonTrackerPatternID == nil {
+			continue
+		}
+
+		id := *pattern.CommonTrackerPatternID
+		if _, ok := seen[id]; ok {
+			continue
+		}
+
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	commons, err := r.cookieBanner.GetCommonTrackerPatternsByIDs(ctx, ids...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load common tracker patterns: %w", err)
+	}
+
+	return types.AttributionByOrgPatternID(patterns, commons), nil
+}
+
+func (r *Resolver) newTrackerPattern(
+	ctx context.Context,
+	pattern *coredata.TrackerPattern,
+) (*types.TrackerPattern, error) {
+	attributions, err := r.trackerPatternAttributions(ctx, pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	var attribution *coredata.CommonTrackerPatternAttribution
+	if a, ok := attributions[pattern.ID]; ok {
+		attribution = &a
+	}
+
+	return types.NewTrackerPatternWithAttribution(pattern, attribution), nil
+}

--- a/pkg/server/api/mcp/v1/tracker_pattern.go
+++ b/pkg/server/api/mcp/v1/tracker_pattern.go
@@ -34,6 +34,7 @@ func (r *Resolver) trackerPatternAttributions(
 	patterns ...*coredata.TrackerPattern,
 ) (map[gid.GID]coredata.CommonTrackerPatternAttribution, error) {
 	ids := make([]gid.GID, 0, len(patterns))
+
 	seen := make(map[gid.GID]struct{}, len(patterns))
 	for _, pattern := range patterns {
 		if pattern == nil || pattern.CommonTrackerPatternID == nil {

--- a/pkg/server/api/mcp/v1/types/tracker_pattern.go
+++ b/pkg/server/api/mcp/v1/types/tracker_pattern.go
@@ -26,10 +26,6 @@ import (
 	"go.probo.inc/probo/pkg/page"
 )
 
-func NewTrackerPattern(p *coredata.TrackerPattern) *TrackerPattern {
-	return NewTrackerPatternWithAttribution(p, nil)
-}
-
 func NewTrackerPatternWithAttribution(
 	p *coredata.TrackerPattern,
 	attribution *coredata.CommonTrackerPatternAttribution,

--- a/pkg/server/api/mcp/v1/types/tracker_pattern.go
+++ b/pkg/server/api/mcp/v1/types/tracker_pattern.go
@@ -22,13 +22,27 @@ package types
 
 import (
 	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
 )
 
 func NewTrackerPattern(p *coredata.TrackerPattern) *TrackerPattern {
+	return NewTrackerPatternWithAttribution(p, nil)
+}
+
+func NewTrackerPatternWithAttribution(
+	p *coredata.TrackerPattern,
+	attribution *coredata.CommonTrackerPatternAttribution,
+) *TrackerPattern {
 	var source TrackerPatternSource
 	if p.Source != nil {
 		source = TrackerPatternSource(*p.Source)
+	}
+
+	var mapped *TrackerPatternAttribution
+	if attribution != nil {
+		value := TrackerPatternAttribution(*attribution)
+		mapped = &value
 	}
 
 	return &TrackerPattern{
@@ -46,15 +60,52 @@ func NewTrackerPattern(p *coredata.TrackerPattern) *TrackerPattern {
 		Excluded:               p.Excluded,
 		LastMatchedAt:          p.LastMatchedAt,
 		CommonTrackerPatternID: p.CommonTrackerPatternID,
+		Attribution:            mapped,
 		CreatedAt:              p.CreatedAt,
 		UpdatedAt:              p.UpdatedAt,
 	}
 }
 
-func NewListTrackerPatternsOutput(pg *page.Page[*coredata.TrackerPattern, coredata.TrackerPatternOrderField]) ListTrackerPatternsOutput {
+// AttributionByOrgPatternID maps each org pattern to the catalog verdict
+// on its linked common row. Patterns with no catalog link are omitted.
+func AttributionByOrgPatternID(
+	patterns []*coredata.TrackerPattern,
+	commons coredata.CommonTrackerPatterns,
+) map[gid.GID]coredata.CommonTrackerPatternAttribution {
+	byCommon := make(map[gid.GID]coredata.CommonTrackerPatternAttribution, len(commons))
+	for _, common := range commons {
+		byCommon[common.ID] = common.Attribution
+	}
+
+	out := make(map[gid.GID]coredata.CommonTrackerPatternAttribution)
+	for _, pattern := range patterns {
+		if pattern.CommonTrackerPatternID == nil {
+			continue
+		}
+
+		attribution, ok := byCommon[*pattern.CommonTrackerPatternID]
+		if !ok {
+			continue
+		}
+
+		out[pattern.ID] = attribution
+	}
+
+	return out
+}
+
+func NewListTrackerPatternsOutput(
+	pg *page.Page[*coredata.TrackerPattern, coredata.TrackerPatternOrderField],
+	attributions map[gid.GID]coredata.CommonTrackerPatternAttribution,
+) ListTrackerPatternsOutput {
 	patterns := make([]*TrackerPattern, 0, len(pg.Data))
 	for _, p := range pg.Data {
-		patterns = append(patterns, NewTrackerPattern(p))
+		var attribution *coredata.CommonTrackerPatternAttribution
+		if a, ok := attributions[p.ID]; ok {
+			attribution = &a
+		}
+
+		patterns = append(patterns, NewTrackerPatternWithAttribution(p, attribution))
 	}
 
 	var nextCursor *page.CursorKey

--- a/pkg/server/api/mcp/v1/types/tracker_pattern.go
+++ b/pkg/server/api/mcp/v1/types/tracker_pattern.go
@@ -40,6 +40,7 @@ func NewTrackerPatternWithAttribution(
 	}
 
 	var mapped *TrackerPatternAttribution
+
 	if attribution != nil {
 		value := TrackerPatternAttribution(*attribution)
 		mapped = &value
@@ -78,6 +79,7 @@ func AttributionByOrgPatternID(
 	}
 
 	out := make(map[gid.GID]coredata.CommonTrackerPatternAttribution)
+
 	for _, pattern := range patterns {
 		if pattern.CommonTrackerPatternID == nil {
 			continue


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Shows catalog attribution on tracker patterns end-to-end and makes catalog cleanup safer. Previously patterns without a vendor rendered “-”; now we display the inherited verdict (FIRST_PARTY, THIRD_PARTY, NOT_ATTRIBUTABLE, UNDETERMINED), gate it behind the same catalog permission, and keep reviewed catalog rows out of prune; use review <slug> unreviewed first if one must go.

### App: console **`+83`** **`-2`**
- Adds a badge showing attribution in list and detail views with new i18n strings, including THIRD_PARTY and UNDETERMINED.
- Fixes the missing THIRD_PARTY case and makes the switch exhaustive to avoid silent fallthroughs.

### GraphQL API **`+65`** **`-1`**
- Adds CommonTrackerPatternAttribution and TrackerPattern.attribution inheriting the catalog verdict or null when unlinked.
- Enforces the same authorization as commonThirdParty before resolving attribution.

### MCP **`+168`** **`-8`**
- Returns attribution in list/get/add/update/move tools and maps catalog verdicts to org patterns.
- Updates the spec and types; centralizes attribution resolution for single and paged responses.

### prb (CLI) **`+15`** **`-2`**
- tracker-pattern list adds an ATTRIBUTION column.
- tracker-pattern view prints the Attribution line when present.

### proboctl **`+245`** **`-13`**
- commonthirdparty list --with-patterns shows key summaries ordered by confidence with storage kind abbreviations (incl. cache storage) and review state.
- show prints review state and rejection verdict; prune skips any reviewed row.
- Removes a duplicate PowerLinks seed entry.

### Coredata **`+86`** **`-0`**
- Adds PatternSummary and a grouped loader by common third party for efficient listing summaries.
- Resolves duplicate domain ownership deterministically by ordering on created_at and id.

### Package: n8n-node **`+6`** **`-0`**
- trackerPattern.get and getAll include attribution with release notes in `@probo/n8n-nodes-probo`.

### Tests **`+304`** **`-1`**
- E2E covers null vs inherited attribution.
- Unit tests cover grouped summaries and the reviewed-row prune guard.

### Other **`+115`** **`-9`**
- Example app adds `loglevel`, labels headless actions, logs tab and banner events, and persists named loggers after probo-ready.

<sup>Written for commit d996bd7fffca013d2b505e794432508bbf380179. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

