### PR TITLE
Add versioned IAB GVL catalog tables

### DIFF
--- a/pkg/coredata/common_gvl_snapshot.go
+++ b/pkg/coredata/common_gvl_snapshot.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+type (
+	CommonGVLSnapshot struct {
+		ID                      gid.GID         `db:"id"`
+		VendorListVersion       int             `db:"vendor_list_version"`
+		GVLSpecificationVersion int             `db:"gvl_specification_version"`
+		TCFPolicyVersion        int             `db:"tcf_policy_version"`
+		LastUpdated             time.Time       `db:"last_updated"`
+		FetchedAt               time.Time       `db:"fetched_at"`
+		Payload                 json.RawMessage `db:"payload"`
+	}
+)
+
+func (s *CommonGVLSnapshot) LoadByVendorListVersion(
+	ctx context.Context,
+	conn pg.Querier,
+	version int,
+) error {
+	q := `
+SELECT
+    id,
+    vendor_list_version,
+    gvl_specification_version,
+    tcf_policy_version,
+    last_updated,
+    fetched_at,
+    payload
+FROM
+    common_gvl_snapshots
+WHERE
+    vendor_list_version = @vendor_list_version
+LIMIT 1;
+`
+
+	args := pgx.StrictNamedArgs{"vendor_list_version": version}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query common gvl snapshot: %w", err)
+	}
+
+	row, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[CommonGVLSnapshot])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect common gvl snapshot: %w", err)
+	}
+
+	*s = row
+
+	return nil
+}
+
+func (s *CommonGVLSnapshot) Insert(
+	ctx context.Context,
+	conn pg.Querier,
+) error {
+	q := `
+INSERT INTO common_gvl_snapshots (
+    id,
+    vendor_list_version,
+    gvl_specification_version,
+    tcf_policy_version,
+    last_updated,
+    fetched_at,
+    payload
+) VALUES (
+    @id,
+    @vendor_list_version,
+    @gvl_specification_version,
+    @tcf_policy_version,
+    @last_updated,
+    @fetched_at,
+    @payload
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":                        s.ID,
+		"vendor_list_version":       s.VendorListVersion,
+		"gvl_specification_version": s.GVLSpecificationVersion,
+		"tcf_policy_version":        s.TCFPolicyVersion,
+		"last_updated":              s.LastUpdated,
+		"fetched_at":                s.FetchedAt,
+		"payload":                   s.Payload,
+	}
+
+	if _, err := conn.Exec(ctx, q, args); err != nil {
+		return fmt.Errorf("cannot insert common gvl snapshot: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/common_gvl_state.go
+++ b/pkg/coredata/common_gvl_state.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	CommonGVLState struct {
+		LatestVendorListVersion *int      `db:"latest_vendor_list_version"`
+		ETag                    *string   `db:"etag"`
+		CacheMaxAgeSeconds      *int      `db:"cache_max_age_seconds"`
+		LastFetchedAt           time.Time `db:"last_fetched_at"`
+	}
+)
+
+func (s *CommonGVLState) Load(
+	ctx context.Context,
+	conn pg.Querier,
+) error {
+	q := `
+SELECT
+    latest_vendor_list_version,
+    etag,
+    cache_max_age_seconds,
+    last_fetched_at
+FROM
+    common_gvl_state
+WHERE
+    singleton
+LIMIT 1;
+`
+
+	rows, err := conn.Query(ctx, q)
+	if err != nil {
+		return fmt.Errorf("cannot query common gvl state: %w", err)
+	}
+
+	row, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[CommonGVLState])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect common gvl state: %w", err)
+	}
+
+	*s = row
+
+	return nil
+}
+
+func (s *CommonGVLState) Upsert(
+	ctx context.Context,
+	conn pg.Querier,
+) error {
+	q := `
+INSERT INTO common_gvl_state (
+    singleton,
+    latest_vendor_list_version,
+    etag,
+    cache_max_age_seconds,
+    last_fetched_at
+) VALUES (
+    TRUE,
+    @latest_vendor_list_version,
+    @etag,
+    @cache_max_age_seconds,
+    @last_fetched_at
+)
+ON CONFLICT (singleton) DO UPDATE
+SET
+    latest_vendor_list_version = EXCLUDED.latest_vendor_list_version,
+    etag                       = EXCLUDED.etag,
+    cache_max_age_seconds      = EXCLUDED.cache_max_age_seconds,
+    last_fetched_at            = EXCLUDED.last_fetched_at
+`
+
+	args := pgx.StrictNamedArgs{
+		"latest_vendor_list_version": s.LatestVendorListVersion,
+		"etag":                       s.ETag,
+		"cache_max_age_seconds":      s.CacheMaxAgeSeconds,
+		"last_fetched_at":            s.LastFetchedAt,
+	}
+
+	if _, err := conn.Exec(ctx, q, args); err != nil {
+		return fmt.Errorf("cannot upsert common gvl state: %w", err)
+	}
+
+	return nil
+}
+
+// IsFresh reports whether a previous fetch is still inside IAB's Cache-Control
+// max-age, so a new HTTP request should not be made.
+func (s CommonGVLState) IsFresh(now time.Time) bool {
+	if s.LastFetchedAt.IsZero() || s.CacheMaxAgeSeconds == nil || *s.CacheMaxAgeSeconds <= 0 {
+		return false
+	}
+
+	return now.Before(s.LastFetchedAt.Add(time.Duration(*s.CacheMaxAgeSeconds) * time.Second))
+}

--- a/pkg/coredata/common_gvl_vendor.go
+++ b/pkg/coredata/common_gvl_vendor.go
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+type (
+	CommonGVLVendor struct {
+		ID                  gid.GID    `db:"id"`
+		IABVendorID         int        `db:"iab_vendor_id"`
+		VendorListVersion   int        `db:"vendor_list_version"`
+		Name                string     `db:"name"`
+		DeletedDate         *time.Time `db:"deleted_date"`
+		Purposes            []int32    `db:"purposes"`
+		LegIntPurposes      []int32    `db:"leg_int_purposes"`
+		FlexiblePurposes    []int32    `db:"flexible_purposes"`
+		SpecialPurposes     []int32    `db:"special_purposes"`
+		Features            []int32    `db:"features"`
+		SpecialFeatures     []int32    `db:"special_features"`
+		PolicyURL           *string    `db:"policy_url"`
+		UsesCookies         *bool      `db:"uses_cookies"`
+		CookieRefresh       *bool      `db:"cookie_refresh"`
+		UsesNonCookieAccess *bool      `db:"uses_non_cookie_access"`
+		CookieMaxAgeSeconds *int       `db:"cookie_max_age_seconds"`
+		CreatedAt           time.Time  `db:"created_at"`
+		UpdatedAt           time.Time  `db:"updated_at"`
+	}
+)
+
+func (v *CommonGVLVendor) LoadByIABVendorID(
+	ctx context.Context,
+	conn pg.Querier,
+	iabVendorID int,
+) error {
+	q := `
+SELECT
+    id,
+    iab_vendor_id,
+    vendor_list_version,
+    name,
+    deleted_date,
+    purposes,
+    leg_int_purposes,
+    flexible_purposes,
+    special_purposes,
+    features,
+    special_features,
+    policy_url,
+    uses_cookies,
+    cookie_refresh,
+    uses_non_cookie_access,
+    cookie_max_age_seconds,
+    created_at,
+    updated_at
+FROM
+    common_gvl_vendors
+WHERE
+    iab_vendor_id = @iab_vendor_id
+LIMIT 1;
+`
+
+	args := pgx.StrictNamedArgs{"iab_vendor_id": iabVendorID}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query common gvl vendor: %w", err)
+	}
+
+	row, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[CommonGVLVendor])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect common gvl vendor: %w", err)
+	}
+
+	*v = row
+
+	return nil
+}
+
+func (v *CommonGVLVendor) Upsert(
+	ctx context.Context,
+	conn pg.Querier,
+) (inserted bool, err error) {
+	q := `
+INSERT INTO common_gvl_vendors (
+    id,
+    iab_vendor_id,
+    vendor_list_version,
+    name,
+    deleted_date,
+    purposes,
+    leg_int_purposes,
+    flexible_purposes,
+    special_purposes,
+    features,
+    special_features,
+    policy_url,
+    uses_cookies,
+    cookie_refresh,
+    uses_non_cookie_access,
+    cookie_max_age_seconds,
+    created_at,
+    updated_at
+) VALUES (
+    @id,
+    @iab_vendor_id,
+    @vendor_list_version,
+    @name,
+    @deleted_date,
+    @purposes,
+    @leg_int_purposes,
+    @flexible_purposes,
+    @special_purposes,
+    @features,
+    @special_features,
+    @policy_url,
+    @uses_cookies,
+    @cookie_refresh,
+    @uses_non_cookie_access,
+    @cookie_max_age_seconds,
+    @created_at,
+    @updated_at
+)
+ON CONFLICT (iab_vendor_id) DO UPDATE
+SET
+    vendor_list_version    = EXCLUDED.vendor_list_version,
+    name                   = EXCLUDED.name,
+    deleted_date           = EXCLUDED.deleted_date,
+    purposes               = EXCLUDED.purposes,
+    leg_int_purposes       = EXCLUDED.leg_int_purposes,
+    flexible_purposes      = EXCLUDED.flexible_purposes,
+    special_purposes       = EXCLUDED.special_purposes,
+    features               = EXCLUDED.features,
+    special_features       = EXCLUDED.special_features,
+    policy_url             = EXCLUDED.policy_url,
+    uses_cookies           = EXCLUDED.uses_cookies,
+    cookie_refresh         = EXCLUDED.cookie_refresh,
+    uses_non_cookie_access = EXCLUDED.uses_non_cookie_access,
+    cookie_max_age_seconds = EXCLUDED.cookie_max_age_seconds,
+    updated_at             = EXCLUDED.updated_at
+RETURNING
+    id,
+    iab_vendor_id,
+    vendor_list_version,
+    name,
+    deleted_date,
+    purposes,
+    leg_int_purposes,
+    flexible_purposes,
+    special_purposes,
+    features,
+    special_features,
+    policy_url,
+    uses_cookies,
+    cookie_refresh,
+    uses_non_cookie_access,
+    cookie_max_age_seconds,
+    created_at,
+    updated_at
+`
+
+	originalID := v.ID
+
+	args := pgx.StrictNamedArgs{
+		"id":                     v.ID,
+		"iab_vendor_id":          v.IABVendorID,
+		"vendor_list_version":    v.VendorListVersion,
+		"name":                   v.Name,
+		"deleted_date":           v.DeletedDate,
+		"purposes":               emptyInt32s(v.Purposes),
+		"leg_int_purposes":       emptyInt32s(v.LegIntPurposes),
+		"flexible_purposes":      emptyInt32s(v.FlexiblePurposes),
+		"special_purposes":       emptyInt32s(v.SpecialPurposes),
+		"features":               emptyInt32s(v.Features),
+		"special_features":       emptyInt32s(v.SpecialFeatures),
+		"policy_url":             v.PolicyURL,
+		"uses_cookies":           v.UsesCookies,
+		"cookie_refresh":         v.CookieRefresh,
+		"uses_non_cookie_access": v.UsesNonCookieAccess,
+		"cookie_max_age_seconds": v.CookieMaxAgeSeconds,
+		"created_at":             v.CreatedAt,
+		"updated_at":             v.UpdatedAt,
+	}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return false, fmt.Errorf("cannot upsert common gvl vendor: %w", err)
+	}
+	defer rows.Close()
+
+	row, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[CommonGVLVendor])
+	if err != nil {
+		return false, fmt.Errorf("cannot collect upserted common gvl vendor: %w", err)
+	}
+
+	*v = row
+
+	return v.ID == originalID, nil
+}
+
+func emptyInt32s(values []int32) []int32 {
+	if values == nil {
+		return []int32{}
+	}
+
+	return values
+}

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -159,6 +159,8 @@ const (
 	BotMessageEntityType                             uint16 = 127
 	BotThreadSubjectEntityType                       uint16 = 128
 	TreatmentPlanEntityType                          uint16 = 129
+	CommonGVLSnapshotEntityType                      uint16 = 130
+	CommonGVLVendorEntityType                        uint16 = 131
 )
 
 func NewEntityFromID(id gid.GID) (any, bool) {
@@ -403,6 +405,10 @@ func NewEntityFromID(id gid.GID) (any, bool) {
 		return &BotThreadSubject{ID: id}, true
 	case TreatmentPlanEntityType:
 		return &TreatmentPlan{ID: id}, true
+	case CommonGVLSnapshotEntityType:
+		return &CommonGVLSnapshot{ID: id}, true
+	case CommonGVLVendorEntityType:
+		return &CommonGVLVendor{ID: id}, true
 	default:
 		return nil, false
 	}

--- a/pkg/coredata/migrations/20260825T133500Z.sql
+++ b/pkg/coredata/migrations/20260825T133500Z.sql
@@ -1,0 +1,58 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+CREATE TABLE common_gvl_snapshots (
+    id                        TEXT PRIMARY KEY,
+    vendor_list_version       INTEGER NOT NULL UNIQUE,
+    gvl_specification_version INTEGER NOT NULL,
+    tcf_policy_version        INTEGER NOT NULL,
+    last_updated              TIMESTAMP WITH TIME ZONE NOT NULL,
+    fetched_at                TIMESTAMP WITH TIME ZONE NOT NULL,
+    payload                   JSONB NOT NULL
+);
+
+CREATE TABLE common_gvl_state (
+    singleton                  BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    latest_vendor_list_version INTEGER REFERENCES common_gvl_snapshots (vendor_list_version),
+    etag                       TEXT,
+    cache_max_age_seconds      INTEGER,
+    last_fetched_at            TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE TABLE common_gvl_vendors (
+    id                    TEXT PRIMARY KEY,
+    iab_vendor_id         INTEGER NOT NULL UNIQUE,
+    vendor_list_version   INTEGER NOT NULL REFERENCES common_gvl_snapshots (vendor_list_version),
+    name                  TEXT NOT NULL,
+    deleted_date          TIMESTAMP WITH TIME ZONE,
+    purposes              INTEGER[] NOT NULL DEFAULT '{}',
+    leg_int_purposes      INTEGER[] NOT NULL DEFAULT '{}',
+    flexible_purposes     INTEGER[] NOT NULL DEFAULT '{}',
+    special_purposes      INTEGER[] NOT NULL DEFAULT '{}',
+    features              INTEGER[] NOT NULL DEFAULT '{}',
+    special_features      INTEGER[] NOT NULL DEFAULT '{}',
+    policy_url            TEXT,
+    uses_cookies          BOOLEAN,
+    cookie_refresh        BOOLEAN,
+    uses_non_cookie_access BOOLEAN,
+    cookie_max_age_seconds INTEGER,
+    created_at            TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at            TIMESTAMP WITH TIME ZONE NOT NULL
+);


### PR DESCRIPTION
Closes https://linear.app/probo/issue/ENG-783/import-gvl-command


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds versioned IAB GVL storage and coredata models to keep immutable vendor-list snapshots, a latest fetch state, and per-vendor records. This lets TCF resolve IAB vendor IDs without merging them into the common third-party register; a schema migration is required.

### Coredata **`+555`** **`-0`**
- Adds SQL migration creating `common_gvl_snapshots`, `common_gvl_state` (singleton), and `common_gvl_vendors` (FK to snapshots, unique `iab_vendor_id`).
- Introduces `CommonGVLSnapshot` with load-by-version and insert helpers.
- Introduces `CommonGVLState` with load/upsert helpers and an `IsFresh` cache check based on `Cache-Control`.
- Introduces `CommonGVLVendor` with load-by-IAB ID and upsert that updates on conflict by `iab_vendor_id`.
- Registers `CommonGVLSnapshot` and `CommonGVLVendor` entity types in the ID registry.
- Rollout: apply migration `20260825T133500Z.sql` before deploying; no backfill is required.

<sup>Written for commit ea358a7462882a44a06a4983ef2c093151015a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



