### PR TITLE
Add fork for risk analyses

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -2509,7 +2509,7 @@
     "messages": { "error": "Error" },
     "errors": { "delete": "Failed to delete risk analysis" },
     "deleteConfirmation": "This will permanently delete this risk analysis and all its diagrams, nodes, processes, and threats. This action cannot be undone.",
-    "actions": { "edit": "Edit", "delete": "Delete", "showMore": "Show more" },
+    "actions": { "fork": "Fork", "edit": "Edit", "delete": "Delete", "showMore": "Show more" },
     "details": "Details",
     "fields": { "period": "Period", "matrixSize": "Matrix size", "createdAt": "Created at", "updatedAt": "Updated at" },
     "diagrams": "Diagrams",
@@ -2521,7 +2521,8 @@
     "title": "Risk Analyses",
     "description": "Manage risk analyses with diagrams, nodes, processes, threats, and scenarios.",
     "columns": { "name": "Name", "description": "Description", "period": "Period", "matrixSize": "Matrix", "created": "Created" },
-    "empty": "No risk analyses yet."
+    "empty": "No risk analyses yet.",
+    "actions": { "fork": "Fork" }
   },
   "riskAnalysisBoundaryActions": {
     "breadcrumb": { "boundaries": "Boundaries" },
@@ -2565,6 +2566,17 @@
     },
     "placeholders": { "name": "e.g. Platform Threat Model 2026", "description": "Describe the scope and purpose of this assessment..." },
     "actions": { "create": "Create" }
+  },
+  "forkRiskAnalysisDialog": {
+    "title": "Fork Risk Analysis",
+    "breadcrumb": { "riskAnalyses": "Risk Analyses" },
+    "fields": { "name": "Name", "description": "Description", "matrixSize": "Matrix size", "periodStart": "Period start", "periodEnd": "Period end" },
+    "validation": {
+      "nameRequired": "This field is required",
+      "periodEndBeforeStart": "Period end must be on or after period start"
+    },
+    "placeholders": { "name": "e.g. Platform Threat Model 2026", "description": "Describe the scope and purpose of this assessment..." },
+    "actions": { "fork": "Fork" }
   },
   "updateRiskAnalysisDialog": {
     "title": "Edit Risk Analysis",

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -4803,6 +4803,7 @@
     "actions": {
       "edit": "Modifier",
       "delete": "Supprimer",
+      "fork": "Fork",
       "showMore": "Afficher plus"
     },
     "details": "Détails",
@@ -4830,7 +4831,10 @@
       "matrixSize": "Matrice",
       "created": "Créé le"
     },
-    "empty": "Aucune analyse des risques pour le moment."
+    "empty": "Aucune analyse des risques pour le moment.",
+    "actions": {
+      "fork": "Fork"
+    }
   },
   "riskAnalysisBoundaryActions": {
     "breadcrumb": {
@@ -4941,6 +4945,30 @@
     },
     "actions": {
       "create": "Créer"
+    }
+  },
+  "forkRiskAnalysisDialog": {
+    "title": "Fork de l’analyse des risques",
+    "breadcrumb": {
+      "riskAnalyses": "Analyses des risques"
+    },
+    "fields": {
+      "name": "Nom",
+      "description": "Description",
+      "matrixSize": "Taille de matrice",
+      "periodStart": "Début de période",
+      "periodEnd": "Fin de période"
+    },
+    "validation": {
+      "nameRequired": "Ce champ est requis",
+      "periodEndBeforeStart": "La fin de période doit être égale ou postérieure au début"
+    },
+    "placeholders": {
+      "name": "ex. Modèle de menace de la plateforme 2026",
+      "description": "Décrivez la portée et l’objectif de cette analyse..."
+    },
+    "actions": {
+      "fork": "Fork"
     }
   },
   "updateRiskAnalysisDialog": {

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -4793,6 +4793,7 @@
     "actions": {
       "edit": "Bewerken",
       "delete": "Verwijderen",
+      "fork": "Forken",
       "showMore": "Meer tonen"
     },
     "details": "Details",
@@ -4820,7 +4821,10 @@
       "matrixSize": "Matrix",
       "created": "Aangemaakt"
     },
-    "empty": "Nog geen risicobeoordelingen."
+    "empty": "Nog geen risicobeoordelingen.",
+    "actions": {
+      "fork": "Forken"
+    }
   },
   "riskAnalysisBoundaryActions": {
     "breadcrumb": {
@@ -4931,6 +4935,30 @@
     },
     "actions": {
       "create": "Aanmaken"
+    }
+  },
+  "forkRiskAnalysisDialog": {
+    "title": "Risicobeoordeling forken",
+    "breadcrumb": {
+      "riskAnalyses": "Risicobeoordelingen"
+    },
+    "fields": {
+      "name": "Naam",
+      "description": "Beschrijving",
+      "matrixSize": "Matrixgrootte",
+      "periodStart": "Periode start",
+      "periodEnd": "Periode eind"
+    },
+    "validation": {
+      "nameRequired": "Dit veld is verplicht",
+      "periodEndBeforeStart": "Periode eind moet op of na periode start liggen"
+    },
+    "placeholders": {
+      "name": "bijv. Platform Dreigingsmodel 2026",
+      "description": "Beschrijf de reikwijdte en het doel van deze beoordeling..."
+    },
+    "actions": {
+      "fork": "Forken"
     }
   },
   "updateRiskAnalysisDialog": {

--- a/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysesPage.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysesPage.tsx
@@ -19,7 +19,6 @@
 // SOFTWARE.
 
 import { usePageTitle } from "@probo/hooks";
-import { dateFormat } from "@probo/i18n";
 import {
   PageHeader,
   Tbody,
@@ -40,10 +39,9 @@ import type { RiskAnalysesPageFragment$key } from "#/__generated__/core/RiskAnal
 import type { RiskAnalysesPageQuery } from "#/__generated__/core/RiskAnalysesPageQuery.graphql";
 import type { RiskAnalysesPageRefetchQuery } from "#/__generated__/core/RiskAnalysesPageRefetchQuery.graphql";
 import { SortableTable, SortableTh } from "#/components/SortableTable";
-import { useOrganizationId } from "#/hooks/useOrganizationId";
 
 import { CreateRiskAnalysisDialog } from "./_components/CreateRiskAnalysisDialog";
-import { formatMatrixSize } from "./_components/matrixSize";
+import { RiskAnalysisListItem } from "./_components/RiskAnalysisListItem";
 
 export const riskAnalysesPageQuery = graphql`
   query RiskAnalysesPageQuery($organizationId: ID!) {
@@ -85,17 +83,7 @@ const riskAnalysesFragment = graphql`
       edges {
         node {
           id
-          name
-          description
-          period {
-            start
-            end
-          }
-          matrixSize {
-            rows
-            cols
-          }
-          createdAt
+          ...RiskAnalysisListItem_riskAnalysis
         }
       }
     }
@@ -107,8 +95,7 @@ interface RiskAnalysesPageProps {
 }
 
 export default function RiskAnalysesPage({ queryRef }: RiskAnalysesPageProps) {
-  const { i18n, t } = useTranslation();
-  const organizationId = useOrganizationId();
+  const { t } = useTranslation();
 
   const data = usePreloadedQuery<RiskAnalysesPageQuery>(riskAnalysesPageQuery, queryRef);
   const { data: fragmentData, ...pagination } = usePaginationFragment<
@@ -164,37 +151,23 @@ export default function RiskAnalysesPage({ queryRef }: RiskAnalysesPageProps) {
             <SortableTh field="CREATED_AT">
               {t("riskAnalysesPage.columns.created")}
             </SortableTh>
+            <Th />
           </Tr>
         </Thead>
         <Tbody>
           {riskAnalyses.length === 0 && (
             <Tr>
-              <Td colSpan={5} className="text-center text-txt-secondary">
+              <Td colSpan={6} className="text-center text-txt-secondary">
                 {t("riskAnalysesPage.empty")}
               </Td>
             </Tr>
           )}
           {riskAnalyses.map(ra => (
-            <Tr
+            <RiskAnalysisListItem
               key={ra.id}
-              to={`/organizations/${organizationId}/risk-management/risk-analyses/${ra.id}/treatment-plans`}
-            >
-              <Td className="w-px whitespace-nowrap font-medium">{ra.name}</Td>
-              <Td className="text-txt-secondary max-w-md">
-                {ra.description || "—"}
-              </Td>
-              <Td className="w-px whitespace-nowrap text-txt-secondary">
-                {ra.period
-                  ? `${ra.period.start ? dateFormat(i18n.language, ra.period.start) : "—"} – ${ra.period.end ? dateFormat(i18n.language, ra.period.end) : "—"}`
-                  : "—"}
-              </Td>
-              <Td className="w-px whitespace-nowrap text-txt-secondary">
-                {formatMatrixSize(ra.matrixSize.rows, ra.matrixSize.cols)}
-              </Td>
-              <Td className="w-px whitespace-nowrap text-txt-secondary">
-                {dateFormat(i18n.language, ra.createdAt)}
-              </Td>
-            </Tr>
+              riskAnalysisKey={ra}
+              connectionId={connectionId}
+            />
           ))}
         </Tbody>
       </SortableTable>

--- a/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysisDetailLayout.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysisDetailLayout.tsx
@@ -21,14 +21,10 @@
 import { usePageTitle } from "@probo/hooks";
 import { dateFormat } from "@probo/i18n";
 import {
-  ActionDropdown,
   Card,
-  DropdownItem,
-  IconTrashCan,
   PageHeader,
   TabLink,
   Tabs,
-  useConfirm,
 } from "@probo/ui";
 import { useTranslation } from "react-i18next";
 import {
@@ -39,14 +35,12 @@ import {
 } from "react-relay";
 import { Outlet, useNavigate } from "react-router";
 
-import type { RiskAnalysisDetailLayoutDeleteMutation } from "#/__generated__/core/RiskAnalysisDetailLayoutDeleteMutation.graphql";
 import type { RiskAnalysisDetailLayoutQuery } from "#/__generated__/core/RiskAnalysisDetailLayoutQuery.graphql";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 import { NotFoundError } from "#/lib/relay/errors";
-import { useMutation } from "#/lib/relay/useMutation";
 
 import { formatMatrixSize } from "./_components/matrixSize";
-import { UpdateRiskAnalysisDialog } from "./_components/UpdateRiskAnalysisDialog";
+import { RiskAnalysisActions } from "./_components/RiskAnalysisActions";
 
 export const riskAnalysisDetailLayoutQuery = graphql`
   query RiskAnalysisDetailLayoutQuery($riskAnalysisId: ID!) {
@@ -66,20 +60,8 @@ export const riskAnalysisDetailLayoutQuery = graphql`
         }
         createdAt
         updatedAt
-        canUpdate: permission(action: "risk-management:risk-analysis:update")
-        canDelete: permission(action: "risk-management:risk-analysis:delete")
+        ...RiskAnalysisActions_riskAnalysis
       }
-    }
-  }
-`;
-
-const deleteMutation = graphql`
-  mutation RiskAnalysisDetailLayoutDeleteMutation(
-    $input: DeleteRiskAnalysisInput!
-    $connections: [ID!]!
-  ) {
-    deleteRiskAnalysis(input: $input) {
-      deletedRiskAnalysisId @deleteEdge(connections: $connections)
     }
   }
 `;
@@ -94,16 +76,11 @@ export default function RiskAnalysisDetailLayout({ queryRef }: RiskAnalysisDetai
   const { i18n, t } = useTranslation();
   const organizationId = useOrganizationId();
   const navigate = useNavigate();
-  const confirm = useConfirm();
   const data = usePreloadedQuery<RiskAnalysisDetailLayoutQuery>(
     riskAnalysisDetailLayoutQuery,
     queryRef,
   );
   const ra = data.node;
-  const [deleteRiskAnalysis] = useMutation<RiskAnalysisDetailLayoutDeleteMutation>(
-    deleteMutation,
-    { errorToast: t("riskAnalysisDetailPage.errors.delete") },
-  );
 
   usePageTitle(
     ra?.__typename === "RiskAnalysis"
@@ -126,52 +103,17 @@ export default function RiskAnalysisDetailLayout({ queryRef }: RiskAnalysisDetai
     ? `${ra.period.start ? dateFormat(i18n.language, ra.period.start) : "—"} – ${ra.period.end ? dateFormat(i18n.language, ra.period.end) : "—"}`
     : "—";
 
-  const handleDelete = () => {
-    confirm(
-      async () => {
-        await deleteRiskAnalysis({
-          variables: {
-            input: { riskAnalysisId: raId },
-            connections: [listConnectionId],
-          },
-        });
-        void navigate(listUrl);
-      },
-      { message: t("riskAnalysisDetailPage.deleteConfirmation") },
-    );
-  };
-
   return (
     <div className="space-y-6">
       <PageHeader title={ra.name} description={ra.description}>
-        {ra.canUpdate
-          ? (
-              <UpdateRiskAnalysisDialog
-                riskAnalysis={{
-                  id: raId,
-                  name: ra.name ?? "",
-                  description: ra.description,
-                  period: ra.period
-                    ? { start: ra.period.start, end: ra.period.end }
-                    : ra.period,
-                }}
-                canDelete={ra.canDelete}
-                onDelete={handleDelete}
-              />
-            )
-          : ra.canDelete
-            ? (
-                <ActionDropdown variant="secondary">
-                  <DropdownItem
-                    variant="danger"
-                    icon={IconTrashCan}
-                    onClick={handleDelete}
-                  >
-                    {t("riskAnalysisDetailPage.actions.delete")}
-                  </DropdownItem>
-                </ActionDropdown>
-              )
-            : null}
+        <RiskAnalysisActions
+          riskAnalysisKey={ra}
+          connectionId={listConnectionId}
+          variant="secondary"
+          onDeleted={() => {
+            void navigate(listUrl);
+          }}
+        />
       </PageHeader>
 
       <Card padded>

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_components/ForkRiskAnalysisDialog.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_components/ForkRiskAnalysisDialog.tsx
@@ -26,32 +26,37 @@ import {
   DialogContent,
   DialogFooter,
   Field,
-  IconPlusLarge,
   Input,
-  Option,
   useDialogRef,
 } from "@probo/ui";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { graphql } from "react-relay";
+import { graphql, useFragment } from "react-relay";
 
-import type { CreateRiskAnalysisDialogCreateMutation } from "#/__generated__/core/CreateRiskAnalysisDialogCreateMutation.graphql";
-import { ControlledField } from "#/components/form/ControlledField";
-import { useOrganizationId } from "#/hooks/useOrganizationId";
+import type { ForkRiskAnalysisDialog_riskAnalysis$key } from "#/__generated__/core/ForkRiskAnalysisDialog_riskAnalysis.graphql";
+import type { ForkRiskAnalysisDialogMutation } from "#/__generated__/core/ForkRiskAnalysisDialogMutation.graphql";
 import { useMutation } from "#/lib/relay/useMutation";
 
-import {
-  matrixSizeFromOption,
-  type RiskAnalysisMatrixSizeOption,
-  riskAnalysisMatrixSizeOptions,
-} from "./matrixSize";
+import { formatMatrixSize } from "./matrixSize";
 
-const createMutation = graphql`
-  mutation CreateRiskAnalysisDialogCreateMutation(
-    $input: CreateRiskAnalysisInput!
+export const forkRiskAnalysisDialogFragment = graphql`
+  fragment ForkRiskAnalysisDialog_riskAnalysis on RiskAnalysis {
+    id
+    name
+    description
+    matrixSize {
+      rows
+      cols
+    }
+  }
+`;
+
+const forkMutation = graphql`
+  mutation ForkRiskAnalysisDialogMutation(
+    $input: ForkRiskAnalysisInput!
     $connections: [ID!]!
   ) {
-    createRiskAnalysis(input: $input) {
+    forkRiskAnalysis(input: $input) {
       riskAnalysisEdge @prependEdge(connections: $connections) {
         node {
           id
@@ -67,23 +72,30 @@ type FormData = {
   description: string;
   periodStart: string;
   periodEnd: string;
-  matrixSize: RiskAnalysisMatrixSizeOption;
 };
 
-export function CreateRiskAnalysisDialog(props: {
+interface ForkRiskAnalysisDialogProps {
+  riskAnalysisKey: ForkRiskAnalysisDialog_riskAnalysis$key;
   connectionId: string;
-}) {
+  dialogRef?: ReturnType<typeof useDialogRef>;
+}
+
+export function ForkRiskAnalysisDialog({
+  riskAnalysisKey,
+  connectionId,
+  dialogRef: dialogRefFromParent,
+}: ForkRiskAnalysisDialogProps) {
   const { t } = useTranslation();
-  const organizationId = useOrganizationId();
-  const dialogRef = useDialogRef();
-  const [createRiskAnalysis, isCreating] = useMutation<CreateRiskAnalysisDialogCreateMutation>(createMutation);
-  const { register, handleSubmit, reset, control, formState } = useForm<FormData>({
-    defaultValues: {
-      name: "",
-      description: "",
+  const localDialogRef = useDialogRef();
+  const dialogRef = dialogRefFromParent ?? localDialogRef;
+  const riskAnalysis = useFragment(forkRiskAnalysisDialogFragment, riskAnalysisKey);
+  const [forkRiskAnalysis, isForking] = useMutation<ForkRiskAnalysisDialogMutation>(forkMutation);
+  const { register, handleSubmit, formState } = useForm<FormData>({
+    values: {
+      name: riskAnalysis.name,
+      description: riskAnalysis.description ?? "",
       periodStart: "",
       periodEnd: "",
-      matrixSize: "5x5",
     },
   });
 
@@ -98,19 +110,17 @@ export function CreateRiskAnalysisDialog(props: {
       : null;
 
     try {
-      await createRiskAnalysis({
+      await forkRiskAnalysis({
         variables: {
           input: {
-            organizationId,
+            riskAnalysisId: riskAnalysis.id,
             name: data.name,
             description: data.description || null,
             period,
-            matrixSize: matrixSizeFromOption(data.matrixSize),
           },
-          connections: [props.connectionId],
+          connections: [connectionId],
         },
       });
-      reset();
       dialogRef.current?.close();
     } catch {
       // Error toast is handled by useMutation.
@@ -121,54 +131,48 @@ export function CreateRiskAnalysisDialog(props: {
     <Dialog
       className="max-w-lg"
       ref={dialogRef}
-      trigger={(
-        <Button icon={IconPlusLarge} variant="primary">
-          {t("createRiskAnalysisDialog.title")}
-        </Button>
-      )}
       title={(
         <Breadcrumb
-          items={[t("createRiskAnalysisDialog.breadcrumb.riskAnalyses"), t("createRiskAnalysisDialog.title")]}
+          items={[
+            t("forkRiskAnalysisDialog.breadcrumb.riskAnalyses"),
+            t("forkRiskAnalysisDialog.title"),
+          ]}
         />
       )}
     >
       <form onSubmit={e => void handleSubmit(onSubmit)(e)}>
         <DialogContent padded className="space-y-4">
           <Field
-            label={t("createRiskAnalysisDialog.fields.name")}
-            {...register("name", { required: t("createRiskAnalysisDialog.validation.nameRequired") })}
+            label={t("forkRiskAnalysisDialog.fields.name")}
+            {...register("name", { required: t("forkRiskAnalysisDialog.validation.nameRequired") })}
             type="text"
             error={formState.errors.name?.message}
-            placeholder={t("createRiskAnalysisDialog.placeholders.name")}
+            placeholder={t("forkRiskAnalysisDialog.placeholders.name")}
           />
           <Field
-            label={t("createRiskAnalysisDialog.fields.description")}
+            label={t("forkRiskAnalysisDialog.fields.description")}
             {...register("description")}
             type="textarea"
             rows={3}
-            placeholder={t("createRiskAnalysisDialog.placeholders.description")}
+            placeholder={t("forkRiskAnalysisDialog.placeholders.description")}
           />
-          <ControlledField
-            control={control}
-            name="matrixSize"
-            type="select"
-            label={t("createRiskAnalysisDialog.fields.matrixSize")}
-            rules={{ required: t("createRiskAnalysisDialog.validation.matrixSizeRequired") }}
-          >
-            {riskAnalysisMatrixSizeOptions.map(size => (
-              <Option key={size.key} value={size.key}>
-                {t(`createRiskAnalysisDialog.matrixSizes.${size.key}`)}
-              </Option>
-            ))}
-          </ControlledField>
           <Field
-            label={t("createRiskAnalysisDialog.fields.periodStart")}
+            disabled
+            label={t("forkRiskAnalysisDialog.fields.matrixSize")}
+            type="text"
+            value={formatMatrixSize(
+              riskAnalysis.matrixSize.rows,
+              riskAnalysis.matrixSize.cols,
+            )}
+          />
+          <Field
+            label={t("forkRiskAnalysisDialog.fields.periodStart")}
             error={formState.errors.periodStart?.message}
           >
             <Input {...register("periodStart")} type="date" />
           </Field>
           <Field
-            label={t("createRiskAnalysisDialog.fields.periodEnd")}
+            label={t("forkRiskAnalysisDialog.fields.periodEnd")}
             error={formState.errors.periodEnd?.message}
           >
             <Input
@@ -177,15 +181,15 @@ export function CreateRiskAnalysisDialog(props: {
                   !value
                   || !formValues.periodStart
                   || value >= formValues.periodStart
-                  || t("createRiskAnalysisDialog.validation.periodEndBeforeStart"),
+                  || t("forkRiskAnalysisDialog.validation.periodEndBeforeStart"),
               })}
               type="date"
             />
           </Field>
         </DialogContent>
         <DialogFooter>
-          <Button type="submit" disabled={isCreating}>
-            {t("createRiskAnalysisDialog.actions.create")}
+          <Button type="submit" disabled={isForking}>
+            {t("forkRiskAnalysisDialog.actions.fork")}
           </Button>
         </DialogFooter>
       </form>

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_components/RiskAnalysisActions.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_components/RiskAnalysisActions.tsx
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { GitForkIcon } from "@phosphor-icons/react";
+import {
+  ActionDropdown,
+  DropdownItem,
+  IconPencil,
+  IconTrashCan,
+  useConfirm,
+  useDialogRef,
+} from "@probo/ui";
+import type { ComponentProps } from "react";
+import { useTranslation } from "react-i18next";
+import { graphql, useFragment } from "react-relay";
+
+import type { RiskAnalysisActions_riskAnalysis$key } from "#/__generated__/core/RiskAnalysisActions_riskAnalysis.graphql";
+import type { RiskAnalysisActionsDeleteMutation } from "#/__generated__/core/RiskAnalysisActionsDeleteMutation.graphql";
+import { useMutation } from "#/lib/relay/useMutation";
+
+import { ForkRiskAnalysisDialog } from "./ForkRiskAnalysisDialog";
+import { UpdateRiskAnalysisDialog } from "./UpdateRiskAnalysisDialog";
+
+const riskAnalysisActionsFragment = graphql`
+  fragment RiskAnalysisActions_riskAnalysis on RiskAnalysis {
+    id
+    canUpdate: permission(action: "risk-management:risk-analysis:update")
+    canDelete: permission(action: "risk-management:risk-analysis:delete")
+    organization {
+      id
+      canCreateRiskAnalysis: permission(action: "risk-management:risk-analysis:create")
+    }
+    ...ForkRiskAnalysisDialog_riskAnalysis
+    ...UpdateRiskAnalysisDialog_riskAnalysis
+  }
+`;
+
+const deleteMutation = graphql`
+  mutation RiskAnalysisActionsDeleteMutation(
+    $input: DeleteRiskAnalysisInput!
+    $connections: [ID!]!
+  ) {
+    deleteRiskAnalysis(input: $input) {
+      deletedRiskAnalysisId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+interface RiskAnalysisActionsProps {
+  riskAnalysisKey: RiskAnalysisActions_riskAnalysis$key;
+  connectionId: string;
+  variant?: ComponentProps<typeof ActionDropdown>["variant"];
+  onDeleted?: () => void;
+}
+
+export function RiskAnalysisActions({
+  riskAnalysisKey,
+  connectionId,
+  variant,
+  onDeleted,
+}: RiskAnalysisActionsProps) {
+  const { t } = useTranslation();
+  const confirm = useConfirm();
+  const forkDialogRef = useDialogRef();
+  const editDialogRef = useDialogRef();
+  const riskAnalysis = useFragment(riskAnalysisActionsFragment, riskAnalysisKey);
+  const [deleteRiskAnalysis] = useMutation<RiskAnalysisActionsDeleteMutation>(
+    deleteMutation,
+    { errorToast: t("riskAnalysisDetailPage.errors.delete") },
+  );
+  const canFork = riskAnalysis.organization?.canCreateRiskAnalysis ?? false;
+
+  if (!canFork && !riskAnalysis.canUpdate && !riskAnalysis.canDelete) {
+    return null;
+  }
+
+  const handleDelete = () => {
+    confirm(
+      async () => {
+        await deleteRiskAnalysis({
+          variables: {
+            input: { riskAnalysisId: riskAnalysis.id },
+            connections: [connectionId],
+          },
+        });
+        onDeleted?.();
+      },
+      { message: t("riskAnalysisDetailPage.deleteConfirmation") },
+    );
+  };
+
+  return (
+    <>
+      {canFork && (
+        <ForkRiskAnalysisDialog
+          riskAnalysisKey={riskAnalysis}
+          connectionId={connectionId}
+          dialogRef={forkDialogRef}
+        />
+      )}
+      {riskAnalysis.canUpdate && (
+        <UpdateRiskAnalysisDialog
+          riskAnalysisKey={riskAnalysis}
+          dialogRef={editDialogRef}
+        />
+      )}
+      <ActionDropdown variant={variant}>
+        {canFork && (
+          <DropdownItem
+            icon={GitForkIcon}
+            onSelect={() => forkDialogRef.current?.open()}
+          >
+            {t("riskAnalysesPage.actions.fork")}
+          </DropdownItem>
+        )}
+        {riskAnalysis.canUpdate && (
+          <DropdownItem
+            icon={IconPencil}
+            onSelect={() => editDialogRef.current?.open()}
+          >
+            {t("riskAnalysisDetailPage.actions.edit")}
+          </DropdownItem>
+        )}
+        {riskAnalysis.canDelete && (
+          <DropdownItem
+            variant="danger"
+            icon={IconTrashCan}
+            onSelect={handleDelete}
+          >
+            {t("riskAnalysisDetailPage.actions.delete")}
+          </DropdownItem>
+        )}
+      </ActionDropdown>
+    </>
+  );
+}

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_components/RiskAnalysisListItem.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_components/RiskAnalysisListItem.tsx
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { dateFormat } from "@probo/i18n";
+import {
+  Td,
+  Tr,
+} from "@probo/ui";
+import { useTranslation } from "react-i18next";
+import { graphql, useFragment } from "react-relay";
+
+import type { RiskAnalysisListItem_riskAnalysis$key } from "#/__generated__/core/RiskAnalysisListItem_riskAnalysis.graphql";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+
+import { formatMatrixSize } from "./matrixSize";
+import { RiskAnalysisActions } from "./RiskAnalysisActions";
+
+const riskAnalysisListItemFragment = graphql`
+  fragment RiskAnalysisListItem_riskAnalysis on RiskAnalysis {
+    id
+    name
+    description
+    period {
+      start
+      end
+    }
+    matrixSize {
+      rows
+      cols
+    }
+    createdAt
+    ...RiskAnalysisActions_riskAnalysis
+  }
+`;
+
+interface RiskAnalysisListItemProps {
+  riskAnalysisKey: RiskAnalysisListItem_riskAnalysis$key;
+  connectionId: string;
+}
+
+export function RiskAnalysisListItem({
+  riskAnalysisKey,
+  connectionId,
+}: RiskAnalysisListItemProps) {
+  const { i18n } = useTranslation();
+  const organizationId = useOrganizationId();
+  const riskAnalysis = useFragment(riskAnalysisListItemFragment, riskAnalysisKey);
+
+  return (
+    <Tr
+      to={`/organizations/${organizationId}/risk-management/risk-analyses/${riskAnalysis.id}/treatment-plans`}
+    >
+      <Td className="w-px whitespace-nowrap font-medium">{riskAnalysis.name}</Td>
+      <Td className="text-txt-secondary max-w-md">
+        {riskAnalysis.description || "—"}
+      </Td>
+      <Td className="w-px whitespace-nowrap text-txt-secondary">
+        {riskAnalysis.period
+          ? `${riskAnalysis.period.start ? dateFormat(i18n.language, riskAnalysis.period.start) : "—"} – ${riskAnalysis.period.end ? dateFormat(i18n.language, riskAnalysis.period.end) : "—"}`
+          : "—"}
+      </Td>
+      <Td className="w-px whitespace-nowrap text-txt-secondary">
+        {formatMatrixSize(riskAnalysis.matrixSize.rows, riskAnalysis.matrixSize.cols)}
+      </Td>
+      <Td className="w-px whitespace-nowrap text-txt-secondary">
+        {dateFormat(i18n.language, riskAnalysis.createdAt)}
+      </Td>
+      <Td noLink width={50} className="w-px text-end">
+        <div onClick={event => event.stopPropagation()}>
+          <RiskAnalysisActions
+            riskAnalysisKey={riskAnalysis}
+            connectionId={connectionId}
+          />
+        </div>
+      </Td>
+    </Tr>
+  );
+}

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_components/UpdateRiskAnalysisDialog.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_components/UpdateRiskAnalysisDialog.tsx
@@ -20,25 +20,34 @@
 
 import { formatDatetime, toDateInput } from "@probo/helpers";
 import {
-  ActionDropdown,
   Breadcrumb,
   Button,
   Dialog,
   DialogContent,
   DialogFooter,
-  DropdownItem,
   Field,
-  IconPencil,
-  IconTrashCan,
   Input,
   useDialogRef,
 } from "@probo/ui";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { graphql } from "react-relay";
+import { graphql, useFragment } from "react-relay";
 
+import type { UpdateRiskAnalysisDialog_riskAnalysis$key } from "#/__generated__/core/UpdateRiskAnalysisDialog_riskAnalysis.graphql";
 import type { UpdateRiskAnalysisDialogMutation } from "#/__generated__/core/UpdateRiskAnalysisDialogMutation.graphql";
 import { useMutation } from "#/lib/relay/useMutation";
+
+export const updateRiskAnalysisDialogFragment = graphql`
+  fragment UpdateRiskAnalysisDialog_riskAnalysis on RiskAnalysis {
+    id
+    name
+    description
+    period {
+      start
+      end
+    }
+  }
+`;
 
 const updateMutation = graphql`
   mutation UpdateRiskAnalysisDialogMutation(
@@ -70,28 +79,24 @@ type FormData = {
   periodEnd: string;
 };
 
-export function UpdateRiskAnalysisDialog(props: {
-  riskAnalysis: {
-    id: string;
-    name: string;
-    description: string | null | undefined;
-    period: {
-      start: string | null | undefined;
-      end: string | null | undefined;
-    } | null | undefined;
-  };
-  canDelete?: boolean;
-  onDelete?: () => void;
-}) {
+interface UpdateRiskAnalysisDialogProps {
+  riskAnalysisKey: UpdateRiskAnalysisDialog_riskAnalysis$key;
+  dialogRef: ReturnType<typeof useDialogRef>;
+}
+
+export function UpdateRiskAnalysisDialog({
+  riskAnalysisKey,
+  dialogRef,
+}: UpdateRiskAnalysisDialogProps) {
   const { t } = useTranslation();
-  const dialogRef = useDialogRef();
+  const riskAnalysis = useFragment(updateRiskAnalysisDialogFragment, riskAnalysisKey);
   const [updateRiskAnalysis, isUpdating] = useMutation<UpdateRiskAnalysisDialogMutation>(updateMutation);
   const { register, handleSubmit, formState } = useForm<FormData>({
     values: {
-      name: props.riskAnalysis.name,
-      description: props.riskAnalysis.description ?? "",
-      periodStart: toDateInput(props.riskAnalysis.period?.start),
-      periodEnd: toDateInput(props.riskAnalysis.period?.end),
+      name: riskAnalysis.name,
+      description: riskAnalysis.description ?? "",
+      periodStart: toDateInput(riskAnalysis.period?.start),
+      periodEnd: toDateInput(riskAnalysis.period?.end),
     },
   });
 
@@ -100,7 +105,7 @@ export function UpdateRiskAnalysisDialog(props: {
       await updateRiskAnalysis({
         variables: {
           input: {
-            id: props.riskAnalysis.id,
+            id: riskAnalysis.id,
             name: data.name,
             description: data.description || null,
             period: {
@@ -117,81 +122,62 @@ export function UpdateRiskAnalysisDialog(props: {
   };
 
   return (
-    <>
-      <ActionDropdown variant="secondary">
-        <DropdownItem
-          icon={IconPencil}
-          onSelect={() => dialogRef.current?.open()}
-        >
-          {t("riskAnalysisDetailPage.actions.edit")}
-        </DropdownItem>
-        {props.canDelete && props.onDelete && (
-          <DropdownItem
-            variant="danger"
-            icon={IconTrashCan}
-            onClick={props.onDelete}
-          >
-            {t("riskAnalysisDetailPage.actions.delete")}
-          </DropdownItem>
-        )}
-      </ActionDropdown>
-      <Dialog
-        className="max-w-lg"
-        ref={dialogRef}
-        title={(
-          <Breadcrumb
-            items={[
-              t("updateRiskAnalysisDialog.breadcrumb.riskAnalyses"),
-              t("updateRiskAnalysisDialog.title"),
-            ]}
+    <Dialog
+      className="max-w-lg"
+      ref={dialogRef}
+      title={(
+        <Breadcrumb
+          items={[
+            t("updateRiskAnalysisDialog.breadcrumb.riskAnalyses"),
+            t("updateRiskAnalysisDialog.title"),
+          ]}
+        />
+      )}
+    >
+      <form onSubmit={e => void handleSubmit(onSubmit)(e)}>
+        <DialogContent padded className="space-y-4">
+          <Field
+            label={t("updateRiskAnalysisDialog.fields.name")}
+            {...register("name", { required: t("updateRiskAnalysisDialog.validation.nameRequired") })}
+            type="text"
+            error={formState.errors.name?.message}
+            placeholder={t("updateRiskAnalysisDialog.placeholders.name")}
           />
-        )}
-      >
-        <form onSubmit={e => void handleSubmit(onSubmit)(e)}>
-          <DialogContent padded className="space-y-4">
-            <Field
-              label={t("updateRiskAnalysisDialog.fields.name")}
-              {...register("name", { required: t("updateRiskAnalysisDialog.validation.nameRequired") })}
-              type="text"
-              error={formState.errors.name?.message}
-              placeholder={t("updateRiskAnalysisDialog.placeholders.name")}
+          <Field
+            label={t("updateRiskAnalysisDialog.fields.description")}
+            {...register("description")}
+            type="textarea"
+            rows={3}
+            placeholder={t("updateRiskAnalysisDialog.placeholders.description")}
+          />
+          <Field
+            label={t("updateRiskAnalysisDialog.fields.periodStart")}
+            error={formState.errors.periodStart?.message}
+          >
+            <Input {...register("periodStart")} type="date" />
+          </Field>
+          <Field
+            label={t("updateRiskAnalysisDialog.fields.periodEnd")}
+            error={formState.errors.periodEnd?.message}
+          >
+            <Input
+              {...register("periodEnd", {
+                validate: (value, formValues) =>
+                  !value
+                  || !formValues.periodStart
+                  || value >= formValues.periodStart
+                  || t("updateRiskAnalysisDialog.validation.periodEndBeforeStart"),
+              })}
+              type="date"
             />
-            <Field
-              label={t("updateRiskAnalysisDialog.fields.description")}
-              {...register("description")}
-              type="textarea"
-              rows={3}
-              placeholder={t("updateRiskAnalysisDialog.placeholders.description")}
-            />
-            <Field
-              label={t("updateRiskAnalysisDialog.fields.periodStart")}
-              error={formState.errors.periodStart?.message}
-            >
-              <Input {...register("periodStart")} type="date" />
-            </Field>
-            <Field
-              label={t("updateRiskAnalysisDialog.fields.periodEnd")}
-              error={formState.errors.periodEnd?.message}
-            >
-              <Input
-                {...register("periodEnd", {
-                  validate: (value, formValues) =>
-                    !value
-                    || !formValues.periodStart
-                    || value >= formValues.periodStart
-                    || t("updateRiskAnalysisDialog.validation.periodEndBeforeStart"),
-                })}
-                type="date"
-              />
-            </Field>
-          </DialogContent>
-          <DialogFooter>
-            <Button type="submit" disabled={isUpdating}>
-              {t("updateRiskAnalysisDialog.actions.save")}
-            </Button>
-          </DialogFooter>
-        </form>
-      </Dialog>
-    </>
+          </Field>
+        </DialogContent>
+        <DialogFooter>
+          <Button type="submit" disabled={isUpdating}>
+            {t("updateRiskAnalysisDialog.actions.save")}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Dialog>
   );
 }

--- a/e2e/console/risk_analysis_fork_test.go
+++ b/e2e/console/risk_analysis_fork_test.go
@@ -1,0 +1,618 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package console_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+const forkRiskAnalysisMutation = `
+	mutation($input: ForkRiskAnalysisInput!) {
+		forkRiskAnalysis(input: $input) {
+			riskAnalysisEdge {
+				node {
+					id
+					name
+					description
+					period { start end }
+					matrixSize { rows cols }
+				}
+			}
+		}
+	}
+`
+
+type forkRiskAnalysisResult struct {
+	ForkRiskAnalysis struct {
+		RiskAnalysisEdge struct {
+			Node struct {
+				ID          string  `json:"id"`
+				Name        string  `json:"name"`
+				Description *string `json:"description"`
+				Period      *struct {
+					Start *string `json:"start"`
+					End   *string `json:"end"`
+				} `json:"period"`
+				MatrixSize struct {
+					Rows int `json:"rows"`
+					Cols int `json:"cols"`
+				} `json:"matrixSize"`
+			} `json:"node"`
+		} `json:"riskAnalysisEdge"`
+	} `json:"forkRiskAnalysis"`
+}
+
+func TestRiskAnalysis_Fork(t *testing.T) {
+	t.Parallel()
+
+	t.Run("copies diagrams treatment plans and relations", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		graph := populateRiskAnalysisRelationGraph(t, owner)
+		childBoundaryID := factory.CreateRiskAnalysisBoundary(
+			owner,
+			graph.scopeID,
+			factory.Attrs{
+				"name":             factory.SafeName("Child boundary"),
+				"parentBoundaryId": graph.boundaryID,
+			},
+		)
+		measureID := factory.CreateMeasure(owner)
+		tpID := factory.CreateTreatmentPlan(
+			owner,
+			graph.riskID,
+			graph.assessmentID,
+			factory.Attrs{"inherentLikelihood": 3, "inherentImpact": 4},
+		)
+		factory.LinkTreatmentPlanMeasure(owner, tpID, measureID)
+
+		var result forkRiskAnalysisResult
+
+		err := owner.Execute(
+			forkRiskAnalysisMutation,
+			map[string]any{
+				"input": map[string]any{
+					"riskAnalysisId": graph.assessmentID,
+					"name":           "Forked analysis",
+					"description":    "Forked description",
+				},
+			},
+			&result,
+		)
+		require.NoError(t, err)
+
+		forkedID := result.ForkRiskAnalysis.RiskAnalysisEdge.Node.ID
+		require.NotEmpty(t, forkedID)
+		assert.NotEqual(t, graph.assessmentID, forkedID)
+		assert.Equal(t, "Forked analysis", result.ForkRiskAnalysis.RiskAnalysisEdge.Node.Name)
+		require.NotNil(t, result.ForkRiskAnalysis.RiskAnalysisEdge.Node.Description)
+		assert.Equal(t, "Forked description", *result.ForkRiskAnalysis.RiskAnalysisEdge.Node.Description)
+		assert.Nil(t, result.ForkRiskAnalysis.RiskAnalysisEdge.Node.Period)
+		assert.Equal(t, 5, result.ForkRiskAnalysis.RiskAnalysisEdge.Node.MatrixSize.Rows)
+		assert.Equal(t, 5, result.ForkRiskAnalysis.RiskAnalysisEdge.Node.MatrixSize.Cols)
+
+		var copied struct {
+			Node struct {
+				Diagrams struct {
+					Edges []struct {
+						Node struct {
+							ID         string `json:"id"`
+							Name       string `json:"name"`
+							Boundaries struct {
+								Edges []struct {
+									Node struct {
+										ID               string  `json:"id"`
+										Name             string  `json:"name"`
+										ParentBoundaryID *string `json:"parentBoundaryId"`
+									} `json:"node"`
+								} `json:"edges"`
+							} `json:"boundaries"`
+							Nodes struct {
+								Edges []struct {
+									Node struct {
+										ID         string  `json:"id"`
+										Name       string  `json:"name"`
+										BoundaryID *string `json:"boundaryId"`
+									} `json:"node"`
+								} `json:"edges"`
+							} `json:"nodes"`
+							Processes struct {
+								Edges []struct {
+									Node struct {
+										ID           string `json:"id"`
+										Name         string `json:"name"`
+										SourceNodeID string `json:"sourceNodeId"`
+										TargetNodeID string `json:"targetNodeId"`
+									} `json:"node"`
+								} `json:"edges"`
+							} `json:"processes"`
+							Threats struct {
+								Edges []struct {
+									Node struct {
+										ID        string `json:"id"`
+										Name      string `json:"name"`
+										ProcessID string `json:"processId"`
+									} `json:"node"`
+								} `json:"edges"`
+							} `json:"threats"`
+							Scenarios struct {
+								Edges []struct {
+									Node struct {
+										ID      string `json:"id"`
+										Name    string `json:"name"`
+										Threats struct {
+											Edges []struct {
+												Node struct {
+													ID string `json:"id"`
+												} `json:"node"`
+											} `json:"edges"`
+										} `json:"threats"`
+										Risks struct {
+											Edges []struct {
+												Node struct {
+													ID string `json:"id"`
+												} `json:"node"`
+											} `json:"edges"`
+										} `json:"risks"`
+									} `json:"node"`
+								} `json:"edges"`
+							} `json:"scenarios"`
+						} `json:"node"`
+					} `json:"edges"`
+				} `json:"diagrams"`
+				TreatmentPlans struct {
+					Edges []struct {
+						Node struct {
+							ID                 string `json:"id"`
+							InherentLikelihood int    `json:"inherentLikelihood"`
+							InherentImpact     int    `json:"inherentImpact"`
+							Risk               struct {
+								ID string `json:"id"`
+							} `json:"risk"`
+							Measures struct {
+								Edges []struct {
+									Node struct {
+										ID string `json:"id"`
+									} `json:"node"`
+								} `json:"edges"`
+							} `json:"measures"`
+						} `json:"node"`
+					} `json:"edges"`
+				} `json:"treatmentPlans"`
+			} `json:"node"`
+		}
+
+		err = owner.Execute(`
+			query($id: ID!) {
+				node(id: $id) {
+					... on RiskAnalysis {
+						diagrams(first: 10) {
+							edges {
+								node {
+									id
+									name
+									boundaries(first: 10) {
+										edges { node { id name parentBoundaryId } }
+									}
+									nodes(first: 10) {
+										edges { node { id name boundaryId } }
+									}
+									processes(first: 10) {
+										edges { node { id name sourceNodeId targetNodeId } }
+									}
+									threats(first: 10) {
+										edges { node { id name processId } }
+									}
+									scenarios(first: 10) {
+										edges {
+											node {
+												id
+												name
+												threats(first: 10) { edges { node { id } } }
+												risks(first: 10) { edges { node { id } } }
+											}
+										}
+									}
+								}
+							}
+						}
+						treatmentPlans(first: 10) {
+							edges {
+								node {
+									id
+									inherentLikelihood
+									inherentImpact
+									risk { id }
+									measures(first: 10) { edges { node { id } } }
+								}
+							}
+						}
+					}
+				}
+			}
+		`, map[string]any{"id": forkedID}, &copied)
+		require.NoError(t, err)
+
+		require.Len(t, copied.Node.Diagrams.Edges, 1)
+		diagram := copied.Node.Diagrams.Edges[0].Node
+		assert.NotEqual(t, graph.scopeID, diagram.ID)
+
+		require.Len(t, diagram.Boundaries.Edges, 2)
+
+		boundariesByName := map[string]struct {
+			ID               string
+			ParentBoundaryID *string
+		}{}
+
+		for _, edge := range diagram.Boundaries.Edges {
+			assert.NotEqual(t, graph.boundaryID, edge.Node.ID)
+			assert.NotEqual(t, childBoundaryID, edge.Node.ID)
+
+			boundariesByName[edge.Node.Name] = struct {
+				ID               string
+				ParentBoundaryID *string
+			}{ID: edge.Node.ID, ParentBoundaryID: edge.Node.ParentBoundaryID}
+		}
+
+		var parentName, childName string
+
+		for name, boundary := range boundariesByName {
+			if boundary.ParentBoundaryID == nil {
+				parentName = name
+			} else {
+				childName = name
+			}
+		}
+
+		require.NotEmpty(t, parentName)
+		require.NotEmpty(t, childName)
+		require.NotNil(t, boundariesByName[childName].ParentBoundaryID)
+		assert.Equal(t, boundariesByName[parentName].ID, *boundariesByName[childName].ParentBoundaryID)
+
+		require.Len(t, diagram.Nodes.Edges, 3)
+
+		nodesByID := map[string]string{}
+
+		for _, edge := range diagram.Nodes.Edges {
+			assert.NotEqual(t, graph.sourceNodeID, edge.Node.ID)
+			assert.NotEqual(t, graph.targetNodeID, edge.Node.ID)
+			assert.NotEqual(t, graph.boundedNodeID, edge.Node.ID)
+
+			nodesByID[edge.Node.ID] = edge.Node.Name
+
+			if edge.Node.BoundaryID != nil {
+				assert.Equal(t, boundariesByName[parentName].ID, *edge.Node.BoundaryID)
+			}
+		}
+
+		require.Len(t, diagram.Processes.Edges, 1)
+		process := diagram.Processes.Edges[0].Node
+		assert.NotEqual(t, graph.processID, process.ID)
+		_, ok := nodesByID[process.SourceNodeID]
+		assert.True(t, ok)
+		_, ok = nodesByID[process.TargetNodeID]
+		assert.True(t, ok)
+
+		require.Len(t, diagram.Threats.Edges, 1)
+		threat := diagram.Threats.Edges[0].Node
+		assert.NotEqual(t, graph.threatID, threat.ID)
+		assert.Equal(t, process.ID, threat.ProcessID)
+
+		require.Len(t, diagram.Scenarios.Edges, 1)
+		scenario := diagram.Scenarios.Edges[0].Node
+		assert.NotEqual(t, graph.scenarioID, scenario.ID)
+		require.Len(t, scenario.Threats.Edges, 1)
+		assert.Equal(t, threat.ID, scenario.Threats.Edges[0].Node.ID)
+		require.Len(t, scenario.Risks.Edges, 1)
+		assert.Equal(t, graph.riskID, scenario.Risks.Edges[0].Node.ID)
+
+		require.Len(t, copied.Node.TreatmentPlans.Edges, 1)
+		copiedTP := copied.Node.TreatmentPlans.Edges[0].Node
+		assert.NotEqual(t, tpID, copiedTP.ID)
+		assert.Equal(t, graph.riskID, copiedTP.Risk.ID)
+		assert.Equal(t, 3, copiedTP.InherentLikelihood)
+		assert.Equal(t, 4, copiedTP.InherentImpact)
+		require.Len(t, copiedTP.Measures.Edges, 1)
+		assert.Equal(t, measureID, copiedTP.Measures.Edges[0].Node.ID)
+	})
+
+	t.Run("copies scenario threats linked across diagrams", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		sourceID := factory.CreateRiskAnalysis(owner, factory.Attrs{"name": "Cross-diagram source"})
+
+		scenarioDiagramID := factory.CreateRiskAnalysisDiagram(
+			owner,
+			sourceID,
+			factory.Attrs{"name": "Scenario diagram"},
+		)
+		threatDiagramID := factory.CreateRiskAnalysisDiagram(
+			owner,
+			sourceID,
+			factory.Attrs{"name": "Threat diagram"},
+		)
+		sourceNodeID := factory.CreateRiskAnalysisNode(
+			owner,
+			threatDiagramID,
+			factory.Attrs{"nodeType": "ENTITY", "name": "Source node"},
+		)
+		targetNodeID := factory.CreateRiskAnalysisNode(
+			owner,
+			threatDiagramID,
+			factory.Attrs{"nodeType": "ASSET", "name": "Target node"},
+		)
+		processID := factory.CreateRiskAnalysisProcess(
+			owner,
+			threatDiagramID,
+			sourceNodeID,
+			targetNodeID,
+			factory.Attrs{"name": "Process"},
+		)
+		threatID := factory.CreateRiskAnalysisThreat(
+			owner,
+			threatDiagramID,
+			processID,
+			factory.Attrs{"name": "Later-diagram threat", "category": "Confidentiality"},
+		)
+		scenarioID := factory.CreateRiskAnalysisScenario(
+			owner,
+			scenarioDiagramID,
+			factory.Attrs{"name": "Earlier-diagram scenario"},
+		)
+		factory.LinkRiskAnalysisScenarioThreat(owner, scenarioID, threatID)
+
+		var result forkRiskAnalysisResult
+
+		err := owner.Execute(
+			forkRiskAnalysisMutation,
+			map[string]any{
+				"input": map[string]any{
+					"riskAnalysisId": sourceID,
+					"name":           "Cross-diagram fork",
+				},
+			},
+			&result,
+		)
+		require.NoError(t, err)
+
+		forkedID := result.ForkRiskAnalysis.RiskAnalysisEdge.Node.ID
+		require.NotEmpty(t, forkedID)
+
+		var copied struct {
+			Node struct {
+				Diagrams struct {
+					Edges []struct {
+						Node struct {
+							ID      string `json:"id"`
+							Name    string `json:"name"`
+							Threats struct {
+								Edges []struct {
+									Node struct {
+										ID string `json:"id"`
+									} `json:"node"`
+								} `json:"edges"`
+							} `json:"threats"`
+							Scenarios struct {
+								Edges []struct {
+									Node struct {
+										ID      string `json:"id"`
+										Name    string `json:"name"`
+										Threats struct {
+											Edges []struct {
+												Node struct {
+													ID string `json:"id"`
+												} `json:"node"`
+											} `json:"edges"`
+										} `json:"threats"`
+									} `json:"node"`
+								} `json:"edges"`
+							} `json:"scenarios"`
+						} `json:"node"`
+					} `json:"edges"`
+				} `json:"diagrams"`
+			} `json:"node"`
+		}
+
+		err = owner.Execute(`
+			query($id: ID!) {
+				node(id: $id) {
+					... on RiskAnalysis {
+						diagrams(first: 10) {
+							edges {
+								node {
+									id
+									name
+									threats(first: 10) { edges { node { id } } }
+									scenarios(first: 10) {
+										edges {
+											node {
+												id
+												name
+												threats(first: 10) { edges { node { id } } }
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		`, map[string]any{"id": forkedID}, &copied)
+		require.NoError(t, err)
+		require.Len(t, copied.Node.Diagrams.Edges, 2)
+
+		diagramsByName := map[string]int{}
+
+		for i, edge := range copied.Node.Diagrams.Edges {
+			assert.NotEqual(t, scenarioDiagramID, edge.Node.ID)
+			assert.NotEqual(t, threatDiagramID, edge.Node.ID)
+			diagramsByName[edge.Node.Name] = i
+		}
+
+		scenarioIdx, ok := diagramsByName["Scenario diagram"]
+		require.True(t, ok)
+		threatIdx, ok := diagramsByName["Threat diagram"]
+		require.True(t, ok)
+
+		scenarioDiagram := copied.Node.Diagrams.Edges[scenarioIdx].Node
+		threatDiagram := copied.Node.Diagrams.Edges[threatIdx].Node
+
+		require.Len(t, threatDiagram.Threats.Edges, 1)
+		require.Len(t, scenarioDiagram.Scenarios.Edges, 1)
+		assert.Equal(t, "Earlier-diagram scenario", scenarioDiagram.Scenarios.Edges[0].Node.Name)
+		require.Len(t, scenarioDiagram.Scenarios.Edges[0].Node.Threats.Edges, 1)
+		assert.Equal(
+			t,
+			threatDiagram.Threats.Edges[0].Node.ID,
+			scenarioDiagram.Scenarios.Edges[0].Node.Threats.Edges[0].Node.ID,
+		)
+	})
+
+	t.Run("copies matrix size and uses supplied period", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		var created struct {
+			CreateRiskAnalysis struct {
+				RiskAnalysisEdge struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"riskAnalysisEdge"`
+			} `json:"createRiskAnalysis"`
+		}
+
+		err := owner.Execute(`
+			mutation($input: CreateRiskAnalysisInput!) {
+				createRiskAnalysis(input: $input) {
+					riskAnalysisEdge { node { id } }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"organizationId": owner.GetOrganizationID().String(),
+				"name":           "Source with period",
+				"matrixSize":     map[string]any{"rows": 3, "cols": 3},
+				"period": map[string]any{
+					"start": "2025-01-01T00:00:00Z",
+					"end":   "2025-12-31T00:00:00Z",
+				},
+			},
+		}, &created)
+		require.NoError(t, err)
+
+		sourceID := created.CreateRiskAnalysis.RiskAnalysisEdge.Node.ID
+
+		var result forkRiskAnalysisResult
+
+		err = owner.Execute(
+			forkRiskAnalysisMutation,
+			map[string]any{
+				"input": map[string]any{
+					"riskAnalysisId": sourceID,
+					"name":           "Forked with new period",
+					"period": map[string]any{
+						"start": "2026-01-01T00:00:00Z",
+						"end":   "2026-12-31T00:00:00Z",
+					},
+				},
+			},
+			&result,
+		)
+		require.NoError(t, err)
+
+		node := result.ForkRiskAnalysis.RiskAnalysisEdge.Node
+		assert.Equal(t, 3, node.MatrixSize.Rows)
+		assert.Equal(t, 3, node.MatrixSize.Cols)
+		require.NotNil(t, node.Period)
+		require.NotNil(t, node.Period.Start)
+		require.NotNil(t, node.Period.End)
+		assert.Contains(t, *node.Period.Start, "2026-01-01")
+		assert.Contains(t, *node.Period.End, "2026-12-31")
+		assert.NotContains(t, *node.Period.Start, "2025")
+	})
+
+	t.Run("forks empty analysis", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		sourceID := factory.CreateRiskAnalysis(owner, factory.Attrs{"name": "Empty source"})
+
+		var result forkRiskAnalysisResult
+
+		err := owner.Execute(
+			forkRiskAnalysisMutation,
+			map[string]any{
+				"input": map[string]any{
+					"riskAnalysisId": sourceID,
+					"name":           "Empty fork",
+				},
+			},
+			&result,
+		)
+		require.NoError(t, err)
+		assert.NotEqual(t, sourceID, result.ForkRiskAnalysis.RiskAnalysisEdge.Node.ID)
+		assert.Equal(t, "Empty fork", result.ForkRiskAnalysis.RiskAnalysisEdge.Node.Name)
+	})
+}
+
+func TestRiskAnalysis_Fork_RBAC(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+	sourceID := factory.CreateRiskAnalysis(owner)
+
+	_, err := viewer.Do(
+		forkRiskAnalysisMutation,
+		map[string]any{
+			"input": map[string]any{
+				"riskAnalysisId": sourceID,
+				"name":           "Viewer fork",
+			},
+		},
+	)
+	testutil.RequireForbiddenError(t, err, "viewer cannot fork risk analysis")
+}
+
+func TestRiskAnalysis_Fork_TenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	owner1 := testutil.NewClient(t, testutil.RoleOwner)
+	owner2 := testutil.NewClient(t, testutil.RoleOwner)
+	sourceID := factory.CreateRiskAnalysis(owner1)
+
+	_, err := owner2.Do(
+		forkRiskAnalysisMutation,
+		map[string]any{
+			"input": map[string]any{
+				"riskAnalysisId": sourceID,
+				"name":           "Cross tenant fork",
+			},
+		},
+	)
+	testutil.RequireErrorCode(t, err, "NOT_FOUND", "cannot fork a risk analysis from another tenant")
+}

--- a/e2e/mcp/risk_analysis_fork_test.go
+++ b/e2e/mcp/risk_analysis_fork_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+func TestMCP_RiskAnalysis_Fork(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	mc := testutil.NewMCPClient(t, owner)
+	sourceID := factory.CreateRiskAnalysis(owner, factory.Attrs{"name": "MCP source"})
+	factory.CreateRiskAnalysisDiagram(owner, sourceID, factory.Attrs{"name": "MCP diagram"})
+
+	var result struct {
+		RiskAnalysis struct {
+			ID         string `json:"id"`
+			Name       string `json:"name"`
+			MatrixSize struct {
+				Rows int `json:"rows"`
+				Cols int `json:"cols"`
+			} `json:"matrix_size"`
+		} `json:"risk_analysis"`
+	}
+	mc.CallToolInto("forkRiskAnalysis", map[string]any{
+		"id":   sourceID,
+		"name": "MCP forked",
+	}, &result)
+	require.NotEmpty(t, result.RiskAnalysis.ID)
+	assert.NotEqual(t, sourceID, result.RiskAnalysis.ID)
+	assert.Equal(t, "MCP forked", result.RiskAnalysis.Name)
+	assert.Equal(t, 5, result.RiskAnalysis.MatrixSize.Rows)
+	assert.Equal(t, 5, result.RiskAnalysis.MatrixSize.Cols)
+}

--- a/packages/n8n-node/nodes/Probo/actions/riskAnalysis/fork.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/riskAnalysis/fork.operation.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Risk Analysis ID',
+		name: 'riskAnalysisId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['riskAnalysis'],
+				operation: ['fork'],
+			},
+		},
+		default: '',
+		description: 'The ID of the risk analysis to fork',
+		required: true,
+	},
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['riskAnalysis'],
+				operation: ['fork'],
+			},
+		},
+		default: '',
+		description: 'The name of the forked risk analysis',
+		required: true,
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['riskAnalysis'],
+				operation: ['fork'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				default: '',
+				description: 'The description of the forked risk analysis',
+			},
+			{
+				displayName: 'Period Start',
+				name: 'periodStart',
+				type: 'dateTime',
+				default: '',
+				description: 'Start of the analysis period',
+			},
+			{
+				displayName: 'Period End',
+				name: 'periodEnd',
+				type: 'dateTime',
+				default: '',
+				description: 'End of the analysis period',
+			},
+		],
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const riskAnalysisId = this.getNodeParameter('riskAnalysisId', itemIndex) as string;
+	const name = this.getNodeParameter('name', itemIndex) as string;
+	const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as {
+		description?: string;
+		periodStart?: string;
+		periodEnd?: string;
+	};
+
+	const query = `
+		mutation ForkRiskAnalysis($input: ForkRiskAnalysisInput!) {
+			forkRiskAnalysis(input: $input) {
+				riskAnalysisEdge {
+					node {
+						id
+						name
+						description
+						period {
+							start
+							end
+						}
+						matrixSize {
+							rows
+							cols
+						}
+						createdAt
+						updatedAt
+					}
+				}
+			}
+		}
+	`;
+
+	const input: Record<string, unknown> = {
+		riskAnalysisId,
+		name,
+	};
+	if (additionalFields.description) input.description = additionalFields.description;
+	if (additionalFields.periodStart || additionalFields.periodEnd) {
+		input.period = {
+			...(additionalFields.periodStart ? { start: additionalFields.periodStart } : {}),
+			...(additionalFields.periodEnd ? { end: additionalFields.periodEnd } : {}),
+		};
+	}
+
+	const responseData = await proboApiRequest.call(this, query, { input });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/riskAnalysis/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/riskAnalysis/index.ts
@@ -24,6 +24,7 @@ import * as getOp from './get.operation';
 import * as getAllOp from './getAll.operation';
 import * as updateOp from './update.operation';
 import * as deleteOp from './delete.operation';
+import * as forkOp from './fork.operation';
 import * as createDiagramOp from './createDiagram.operation';
 import * as getDiagramOp from './getDiagram.operation';
 import * as getAllDiagramsOp from './getAllDiagrams.operation';
@@ -155,6 +156,12 @@ export const description: INodeProperties[] = [
 				value: 'deleteThreat',
 				description: 'Delete a threat',
 				action: 'Delete a threat',
+			},
+			{
+				name: 'Fork',
+				value: 'fork',
+				description: 'Fork a risk analysis, copying diagrams and treatment plans',
+				action: 'Fork a risk analysis',
 			},
 			{
 				name: 'Get',
@@ -314,6 +321,7 @@ export const description: INodeProperties[] = [
 	...getAllOp.description,
 	...updateOp.description,
 	...deleteOp.description,
+	...forkOp.description,
 	...createDiagramOp.description,
 	...getDiagramOp.description,
 	...getAllDiagramsOp.description,
@@ -357,6 +365,7 @@ export {
 	getAllOp as getAll,
 	updateOp as update,
 	deleteOp as delete,
+	forkOp as fork,
 	createDiagramOp as createDiagram,
 	getDiagramOp as getDiagram,
 	getAllDiagramsOp as getAllDiagrams,

--- a/pkg/cmd/risk-analysis/fork/fork.go
+++ b/pkg/cmd/risk-analysis/fork/fork.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package fork
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const forkMutation = `
+mutation($input: ForkRiskAnalysisInput!) {
+  forkRiskAnalysis(input: $input) {
+    riskAnalysisEdge {
+      node {
+        id
+        name
+        description
+        period {
+          start
+          end
+        }
+        matrixSize {
+          rows
+          cols
+        }
+        createdAt
+        updatedAt
+      }
+    }
+  }
+}
+`
+
+type forkResponse struct {
+	ForkRiskAnalysis struct {
+		RiskAnalysisEdge struct {
+			Node struct {
+				ID          string  `json:"id"`
+				Name        string  `json:"name"`
+				Description *string `json:"description"`
+				Period      *struct {
+					Start *string `json:"start"`
+					End   *string `json:"end"`
+				} `json:"period"`
+				MatrixSize struct {
+					Rows int `json:"rows"`
+					Cols int `json:"cols"`
+				} `json:"matrixSize"`
+				CreatedAt string `json:"createdAt"`
+				UpdatedAt string `json:"updatedAt"`
+			} `json:"node"`
+		} `json:"riskAnalysisEdge"`
+	} `json:"forkRiskAnalysis"`
+}
+
+func NewCmdFork(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagName        string
+		flagDescription string
+		flagPeriodStart string
+		flagPeriodEnd   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "fork <id>",
+		Short: "Fork a risk analysis",
+		Example: `  # Fork a risk analysis interactively
+  prb risk-analysis fork <id>
+
+  # Fork a risk analysis non-interactively
+  prb risk-analysis fork <id> --name "Annual Risk Analysis" --period-start 2026-01-01T00:00:00Z --period-end 2026-12-31T00:00:00Z`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			if f.IOStreams.IsInteractive() {
+				if flagName == "" {
+					err := huh.NewInput().
+						Title("Risk analysis name").
+						Value(&flagName).
+						Run()
+					if err != nil {
+						return err
+					}
+				}
+			}
+
+			if flagName == "" {
+				return fmt.Errorf("name is required; pass --name or run interactively")
+			}
+
+			input := map[string]any{
+				"riskAnalysisId": args[0],
+				"name":           flagName,
+			}
+
+			if flagDescription != "" {
+				input["description"] = flagDescription
+			}
+
+			if flagPeriodStart != "" || flagPeriodEnd != "" {
+				period := map[string]any{}
+
+				if flagPeriodStart != "" {
+					if _, err := time.Parse(time.RFC3339, flagPeriodStart); err != nil {
+						return fmt.Errorf(
+							"--period-start must be RFC3339 (e.g. 2026-01-01T00:00:00Z): %w",
+							err,
+						)
+					}
+
+					period["start"] = flagPeriodStart
+				}
+
+				if flagPeriodEnd != "" {
+					if _, err := time.Parse(time.RFC3339, flagPeriodEnd); err != nil {
+						return fmt.Errorf(
+							"--period-end must be RFC3339 (e.g. 2026-12-31T00:00:00Z): %w",
+							err,
+						)
+					}
+
+					period["end"] = flagPeriodEnd
+				}
+
+				input["period"] = period
+			}
+
+			data, err := client.Do(
+				forkMutation,
+				map[string]any{"input": input},
+			)
+			if err != nil {
+				return err
+			}
+
+			var resp forkResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			r := resp.ForkRiskAnalysis.RiskAnalysisEdge.Node
+			_, _ = fmt.Fprintf(
+				f.IOStreams.Out,
+				"Forked risk analysis %s (%s)\n",
+				r.ID,
+				r.Name,
+			)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagName, "name", "", "Risk analysis name (required)")
+	cmd.Flags().StringVar(&flagDescription, "description", "", "Risk analysis description")
+	cmd.Flags().StringVar(
+		&flagPeriodStart,
+		"period-start",
+		"",
+		"Period start in RFC3339 format (e.g. 2026-01-01T00:00:00Z)",
+	)
+	cmd.Flags().StringVar(
+		&flagPeriodEnd,
+		"period-end",
+		"",
+		"Period end in RFC3339 format (e.g. 2026-12-31T00:00:00Z)",
+	)
+
+	return cmd
+}

--- a/pkg/cmd/risk-analysis/risk_analysis.go
+++ b/pkg/cmd/risk-analysis/risk_analysis.go
@@ -27,6 +27,7 @@ import (
 	"go.probo.inc/probo/pkg/cmd/risk-analysis/create"
 	"go.probo.inc/probo/pkg/cmd/risk-analysis/delete"
 	"go.probo.inc/probo/pkg/cmd/risk-analysis/diagram"
+	"go.probo.inc/probo/pkg/cmd/risk-analysis/fork"
 	"go.probo.inc/probo/pkg/cmd/risk-analysis/list"
 	"go.probo.inc/probo/pkg/cmd/risk-analysis/node"
 	"go.probo.inc/probo/pkg/cmd/risk-analysis/process"
@@ -44,6 +45,7 @@ func NewCmdRiskAnalysis(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.AddCommand(list.NewCmdList(f))
 	cmd.AddCommand(create.NewCmdCreate(f))
+	cmd.AddCommand(fork.NewCmdFork(f))
 	cmd.AddCommand(view.NewCmdView(f))
 	cmd.AddCommand(update.NewCmdUpdate(f))
 	cmd.AddCommand(delete.NewCmdDelete(f))

--- a/pkg/coredata/risk_analysis_scenario_threat.go
+++ b/pkg/coredata/risk_analysis_scenario_threat.go
@@ -96,6 +96,47 @@ WHERE
 	return err
 }
 
+func (sts *RiskAnalysisScenarioThreats) LoadByScenarioIDs(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	scenarioIDs []gid.GID,
+) error {
+	if len(scenarioIDs) == 0 {
+		*sts = nil
+		return nil
+	}
+
+	q := `
+SELECT
+	risk_analysis_scenario_id,
+	risk_analysis_threat_id,
+	created_at
+FROM
+	risk_analysis_scenario_threats
+WHERE
+	%s
+	AND risk_analysis_scenario_id = ANY(@scenario_ids)
+`
+	q = fmt.Sprintf(q, scope.SQLFragment())
+	args := pgx.StrictNamedArgs{"scenario_ids": scenarioIDs}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query risk scenario threats: %w", err)
+	}
+
+	results, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[RiskAnalysisScenarioThreat])
+	if err != nil {
+		return fmt.Errorf("cannot collect risk scenario threats: %w", err)
+	}
+
+	*sts = results
+
+	return nil
+}
+
 func (ts *RiskAnalysisThreats) LoadByScenarioID(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/riskmanagement/fork.go
+++ b/pkg/riskmanagement/fork.go
@@ -1,0 +1,676 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package riskmanagement
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+)
+
+func (s *Service) Fork(
+	ctx context.Context,
+	scope coredata.Scoper,
+	req ForkRiskAnalysisRequest,
+) (*coredata.RiskAnalysis, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	now := time.Now()
+	forked := &coredata.RiskAnalysis{}
+
+	err := s.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			source := &coredata.RiskAnalysis{}
+			if err := source.LoadByID(ctx, tx, scope, req.RiskAnalysisID); err != nil {
+				return fmt.Errorf("cannot load risk analysis: %w", err)
+			}
+
+			*forked = coredata.RiskAnalysis{
+				ID:             gid.New(scope.GetTenantID(), coredata.RiskAnalysisEntityType),
+				OrganizationID: source.OrganizationID,
+				Name:           req.Name,
+				Description:    req.Description,
+				MatrixRows:     source.MatrixRows,
+				MatrixCols:     source.MatrixCols,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			}
+
+			if req.Period != nil {
+				forked.PeriodStart = req.Period.Start
+				forked.PeriodEnd = req.Period.End
+			}
+
+			if err := forked.Insert(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot insert forked risk analysis: %w", err)
+			}
+
+			idMap := make(map[gid.GID]gid.GID)
+			if err := copyDiagrams(ctx, tx, scope, source.ID, forked, now, idMap); err != nil {
+				return fmt.Errorf("cannot copy diagrams: %w", err)
+			}
+
+			if err := copyTreatmentPlans(ctx, tx, scope, source.ID, forked, now, idMap); err != nil {
+				return fmt.Errorf("cannot copy treatment plans: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return forked, nil
+}
+
+func copyDiagrams(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	sourceAnalysisID gid.GID,
+	forked *coredata.RiskAnalysis,
+	now time.Time,
+	idMap map[gid.GID]gid.GID,
+) error {
+	diagrams, err := page.LoadAll(
+		ctx,
+		page.OrderBy[coredata.RiskAnalysisDiagramOrderField]{
+			Field:     coredata.RiskAnalysisDiagramOrderFieldCreatedAt,
+			Direction: page.OrderDirectionAsc,
+		},
+		func(ctx context.Context, cursor *page.Cursor[coredata.RiskAnalysisDiagramOrderField]) ([]*coredata.RiskAnalysisDiagram, error) {
+			var batch coredata.RiskAnalysisDiagrams
+			if err := batch.LoadByRiskAnalysisID(ctx, tx, scope, sourceAnalysisID, cursor); err != nil {
+				return nil, fmt.Errorf("cannot load diagrams: %w", err)
+			}
+
+			return batch, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("cannot load all diagrams: %w", err)
+	}
+
+	var sourceScenarioIDs []gid.GID
+
+	for _, diagram := range diagrams {
+		scenarioIDs, err := copyDiagram(ctx, tx, scope, diagram, forked, now, idMap)
+		if err != nil {
+			return fmt.Errorf("cannot copy diagram: %w", err)
+		}
+
+		sourceScenarioIDs = append(sourceScenarioIDs, scenarioIDs...)
+	}
+
+	// Scenario-threat links can span diagrams, so remap them only after
+	// every diagram's threats are in idMap.
+	if err := copyScenarioThreats(ctx, tx, scope, sourceScenarioIDs, now, idMap); err != nil {
+		return fmt.Errorf("cannot copy scenario threats: %w", err)
+	}
+
+	return nil
+}
+
+func copyDiagram(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	source *coredata.RiskAnalysisDiagram,
+	forked *coredata.RiskAnalysis,
+	now time.Time,
+	idMap map[gid.GID]gid.GID,
+) ([]gid.GID, error) {
+	copied := &coredata.RiskAnalysisDiagram{
+		ID:             gid.New(scope.GetTenantID(), coredata.RiskAnalysisDiagramEntityType),
+		OrganizationID: forked.OrganizationID,
+		RiskAnalysisID: forked.ID,
+		Name:           source.Name,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	idMap[source.ID] = copied.ID
+
+	if err := copied.Insert(ctx, tx, scope); err != nil {
+		return nil, fmt.Errorf("cannot insert diagram: %w", err)
+	}
+
+	if err := copyBoundaries(ctx, tx, scope, source.ID, copied, now, idMap); err != nil {
+		return nil, fmt.Errorf("cannot copy boundaries: %w", err)
+	}
+
+	if err := copyNodes(ctx, tx, scope, source.ID, copied, now, idMap); err != nil {
+		return nil, fmt.Errorf("cannot copy nodes: %w", err)
+	}
+
+	if err := copyProcesses(ctx, tx, scope, source.ID, copied, now, idMap); err != nil {
+		return nil, fmt.Errorf("cannot copy processes: %w", err)
+	}
+
+	if err := copyThreats(ctx, tx, scope, source.ID, copied, now, idMap); err != nil {
+		return nil, fmt.Errorf("cannot copy threats: %w", err)
+	}
+
+	scenarioIDs, err := copyScenarios(ctx, tx, scope, source.ID, copied, now, idMap)
+	if err != nil {
+		return nil, fmt.Errorf("cannot copy scenarios: %w", err)
+	}
+
+	return scenarioIDs, nil
+}
+
+func copyBoundaries(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	sourceDiagramID gid.GID,
+	copiedDiagram *coredata.RiskAnalysisDiagram,
+	now time.Time,
+	idMap map[gid.GID]gid.GID,
+) error {
+	boundaries, err := page.LoadAll(
+		ctx,
+		page.OrderBy[coredata.RiskAnalysisBoundaryOrderField]{
+			Field:     coredata.RiskAnalysisBoundaryOrderFieldCreatedAt,
+			Direction: page.OrderDirectionAsc,
+		},
+		func(ctx context.Context, cursor *page.Cursor[coredata.RiskAnalysisBoundaryOrderField]) ([]*coredata.RiskAnalysisBoundary, error) {
+			var batch coredata.RiskAnalysisBoundaries
+			if err := batch.LoadByRiskAnalysisDiagramID(ctx, tx, scope, sourceDiagramID, cursor); err != nil {
+				return nil, fmt.Errorf("cannot load boundaries: %w", err)
+			}
+
+			return batch, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("cannot load all boundaries: %w", err)
+	}
+
+	ordered, err := orderBoundaries(boundaries)
+	if err != nil {
+		return fmt.Errorf("cannot order boundaries: %w", err)
+	}
+
+	for _, source := range ordered {
+		copied := &coredata.RiskAnalysisBoundary{
+			ID:                    gid.New(scope.GetTenantID(), coredata.RiskAnalysisBoundaryEntityType),
+			OrganizationID:        copiedDiagram.OrganizationID,
+			RiskAnalysisDiagramID: copiedDiagram.ID,
+			Name:                  source.Name,
+			CreatedAt:             now,
+			UpdatedAt:             now,
+		}
+
+		parentID, err := remapOptionalID(idMap, source.ParentBoundaryID)
+		if err != nil {
+			return fmt.Errorf("cannot remap parent boundary: %w", err)
+		}
+
+		copied.ParentBoundaryID = parentID
+		idMap[source.ID] = copied.ID
+
+		if err := copied.Insert(ctx, tx, scope); err != nil {
+			return fmt.Errorf("cannot insert boundary: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func copyNodes(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	sourceDiagramID gid.GID,
+	copiedDiagram *coredata.RiskAnalysisDiagram,
+	now time.Time,
+	idMap map[gid.GID]gid.GID,
+) error {
+	nodes, err := page.LoadAll(
+		ctx,
+		page.OrderBy[coredata.RiskAnalysisNodeOrderField]{
+			Field:     coredata.RiskAnalysisNodeOrderFieldCreatedAt,
+			Direction: page.OrderDirectionAsc,
+		},
+		func(ctx context.Context, cursor *page.Cursor[coredata.RiskAnalysisNodeOrderField]) ([]*coredata.RiskAnalysisNode, error) {
+			var batch coredata.RiskAnalysisNodes
+			if err := batch.LoadByRiskAnalysisDiagramID(ctx, tx, scope, sourceDiagramID, cursor); err != nil {
+				return nil, fmt.Errorf("cannot load nodes: %w", err)
+			}
+
+			return batch, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("cannot load all nodes: %w", err)
+	}
+
+	for _, source := range nodes {
+		copied := &coredata.RiskAnalysisNode{
+			ID:                    gid.New(scope.GetTenantID(), coredata.RiskAnalysisNodeEntityType),
+			OrganizationID:        copiedDiagram.OrganizationID,
+			RiskAnalysisDiagramID: copiedDiagram.ID,
+			NodeType:              source.NodeType,
+			Name:                  source.Name,
+			CreatedAt:             now,
+			UpdatedAt:             now,
+		}
+
+		boundaryID, err := remapOptionalID(idMap, source.BoundaryID)
+		if err != nil {
+			return fmt.Errorf("cannot remap node boundary: %w", err)
+		}
+
+		copied.BoundaryID = boundaryID
+		idMap[source.ID] = copied.ID
+
+		if err := copied.Insert(ctx, tx, scope); err != nil {
+			return fmt.Errorf("cannot insert node: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func copyProcesses(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	sourceDiagramID gid.GID,
+	copiedDiagram *coredata.RiskAnalysisDiagram,
+	now time.Time,
+	idMap map[gid.GID]gid.GID,
+) error {
+	processes, err := page.LoadAll(
+		ctx,
+		page.OrderBy[coredata.RiskAnalysisProcessOrderField]{
+			Field:     coredata.RiskAnalysisProcessOrderFieldCreatedAt,
+			Direction: page.OrderDirectionAsc,
+		},
+		func(ctx context.Context, cursor *page.Cursor[coredata.RiskAnalysisProcessOrderField]) ([]*coredata.RiskAnalysisProcess, error) {
+			var batch coredata.RiskAnalysisProcesses
+			if err := batch.LoadByRiskAnalysisDiagramID(ctx, tx, scope, sourceDiagramID, cursor); err != nil {
+				return nil, fmt.Errorf("cannot load processes: %w", err)
+			}
+
+			return batch, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("cannot load all processes: %w", err)
+	}
+
+	for _, source := range processes {
+		sourceNodeID, err := remapID(idMap, source.SourceNodeID)
+		if err != nil {
+			return fmt.Errorf("cannot remap process source node: %w", err)
+		}
+
+		targetNodeID, err := remapID(idMap, source.TargetNodeID)
+		if err != nil {
+			return fmt.Errorf("cannot remap process target node: %w", err)
+		}
+
+		copied := &coredata.RiskAnalysisProcess{
+			ID:                    gid.New(scope.GetTenantID(), coredata.RiskAnalysisProcessEntityType),
+			OrganizationID:        copiedDiagram.OrganizationID,
+			RiskAnalysisDiagramID: copiedDiagram.ID,
+			SourceNodeID:          sourceNodeID,
+			TargetNodeID:          targetNodeID,
+			Name:                  source.Name,
+			CreatedAt:             now,
+			UpdatedAt:             now,
+		}
+		idMap[source.ID] = copied.ID
+
+		if err := copied.Insert(ctx, tx, scope); err != nil {
+			return fmt.Errorf("cannot insert process: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func copyThreats(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	sourceDiagramID gid.GID,
+	copiedDiagram *coredata.RiskAnalysisDiagram,
+	now time.Time,
+	idMap map[gid.GID]gid.GID,
+) error {
+	threats, err := page.LoadAll(
+		ctx,
+		page.OrderBy[coredata.RiskAnalysisThreatOrderField]{
+			Field:     coredata.RiskAnalysisThreatOrderFieldCreatedAt,
+			Direction: page.OrderDirectionAsc,
+		},
+		func(ctx context.Context, cursor *page.Cursor[coredata.RiskAnalysisThreatOrderField]) ([]*coredata.RiskAnalysisThreat, error) {
+			var batch coredata.RiskAnalysisThreats
+			if err := batch.LoadByRiskAnalysisDiagramID(ctx, tx, scope, sourceDiagramID, cursor); err != nil {
+				return nil, fmt.Errorf("cannot load threats: %w", err)
+			}
+
+			return batch, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("cannot load all threats: %w", err)
+	}
+
+	for _, source := range threats {
+		processID, err := remapID(idMap, source.ProcessID)
+		if err != nil {
+			return fmt.Errorf("cannot remap threat process: %w", err)
+		}
+
+		copied := &coredata.RiskAnalysisThreat{
+			ID:                    gid.New(scope.GetTenantID(), coredata.RiskAnalysisThreatEntityType),
+			OrganizationID:        copiedDiagram.OrganizationID,
+			RiskAnalysisDiagramID: copiedDiagram.ID,
+			ProcessID:             processID,
+			Name:                  source.Name,
+			Category:              source.Category,
+			CreatedAt:             now,
+			UpdatedAt:             now,
+		}
+		idMap[source.ID] = copied.ID
+
+		if err := copied.Insert(ctx, tx, scope); err != nil {
+			return fmt.Errorf("cannot insert threat: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func copyScenarios(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	sourceDiagramID gid.GID,
+	copiedDiagram *coredata.RiskAnalysisDiagram,
+	now time.Time,
+	idMap map[gid.GID]gid.GID,
+) ([]gid.GID, error) {
+	scenarios, err := page.LoadAll(
+		ctx,
+		page.OrderBy[coredata.RiskAnalysisScenarioOrderField]{
+			Field:     coredata.RiskAnalysisScenarioOrderFieldCreatedAt,
+			Direction: page.OrderDirectionAsc,
+		},
+		func(ctx context.Context, cursor *page.Cursor[coredata.RiskAnalysisScenarioOrderField]) ([]*coredata.RiskAnalysisScenario, error) {
+			var batch coredata.RiskAnalysisScenarios
+			if err := batch.LoadByRiskAnalysisDiagramID(ctx, tx, scope, sourceDiagramID, cursor); err != nil {
+				return nil, fmt.Errorf("cannot load scenarios: %w", err)
+			}
+
+			return batch, nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load all scenarios: %w", err)
+	}
+
+	sourceScenarioIDs := make([]gid.GID, 0, len(scenarios))
+	for _, source := range scenarios {
+		copied := &coredata.RiskAnalysisScenario{
+			ID:                    gid.New(scope.GetTenantID(), coredata.RiskAnalysisScenarioEntityType),
+			OrganizationID:        copiedDiagram.OrganizationID,
+			RiskAnalysisDiagramID: copiedDiagram.ID,
+			Name:                  source.Name,
+			Description:           source.Description,
+			CreatedAt:             now,
+			UpdatedAt:             now,
+		}
+		idMap[source.ID] = copied.ID
+		sourceScenarioIDs = append(sourceScenarioIDs, source.ID)
+
+		if err := copied.Insert(ctx, tx, scope); err != nil {
+			return nil, fmt.Errorf("cannot insert scenario: %w", err)
+		}
+	}
+
+	if err := copyScenarioRisks(ctx, tx, scope, sourceScenarioIDs, now, idMap); err != nil {
+		return nil, fmt.Errorf("cannot copy scenario risks: %w", err)
+	}
+
+	return sourceScenarioIDs, nil
+}
+
+func copyScenarioThreats(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	sourceScenarioIDs []gid.GID,
+	now time.Time,
+	idMap map[gid.GID]gid.GID,
+) error {
+	var links coredata.RiskAnalysisScenarioThreats
+	if err := links.LoadByScenarioIDs(ctx, tx, scope, sourceScenarioIDs); err != nil {
+		return fmt.Errorf("cannot load scenario threats: %w", err)
+	}
+
+	for _, link := range links {
+		scenarioID, err := remapID(idMap, link.RiskAnalysisScenarioID)
+		if err != nil {
+			return fmt.Errorf("cannot remap scenario threat scenario: %w", err)
+		}
+
+		threatID, err := remapID(idMap, link.RiskAnalysisThreatID)
+		if err != nil {
+			return fmt.Errorf("cannot remap scenario threat: %w", err)
+		}
+
+		copied := &coredata.RiskAnalysisScenarioThreat{
+			RiskAnalysisScenarioID: scenarioID,
+			RiskAnalysisThreatID:   threatID,
+			CreatedAt:              now,
+		}
+		if err := copied.Insert(ctx, tx, scope); err != nil {
+			return fmt.Errorf("cannot insert scenario threat: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func copyScenarioRisks(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	sourceScenarioIDs []gid.GID,
+	now time.Time,
+	idMap map[gid.GID]gid.GID,
+) error {
+	var links coredata.RiskAnalysisScenarioRisks
+	if err := links.LoadByScenarioIDs(ctx, tx, scope, sourceScenarioIDs); err != nil {
+		return fmt.Errorf("cannot load scenario risks: %w", err)
+	}
+
+	for _, link := range links {
+		scenarioID, err := remapID(idMap, link.RiskAnalysisScenarioID)
+		if err != nil {
+			return fmt.Errorf("cannot remap scenario risk scenario: %w", err)
+		}
+
+		copied := &coredata.RiskAnalysisScenarioRisk{
+			RiskAnalysisScenarioID: scenarioID,
+			RiskID:                 link.RiskID,
+			CreatedAt:              now,
+		}
+		if err := copied.Insert(ctx, tx, scope); err != nil {
+			return fmt.Errorf("cannot insert scenario risk: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func copyTreatmentPlans(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	sourceAnalysisID gid.GID,
+	forked *coredata.RiskAnalysis,
+	now time.Time,
+	idMap map[gid.GID]gid.GID,
+) error {
+	plans, err := page.LoadAll(
+		ctx,
+		page.OrderBy[coredata.TreatmentPlanOrderField]{
+			Field:     coredata.TreatmentPlanOrderFieldCreatedAt,
+			Direction: page.OrderDirectionAsc,
+		},
+		func(ctx context.Context, cursor *page.Cursor[coredata.TreatmentPlanOrderField]) ([]*coredata.TreatmentPlan, error) {
+			var batch coredata.TreatmentPlans
+			if err := batch.LoadByRiskAnalysisID(
+				ctx,
+				tx,
+				scope,
+				sourceAnalysisID,
+				cursor,
+				coredata.NewTreatmentPlanFilter(nil, nil, nil),
+			); err != nil {
+				return nil, fmt.Errorf("cannot load treatment plans: %w", err)
+			}
+
+			return batch, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("cannot load all treatment plans: %w", err)
+	}
+
+	sourcePlanIDs := make([]gid.GID, 0, len(plans))
+	for _, source := range plans {
+		copied := &coredata.TreatmentPlan{
+			ID:                 gid.New(scope.GetTenantID(), coredata.TreatmentPlanEntityType),
+			OrganizationID:     forked.OrganizationID,
+			RiskID:             source.RiskID,
+			RiskAnalysisID:     forked.ID,
+			Treatment:          source.Treatment,
+			OwnerID:            source.OwnerID,
+			InherentLikelihood: source.InherentLikelihood,
+			InherentImpact:     source.InherentImpact,
+			ResidualLikelihood: source.ResidualLikelihood,
+			ResidualImpact:     source.ResidualImpact,
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		}
+		idMap[source.ID] = copied.ID
+		sourcePlanIDs = append(sourcePlanIDs, source.ID)
+
+		if err := copied.Insert(ctx, tx, scope); err != nil {
+			return fmt.Errorf("cannot insert treatment plan: %w", err)
+		}
+	}
+
+	var mappings coredata.TreatmentPlanMeasures
+	if err := mappings.LoadByTreatmentPlanIDs(ctx, tx, scope, sourcePlanIDs); err != nil {
+		return fmt.Errorf("cannot load treatment plan measures: %w", err)
+	}
+
+	for _, mapping := range mappings {
+		planID, err := remapID(idMap, mapping.TreatmentPlanID)
+		if err != nil {
+			return fmt.Errorf("cannot remap treatment plan measure: %w", err)
+		}
+
+		copied := coredata.TreatmentPlanMeasure{
+			TreatmentPlanID: planID,
+			MeasureID:       mapping.MeasureID,
+			OrganizationID:  forked.OrganizationID,
+			CreatedAt:       now,
+		}
+		if err := copied.Insert(ctx, tx, scope); err != nil {
+			return fmt.Errorf("cannot insert treatment plan measure: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func orderBoundaries(boundaries []*coredata.RiskAnalysisBoundary) ([]*coredata.RiskAnalysisBoundary, error) {
+	remaining := make(map[gid.GID]*coredata.RiskAnalysisBoundary, len(boundaries))
+	for _, boundary := range boundaries {
+		remaining[boundary.ID] = boundary
+	}
+
+	ordered := make([]*coredata.RiskAnalysisBoundary, 0, len(boundaries))
+	emitted := make(map[gid.GID]struct{}, len(boundaries))
+
+	for len(remaining) > 0 {
+		progress := false
+
+		for id, boundary := range remaining {
+			if boundary.ParentBoundaryID != nil {
+				if _, ok := emitted[*boundary.ParentBoundaryID]; !ok {
+					continue
+				}
+			}
+
+			ordered = append(ordered, boundary)
+			emitted[id] = struct{}{}
+			delete(remaining, id)
+
+			progress = true
+		}
+
+		if !progress {
+			return nil, fmt.Errorf("cannot order boundaries: cycle detected")
+		}
+	}
+
+	return ordered, nil
+}
+
+func remapID(idMap map[gid.GID]gid.GID, old gid.GID) (gid.GID, error) {
+	mapped, ok := idMap[old]
+	if !ok {
+		return gid.GID{}, fmt.Errorf("cannot remap id %s: mapping not found", old)
+	}
+
+	return mapped, nil
+}
+
+func remapOptionalID(idMap map[gid.GID]gid.GID, old *gid.GID) (*gid.GID, error) {
+	if old == nil {
+		return nil, nil
+	}
+
+	mapped, err := remapID(idMap, *old)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mapped, nil
+}

--- a/pkg/riskmanagement/fork_test.go
+++ b/pkg/riskmanagement/fork_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package riskmanagement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+func TestOrderBoundaries_ParentFirst(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	rootID := gid.New(tenantID, coredata.RiskAnalysisBoundaryEntityType)
+	childID := gid.New(tenantID, coredata.RiskAnalysisBoundaryEntityType)
+	grandchildID := gid.New(tenantID, coredata.RiskAnalysisBoundaryEntityType)
+
+	grandchild := &coredata.RiskAnalysisBoundary{ID: grandchildID, ParentBoundaryID: &childID}
+	child := &coredata.RiskAnalysisBoundary{ID: childID, ParentBoundaryID: &rootID}
+	root := &coredata.RiskAnalysisBoundary{ID: rootID}
+
+	ordered, err := orderBoundaries([]*coredata.RiskAnalysisBoundary{grandchild, child, root})
+	require.NoError(t, err)
+	require.Len(t, ordered, 3)
+	assert.Equal(t, rootID, ordered[0].ID)
+	assert.Equal(t, childID, ordered[1].ID)
+	assert.Equal(t, grandchildID, ordered[2].ID)
+}
+
+func TestOrderBoundaries_Cycle(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	aID := gid.New(tenantID, coredata.RiskAnalysisBoundaryEntityType)
+	bID := gid.New(tenantID, coredata.RiskAnalysisBoundaryEntityType)
+
+	a := &coredata.RiskAnalysisBoundary{ID: aID, ParentBoundaryID: &bID}
+	b := &coredata.RiskAnalysisBoundary{ID: bID, ParentBoundaryID: &aID}
+
+	_, err := orderBoundaries([]*coredata.RiskAnalysisBoundary{a, b})
+	require.Error(t, err)
+}

--- a/pkg/riskmanagement/service.go
+++ b/pkg/riskmanagement/service.go
@@ -166,6 +166,13 @@ type (
 		RiskAnalysisScenarioID gid.GID
 		RiskID                 gid.GID
 	}
+
+	ForkRiskAnalysisRequest struct {
+		RiskAnalysisID gid.GID
+		Name           string
+		Description    *string
+		Period         *Period
+	}
 )
 
 func (r *CreateRiskAnalysisRequest) Validate() error {
@@ -187,6 +194,19 @@ func (r *UpdateRiskAnalysisRequest) Validate() error {
 	v := validator.New()
 	v.Check(r.ID, "id", validator.Required(), validator.GID(coredata.RiskAnalysisEntityType))
 	v.Check(r.Name, "name", validator.SafeTextNoNewLine(TitleMaxLength))
+	v.Check(r.Description, "description", validator.SafeText(ContentMaxLength))
+
+	if r.Period != nil {
+		validatePeriodRange(v, r.Period.Start, r.Period.End)
+	}
+
+	return v.Error()
+}
+
+func (r *ForkRiskAnalysisRequest) Validate() error {
+	v := validator.New()
+	v.Check(r.RiskAnalysisID, "risk_analysis_id", validator.Required(), validator.GID(coredata.RiskAnalysisEntityType))
+	v.Check(r.Name, "name", validator.Required(), validator.SafeTextNoNewLine(TitleMaxLength))
 	v.Check(r.Description, "description", validator.SafeText(ContentMaxLength))
 
 	if r.Period != nil {

--- a/pkg/server/api/console/v1/graphql/risk_analysis.graphql
+++ b/pkg/server/api/console/v1/graphql/risk_analysis.graphql
@@ -477,6 +477,9 @@ extend type Mutation {
     deleteRiskAnalysis(
         input: DeleteRiskAnalysisInput!
     ): DeleteRiskAnalysisPayload!
+    forkRiskAnalysis(
+        input: ForkRiskAnalysisInput!
+    ): ForkRiskAnalysisPayload!
 
     createRiskAnalysisDiagram(
         input: CreateRiskAnalysisDiagramInput!
@@ -584,6 +587,17 @@ type UpdateRiskAnalysisPayload {
 
 type DeleteRiskAnalysisPayload {
     deletedRiskAnalysisId: ID!
+}
+
+input ForkRiskAnalysisInput {
+    riskAnalysisId: ID!
+    name: String!
+    description: String
+    period: PeriodInput
+}
+
+type ForkRiskAnalysisPayload {
+    riskAnalysisEdge: RiskAnalysisConnectionEdge!
 }
 
 input CreateRiskAnalysisDiagramInput {

--- a/pkg/server/api/console/v1/risk_analysis_resolvers.go
+++ b/pkg/server/api/console/v1/risk_analysis_resolvers.go
@@ -125,6 +125,74 @@ func (r *mutationResolver) DeleteRiskAnalysis(ctx context.Context, input types.D
 	return &types.DeleteRiskAnalysisPayload{DeletedRiskAnalysisID: input.RiskAnalysisID}, nil
 }
 
+// ForkRiskAnalysis is the resolver for the forkRiskAnalysis field.
+func (r *mutationResolver) ForkRiskAnalysis(ctx context.Context, input types.ForkRiskAnalysisInput) (*types.ForkRiskAnalysisPayload, error) {
+	scope, err := r.authorize(ctx, input.RiskAnalysisID, riskmanagement.ActionRiskAnalysisGet)
+	if err != nil {
+		if gqlutils.IsForbidden(err) {
+			return nil, gqlutils.NotFoundf(ctx, "risk analysis not found")
+		}
+
+		return nil, err
+	}
+
+	source, err := r.riskManagement.Get(ctx, scope, input.RiskAnalysisID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return nil, gqlutils.NotFound(ctx, err)
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot load risk analysis", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	scope, err = r.authorize(ctx, source.OrganizationID, riskmanagement.ActionRiskAnalysisCreate)
+	if err != nil {
+		return nil, err
+	}
+
+	var period *riskmanagement.Period
+	if input.Period != nil {
+		period = &riskmanagement.Period{
+			Start: input.Period.Start,
+			End:   input.Period.End,
+		}
+	}
+
+	ra, err := r.riskManagement.Fork(
+		ctx,
+		scope,
+		riskmanagement.ForkRiskAnalysisRequest{
+			RiskAnalysisID: input.RiskAnalysisID,
+			Name:           input.Name,
+			Description:    input.Description,
+			Period:         period,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return nil, gqlutils.NotFound(ctx, err)
+		}
+
+		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
+			return nil, gqlutils.Conflict(ctx, err)
+		}
+
+		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
+			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot fork risk analysis", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return &types.ForkRiskAnalysisPayload{
+		RiskAnalysisEdge: types.NewRiskAnalysisConnectionEdge(ra, coredata.RiskAnalysisOrderFieldCreatedAt),
+	}, nil
+}
+
 // CreateRiskAnalysisDiagram is the resolver for the createRiskAnalysisDiagram field.
 func (r *mutationResolver) CreateRiskAnalysisDiagram(ctx context.Context, input types.CreateRiskAnalysisDiagramInput) (*types.CreateRiskAnalysisDiagramPayload, error) {
 	scope, err := r.authorize(ctx, input.RiskAnalysisID, riskmanagement.ActionRiskAnalysisDiagramCreate)

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -6630,6 +6630,70 @@ func (r *Resolver) DeleteRiskAnalysisTool(ctx context.Context, req *mcp.CallTool
 		DeletedRiskAnalysisID: input.ID,
 	}, nil
 }
+
+func (r *Resolver) ForkRiskAnalysisTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ForkRiskAnalysisInput) (*mcp.CallToolResult, types.ForkRiskAnalysisOutput, error) {
+	scope, err := r.Authorize(ctx, input.ID, riskmanagement.ActionRiskAnalysisGet)
+	if err != nil {
+		return nil, types.ForkRiskAnalysisOutput{}, err
+	}
+
+	source, err := r.riskManagement.Get(ctx, scope, input.ID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return nil, types.ForkRiskAnalysisOutput{}, fmt.Errorf("resource not found")
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot load risk analysis", log.Error(err))
+
+		return nil, types.ForkRiskAnalysisOutput{}, fmt.Errorf("internal server error")
+	}
+
+	scope, err = r.Authorize(ctx, source.OrganizationID, riskmanagement.ActionRiskAnalysisCreate)
+	if err != nil {
+		return nil, types.ForkRiskAnalysisOutput{}, err
+	}
+
+	var period *riskmanagement.Period
+	if input.Period != nil {
+		period = &riskmanagement.Period{
+			Start: input.Period.Start,
+			End:   input.Period.End,
+		}
+	}
+
+	ra, err := r.riskManagement.Fork(
+		ctx,
+		scope,
+		riskmanagement.ForkRiskAnalysisRequest{
+			RiskAnalysisID: input.ID,
+			Name:           input.Name,
+			Description:    input.Description,
+			Period:         period,
+		},
+	)
+	if err != nil {
+		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
+			return nil, types.ForkRiskAnalysisOutput{}, validationErrors
+		}
+
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return nil, types.ForkRiskAnalysisOutput{}, fmt.Errorf("resource not found")
+		}
+
+		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
+			return nil, types.ForkRiskAnalysisOutput{}, fmt.Errorf("resource already exists")
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot fork risk analysis", log.Error(err))
+
+		return nil, types.ForkRiskAnalysisOutput{}, fmt.Errorf("internal server error")
+	}
+
+	return nil, types.ForkRiskAnalysisOutput{
+		RiskAnalysis: types.NewRiskAnalysis(ra),
+	}, nil
+}
+
 func (r *Resolver) ListRiskAnalysisDiagramsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRiskAnalysisDiagramsInput) (*mcp.CallToolResult, types.ListRiskAnalysisDiagramsOutput, error) {
 	scope, err := r.Authorize(ctx, input.RiskAnalysisID, riskmanagement.ActionRiskAnalysisDiagramList)
 	if err != nil {

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -13941,6 +13941,33 @@ components:
           $ref: "#/components/schemas/GID"
           description: Deleted risk assessment ID
 
+    ForkRiskAnalysisInput:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Source risk analysis ID
+        name:
+          type: string
+          description: Forked risk analysis name
+        description:
+          type: string
+          description: Forked risk analysis description
+        period:
+          $ref: "#/components/schemas/Period"
+          description: Analysis period (not copied from the source)
+
+    ForkRiskAnalysisOutput:
+      type: object
+      required:
+        - risk_analysis
+      properties:
+        risk_analysis:
+          $ref: "#/components/schemas/RiskAnalysis"
+
     ListRiskAnalysisDiagramsInput:
       type: object
       required:
@@ -18673,6 +18700,18 @@ tools:
       $ref: "#/components/schemas/DeleteRiskAnalysisInput"
     outputSchema:
       $ref: "#/components/schemas/DeleteRiskAnalysisOutput"
+  - name: forkRiskAnalysis
+    title: Fork Risk Analysis
+    description: Fork a risk analysis, copying diagrams, treatment plans, and their relations
+    hints:
+      readonly: false
+      destructive: false
+      idempotent: false
+      openWorld: false
+    inputSchema:
+      $ref: "#/components/schemas/ForkRiskAnalysisInput"
+    outputSchema:
+      $ref: "#/components/schemas/ForkRiskAnalysisOutput"
   - name: listRiskAnalysisDiagrams
     title: List Risk Analysis Diagrams
     description: List all diagrams for a risk analysis


### PR DESCRIPTION
Copy diagrams, treatment plans, and their
relations into a new analysis so a later
period can reuse the graph without rebuilding
it. Matrix size stays on the source; period
starts empty.