### PR TITLE
Reconstruct the risk analysis treatment plans as of a date

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -2659,6 +2659,7 @@
     "unplannedWarning_one": "{{count}} linked risk has no treatment plan yet.",
     "unplannedWarning_other": "{{count}} linked risks have no treatment plan yet.",
     "filter": "{{state}} · L{{likelihood}} × I{{impact}}",
+    "asOf": "As of",
     "search": "Search risks",
     "states": { "inherent": "Inherent", "net": "Net", "residual": "Residual" },
     "axes": { "likelihood": "Likelihood", "impact": "Impact" },
@@ -2678,7 +2679,6 @@
     "scoreProgress": "{{inherent}} → {{net}} → {{residual}}",
     "progress": "{{done}}/{{total}}",
     "progressEmpty": "No measures",
-    "unassigned": "Unassigned",
     "actions": {
       "tasks": "Tasks",
       "edit": "Edit",
@@ -2694,12 +2694,12 @@
   "riskTreatmentPlanListItem": {
     "deleteConfirmation": "This will permanently delete the treatment plan for \"{{name}}\". This action cannot be undone.",
     "scoreProgress": "{{inherent}} → {{net}} → {{residual}}",
-    "unassigned": "Unassigned",
     "actions": { "measures": "Measures", "edit": "Edit", "delete": "Delete" }
   },
   "treatmentPlanMeasureList": {
     "title": "Measures",
     "empty": "No measures linked yet.",
+    "deleted": "Deleted measure",
     "acceptedEmpty": "Accepted risks cannot have linked measures.",
     "actions": { "create": "New measure", "link": "Link measure", "unlink": "Unlink", "showMore": "Show more" }
   },

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -5140,6 +5140,7 @@
     "unplannedWarning_one": "{{count}} risque lié n’a pas encore de plan de traitement.",
     "unplannedWarning_other": "{{count}} risques liés n’ont pas encore de plan de traitement.",
     "filter": "{{state}} · L{{likelihood}} × I{{impact}}",
+    "asOf": "En date du",
     "search": "Rechercher des risques",
     "states": {
       "inherent": "Inhérent",
@@ -5168,7 +5169,6 @@
     "scoreProgress": "{{inherent}} → {{net}} → {{residual}}",
     "progress": "{{done}}/{{total}}",
     "progressEmpty": "Aucune mesure",
-    "unassigned": "Non attribué",
     "actions": {
       "tasks": "Tâches",
       "edit": "Modifier",
@@ -5189,7 +5189,6 @@
   "riskTreatmentPlanListItem": {
     "deleteConfirmation": "Cela supprimera définitivement le plan de traitement de « {{name}} ». Cette action est irréversible.",
     "scoreProgress": "{{inherent}} → {{net}} → {{residual}}",
-    "unassigned": "Non attribué",
     "actions": {
       "measures": "Mesures",
       "edit": "Modifier",
@@ -5199,6 +5198,7 @@
   "treatmentPlanMeasureList": {
     "title": "Mesures",
     "empty": "Aucune mesure liée pour le moment.",
+    "deleted": "Mesure supprimée",
     "acceptedEmpty": "Les risques acceptés ne peuvent pas avoir de mesures liées.",
     "actions": {
       "create": "Nouvelle mesure",

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -5130,6 +5130,7 @@
     "unplannedWarning_one": "{{count}} gekoppeld risico heeft nog geen behandelplan.",
     "unplannedWarning_other": "{{count}} gekoppelde risico’s hebben nog geen behandelplan.",
     "filter": "{{state}} · L{{likelihood}} × I{{impact}}",
+    "asOf": "Per",
     "search": "Zoek risico's",
     "states": {
       "inherent": "Inherent",
@@ -5158,7 +5159,6 @@
     "scoreProgress": "{{inherent}} → {{net}} → {{residual}}",
     "progress": "{{done}}/{{total}}",
     "progressEmpty": "Geen maatregelen",
-    "unassigned": "Niet toegewezen",
     "actions": {
       "tasks": "Taken",
       "edit": "Bewerken",
@@ -5179,7 +5179,6 @@
   "riskTreatmentPlanListItem": {
     "deleteConfirmation": "Dit verwijdert het behandelplan voor \"{{name}}\" permanent. Deze actie kan niet ongedaan worden gemaakt.",
     "scoreProgress": "{{inherent}} → {{net}} → {{residual}}",
-    "unassigned": "Niet toegewezen",
     "actions": {
       "measures": "Maatregelen",
       "edit": "Bewerken",
@@ -5189,6 +5188,7 @@
   "treatmentPlanMeasureList": {
     "title": "Maatregelen",
     "empty": "Nog geen maatregelen gekoppeld.",
+    "deleted": "Verwijderde maatregel",
     "acceptedEmpty": "Geaccepteerde risico's kunnen geen maatregelen hebben.",
     "actions": {
       "create": "Nieuwe maatregel",

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_components/RiskAnalysisMatrices.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_components/RiskAnalysisMatrices.tsx
@@ -19,13 +19,14 @@
 // SOFTWARE.
 
 import { getRiskImpacts, getRiskLikelihoods } from "@probo/helpers";
-import { Card, RisksChart } from "@probo/ui";
+import { Card, IconClock, Input, RisksChart } from "@probo/ui";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
 
 import type { RiskAnalysisMatrices_analysis$key } from "#/__generated__/core/RiskAnalysisMatrices_analysis.graphql";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 
+import { asOfDateBounds, clampDateInput, matrixAsOf } from "../_lib/matrixAsOf";
 import {
   graphqlScoreTypes,
   type MatrixCell,
@@ -36,12 +37,16 @@ import { useMatrixCellFilter } from "../_lib/useMatrixCellFilter";
 const severityColors = ["bg-txt-success", "bg-txt-warning", "bg-txt-danger"] as const;
 
 export const riskAnalysisMatricesFragment = graphql`
-  fragment RiskAnalysisMatrices_analysis on RiskAnalysis {
+  fragment RiskAnalysisMatrices_analysis on RiskAnalysis
+  @argumentDefinitions(
+    asOf: { type: "Datetime", defaultValue: null }
+  ) {
+    createdAt
     matrixSize {
       rows
       cols
     }
-    matrixCells {
+    matrixCells(asOf: $asOf) {
       type
       likelihood
       impact
@@ -52,6 +57,9 @@ export const riskAnalysisMatricesFragment = graphql`
 
 interface RiskAnalysisMatricesProps {
   analysisKey: RiskAnalysisMatrices_analysis$key;
+  asOfDate: string;
+  isPending: boolean;
+  onAsOfDateChange: (date: string) => void;
 }
 
 function selectedChartCell(
@@ -65,8 +73,8 @@ function selectedChartCell(
   return { likelihood: cell.likelihood, impact: cell.impact };
 }
 
-function cellCountsForScoreType(
-  counts: ReadonlyArray<{
+function cellCountsForType(
+  cells: ReadonlyArray<{
     type: string;
     likelihood: number;
     impact: number;
@@ -74,9 +82,9 @@ function cellCountsForScoreType(
   }>,
   type: MatrixScoreType,
 ) {
-  const graphqlType = graphqlScoreTypes[type];
-  return counts
-    .filter(cell => cell.type === graphqlType)
+  const scoreType = graphqlScoreTypes[type];
+  return cells
+    .filter(cell => cell.type === scoreType)
     .map(cell => ({
       likelihood: cell.likelihood,
       impact: cell.impact,
@@ -84,7 +92,12 @@ function cellCountsForScoreType(
     }));
 }
 
-export function RiskAnalysisMatrices({ analysisKey }: RiskAnalysisMatricesProps) {
+export function RiskAnalysisMatrices({
+  analysisKey,
+  asOfDate,
+  isPending,
+  onAsOfDateChange,
+}: RiskAnalysisMatricesProps) {
   const { t } = useTranslation();
   const organizationId = useOrganizationId();
   const { cell, toggleCell } = useMatrixCellFilter();
@@ -94,7 +107,14 @@ export function RiskAnalysisMatrices({ analysisKey }: RiskAnalysisMatricesProps)
   }
 
   const matrixSize = { rows: analysis.matrixSize.rows, cols: analysis.matrixSize.cols };
-  const counts = analysis.matrixCells ?? [];
+  const { minDate, maxDate } = asOfDateBounds(analysis.createdAt);
+  const cells = analysis.matrixCells;
+  const hasAsOf = matrixAsOf(asOfDate) != null;
+
+  const handleAsOfDateChange = (value: string) => {
+    onAsOfDateChange(clampDateInput(value, minDate, maxDate));
+  };
+
   const impacts = getRiskImpacts(t, matrixSize.cols);
   const likelihoods = getRiskLikelihoods(t, matrixSize.rows);
   const formatScale = (items: ReadonlyArray<{ value: number; label: string }>) =>
@@ -112,11 +132,30 @@ export function RiskAnalysisMatrices({ analysisKey }: RiskAnalysisMatricesProps)
 
   return (
     <Card padded className="space-y-6 overflow-visible">
-      <div className="grid grid-cols-3 gap-6">
+      <div className="flex items-center justify-end gap-2">
+        <IconClock size={16} className="text-txt-secondary" />
+        <label htmlFor="asOf" className="text-sm font-medium text-txt-primary whitespace-nowrap">
+          {t("riskAnalysisTreatmentPlansPage.asOf")}
+        </label>
+        <Input
+          type="date"
+          name="asOf"
+          id="asOf"
+          className={hasAsOf ? "w-40" : "w-40 text-txt-secondary"}
+          value={hasAsOf ? asOfDate : ""}
+          min={minDate}
+          max={maxDate}
+          onChange={event => handleAsOfDateChange(event.target.value)}
+        />
+      </div>
+      <div
+        aria-busy={isPending}
+        className={`grid grid-cols-3 gap-6 transition-opacity ${isPending ? "opacity-60" : ""}`}
+      >
         <RisksChart
           organizationId={organizationId}
           type="inherent"
-          cellCounts={cellCountsForScoreType(counts, "inherent")}
+          cellCounts={cellCountsForType(cells, "inherent")}
           matrixSize={matrixSize}
           variant="bare"
           selectedCell={selectedChartCell(cell, "inherent")}
@@ -125,7 +164,7 @@ export function RiskAnalysisMatrices({ analysisKey }: RiskAnalysisMatricesProps)
         <RisksChart
           organizationId={organizationId}
           type="net"
-          cellCounts={cellCountsForScoreType(counts, "net")}
+          cellCounts={cellCountsForType(cells, "net")}
           matrixSize={matrixSize}
           variant="bare"
           selectedCell={selectedChartCell(cell, "net")}
@@ -134,7 +173,7 @@ export function RiskAnalysisMatrices({ analysisKey }: RiskAnalysisMatricesProps)
         <RisksChart
           organizationId={organizationId}
           type="residual"
-          cellCounts={cellCountsForScoreType(counts, "residual")}
+          cellCounts={cellCountsForType(cells, "residual")}
           matrixSize={matrixSize}
           variant="bare"
           selectedCell={selectedChartCell(cell, "residual")}

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_components/RiskAnalysisPlansSection.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_components/RiskAnalysisPlansSection.tsx
@@ -31,19 +31,28 @@ import {
   Thead,
   Tr,
 } from "@probo/ui";
-import { Suspense, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { type ReactNode, Suspense, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
-import { graphql, useFragment, usePaginationFragment } from "react-relay";
+import { graphql, usePaginationFragment, useRefetchableFragment } from "react-relay";
 
-import type { RiskAnalysisPlansSection_analysis$key } from "#/__generated__/core/RiskAnalysisPlansSection_analysis.graphql";
+import type {
+  RiskAnalysisPlansSection_analysis$data,
+  RiskAnalysisPlansSection_analysis$key,
+} from "#/__generated__/core/RiskAnalysisPlansSection_analysis.graphql";
 import type { RiskAnalysisPlansSection_plans$key } from "#/__generated__/core/RiskAnalysisPlansSection_plans.graphql";
-import type { RiskAnalysisPlansSection_unplanned$key } from "#/__generated__/core/RiskAnalysisPlansSection_unplanned.graphql";
+import type {
+  RiskAnalysisPlansSection_unplanned$data,
+  RiskAnalysisPlansSection_unplanned$key,
+} from "#/__generated__/core/RiskAnalysisPlansSection_unplanned.graphql";
 import type { RiskAnalysisPlansSectionPlansQuery } from "#/__generated__/core/RiskAnalysisPlansSectionPlansQuery.graphql";
+import type { RiskAnalysisPlansSectionRefetchQuery } from "#/__generated__/core/RiskAnalysisPlansSectionRefetchQuery.graphql";
 import type { RiskAnalysisPlansSectionUnplannedQuery } from "#/__generated__/core/RiskAnalysisPlansSectionUnplannedQuery.graphql";
 import { LinkCardSkeleton } from "#/components/skeletons/LinkCardSkeleton";
 import { type Order, SortableContext, SortableTh } from "#/components/SortableTable";
 
+import { asOfDateBounds, clampDateInput, matrixAsOf } from "../_lib/matrixAsOf";
 import { treatmentPlanFilterFromCell } from "../_lib/matrixCell";
+import { useMatrixAsOf } from "../_lib/useMatrixAsOf";
 import { useMatrixCellFilter } from "../_lib/useMatrixCellFilter";
 import { LinkedRiskListItem } from "../treatment-plans/_components/LinkedRiskListItem";
 import { TreatmentPlanListItem } from "../treatment-plans/_components/TreatmentPlanListItem";
@@ -62,6 +71,7 @@ const riskAnalysisPlansSectionPlansFragment = graphql`
     before: { type: "CursorKey", defaultValue: null }
     filter: { type: "TreatmentPlanFilter", defaultValue: null }
     orderBy: { type: "TreatmentPlanOrder", defaultValue: null }
+    asOf: { type: "Datetime", defaultValue: null }
   ) {
     treatmentPlans(
       first: $first
@@ -70,14 +80,15 @@ const riskAnalysisPlansSectionPlansFragment = graphql`
       before: $before
       filter: $filter
       orderBy: $orderBy
+      asOf: $asOf
     )
-      @connection(key: "RiskAnalysisPlansSection_treatmentPlans", filters: ["filter", "orderBy"]) {
+      @connection(key: "RiskAnalysisPlansSection_treatmentPlans", filters: ["filter", "orderBy", "asOf"]) {
       __id
       totalCount
       edges {
         node {
           id
-          ...TreatmentPlanListItem_treatmentPlan
+          ...TreatmentPlanListItem_treatmentPlan @arguments(asOf: $asOf)
         }
       }
     }
@@ -114,20 +125,36 @@ const riskAnalysisPlansSectionUnplannedFragment = graphql`
 
 export const riskAnalysisPlansSectionFragment = graphql`
   fragment RiskAnalysisPlansSection_analysis on RiskAnalysis
+  @refetchable(queryName: "RiskAnalysisPlansSectionRefetchQuery")
   @argumentDefinitions(
     filter: { type: "TreatmentPlanFilter", defaultValue: null }
+    asOf: { type: "Datetime", defaultValue: null }
+    includeUnplanned: { type: "Boolean!" }
+    orderBy: { type: "TreatmentPlanOrder", defaultValue: null }
   ) {
     id
+    createdAt
     matrixSize {
       rows
       cols
     }
-    ...RiskAnalysisMatrices_analysis
+    ...RiskAnalysisMatrices_analysis @arguments(asOf: $asOf)
     ...LinkedRiskListItem_analysis
-    ...RiskAnalysisPlansSection_plans @arguments(filter: $filter)
-    ...RiskAnalysisPlansSection_unplanned
+    ...RiskAnalysisPlansSection_plans @arguments(filter: $filter, asOf: $asOf, orderBy: $orderBy)
+    ...RiskAnalysisPlansSection_unplanned @include(if: $includeUnplanned)
   }
 `;
+
+type UnplannedPlans = {
+  risks: ReadonlyArray<
+    RiskAnalysisPlansSection_unplanned$data["scenarioRisks"]["edges"][number]["node"]
+  >;
+  totalCount: number;
+  hasNext: boolean;
+  isLoadingNext: boolean;
+  loadNext: (count: number) => void;
+  refetch: () => void;
+};
 
 interface RiskAnalysisPlansSectionProps {
   analysisKey: RiskAnalysisPlansSection_analysis$key;
@@ -144,7 +171,67 @@ export function RiskAnalysisPlansSection({ analysisKey }: RiskAnalysisPlansSecti
 function RiskAnalysisPlansSectionContent({ analysisKey }: RiskAnalysisPlansSectionProps) {
   const { t } = useTranslation();
   const { cell, clear } = useMatrixCellFilter();
-  const analysis = useFragment(riskAnalysisPlansSectionFragment, analysisKey);
+  const { asOfDate, setAsOfDate } = useMatrixAsOf();
+  const [isPending, startTransition] = useTransition();
+  const [order, setOrder] = useState<Order>({ direction: "DESC", field: "" });
+  const [analysis, refetch] = useRefetchableFragment<
+    RiskAnalysisPlansSectionRefetchQuery,
+    RiskAnalysisPlansSection_analysis$key
+  >(riskAnalysisPlansSectionFragment, analysisKey);
+  const { minDate, maxDate } = asOfDateBounds(analysis.createdAt);
+  const clampedAsOfDate = clampDateInput(asOfDate, minDate, maxDate);
+  const asOfNeedsClamp = clampedAsOfDate !== asOfDate;
+  const skipInitialAsOfRefetch = useRef(!asOfNeedsClamp);
+  const asOfPending = isPending || asOfNeedsClamp;
+  const wantUnplanned = matrixAsOf(clampedAsOfDate) == null;
+  const orderBy = useMemo(() => categoryOrder(order), [order]);
+  const orderByRef = useRef(orderBy);
+  const [unplannedReady, setUnplannedReady] = useState(!asOfNeedsClamp && wantUnplanned);
+  if (!wantUnplanned && unplannedReady) {
+    setUnplannedReady(false);
+  }
+
+  useEffect(() => {
+    orderByRef.current = orderBy;
+  });
+
+  useEffect(() => {
+    if (asOfNeedsClamp) {
+      setAsOfDate(clampedAsOfDate, { clearCellFilter: false });
+    }
+  }, [asOfNeedsClamp, clampedAsOfDate, setAsOfDate]);
+
+  useEffect(() => {
+    if (skipInitialAsOfRefetch.current) {
+      skipInitialAsOfRefetch.current = false;
+      return;
+    }
+
+    let cancelled = false;
+    startTransition(() => {
+      refetch(
+        {
+          asOf: matrixAsOf(clampedAsOfDate),
+          filter: treatmentPlanFilterFromCell(cell),
+          includeUnplanned: wantUnplanned,
+          orderBy: orderByRef.current,
+        },
+        {
+          onComplete: (error) => {
+            if (cancelled || error) {
+              return;
+            }
+
+            setUnplannedReady(wantUnplanned);
+          },
+        },
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [clampedAsOfDate, cell, refetch, wantUnplanned]);
 
   if (!analysis.id || !analysis.matrixSize) {
     return null;
@@ -152,7 +239,12 @@ function RiskAnalysisPlansSectionContent({ analysisKey }: RiskAnalysisPlansSecti
 
   return (
     <div className="space-y-4">
-      <RiskAnalysisMatrices analysisKey={analysis} />
+      <RiskAnalysisMatrices
+        analysisKey={analysis}
+        asOfDate={clampedAsOfDate}
+        isPending={asOfPending}
+        onAsOfDateChange={setAsOfDate}
+      />
       {cell && (
         <div className="flex justify-end">
           <Button variant="secondary" icon={IconCrossLargeX} onClick={clear}>
@@ -165,22 +257,42 @@ function RiskAnalysisPlansSectionContent({ analysisKey }: RiskAnalysisPlansSecti
         </div>
       )}
       <Suspense fallback={<LinkCardSkeleton />}>
-        <RiskAnalysisPlansTable analysisKey={analysisKey} />
+        <RiskAnalysisPlansTable
+          analysis={analysis}
+          asOfDate={clampedAsOfDate}
+          isPending={asOfPending}
+          unplannedReady={unplannedReady}
+          order={order}
+          orderBy={orderBy}
+          onOrderChange={setOrder}
+        />
       </Suspense>
     </div>
   );
 }
 
 function RiskAnalysisPlansTable({
-  analysisKey,
+  analysis,
+  asOfDate,
+  isPending,
+  unplannedReady,
+  order,
+  orderBy,
+  onOrderChange,
 }: {
-  analysisKey: RiskAnalysisPlansSection_analysis$key;
+  analysis: RiskAnalysisPlansSection_analysis$data;
+  asOfDate: string;
+  isPending: boolean;
+  unplannedReady: boolean;
+  order: Order;
+  orderBy: ReturnType<typeof categoryOrder>;
+  onOrderChange: (order: Order) => void;
 }) {
   const { t } = useTranslation();
   const { cell } = useMatrixCellFilter();
-  const [order, setOrder] = useState<Order>({ direction: "DESC", field: "" });
   const [, startTransition] = useTransition();
-  const analysis = useFragment(riskAnalysisPlansSectionFragment, analysisKey);
+  const asOf = matrixAsOf(asOfDate);
+  const hasAsOf = asOf != null;
   const {
     data: plansData,
     hasNext: plansHasNext,
@@ -191,26 +303,16 @@ function RiskAnalysisPlansTable({
     RiskAnalysisPlansSectionPlansQuery,
     RiskAnalysisPlansSection_plans$key
   >(riskAnalysisPlansSectionPlansFragment, analysis);
-  const {
-    data: unplannedData,
-    hasNext: unplannedHasNext,
-    isLoadingNext: unplannedLoadingNext,
-    loadNext: loadNextUnplanned,
-    refetch: refetchUnplanned,
-  } = usePaginationFragment<
-    RiskAnalysisPlansSectionUnplannedQuery,
-    RiskAnalysisPlansSection_unplanned$key
-  >(riskAnalysisPlansSectionUnplannedFragment, analysis);
   const filter = useMemo(
     () => treatmentPlanFilterFromCell(cell),
     [cell],
   );
-  const orderBy = useMemo(
-    () => categoryOrder(order),
-    [order],
-  );
+  const plansQueryRef = useRef({ asOf, filter });
   const skipFirstPlansRefetch = useRef(true);
-  const skipFirstUnplannedRefetch = useRef(true);
+
+  useEffect(() => {
+    plansQueryRef.current = { asOf, filter };
+  });
 
   useEffect(() => {
     if (skipFirstPlansRefetch.current) {
@@ -218,19 +320,13 @@ function RiskAnalysisPlansTable({
       return;
     }
     startTransition(() => {
-      refetchPlans({ filter, orderBy });
+      refetchPlans({
+        asOf: plansQueryRef.current.asOf,
+        filter: plansQueryRef.current.filter,
+        orderBy,
+      });
     });
-  }, [filter, orderBy, refetchPlans, startTransition]);
-
-  useEffect(() => {
-    if (skipFirstUnplannedRefetch.current) {
-      skipFirstUnplannedRefetch.current = false;
-      return;
-    }
-    startTransition(() => {
-      refetchUnplanned({ orderBy });
-    });
-  }, [orderBy, refetchUnplanned, startTransition]);
+  }, [orderBy, refetchPlans]);
 
   if (!analysis.matrixSize) {
     return null;
@@ -239,107 +335,172 @@ function RiskAnalysisPlansTable({
   const matrixSize = { rows: analysis.matrixSize.rows, cols: analysis.matrixSize.cols };
   const plans = plansData.treatmentPlans?.edges.map(edge => edge.node) ?? [];
   const connectionId = plansData.treatmentPlans?.__id ?? "";
-  const unplannedRisks = unplannedData.scenarioRisks?.edges.map(edge => edge.node) ?? [];
-  const unplannedTotal = unplannedData.scenarioRisks?.totalCount ?? 0;
-  const visibleUnplannedRisks = cell ? [] : unplannedRisks;
-  const showMore = cell ? plansHasNext : plansHasNext || unplannedHasNext;
-  const loadingMore = plansLoadingNext || unplannedLoadingNext;
 
-  const reload = () => {
-    startTransition(() => {
-      refetchPlans({ filter, orderBy }, { fetchPolicy: "network-only" });
-      refetchUnplanned({ orderBy }, { fetchPolicy: "network-only" });
-    });
+  const renderTable = (unplanned: UnplannedPlans | null) => {
+    const visibleUnplannedRisks = hasAsOf || cell ? [] : (unplanned?.risks ?? []);
+    const unplannedTotal = unplanned?.totalCount ?? 0;
+    const showMore = hasAsOf || cell
+      ? plansHasNext
+      : plansHasNext || (unplanned?.hasNext ?? false);
+    const loadingMore = plansLoadingNext || (unplanned?.isLoadingNext ?? false);
+    const reload = () => {
+      startTransition(() => {
+        refetchPlans({ filter, orderBy, asOf }, { fetchPolicy: "network-only" });
+        unplanned?.refetch();
+      });
+    };
+    const isEmpty = plans.length === 0 && visibleUnplannedRisks.length === 0;
+    const rows = [
+      ...plans.map(plan => ({ kind: "plan" as const, plan })),
+      ...visibleUnplannedRisks.map(risk => ({ kind: "unplanned" as const, risk })),
+    ];
+
+    return (
+      <div
+        aria-busy={isPending}
+        className={`space-y-4 transition-opacity ${isPending ? "opacity-60" : ""}`}
+      >
+        {unplannedTotal > 0 && (
+          <div className="flex items-center gap-3 rounded-lg bg-warning px-4 py-3 text-sm text-txt-warning">
+            <IconWarning size={16} className="shrink-0" />
+            {t("riskAnalysisTreatmentPlansPage.unplannedWarning", {
+              count: unplannedTotal,
+            })}
+          </div>
+        )}
+        <SortableContext value={{ order, changeOrder: onOrderChange }}>
+          <Table>
+            <Thead>
+              <Tr>
+                <Th>{t("riskAnalysisTreatmentPlansPage.columns.risk")}</Th>
+                <SortableTh field="CATEGORY" className="w-px pr-6">
+                  {t("riskAnalysisTreatmentPlansPage.columns.category")}
+                </SortableTh>
+                <Th className="w-px pr-6">{t("riskAnalysisTreatmentPlansPage.columns.treatment")}</Th>
+                <Th className="w-px pr-6">{t("riskAnalysisTreatmentPlansPage.columns.owner")}</Th>
+                <Th className="w-px pr-6">{t("riskAnalysisTreatmentPlansPage.columns.scores")}</Th>
+                <Th className="w-px pr-6">{t("riskAnalysisTreatmentPlansPage.columns.progress")}</Th>
+                <Th width={48} className="w-px" />
+              </Tr>
+            </Thead>
+            <Tbody>
+              {isEmpty && (
+                <Tr>
+                  <Td
+                    colSpan={7}
+                    className="text-center text-txt-secondary"
+                  >
+                    {cell
+                      ? t("riskAnalysisTreatmentPlansPage.emptyFilter")
+                      : t("riskAnalysisTreatmentPlansPage.empty")}
+                  </Td>
+                </Tr>
+              )}
+              {rows.map(row =>
+                row.kind === "plan"
+                  ? (
+                      <TreatmentPlanListItem
+                        key={row.plan.id}
+                        treatmentPlanKey={row.plan}
+                        connectionId={connectionId}
+                        matrixSize={matrixSize}
+                        readOnly={hasAsOf}
+                        onChanged={reload}
+                      />
+                    )
+                  : (
+                      <LinkedRiskListItem
+                        key={row.risk.id}
+                        riskKey={row.risk}
+                        analysisKey={analysis}
+                        connectionId={connectionId}
+                        matrixSize={matrixSize}
+                        onCreated={reload}
+                      />
+                    ),
+              )}
+            </Tbody>
+          </Table>
+        </SortableContext>
+        {showMore && (
+          <Button
+            variant="tertiary"
+            onClick={() => {
+              if (plansHasNext) {
+                loadNextPlans(TREATMENT_PLAN_PAGE_SIZE);
+                return;
+              }
+              unplanned?.loadNext(TREATMENT_PLAN_PAGE_SIZE);
+            }}
+            className="mx-auto"
+            disabled={loadingMore}
+            icon={loadingMore ? Spinner : IconChevronDown}
+          >
+            {t("sortableTable.actions.showMore")}
+          </Button>
+        )}
+      </div>
+    );
   };
 
-  const isEmpty = plans.length === 0 && visibleUnplannedRisks.length === 0;
-  const rows = [
-    ...plans.map(plan => ({ kind: "plan" as const, plan })),
-    ...visibleUnplannedRisks.map(risk => ({ kind: "unplanned" as const, risk })),
-  ];
+  if (hasAsOf || !unplannedReady) {
+    return renderTable(null);
+  }
 
   return (
-    <div className="space-y-4">
-      {unplannedTotal > 0 && (
-        <div className="flex items-center gap-3 rounded-lg bg-warning px-4 py-3 text-sm text-txt-warning">
-          <IconWarning size={16} className="shrink-0" />
-          {t("riskAnalysisTreatmentPlansPage.unplannedWarning", {
-            count: unplannedTotal,
-          })}
-        </div>
-      )}
-      <SortableContext value={{ order, changeOrder: setOrder }}>
-        <Table>
-          <Thead>
-            <Tr>
-              <Th>{t("riskAnalysisTreatmentPlansPage.columns.risk")}</Th>
-              <SortableTh field="CATEGORY" className="w-px pr-6">
-                {t("riskAnalysisTreatmentPlansPage.columns.category")}
-              </SortableTh>
-              <Th className="w-px pr-6">{t("riskAnalysisTreatmentPlansPage.columns.treatment")}</Th>
-              <Th className="w-px pr-6">{t("riskAnalysisTreatmentPlansPage.columns.owner")}</Th>
-              <Th className="w-px pr-6">{t("riskAnalysisTreatmentPlansPage.columns.scores")}</Th>
-              <Th className="w-px pr-6">{t("riskAnalysisTreatmentPlansPage.columns.progress")}</Th>
-              <Th width={48} className="w-px" />
-            </Tr>
-          </Thead>
-          <Tbody>
-            {isEmpty && (
-              <Tr>
-                <Td
-                  colSpan={7}
-                  className="text-center text-txt-secondary"
-                >
-                  {cell
-                    ? t("riskAnalysisTreatmentPlansPage.emptyFilter")
-                    : t("riskAnalysisTreatmentPlansPage.empty")}
-                </Td>
-              </Tr>
-            )}
-            {rows.map(row =>
-              row.kind === "plan"
-                ? (
-                    <TreatmentPlanListItem
-                      key={row.plan.id}
-                      treatmentPlanKey={row.plan}
-                      connectionId={connectionId}
-                      matrixSize={matrixSize}
-                      onChanged={reload}
-                    />
-                  )
-                : (
-                    <LinkedRiskListItem
-                      key={row.risk.id}
-                      riskKey={row.risk}
-                      analysisKey={analysis}
-                      connectionId={connectionId}
-                      matrixSize={matrixSize}
-                      onCreated={reload}
-                    />
-                  ),
-            )}
-          </Tbody>
-        </Table>
-      </SortableContext>
-      {showMore && (
-        <Button
-          variant="tertiary"
-          onClick={() => {
-            if (plansHasNext) {
-              loadNextPlans(TREATMENT_PLAN_PAGE_SIZE);
-              return;
-            }
-            loadNextUnplanned(TREATMENT_PLAN_PAGE_SIZE);
-          }}
-          className="mx-auto"
-          disabled={loadingMore}
-          icon={loadingMore ? Spinner : IconChevronDown}
-        >
-          {t("sortableTable.actions.showMore")}
-        </Button>
-      )}
-    </div>
+    <RiskAnalysisUnplannedPlans
+      analysisKey={analysis}
+      orderBy={orderBy}
+    >
+      {unplanned => renderTable(unplanned)}
+    </RiskAnalysisUnplannedPlans>
   );
+}
+
+function RiskAnalysisUnplannedPlans({
+  analysisKey,
+  orderBy,
+  children,
+}: {
+  analysisKey: RiskAnalysisPlansSection_unplanned$key;
+  orderBy: ReturnType<typeof categoryOrder>;
+  children: (unplanned: UnplannedPlans) => ReactNode;
+}) {
+  const [, startTransition] = useTransition();
+  const {
+    data,
+    hasNext,
+    isLoadingNext,
+    loadNext,
+    refetch,
+  } = usePaginationFragment<
+    RiskAnalysisPlansSectionUnplannedQuery,
+    RiskAnalysisPlansSection_unplanned$key
+  >(riskAnalysisPlansSectionUnplannedFragment, analysisKey);
+  const skipFirstRefetch = useRef(true);
+
+  useEffect(() => {
+    if (skipFirstRefetch.current) {
+      skipFirstRefetch.current = false;
+      return;
+    }
+    startTransition(() => {
+      refetch({ orderBy });
+    });
+  }, [orderBy, refetch, startTransition]);
+
+  const risks = data.scenarioRisks?.edges.map(edge => edge.node) ?? [];
+
+  return children({
+    risks,
+    totalCount: data.scenarioRisks?.totalCount ?? 0,
+    hasNext,
+    isLoadingNext,
+    loadNext,
+    refetch: () => {
+      refetch({ orderBy }, { fetchPolicy: "network-only" });
+    },
+  });
 }
 
 function categoryOrder(order: Order) {

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_lib/matrixAsOf.ts
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_lib/matrixAsOf.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { todayAsDateInput } from "@probo/helpers";
+
+export const matrixAsOfParam = "asOf";
+
+const dateInputPattern = /^\d{4}-\d{2}-\d{2}$/;
+
+function isCalendarDateInput(value: string): boolean {
+  if (!dateInputPattern.test(value)) {
+    return false;
+  }
+
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    parsed.getUTCFullYear() === year
+    && parsed.getUTCMonth() === month - 1
+    && parsed.getUTCDate() === day
+  );
+}
+
+function localDateInput(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
+
+function createdOnDateInput(createdAt: string): string {
+  const parsed = new Date(createdAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return todayAsDateInput();
+  }
+
+  return localDateInput(parsed);
+}
+
+export function parseAsOfDate(params: URLSearchParams): string {
+  const today = todayAsDateInput();
+  const value = params.get(matrixAsOfParam);
+  if (!value || !isCalendarDateInput(value) || value >= today) {
+    return today;
+  }
+
+  return value;
+}
+
+export function clampDateInput(dateInput: string, min: string, max: string): string {
+  if (!dateInput || dateInput > max) {
+    return max;
+  }
+  if (dateInput < min) {
+    return min;
+  }
+  return dateInput;
+}
+
+export function asOfDateBounds(createdAt: string): { minDate: string; maxDate: string } {
+  const createdDate = createdOnDateInput(createdAt);
+  const maxDate = todayAsDateInput();
+  const minDate = createdDate > maxDate ? maxDate : createdDate;
+
+  return { minDate, maxDate };
+}
+
+export function matrixAsOf(dateInput: string): string | null {
+  const date = dateInput || todayAsDateInput();
+  if (date === todayAsDateInput()) {
+    return null;
+  }
+
+  const year = Number(date.slice(0, 4));
+  const month = Number(date.slice(5, 7));
+  const day = Number(date.slice(8, 10));
+
+  return new Date(Date.UTC(year, month - 1, day + 1)).toISOString();
+}

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_lib/useMatrixAsOf.ts
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_lib/useMatrixAsOf.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { todayAsDateInput } from "@probo/helpers";
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router";
+
+import { matrixAsOfParam, parseAsOfDate } from "./matrixAsOf";
+
+function writeAsOfDate(
+  params: URLSearchParams,
+  dateInput: string,
+  options?: { clearCellFilter?: boolean },
+): URLSearchParams {
+  const next = new URLSearchParams(params);
+  const today = todayAsDateInput();
+  if (!dateInput || dateInput >= today) {
+    next.delete(matrixAsOfParam);
+  } else {
+    next.set(matrixAsOfParam, dateInput);
+  }
+
+  if (options?.clearCellFilter !== false) {
+    next.delete("score");
+    next.delete("likelihood");
+    next.delete("impact");
+  }
+
+  return next;
+}
+
+export function useMatrixAsOf() {
+  const [params, setParams] = useSearchParams();
+  const search = params.toString();
+  const asOfDate = useMemo(
+    () => parseAsOfDate(new URLSearchParams(search)),
+    [search],
+  );
+
+  const setAsOfDate = useCallback((
+    next: string,
+    options?: { clearCellFilter?: boolean },
+  ) => {
+    setParams(prev => writeAsOfDate(prev, next, options), {
+      replace: true,
+      preventScrollReset: true,
+    });
+  }, [setParams]);
+
+  return {
+    asOfDate,
+    setAsOfDate,
+  };
+}

--- a/apps/console/src/pages/organizations/risks/risk-analyses/treatment-plans/RiskAnalysisTreatmentPlansPage.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/treatment-plans/RiskAnalysisTreatmentPlansPage.tsx
@@ -29,11 +29,14 @@ export const riskAnalysisTreatmentPlansPageQuery = graphql`
   query RiskAnalysisTreatmentPlansPageQuery(
     $riskAnalysisId: ID!
     $filter: TreatmentPlanFilter
+    $asOf: Datetime
+    $includeUnplanned: Boolean!
   ) {
     node(id: $riskAnalysisId) {
       __typename
       ... on RiskAnalysis {
-        ...RiskAnalysisPlansSection_analysis @arguments(filter: $filter)
+        ...RiskAnalysisPlansSection_analysis
+          @arguments(filter: $filter, asOf: $asOf, includeUnplanned: $includeUnplanned)
       }
     }
   }

--- a/apps/console/src/pages/organizations/risks/risk-analyses/treatment-plans/RiskAnalysisTreatmentPlansPageLoader.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/treatment-plans/RiskAnalysisTreatmentPlansPageLoader.tsx
@@ -18,14 +18,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { Suspense, useEffect, useRef } from "react";
+import { Suspense, useEffect, useMemo } from "react";
 import { useQueryLoader } from "react-relay";
 import { useParams, useSearchParams } from "react-router";
 
 import type { RiskAnalysisTreatmentPlansPageQuery } from "#/__generated__/core/RiskAnalysisTreatmentPlansPageQuery.graphql";
 import { LinkCardSkeleton } from "#/components/skeletons/LinkCardSkeleton";
 
-import { parseMatrixCell, treatmentPlanFilterFromCell } from "../_lib/matrixCell";
+import { matrixAsOf, parseAsOfDate } from "../_lib/matrixAsOf";
+import {
+  parseMatrixCell,
+  treatmentPlanFilterFromCell,
+  type TreatmentPlanFilterInput,
+} from "../_lib/matrixCell";
 
 import RiskAnalysisTreatmentPlansPage, {
   riskAnalysisTreatmentPlansPageQuery,
@@ -34,25 +39,36 @@ import RiskAnalysisTreatmentPlansPage, {
 export default function RiskAnalysisTreatmentPlansPageLoader() {
   const { riskAnalysisId } = useParams<{ riskAnalysisId: string }>();
   const [params] = useSearchParams();
-  const paramsRef = useRef(params);
+  const search = params.toString();
   const [queryRef, loadQuery]
     = useQueryLoader<RiskAnalysisTreatmentPlansPageQuery>(riskAnalysisTreatmentPlansPageQuery);
+  const { asOf, filter, includeUnplanned } = useMemo(() => {
+    const parsed = new URLSearchParams(search);
+    const nextAsOf = matrixAsOf(parseAsOfDate(parsed));
 
-  useEffect(() => {
-    paramsRef.current = params;
-  });
+    return {
+      asOf: nextAsOf,
+      filter: treatmentPlanFilterFromCell(parseMatrixCell(parsed)),
+      includeUnplanned: nextAsOf == null,
+    };
+  }, [search]);
 
   useEffect(() => {
     if (riskAnalysisId) {
       loadQuery({
         riskAnalysisId,
-        filter: treatmentPlanFilterFromCell(parseMatrixCell(paramsRef.current)),
+        filter,
+        asOf,
+        includeUnplanned,
       });
     }
-  }, [loadQuery, riskAnalysisId]);
+  }, [asOf, filter, includeUnplanned, loadQuery, riskAnalysisId]);
 
   const currentQueryRef = queryRef != null
     && queryRef.variables.riskAnalysisId === riskAnalysisId
+    && queryRef.variables.asOf === asOf
+    && queryRef.variables.includeUnplanned === includeUnplanned
+    && sameTreatmentPlanFilter(queryRef.variables.filter, filter)
     ? queryRef
     : null;
 
@@ -65,4 +81,18 @@ export default function RiskAnalysisTreatmentPlansPageLoader() {
       <RiskAnalysisTreatmentPlansPage queryRef={currentQueryRef} />
     </Suspense>
   );
+}
+
+function sameTreatmentPlanFilter(
+  loaded: RiskAnalysisTreatmentPlansPageQuery["variables"]["filter"],
+  wanted: TreatmentPlanFilterInput | null,
+): boolean {
+  if (wanted == null) {
+    return loaded == null;
+  }
+
+  return loaded != null
+    && loaded.scoreType === wanted.scoreType
+    && loaded.likelihood === wanted.likelihood
+    && loaded.impact === wanted.impact;
 }

--- a/apps/console/src/pages/organizations/risks/risk-analyses/treatment-plans/_components/TreatmentPlanListItem.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/treatment-plans/_components/TreatmentPlanListItem.tsx
@@ -41,46 +41,40 @@ import { updateStoreCounter } from "#/hooks/useMutationWithIncrement";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 import { useMutation } from "#/lib/relay/useMutation";
 
-import type { MatrixSize } from "../../_components/matrixSize";
+import { type MatrixSize } from "../../_components/matrixSize";
 
 import { TreatmentPlanMeasureList } from "./TreatmentPlanMeasureList";
+import { TreatmentPlanProgressBar } from "./TreatmentPlanProgressBar";
 import { TreatmentPlanScoreTags } from "./TreatmentPlanScoreTags";
 import { UpdateTreatmentPlanDialog } from "./UpdateTreatmentPlanDialog";
 
 export const treatmentPlanListItemFragment = graphql`
-  fragment TreatmentPlanListItem_treatmentPlan on TreatmentPlan {
+  fragment TreatmentPlanListItem_treatmentPlan on TreatmentPlan
+  @argumentDefinitions(asOf: { type: "Datetime", defaultValue: null }) {
     id
     treatment
     inherentLikelihood
     inherentImpact
     residualLikelihood
     residualImpact
+    category
     owner {
       fullName
     }
     risk {
       id
       name
-      category
     }
     canUpdate: permission(action: "risk-management:treatment-plan:update")
     canDelete: permission(action: "risk-management:treatment-plan:delete")
-    measureCount: measures(first: 0) {
-      totalCount
+    progress {
+      done
+      inProgress
+      notImplemented
+      total
     }
-    implementedMeasures: measures(first: 0, filter: { state: IMPLEMENTED }) {
-      totalCount
-    }
-    inProgressMeasures: measures(first: 0, filter: { state: IN_PROGRESS }) {
-      totalCount
-    }
-    notImplementedMeasures: measures(
-      first: 0
-      filter: { state: NOT_IMPLEMENTED }
-    ) {
-      totalCount
-    }
-    ...TreatmentPlanMeasureList_treatmentPlan
+    ...TreatmentPlanMeasureList_meta
+    ...TreatmentPlanMeasureList_treatmentPlan @arguments(asOf: $asOf)
     ...UpdateTreatmentPlanDialog_treatmentPlan
   }
 `;
@@ -100,6 +94,7 @@ interface TreatmentPlanListItemProps {
   treatmentPlanKey: TreatmentPlanListItem_treatmentPlan$key;
   connectionId: string;
   matrixSize: MatrixSize;
+  readOnly?: boolean;
   onChanged?: () => void;
 }
 
@@ -107,6 +102,7 @@ export function TreatmentPlanListItem({
   treatmentPlanKey,
   connectionId,
   matrixSize,
+  readOnly = false,
   onChanged,
 }: TreatmentPlanListItemProps) {
   const { t } = useTranslation();
@@ -118,21 +114,11 @@ export function TreatmentPlanListItem({
   const treatmentPlan = useFragment(treatmentPlanListItemFragment, treatmentPlanKey);
   const relayEnv = useRelayEnvironment();
   const [deleteTreatmentPlan] = useMutation<TreatmentPlanListItemDeleteMutation>(deleteMutation);
-  const progress = {
-    done: treatmentPlan.implementedMeasures.totalCount,
-    inProgress: treatmentPlan.inProgressMeasures.totalCount,
-    notImplemented: treatmentPlan.notImplementedMeasures.totalCount,
-    total: treatmentPlan.measureCount.totalCount,
-  };
-  const donePct = progress.total === 0
-    ? 0
-    : Math.round((progress.done / progress.total) * 100);
-  const inProgressPct = progress.total === 0
-    ? 0
-    : Math.round((progress.inProgress / progress.total) * 100);
-  const notImplementedPct = progress.total === 0
-    ? 0
-    : Math.round((progress.notImplemented / progress.total) * 100);
+  const progress = treatmentPlan.progress;
+  const inherentLikelihood = treatmentPlan.inherentLikelihood;
+  const inherentImpact = treatmentPlan.inherentImpact;
+  const residualLikelihood = treatmentPlan.residualLikelihood;
+  const residualImpact = treatmentPlan.residualImpact;
 
   const onDelete = () => {
     confirm(
@@ -158,11 +144,13 @@ export function TreatmentPlanListItem({
 
   return (
     <>
-      <UpdateTreatmentPlanDialog
-        dialogRef={formDialogRef}
-        treatmentPlanKey={treatmentPlan}
-        matrixSize={matrixSize}
-      />
+      {!readOnly && (
+        <UpdateTreatmentPlanDialog
+          dialogRef={formDialogRef}
+          treatmentPlanKey={treatmentPlan}
+          matrixSize={matrixSize}
+        />
+      )}
       <Tr
         className="cursor-pointer"
         onClick={() => setExpanded(open => !open)}
@@ -194,7 +182,7 @@ export function TreatmentPlanListItem({
             </Link>
           </div>
         </Td>
-        <Td className="w-px whitespace-nowrap pr-6">{treatmentPlan.risk.category}</Td>
+        <Td className="w-px whitespace-nowrap pr-6">{treatmentPlan.category}</Td>
         <Td className="w-px whitespace-nowrap pr-6">
           {t(`formRiskDialog.treatments.${treatmentPlan.treatment.toLowerCase()}`)}
         </Td>
@@ -203,41 +191,23 @@ export function TreatmentPlanListItem({
         </Td>
         <Td className="w-px whitespace-nowrap pr-6">
           <TreatmentPlanScoreTags
-            inherentLikelihood={treatmentPlan.inherentLikelihood}
-            inherentImpact={treatmentPlan.inherentImpact}
-            residualLikelihood={treatmentPlan.residualLikelihood}
-            residualImpact={treatmentPlan.residualImpact}
+            inherentLikelihood={inherentLikelihood}
+            inherentImpact={inherentImpact}
+            residualLikelihood={residualLikelihood}
+            residualImpact={residualImpact}
             matrixSize={matrixSize}
           />
         </Td>
         <Td className="w-px whitespace-nowrap pr-6">
-          <div className="flex w-28 items-center gap-2">
-            <div className="flex h-1.5 flex-1 overflow-hidden rounded-full bg-border-low">
-              <div
-                className="h-full bg-txt-success"
-                style={{ width: `${donePct}%` }}
-              />
-              <div
-                className="h-full bg-txt-warning"
-                style={{ width: `${inProgressPct}%` }}
-              />
-              <div
-                className="h-full bg-txt-danger"
-                style={{ width: `${notImplementedPct}%` }}
-              />
-            </div>
-            <span className="text-xs tabular-nums text-txt-secondary">
-              {progress.total === 0
-                ? t("treatmentPlanListItem.progressEmpty")
-                : t("treatmentPlanListItem.progress", {
-                    done: progress.done,
-                    total: progress.total,
-                  })}
-            </span>
-          </div>
+          <TreatmentPlanProgressBar
+            done={progress.done}
+            inProgress={progress.inProgress}
+            notImplemented={progress.notImplemented}
+            total={progress.total}
+          />
         </Td>
         <Td noLink width={48} className="w-px text-end">
-          {(treatmentPlan.canUpdate || treatmentPlan.canDelete) && (
+          {!readOnly && (treatmentPlan.canUpdate || treatmentPlan.canDelete) && (
             <div onClick={event => event.stopPropagation()}>
               <ActionDropdown>
                 {treatmentPlan.canUpdate && (

--- a/apps/console/src/pages/organizations/risks/risk-analyses/treatment-plans/_components/TreatmentPlanMeasureList.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/treatment-plans/_components/TreatmentPlanMeasureList.tsx
@@ -25,6 +25,7 @@ import { graphql, useFragment, usePaginationFragment } from "react-relay";
 import { Link } from "react-router";
 
 import type { TreatmentPlanMeasureList_measure$key } from "#/__generated__/core/TreatmentPlanMeasureList_measure.graphql";
+import type { TreatmentPlanMeasureList_meta$key } from "#/__generated__/core/TreatmentPlanMeasureList_meta.graphql";
 import type { TreatmentPlanMeasureList_treatmentPlan$key } from "#/__generated__/core/TreatmentPlanMeasureList_treatmentPlan.graphql";
 import type { TreatmentPlanMeasureListCreateMutation } from "#/__generated__/core/TreatmentPlanMeasureListCreateMutation.graphql";
 import type { TreatmentPlanMeasureListDetachMutation } from "#/__generated__/core/TreatmentPlanMeasureListDetachMutation.graphql";
@@ -36,22 +37,30 @@ import MeasureFormDialog from "#/pages/organizations/measures/dialog/MeasureForm
 
 const PAGE_SIZE = 50;
 
-export const treatmentPlanMeasureListFragment = graphql`
-  fragment TreatmentPlanMeasureList_treatmentPlan on TreatmentPlan
-  @refetchable(queryName: "TreatmentPlanMeasureListPaginationQuery")
-  @argumentDefinitions(
-    first: { type: "Int", defaultValue: 50 }
-    after: { type: "CursorKey", defaultValue: null }
-  ) {
+export const treatmentPlanMeasureListMetaFragment = graphql`
+  fragment TreatmentPlanMeasureList_meta on TreatmentPlan {
     id
     treatment
     canUpdate: permission(action: "risk-management:treatment-plan:update")
     organization {
       canCreateMeasure: permission(action: "core:measure:create")
     }
-    measures(first: $first, after: $after)
-      @connection(key: "TreatmentPlanMeasureList_measures", filters: []) {
+  }
+`;
+
+export const treatmentPlanMeasureListFragment = graphql`
+  fragment TreatmentPlanMeasureList_treatmentPlan on TreatmentPlan
+  @refetchable(queryName: "TreatmentPlanMeasureListPaginationQuery")
+  @argumentDefinitions(
+    first: { type: "Int", defaultValue: 50 }
+    after: { type: "CursorKey", defaultValue: null }
+    asOf: { type: "Datetime", defaultValue: null }
+  ) {
+    id
+    measures(first: $first, after: $after, asOf: $asOf)
+      @connection(key: "TreatmentPlanMeasureList_measures", filters: ["asOf"]) {
       __id
+      asOf
       edges {
         node {
           id
@@ -149,7 +158,7 @@ const detachMeasureMutation = graphql`
 `;
 
 interface TreatmentPlanMeasureListProps {
-  treatmentPlanKey: TreatmentPlanMeasureList_treatmentPlan$key;
+  treatmentPlanKey: TreatmentPlanMeasureList_treatmentPlan$key & TreatmentPlanMeasureList_meta$key;
   onChanged?: () => void;
 }
 
@@ -158,11 +167,18 @@ export function TreatmentPlanMeasureList({
   onChanged,
 }: TreatmentPlanMeasureListProps) {
   const { t } = useTranslation();
+  const meta = useFragment(
+    treatmentPlanMeasureListMetaFragment,
+    treatmentPlanKey as TreatmentPlanMeasureList_meta$key,
+  );
   const { data: treatmentPlan, hasNext, isLoadingNext, loadNext }
     = usePaginationFragment<
       TreatmentPlanMeasureListPaginationQuery,
       TreatmentPlanMeasureList_treatmentPlan$key
-    >(treatmentPlanMeasureListFragment, treatmentPlanKey);
+    >(
+      treatmentPlanMeasureListFragment,
+      treatmentPlanKey as TreatmentPlanMeasureList_treatmentPlan$key,
+    );
   const measures = treatmentPlan.measures?.edges?.map(edge => edge.node) ?? [];
   const connectionId = treatmentPlan.measures?.__id ?? "";
   const [attachMeasure, isAttaching] = useMutation<TreatmentPlanMeasureListCreateMutation>(
@@ -173,8 +189,10 @@ export function TreatmentPlanMeasureList({
   );
   const isLoading = isAttaching || isDetaching;
   const inFlightRef = useRef(false);
-  const accepted = treatmentPlan.treatment === "ACCEPTED";
-  const readOnly = !treatmentPlan.canUpdate || accepted;
+  const accepted = meta.treatment === "ACCEPTED";
+  const hasAsOf = treatmentPlan.measures?.asOf != null;
+  const readOnly = !meta.canUpdate || accepted || hasAsOf;
+  const canCreateMeasure = meta.organization.canCreateMeasure;
 
   const onAttach = async (measureId: string) => {
     if (inFlightRef.current || isLoading) {
@@ -228,7 +246,7 @@ export function TreatmentPlanMeasureList({
         </h3>
         {!readOnly && (
           <div className="flex items-center gap-3">
-            {treatmentPlan.organization.canCreateMeasure && (
+            {canCreateMeasure && (
               <MeasureFormDialog onCreated={onAttach}>
                 <button
                   type="button"
@@ -283,6 +301,7 @@ export function TreatmentPlanMeasureList({
               key={measure.id}
               measureKey={measure}
               readOnly={readOnly}
+              hasAsOf={hasAsOf}
               disabled={isLoading}
               onDetach={(measureId) => {
                 void onDetach(measureId);
@@ -309,26 +328,43 @@ export function TreatmentPlanMeasureList({
 function MeasureRow({
   measureKey,
   readOnly,
+  hasAsOf,
   disabled,
   onDetach,
 }: {
   measureKey: TreatmentPlanMeasureList_measure$key & { id: string };
   readOnly: boolean;
+  hasAsOf: boolean;
   disabled: boolean;
   onDetach: (measureId: string) => void;
 }) {
   const { t } = useTranslation();
   const organizationId = useOrganizationId();
   const measure = useFragment(measureFragment, measureKey);
+  const deleted = measure.name === "";
 
   return (
     <li className="col-span-full grid grid-cols-subgrid items-center py-2.5">
-      <Link
-        to={`/organizations/${organizationId}/governance/measures/${measure.id}`}
-        className="min-w-0 truncate text-sm text-txt-primary hover:underline"
-      >
-        {measure.name}
-      </Link>
+      {deleted
+        ? (
+            <span className="min-w-0 truncate text-sm text-txt-secondary">
+              {t("treatmentPlanMeasureList.deleted")}
+            </span>
+          )
+        : hasAsOf
+          ? (
+              <span className="min-w-0 truncate text-sm text-txt-primary">
+                {measure.name}
+              </span>
+            )
+          : (
+              <Link
+                to={`/organizations/${organizationId}/governance/measures/${measure.id}`}
+                className="min-w-0 truncate text-sm text-txt-primary hover:underline"
+              >
+                {measure.name}
+              </Link>
+            )}
       <MeasureBadge state={measure.state} />
       {!readOnly && (
         <button

--- a/apps/console/src/pages/organizations/risks/risk-analyses/treatment-plans/_components/TreatmentPlanMeasuresDialog.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/treatment-plans/_components/TreatmentPlanMeasuresDialog.tsx
@@ -40,6 +40,7 @@ const treatmentPlanMeasuresDialogQuery = graphql`
         netLikelihood
         netImpact
         netRiskScore
+        ...TreatmentPlanMeasureList_meta
         ...TreatmentPlanMeasureList_treatmentPlan
       }
     }

--- a/apps/console/src/pages/organizations/risks/risk-analyses/treatment-plans/_components/TreatmentPlanProgressBar.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/treatment-plans/_components/TreatmentPlanProgressBar.tsx
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { useTranslation } from "react-i18next";
+
+interface TreatmentPlanProgressBarProps {
+  done: number;
+  inProgress: number;
+  notImplemented: number;
+  total: number;
+}
+
+export function TreatmentPlanProgressBar({
+  done,
+  inProgress,
+  notImplemented,
+  total,
+}: TreatmentPlanProgressBarProps) {
+  const { t } = useTranslation();
+  const doneEnd = total === 0 ? 0 : Math.round((done / total) * 100);
+  const inProgressEnd = total === 0
+    ? 0
+    : Math.round(((done + inProgress) / total) * 100);
+  const paintedEnd = total === 0
+    ? 0
+    : Math.round(((done + inProgress + notImplemented) / total) * 100);
+  const donePct = doneEnd;
+  const inProgressPct = inProgressEnd - doneEnd;
+  const notImplementedPct = paintedEnd - inProgressEnd;
+
+  return (
+    <div className="flex w-28 items-center gap-2">
+      <div className="flex h-1.5 flex-1 overflow-hidden rounded-full bg-border-low">
+        <div
+          className="h-full bg-txt-success"
+          style={{ width: `${donePct}%` }}
+        />
+        <div
+          className="h-full bg-txt-warning"
+          style={{ width: `${inProgressPct}%` }}
+        />
+        <div
+          className="h-full bg-txt-danger"
+          style={{ width: `${notImplementedPct}%` }}
+        />
+      </div>
+      <span className="text-xs tabular-nums text-txt-secondary">
+        {total === 0
+          ? t("treatmentPlanListItem.progressEmpty")
+          : t("treatmentPlanListItem.progress", {
+              done,
+              total,
+            })}
+      </span>
+    </div>
+  );
+}

--- a/e2e/console/risk_analysis_as_of_helpers_test.go
+++ b/e2e/console/risk_analysis_as_of_helpers_test.go
@@ -1,0 +1,358 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package console_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+const (
+	asOfMeasureNodeSelection = `
+		id
+		name
+		category
+		state
+		asOf
+		treatmentPlans(asOf: $asOf) {
+			totalCount
+			edges { node { id asOf } }
+		}
+	`
+
+	asOfPlanNodeSelection = `
+		id
+		asOf
+		category
+		inherentLikelihood
+		inherentImpact
+		netLikelihood
+		netImpact
+		residualLikelihood
+		residualImpact
+		canUpdate: permission(action: "risk-management:treatment-plan:update")
+		canDelete: permission(action: "risk-management:treatment-plan:delete")
+		progress { done inProgress notImplemented total }
+		owner { fullName }
+		risk { id name category }
+		measures(first: 10, asOf: $asOf) {
+			asOf
+			edges { node { id name category state } }
+		}
+	`
+
+	riskAnalysisPlansAsOfQuery = `
+		query($id: ID!, $asOf: Datetime, $first: Int, $orderBy: TreatmentPlanOrder) {
+			node(id: $id) {
+				... on RiskAnalysis {
+					treatmentPlans(asOf: $asOf, first: $first, orderBy: $orderBy) {
+						totalCount
+						edges {
+							node {
+								` + asOfPlanNodeSelection + `
+							}
+						}
+					}
+					matrixCells(asOf: $asOf) {
+						type
+						likelihood
+						impact
+						count
+					}
+				}
+			}
+		}
+	`
+
+	treatmentPlanMeasuresAsOfQuery = `
+		query($id: ID!, $asOf: Datetime, $first: Int, $after: CursorKey, $filter: MeasureFilter) {
+			node(id: $id) {
+				... on TreatmentPlan {
+					__typename
+					asOf
+					measures(first: $first, after: $after, asOf: $asOf, filter: $filter) {
+						asOf
+						edges {
+							node {
+								` + asOfMeasureNodeSelection + `
+							}
+						}
+						pageInfo { hasNextPage endCursor }
+					}
+				}
+			}
+		}
+	`
+
+	measureTreatmentPlansAsOfQuery = `
+		query($id: ID!, $asOf: Datetime) {
+			node(id: $id) {
+				... on Measure {
+					treatmentPlans(asOf: $asOf) {
+						totalCount
+						edges { node { id asOf } }
+					}
+				}
+			}
+		}
+	`
+)
+
+type (
+	asOfMeasureNode struct {
+		ID             string  `json:"id"`
+		Name           string  `json:"name"`
+		Category       string  `json:"category"`
+		State          string  `json:"state"`
+		AsOf           *string `json:"asOf"`
+		TreatmentPlans struct {
+			TotalCount int `json:"totalCount"`
+			Edges      []struct {
+				Node struct {
+					ID   string  `json:"id"`
+					AsOf *string `json:"asOf"`
+				} `json:"node"`
+			} `json:"edges"`
+		} `json:"treatmentPlans"`
+	}
+
+	asOfMeasureConnection struct {
+		AsOf  *string `json:"asOf"`
+		Edges []struct {
+			Node asOfMeasureNode `json:"node"`
+		} `json:"edges"`
+		PageInfo struct {
+			HasNextPage bool    `json:"hasNextPage"`
+			EndCursor   *string `json:"endCursor"`
+		} `json:"pageInfo"`
+	}
+
+	asOfPlanNode struct {
+		ID                 string  `json:"id"`
+		AsOf               *string `json:"asOf"`
+		Category           string  `json:"category"`
+		InherentLikelihood int     `json:"inherentLikelihood"`
+		InherentImpact     int     `json:"inherentImpact"`
+		NetLikelihood      int     `json:"netLikelihood"`
+		NetImpact          int     `json:"netImpact"`
+		ResidualLikelihood int     `json:"residualLikelihood"`
+		ResidualImpact     int     `json:"residualImpact"`
+		CanUpdate          bool    `json:"canUpdate"`
+		CanDelete          bool    `json:"canDelete"`
+		Progress           struct {
+			Done           int `json:"done"`
+			InProgress     int `json:"inProgress"`
+			NotImplemented int `json:"notImplemented"`
+			Total          int `json:"total"`
+		} `json:"progress"`
+		Owner *struct {
+			FullName string `json:"fullName"`
+		} `json:"owner"`
+		Risk struct {
+			ID       string `json:"id"`
+			Name     string `json:"name"`
+			Category string `json:"category"`
+		} `json:"risk"`
+		Measures asOfMeasureConnection `json:"measures"`
+	}
+
+	asOfMatrixCell struct {
+		Type       string `json:"type"`
+		Likelihood int    `json:"likelihood"`
+		Impact     int    `json:"impact"`
+		Count      int    `json:"count"`
+	}
+
+	asOfPlansResult struct {
+		Node struct {
+			TreatmentPlans struct {
+				TotalCount int `json:"totalCount"`
+				Edges      []struct {
+					Node asOfPlanNode `json:"node"`
+				} `json:"edges"`
+			} `json:"treatmentPlans"`
+			MatrixCells []asOfMatrixCell `json:"matrixCells"`
+		} `json:"node"`
+	}
+
+	asOfTreatmentPlanMeasuresResult struct {
+		Typename string
+		AsOf     *string
+		Measures asOfMeasureConnection
+	}
+
+	asOfPlanRefConnection struct {
+		TotalCount int `json:"totalCount"`
+		Edges      []struct {
+			Node struct {
+				ID   string  `json:"id"`
+				AsOf *string `json:"asOf"`
+			} `json:"node"`
+		} `json:"edges"`
+	}
+)
+
+func queryRiskAnalysisPlansAsOf(
+	t *testing.T,
+	client *testutil.Client,
+	analysisID string,
+	asOf *string,
+	first int,
+	orderBy any,
+) asOfPlansResult {
+	t.Helper()
+
+	var result asOfPlansResult
+
+	err := client.Execute(
+		riskAnalysisPlansAsOfQuery,
+		map[string]any{
+			"id":      analysisID,
+			"asOf":    asOf,
+			"first":   first,
+			"orderBy": orderBy,
+		},
+		&result,
+	)
+	require.NoError(t, err)
+
+	return result
+}
+
+func queryTreatmentPlanMeasuresAsOf(
+	t *testing.T,
+	client *testutil.Client,
+	planID string,
+	asOf *string,
+	first int,
+	after *string,
+	filter map[string]any,
+) asOfTreatmentPlanMeasuresResult {
+	t.Helper()
+
+	var result struct {
+		Node struct {
+			Typename string                `json:"__typename"`
+			AsOf     *string               `json:"asOf"`
+			Measures asOfMeasureConnection `json:"measures"`
+		} `json:"node"`
+	}
+
+	err := client.Execute(
+		treatmentPlanMeasuresAsOfQuery,
+		map[string]any{
+			"id":     planID,
+			"asOf":   asOf,
+			"first":  first,
+			"after":  after,
+			"filter": filter,
+		},
+		&result,
+	)
+	require.NoError(t, err)
+
+	return asOfTreatmentPlanMeasuresResult{
+		Typename: result.Node.Typename,
+		AsOf:     result.Node.AsOf,
+		Measures: result.Node.Measures,
+	}
+}
+
+func queryMeasureTreatmentPlansAsOf(
+	t *testing.T,
+	client *testutil.Client,
+	measureID string,
+	asOf *string,
+) asOfPlanRefConnection {
+	t.Helper()
+
+	var result struct {
+		Node struct {
+			TreatmentPlans asOfPlanRefConnection `json:"treatmentPlans"`
+		} `json:"node"`
+	}
+
+	err := client.Execute(
+		measureTreatmentPlansAsOfQuery,
+		map[string]any{"id": measureID, "asOf": asOf},
+		&result,
+	)
+	require.NoError(t, err)
+
+	return result.Node.TreatmentPlans
+}
+
+func asOfMatrixCellCount(
+	cells []asOfMatrixCell,
+	scoreType string,
+	likelihood, impact int,
+) int {
+	for _, cell := range cells {
+		if cell.Type == scoreType && cell.Likelihood == likelihood && cell.Impact == impact {
+			return cell.Count
+		}
+	}
+
+	return 0
+}
+
+func asOfPlanNodes(result asOfPlansResult) []asOfPlanNode {
+	plans := make([]asOfPlanNode, 0, len(result.Node.TreatmentPlans.Edges))
+	for _, edge := range result.Node.TreatmentPlans.Edges {
+		plans = append(plans, edge.Node)
+	}
+
+	return plans
+}
+
+func asOfMeasureNodes(conn asOfMeasureConnection) []asOfMeasureNode {
+	measures := make([]asOfMeasureNode, 0, len(conn.Edges))
+	for _, edge := range conn.Edges {
+		measures = append(measures, edge.Node)
+	}
+
+	return measures
+}
+
+func asOfPlanIDs(plans []asOfPlanNode) []string {
+	ids := make([]string, 0, len(plans))
+	for _, plan := range plans {
+		ids = append(ids, plan.ID)
+	}
+
+	return ids
+}
+
+func asOfPlanByID(t *testing.T, plans []asOfPlanNode, id string) asOfPlanNode {
+	t.Helper()
+
+	for _, plan := range plans {
+		if plan.ID == id {
+			return plan
+		}
+	}
+
+	require.FailNow(t, "treatment plan not found", id)
+
+	return asOfPlanNode{}
+}

--- a/e2e/console/risk_analysis_fork_test.go
+++ b/e2e/console/risk_analysis_fork_test.go
@@ -22,6 +22,7 @@ package console_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,6 +66,15 @@ type forkRiskAnalysisResult struct {
 	} `json:"forkRiskAnalysis"`
 }
 
+func parseDatetime(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	require.NoError(t, err)
+
+	return parsed
+}
+
 func TestRiskAnalysis_Fork(t *testing.T) {
 	t.Parallel()
 
@@ -89,9 +99,24 @@ func TestRiskAnalysis_Fork(t *testing.T) {
 		)
 		factory.LinkTreatmentPlanMeasure(owner, tpID, measureID)
 
-		var result forkRiskAnalysisResult
+		var sourcePlan struct {
+			Node struct {
+				CreatedAt string `json:"createdAt"`
+			} `json:"node"`
+		}
 
 		err := owner.Execute(
+			`query($id: ID!) { node(id: $id) { ... on TreatmentPlan { createdAt } } }`,
+			map[string]any{"id": tpID},
+			&sourcePlan,
+		)
+		require.NoError(t, err)
+
+		sourceCreatedAt := parseDatetime(t, sourcePlan.Node.CreatedAt)
+
+		var result forkRiskAnalysisResult
+
+		err = owner.Execute(
 			forkRiskAnalysisMutation,
 			map[string]any{
 				"input": map[string]any{
@@ -187,6 +212,7 @@ func TestRiskAnalysis_Fork(t *testing.T) {
 					Edges []struct {
 						Node struct {
 							ID                 string `json:"id"`
+							CreatedAt          string `json:"createdAt"`
 							InherentLikelihood int    `json:"inherentLikelihood"`
 							InherentImpact     int    `json:"inherentImpact"`
 							Risk               struct {
@@ -202,11 +228,26 @@ func TestRiskAnalysis_Fork(t *testing.T) {
 						} `json:"node"`
 					} `json:"edges"`
 				} `json:"treatmentPlans"`
+				AsOfPlans struct {
+					Edges []struct {
+						Node struct {
+							ID        string `json:"id"`
+							CreatedAt string `json:"createdAt"`
+							Measures  struct {
+								Edges []struct {
+									Node struct {
+										ID string `json:"id"`
+									} `json:"node"`
+								} `json:"edges"`
+							} `json:"measures"`
+						} `json:"node"`
+					} `json:"edges"`
+				} `json:"asOfPlans"`
 			} `json:"node"`
 		}
 
 		err = owner.Execute(`
-			query($id: ID!) {
+			query($id: ID!, $asOf: Datetime) {
 				node(id: $id) {
 					... on RiskAnalysis {
 						diagrams(first: 10) {
@@ -243,6 +284,7 @@ func TestRiskAnalysis_Fork(t *testing.T) {
 							edges {
 								node {
 									id
+									createdAt
 									inherentLikelihood
 									inherentImpact
 									risk { id }
@@ -250,10 +292,22 @@ func TestRiskAnalysis_Fork(t *testing.T) {
 								}
 							}
 						}
+						asOfPlans: treatmentPlans(first: 10, asOf: $asOf) {
+							edges {
+								node {
+									id
+									createdAt
+									measures(first: 10) { edges { node { id } } }
+								}
+							}
+						}
 					}
 				}
 			}
-		`, map[string]any{"id": forkedID}, &copied)
+		`, map[string]any{
+			"id":   forkedID,
+			"asOf": time.Now().UTC().Format(time.RFC3339Nano),
+		}, &copied)
 		require.NoError(t, err)
 
 		require.Len(t, copied.Node.Diagrams.Edges, 1)
@@ -335,8 +389,44 @@ func TestRiskAnalysis_Fork(t *testing.T) {
 		assert.Equal(t, graph.riskID, copiedTP.Risk.ID)
 		assert.Equal(t, 3, copiedTP.InherentLikelihood)
 		assert.Equal(t, 4, copiedTP.InherentImpact)
+
+		copiedCreatedAt := parseDatetime(t, copiedTP.CreatedAt)
+		assert.False(t, copiedCreatedAt.Before(sourceCreatedAt))
 		require.Len(t, copiedTP.Measures.Edges, 1)
 		assert.Equal(t, measureID, copiedTP.Measures.Edges[0].Node.ID)
+		require.Len(t, copied.Node.AsOfPlans.Edges, 1)
+		assert.Equal(t, copiedTP.CreatedAt, copied.Node.AsOfPlans.Edges[0].Node.CreatedAt)
+		require.Len(t, copied.Node.AsOfPlans.Edges[0].Node.Measures.Edges, 1)
+		assert.Equal(t, measureID, copied.Node.AsOfPlans.Edges[0].Node.Measures.Edges[0].Node.ID)
+
+		var beforeFork struct {
+			Node struct {
+				TreatmentPlans struct {
+					Edges []struct {
+						Node struct {
+							ID string `json:"id"`
+						} `json:"node"`
+					} `json:"edges"`
+				} `json:"treatmentPlans"`
+			} `json:"node"`
+		}
+
+		err = owner.Execute(`
+			query($id: ID!, $asOf: Datetime) {
+				node(id: $id) {
+					... on RiskAnalysis {
+						treatmentPlans(first: 10, asOf: $asOf) {
+							edges { node { id } }
+						}
+					}
+				}
+			}
+		`, map[string]any{
+			"id":   forkedID,
+			"asOf": sourceCreatedAt.Add(-time.Second).UTC().Format(time.RFC3339Nano),
+		}, &beforeFork)
+		require.NoError(t, err)
+		assert.Empty(t, beforeFork.Node.TreatmentPlans.Edges)
 	})
 
 	t.Run("copies scenario threats linked across diagrams", func(t *testing.T) {

--- a/e2e/console/risk_analysis_test.go
+++ b/e2e/console/risk_analysis_test.go
@@ -22,6 +22,7 @@ package console_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1064,4 +1065,467 @@ func TestRiskAnalysisNode_WithBoundary(t *testing.T) {
 	}, &updateResult)
 	require.NoError(t, err)
 	assert.Nil(t, updateResult.UpdateRiskAnalysisNode.RiskAnalysisNode.BoundaryID)
+}
+
+func TestRiskAnalysis_MatrixAsOf(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	riskID := factory.CreateRisk(owner)
+	analysisID := factory.CreateRiskAnalysis(owner)
+	factory.LinkRiskToAnalysis(owner, riskID, analysisID)
+	factory.CreateTreatmentPlan(owner, riskID, analysisID, factory.Attrs{
+		"treatment":          "MITIGATED",
+		"inherentLikelihood": 4,
+		"inherentImpact":     4,
+		"residualLikelihood": 1,
+		"residualImpact":     2,
+	})
+
+	queryPlans := func(asOf *string, first int) asOfPlansResult {
+		t.Helper()
+
+		return queryRiskAnalysisPlansAsOf(t, owner, analysisID, asOf, first, nil)
+	}
+
+	live := queryPlans(nil, 1)
+	require.Equal(t, 1, live.Node.TreatmentPlans.TotalCount)
+	require.Len(t, live.Node.TreatmentPlans.Edges, 1)
+	livePlan := live.Node.TreatmentPlans.Edges[0].Node
+	assert.Nil(t, livePlan.AsOf)
+	assert.Equal(t, 4, livePlan.NetLikelihood)
+	assert.Equal(t, 4, livePlan.NetImpact)
+	require.NotNil(t, livePlan.Owner)
+	assert.NotEmpty(t, livePlan.Owner.FullName)
+	assert.True(t, livePlan.CanUpdate)
+	assert.True(t, livePlan.CanDelete)
+	assert.Equal(t, 0, livePlan.Progress.Total)
+	assert.Equal(t, 1, asOfMatrixCellCount(live.Node.MatrixCells, "NET", 4, 4))
+
+	asOf := time.Now().UTC().Format(time.RFC3339Nano)
+	asOfResult := queryPlans(&asOf, 1)
+	require.Equal(t, 1, asOfResult.Node.TreatmentPlans.TotalCount)
+	require.Len(t, asOfResult.Node.TreatmentPlans.Edges, 1)
+	asOfPlan := asOfResult.Node.TreatmentPlans.Edges[0].Node
+	require.NotNil(t, asOfPlan.AsOf)
+	assert.Equal(t, 4, asOfPlan.NetLikelihood)
+	assert.Equal(t, 4, asOfPlan.NetImpact)
+	assert.False(t, asOfPlan.CanUpdate)
+	assert.False(t, asOfPlan.CanDelete)
+	assert.Equal(t, 1, asOfMatrixCellCount(asOfResult.Node.MatrixCells, "NET", 4, 4))
+
+	measureID := factory.CreateMeasure(owner, factory.Attrs{"name": "Matrix mitigation"})
+	createdPlanID := livePlan.ID
+	factory.LinkTreatmentPlanMeasure(owner, createdPlanID, measureID)
+	updateMeasureState(t, owner, measureID, "IMPLEMENTED")
+
+	afterImplement := queryPlans(nil, 10)
+	require.Len(t, afterImplement.Node.TreatmentPlans.Edges, 1)
+	afterPlan := afterImplement.Node.TreatmentPlans.Edges[0].Node
+	assert.Equal(t, 1, afterPlan.NetLikelihood)
+	assert.Equal(t, 2, afterPlan.NetImpact)
+	require.Len(t, afterPlan.Measures.Edges, 1)
+	assert.Equal(t, measureID, afterPlan.Measures.Edges[0].Node.ID)
+	assert.Equal(t, "Matrix mitigation", afterPlan.Measures.Edges[0].Node.Name)
+	assert.Equal(t, "IMPLEMENTED", afterPlan.Measures.Edges[0].Node.State)
+	assert.Equal(t, 1, afterPlan.Progress.Total)
+	assert.Equal(t, 1, afterPlan.Progress.Done)
+	assert.Equal(t, 1, asOfMatrixCellCount(afterImplement.Node.MatrixCells, "NET", 1, 2))
+	assert.Equal(t, 0, asOfMatrixCellCount(afterImplement.Node.MatrixCells, "NET", 4, 4))
+
+	implementedAsOf := time.Now().UTC().Format(time.RFC3339Nano)
+
+	var deleteResult struct {
+		DeleteTreatmentPlan struct {
+			DeletedTreatmentPlanID string `json:"deletedTreatmentPlanId"`
+		} `json:"deleteTreatmentPlan"`
+	}
+
+	err := owner.Execute(`
+		mutation($input: DeleteTreatmentPlanInput!) {
+			deleteTreatmentPlan(input: $input) {
+				deletedTreatmentPlanId
+			}
+		}
+	`, map[string]any{"input": map[string]any{"treatmentPlanId": createdPlanID}}, &deleteResult)
+	require.NoError(t, err)
+
+	empty := queryPlans(nil, 10)
+	assert.Equal(t, 0, empty.Node.TreatmentPlans.TotalCount)
+	assert.Empty(t, empty.Node.TreatmentPlans.Edges)
+	assert.Equal(t, 0, asOfMatrixCellCount(empty.Node.MatrixCells, "NET", 1, 2))
+
+	restored := queryPlans(&implementedAsOf, 10)
+	require.Equal(t, 1, restored.Node.TreatmentPlans.TotalCount)
+	require.Len(t, restored.Node.TreatmentPlans.Edges, 1)
+	restoredPlan := restored.Node.TreatmentPlans.Edges[0].Node
+	assert.Equal(t, createdPlanID, restoredPlan.ID)
+	assert.Equal(t, 1, restoredPlan.NetLikelihood)
+	assert.Equal(t, 2, restoredPlan.NetImpact)
+	require.NotNil(t, restoredPlan.Owner)
+	assert.NotEmpty(t, restoredPlan.Owner.FullName)
+	assert.False(t, restoredPlan.CanUpdate)
+	assert.False(t, restoredPlan.CanDelete)
+	require.Len(t, restoredPlan.Measures.Edges, 1)
+	assert.Equal(t, measureID, restoredPlan.Measures.Edges[0].Node.ID)
+	assert.Equal(t, "IMPLEMENTED", restoredPlan.Measures.Edges[0].Node.State)
+	assert.Equal(t, 1, restoredPlan.Progress.Total)
+	assert.Equal(t, 1, restoredPlan.Progress.Done)
+	assert.Equal(t, 1, asOfMatrixCellCount(restored.Node.MatrixCells, "NET", 1, 2))
+}
+
+func TestRiskAnalysis_ListMeasuresAsOfViaNode(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	riskID := factory.CreateRisk(owner)
+	analysisID := factory.CreateRiskAnalysis(owner)
+	factory.LinkRiskToAnalysis(owner, riskID, analysisID)
+	planID := factory.CreateTreatmentPlan(owner, riskID, analysisID, factory.Attrs{
+		"treatment":          "MITIGATED",
+		"inherentLikelihood": 3,
+		"inherentImpact":     3,
+	})
+	olderMeasureID := factory.CreateMeasure(owner, factory.Attrs{
+		"name":     "Older as-of measure",
+		"category": "POLICY",
+	})
+	newerMeasureID := factory.CreateMeasure(owner, factory.Attrs{
+		"name":     "Newer as-of measure",
+		"category": "TECHNICAL",
+	})
+	factory.LinkTreatmentPlanMeasure(owner, planID, olderMeasureID)
+	factory.LinkTreatmentPlanMeasure(owner, planID, newerMeasureID)
+	updateMeasureState(t, owner, olderMeasureID, "IMPLEMENTED")
+
+	asOf := time.Now().UTC().Format(time.RFC3339Nano)
+
+	updateMeasureState(t, owner, olderMeasureID, "NOT_IMPLEMENTED")
+	_, err := owner.Do(`
+		mutation($input: UpdateMeasureInput!) {
+			updateMeasure(input: $input) { measure { id } }
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"id":       olderMeasureID,
+			"category": "TRAINING",
+		},
+	})
+	require.NoError(t, err)
+
+	queryMeasures := func(asOf *string, first int, after *string, filter map[string]any) asOfMeasureConnection {
+		t.Helper()
+
+		result := queryTreatmentPlanMeasuresAsOf(t, owner, planID, asOf, first, after, filter)
+		assert.Equal(t, "TreatmentPlan", result.Typename)
+		assert.Nil(t, result.AsOf)
+
+		return result.Measures
+	}
+
+	firstPage := queryMeasures(&asOf, 1, nil, nil)
+	require.True(t, firstPage.PageInfo.HasNextPage)
+	require.NotNil(t, firstPage.PageInfo.EndCursor)
+	require.Len(t, firstPage.Edges, 1)
+
+	secondPage := queryMeasures(&asOf, 1, firstPage.PageInfo.EndCursor, nil)
+	require.Len(t, secondPage.Edges, 1)
+	assert.False(t, secondPage.PageInfo.HasNextPage)
+
+	historical := map[string]struct{ State, Category string }{
+		firstPage.Edges[0].Node.ID: {
+			State:    firstPage.Edges[0].Node.State,
+			Category: firstPage.Edges[0].Node.Category,
+		},
+		secondPage.Edges[0].Node.ID: {
+			State:    secondPage.Edges[0].Node.State,
+			Category: secondPage.Edges[0].Node.Category,
+		},
+	}
+	assert.Contains(t, historical, olderMeasureID)
+	assert.Contains(t, historical, newerMeasureID)
+	assert.Equal(t, "IMPLEMENTED", historical[olderMeasureID].State)
+	assert.Equal(t, "POLICY", historical[olderMeasureID].Category)
+	assert.Equal(t, "TECHNICAL", historical[newerMeasureID].Category)
+
+	filtered := queryMeasures(&asOf, 10, nil, map[string]any{"category": "POLICY"})
+	require.Len(t, filtered.Edges, 1)
+	assert.Equal(t, olderMeasureID, filtered.Edges[0].Node.ID)
+
+	filteredByState := queryMeasures(&asOf, 10, nil, map[string]any{"state": "IMPLEMENTED"})
+	require.Len(t, filteredByState.Edges, 1)
+	assert.Equal(t, olderMeasureID, filteredByState.Edges[0].Node.ID)
+
+	live := queryMeasures(nil, 10, nil, nil)
+	require.Len(t, live.Edges, 2)
+	states := map[string]string{
+		live.Edges[0].Node.ID: live.Edges[0].Node.State,
+		live.Edges[1].Node.ID: live.Edges[1].Node.State,
+	}
+	categories := map[string]string{
+		live.Edges[0].Node.ID: live.Edges[0].Node.Category,
+		live.Edges[1].Node.ID: live.Edges[1].Node.Category,
+	}
+
+	assert.Equal(t, "NOT_IMPLEMENTED", states[olderMeasureID])
+	assert.Equal(t, "TRAINING", categories[olderMeasureID])
+}
+
+func TestRiskAnalysis_DeleteMeasureKeepsAsOfHistory(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	riskID := factory.CreateRisk(owner)
+	analysisID := factory.CreateRiskAnalysis(owner)
+	factory.LinkRiskToAnalysis(owner, riskID, analysisID)
+	planID := factory.CreateTreatmentPlan(owner, riskID, analysisID, factory.Attrs{
+		"treatment":          "MITIGATED",
+		"inherentLikelihood": 3,
+		"inherentImpact":     3,
+	})
+	measureID := factory.CreateMeasure(owner, factory.Attrs{"name": "Keep after delete"})
+	factory.LinkTreatmentPlanMeasure(owner, planID, measureID)
+
+	asOf := time.Now().UTC().Format(time.RFC3339Nano)
+
+	_, err := owner.Do(`
+		mutation($input: UpdateMeasureInput!) {
+			updateMeasure(input: $input) { measure { id name } }
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"id":   measureID,
+			"name": "Gone live",
+		},
+	})
+	require.NoError(t, err)
+
+	var deleted struct {
+		DeleteMeasure struct {
+			DeletedMeasureID string `json:"deletedMeasureId"`
+		} `json:"deleteMeasure"`
+	}
+
+	err = owner.Execute(`
+		mutation($input: DeleteMeasureInput!) {
+			deleteMeasure(input: $input) { deletedMeasureId }
+		}
+	`, map[string]any{
+		"input": map[string]any{"measureId": measureID},
+	}, &deleted)
+	require.NoError(t, err)
+	assert.Equal(t, measureID, deleted.DeleteMeasure.DeletedMeasureID)
+
+	queryMeasures := func(asOf *string) []asOfMeasureNode {
+		t.Helper()
+
+		return asOfMeasureNodes(
+			queryTreatmentPlanMeasuresAsOf(t, owner, planID, asOf, 10, nil, nil).Measures,
+		)
+	}
+
+	assert.Empty(t, queryMeasures(nil))
+
+	historical := queryMeasures(&asOf)
+	require.Len(t, historical, 1)
+	assert.Equal(t, measureID, historical[0].ID)
+	assert.Equal(t, "Keep after delete", historical[0].Name)
+	require.NotNil(t, historical[0].AsOf)
+	assert.Equal(t, 1, historical[0].TreatmentPlans.TotalCount)
+	require.Len(t, historical[0].TreatmentPlans.Edges, 1)
+	assert.Equal(t, planID, historical[0].TreatmentPlans.Edges[0].Node.ID)
+	require.NotNil(t, historical[0].TreatmentPlans.Edges[0].Node.AsOf)
+
+	afterDelete := time.Now().UTC().Format(time.RFC3339Nano)
+	assert.Empty(t, queryMeasures(&afterDelete))
+}
+
+func TestRiskAnalysis_TreatmentPlanCategoryAsOf(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	analysisID := factory.CreateRiskAnalysis(owner)
+	alphaRiskID := factory.CreateRisk(owner, factory.Attrs{"category": "AlphaCat"})
+	zuluRiskID := factory.CreateRisk(owner, factory.Attrs{"category": "ZuluCat"})
+	factory.LinkRiskToAnalysis(owner, alphaRiskID, analysisID)
+	factory.LinkRiskToAnalysis(owner, zuluRiskID, analysisID)
+	alphaPlanID := factory.CreateTreatmentPlan(owner, alphaRiskID, analysisID, factory.Attrs{
+		"treatment":          "MITIGATED",
+		"inherentLikelihood": 2,
+		"inherentImpact":     2,
+	})
+	zuluPlanID := factory.CreateTreatmentPlan(owner, zuluRiskID, analysisID, factory.Attrs{
+		"treatment":          "MITIGATED",
+		"inherentLikelihood": 3,
+		"inherentImpact":     3,
+	})
+
+	asOf := time.Now().UTC().Format(time.RFC3339Nano)
+
+	var updateRisk struct {
+		UpdateRisk struct {
+			Risk struct {
+				ID       string `json:"id"`
+				Category string `json:"category"`
+			} `json:"risk"`
+		} `json:"updateRisk"`
+	}
+
+	err := owner.Execute(`
+		mutation($input: UpdateRiskInput!) {
+			updateRisk(input: $input) {
+				risk { id category }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"id":       alphaRiskID,
+			"category": "ZzzCat",
+		},
+	}, &updateRisk)
+	require.NoError(t, err)
+	assert.Equal(t, "ZzzCat", updateRisk.UpdateRisk.Risk.Category)
+
+	queryPlans := func(asOf *string) []asOfPlanNode {
+		t.Helper()
+
+		return asOfPlanNodes(
+			queryRiskAnalysisPlansAsOf(
+				t,
+				owner,
+				analysisID,
+				asOf,
+				10,
+				map[string]any{"field": "CATEGORY", "direction": "ASC"},
+			),
+		)
+	}
+
+	live := queryPlans(nil)
+	historical := queryPlans(&asOf)
+
+	assert.Equal(t, []string{zuluPlanID, alphaPlanID}, asOfPlanIDs(live))
+	assert.Equal(t, []string{alphaPlanID, zuluPlanID}, asOfPlanIDs(historical))
+
+	liveAlpha := asOfPlanByID(t, live, alphaPlanID)
+	assert.Equal(t, "ZzzCat", liveAlpha.Category)
+	assert.Equal(t, "ZzzCat", liveAlpha.Risk.Category)
+
+	historicalAlpha := asOfPlanByID(t, historical, alphaPlanID)
+	assert.Equal(t, "AlphaCat", historicalAlpha.Category)
+	assert.Equal(t, "ZzzCat", historicalAlpha.Risk.Category)
+}
+
+func TestRiskAnalysis_NestedTreatmentPlansAsOf(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	historicalRiskID := factory.CreateRisk(owner)
+	liveRiskID := factory.CreateRisk(owner)
+	analysisID := factory.CreateRiskAnalysis(owner)
+	factory.LinkRiskToAnalysis(owner, historicalRiskID, analysisID)
+	factory.LinkRiskToAnalysis(owner, liveRiskID, analysisID)
+	historicalPlanID := factory.CreateTreatmentPlan(owner, historicalRiskID, analysisID, factory.Attrs{
+		"treatment":          "MITIGATED",
+		"inherentLikelihood": 2,
+		"inherentImpact":     2,
+	})
+	livePlanID := factory.CreateTreatmentPlan(owner, liveRiskID, analysisID, factory.Attrs{
+		"treatment":          "MITIGATED",
+		"inherentLikelihood": 4,
+		"inherentImpact":     4,
+	})
+	measureID := factory.CreateMeasure(owner, factory.Attrs{"name": "Nested as-of plans"})
+	factory.LinkTreatmentPlanMeasure(owner, historicalPlanID, measureID)
+
+	asOf := time.Now().UTC().Format(time.RFC3339Nano)
+
+	factory.UnlinkTreatmentPlanMeasure(owner, historicalPlanID, measureID)
+	factory.LinkTreatmentPlanMeasure(owner, livePlanID, measureID)
+
+	historical := queryTreatmentPlanMeasuresAsOf(t, owner, historicalPlanID, &asOf, 10, nil, nil)
+	require.Len(t, historical.Measures.Edges, 1)
+
+	historicalMeasure := historical.Measures.Edges[0].Node
+	assert.Equal(t, measureID, historicalMeasure.ID)
+	require.NotNil(t, historicalMeasure.AsOf)
+	assert.Equal(t, 1, historicalMeasure.TreatmentPlans.TotalCount)
+	require.Len(t, historicalMeasure.TreatmentPlans.Edges, 1)
+	assert.Equal(t, historicalPlanID, historicalMeasure.TreatmentPlans.Edges[0].Node.ID)
+	require.NotNil(t, historicalMeasure.TreatmentPlans.Edges[0].Node.AsOf)
+
+	live := queryMeasureTreatmentPlansAsOf(t, owner, measureID, nil)
+	assert.Equal(t, 1, live.TotalCount)
+	require.Len(t, live.Edges, 1)
+	assert.Equal(t, livePlanID, live.Edges[0].Node.ID)
+	assert.Nil(t, live.Edges[0].Node.AsOf)
+}
+
+func TestRiskAnalysis_DeleteRiskRequiresTreatmentPlanHistory(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	riskID := factory.CreateRisk(owner)
+	analysisID := factory.CreateRiskAnalysis(owner)
+	diagramID := factory.CreateRiskAnalysisDiagram(owner, analysisID)
+	scenarioID := factory.CreateRiskAnalysisScenario(owner, diagramID)
+	factory.LinkRiskAnalysisScenarioRisk(owner, scenarioID, riskID)
+	planID := factory.CreateTreatmentPlan(owner, riskID, analysisID, factory.Attrs{
+		"treatment":          "MITIGATED",
+		"inherentLikelihood": 3,
+		"inherentImpact":     3,
+	})
+
+	deleteRisk := func() error {
+		t.Helper()
+
+		_, err := owner.Do(`
+			mutation($input: DeleteRiskInput!) {
+				deleteRisk(input: $input) { deletedRiskId }
+			}
+		`, map[string]any{"input": map[string]any{"riskId": riskID}})
+
+		return err
+	}
+
+	var deleteScenario struct {
+		DeleteRiskAnalysisScenario struct {
+			DeletedRiskAnalysisScenarioID string `json:"deletedRiskAnalysisScenarioId"`
+		} `json:"deleteRiskAnalysisScenario"`
+	}
+
+	err := owner.Execute(`
+		mutation($input: DeleteRiskAnalysisScenarioInput!) {
+			deleteRiskAnalysisScenario(input: $input) {
+				deletedRiskAnalysisScenarioId
+			}
+		}
+	`, map[string]any{"input": map[string]any{"riskAnalysisScenarioId": scenarioID}}, &deleteScenario)
+	require.NoError(t, err)
+
+	testutil.RequireConflictError(t, deleteRisk())
+
+	asOf := time.Now().UTC().Format(time.RFC3339Nano)
+
+	var deletePlan struct {
+		DeleteTreatmentPlan struct {
+			DeletedTreatmentPlanID string `json:"deletedTreatmentPlanId"`
+		} `json:"deleteTreatmentPlan"`
+	}
+
+	err = owner.Execute(`
+		mutation($input: DeleteTreatmentPlanInput!) {
+			deleteTreatmentPlan(input: $input) { deletedTreatmentPlanId }
+		}
+	`, map[string]any{"input": map[string]any{"treatmentPlanId": planID}}, &deletePlan)
+	require.NoError(t, err)
+	assert.Equal(t, planID, deletePlan.DeleteTreatmentPlan.DeletedTreatmentPlanID)
+
+	testutil.RequireConflictError(t, deleteRisk())
+
+	restored := queryRiskAnalysisPlansAsOf(t, owner, analysisID, &asOf, 10, nil)
+	require.Len(t, restored.Node.TreatmentPlans.Edges, 1)
+	assert.Equal(t, planID, restored.Node.TreatmentPlans.Edges[0].Node.ID)
+	assert.Equal(t, riskID, restored.Node.TreatmentPlans.Edges[0].Node.Risk.ID)
+	assert.NotEmpty(t, restored.Node.TreatmentPlans.Edges[0].Node.Risk.Name)
 }

--- a/e2e/console/treatment_plan_test.go
+++ b/e2e/console/treatment_plan_test.go
@@ -848,6 +848,12 @@ func TestTreatmentPlan_FilterByMatrixCell(t *testing.T) {
 	assertFilteredPlanIDs(t, owner, analysisID, "NET", 1, 2, highPlanID)
 	assertFilteredPlanIDs(t, owner, analysisID, "NET", 4, 4)
 	assertFilteredPlanIDs(t, owner, analysisID, "INHERENT", 4, 4, highPlanID)
+
+	openMeasureID := factory.CreateMeasure(owner, factory.Attrs{"name": "Still in progress"})
+	factory.LinkTreatmentPlanMeasure(owner, highPlanID, openMeasureID)
+
+	assertFilteredPlanIDs(t, owner, analysisID, "NET", 4, 4, highPlanID)
+	assertFilteredPlanIDs(t, owner, analysisID, "NET", 1, 2)
 }
 
 func TestTreatmentPlan_RejectIncompleteFilter(t *testing.T) {
@@ -987,6 +993,16 @@ func TestTreatmentPlan_MatrixCounts(t *testing.T) {
 	assert.Equal(t, 1, matrixCellCount(counts, "NET", 1, 2))
 	assert.Equal(t, 1, matrixCellCount(counts, "NET", 2, 3))
 	assert.Equal(t, 0, matrixCellCount(counts, "NET", 4, 4))
+
+	openMeasureID := factory.CreateMeasure(owner, factory.Attrs{"name": "Still in progress"})
+	factory.LinkTreatmentPlanMeasure(owner, highPlanID, openMeasureID)
+
+	counts = queryMatrixCells(t, owner, analysisID)
+	assert.Equal(t, 1, matrixCellCount(counts, "INHERENT", 4, 4))
+	assert.Equal(t, 1, matrixCellCount(counts, "RESIDUAL", 1, 2))
+	assert.Equal(t, 1, matrixCellCount(counts, "NET", 4, 4))
+	assert.Equal(t, 1, matrixCellCount(counts, "NET", 2, 3))
+	assert.Equal(t, 0, matrixCellCount(counts, "NET", 1, 2))
 }
 
 type matrixCellCountRow struct {

--- a/e2e/internal/factory/factory.go
+++ b/e2e/internal/factory/factory.go
@@ -1761,6 +1761,32 @@ func LinkTreatmentPlanMeasure(c *testutil.Client, treatmentPlanID, measureID str
 	require.NoError(c.T, err, "createTreatmentPlanMeasureMapping mutation failed")
 }
 
+func UnlinkTreatmentPlanMeasure(c *testutil.Client, treatmentPlanID, measureID string) {
+	c.T.Helper()
+
+	const query = `
+		mutation($input: DeleteTreatmentPlanMeasureMappingInput!) {
+			deleteTreatmentPlanMeasureMapping(input: $input) {
+				deletedMeasureId
+			}
+		}
+	`
+
+	var result struct {
+		DeleteTreatmentPlanMeasureMapping struct {
+			DeletedMeasureID string `json:"deletedMeasureId"`
+		} `json:"deleteTreatmentPlanMeasureMapping"`
+	}
+
+	err := c.Execute(query, map[string]any{
+		"input": map[string]any{
+			"treatmentPlanId": treatmentPlanID,
+			"measureId":       measureID,
+		},
+	}, &result)
+	require.NoError(c.T, err, "deleteTreatmentPlanMeasureMapping mutation failed")
+}
+
 func CreateRiskAnalysisDiagram(c *testutil.Client, riskAnalysisID string, attrs ...Attrs) string {
 	c.T.Helper()
 

--- a/packages/n8n-node/nodes/Probo/actions/riskAnalysis/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/riskAnalysis/get.operation.ts
@@ -36,6 +36,20 @@ export const description: INodeProperties[] = [
 		description: 'The ID of the risk analysis',
 		required: true,
 	},
+	{
+		displayName: 'As Of',
+		name: 'asOf',
+		type: 'dateTime',
+		displayOptions: {
+			show: {
+				resource: ['riskAnalysis'],
+				operation: ['get'],
+			},
+		},
+		default: '',
+		description:
+			'Reconstruct matrix cells as of this instant. Leave empty to use live tables.',
+	},
 ];
 
 export async function execute(
@@ -43,9 +57,10 @@ export async function execute(
 	itemIndex: number,
 ): Promise<INodeExecutionData> {
 	const riskAnalysisId = this.getNodeParameter('riskAnalysisId', itemIndex) as string;
+	const asOf = this.getNodeParameter('asOf', itemIndex, '') as string;
 
 	const query = `
-		query GetRiskAnalysis($id: ID!) {
+		query GetRiskAnalysis($id: ID!, $asOf: Datetime) {
 			node(id: $id) {
 				... on RiskAnalysis {
 					id
@@ -59,7 +74,7 @@ export async function execute(
 						rows
 						cols
 					}
-					matrixCells {
+					matrixCells(asOf: $asOf) {
 						type
 						likelihood
 						impact
@@ -72,9 +87,12 @@ export async function execute(
 		}
 	`;
 
-	const variables = {
+	const variables: { id: string; asOf?: string } = {
 		id: riskAnalysisId,
 	};
+	if (asOf) {
+		variables.asOf = asOf;
+	}
 
 	const responseData = await proboApiRequest.call(this, query, variables);
 

--- a/packages/n8n-node/nodes/Probo/actions/treatmentPlan/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/treatmentPlan/get.operation.ts
@@ -50,6 +50,7 @@ export async function execute(
 				... on TreatmentPlan {
 					id
 					treatment
+					category
 					inherentLikelihood
 					inherentImpact
 					inherentRiskScore

--- a/packages/n8n-node/nodes/Probo/actions/treatmentPlan/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/treatmentPlan/getAll.operation.ts
@@ -24,6 +24,7 @@ import { proboApiRequestAllItems } from '../../GenericFunctions';
 const treatmentPlanNodeFields = `
 	id
 	treatment
+	category
 	inherentLikelihood
 	inherentImpact
 	inherentRiskScore
@@ -51,11 +52,14 @@ const treatmentPlanNodeFields = `
 `;
 
 function treatmentPlansQuery(parentType: 'Organization' | 'Risk' | 'RiskAnalysis'): string {
+	const asOfArg = parentType === 'RiskAnalysis' ? ', $asOf: Datetime' : '';
+	const asOfField = parentType === 'RiskAnalysis' ? ', asOf: $asOf' : '';
+
 	return `
-		query GetTreatmentPlans($id: ID!, $first: Int, $after: CursorKey, $orderBy: TreatmentPlanOrder, $filter: TreatmentPlanFilter) {
+		query GetTreatmentPlans($id: ID!, $first: Int, $after: CursorKey, $orderBy: TreatmentPlanOrder, $filter: TreatmentPlanFilter${asOfArg}) {
 			node(id: $id) {
 				... on ${parentType} {
-					treatmentPlans(first: $first, after: $after, orderBy: $orderBy, filter: $filter) {
+					treatmentPlans(first: $first, after: $after, orderBy: $orderBy, filter: $filter${asOfField}) {
 						edges {
 							node {
 								${treatmentPlanNodeFields}
@@ -226,6 +230,20 @@ export const description: INodeProperties[] = [
 		default: 0,
 		description: 'Filter by impact. Requires Score Type and Likelihood.',
 	},
+	{
+		displayName: 'As Of',
+		name: 'asOf',
+		type: 'dateTime',
+		displayOptions: {
+			show: {
+				resource: ['treatmentPlan'],
+				operation: ['getAll'],
+			},
+		},
+		default: '',
+		description:
+			'Reconstruct plans as of this instant. Only valid with Risk Analysis ID. Leave empty to use live tables.',
+	},
 ];
 
 export async function execute(
@@ -242,9 +260,14 @@ export async function execute(
 	const scoreType = this.getNodeParameter('scoreType', itemIndex, '') as string;
 	const likelihood = this.getNodeParameter('likelihood', itemIndex, 0) as number;
 	const impact = this.getNodeParameter('impact', itemIndex, 0) as number;
+	const asOf = this.getNodeParameter('asOf', itemIndex, '') as string;
 
 	if (riskId !== '' && riskAnalysisId !== '') {
 		throw new Error('Risk ID and Risk Analysis ID cannot be set together');
+	}
+
+	if (asOf !== '' && riskAnalysisId === '') {
+		throw new Error('As Of can only be set together with Risk Analysis ID');
 	}
 
 	const hasCell = scoreType !== '' || likelihood > 0 || impact > 0;
@@ -268,6 +291,9 @@ export async function execute(
 	}
 	if (hasCell) {
 		variables.filter = { scoreType, likelihood, impact };
+	}
+	if (asOf !== '') {
+		variables.asOf = asOf;
 	}
 
 	const treatmentPlans = await proboApiRequestAllItems.call(

--- a/pkg/cmd/risk-analysis/view/view.go
+++ b/pkg/cmd/risk-analysis/view/view.go
@@ -23,6 +23,7 @@ package view
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
@@ -31,7 +32,7 @@ import (
 )
 
 const viewQuery = `
-query($id: ID!) {
+query($id: ID!, $asOf: Datetime) {
   node(id: $id) {
     __typename
     ... on RiskAnalysis {
@@ -46,7 +47,7 @@ query($id: ID!) {
         rows
         cols
       }
-      matrixCells {
+      matrixCells(asOf: $asOf) {
         type
         likelihood
         impact
@@ -85,7 +86,10 @@ type viewResponse struct {
 }
 
 func NewCmdView(f *cmdutil.Factory) *cobra.Command {
-	var flagOutput *string
+	var (
+		flagAsOf   string
+		flagOutput *string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "view <id>",
@@ -114,9 +118,22 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 				cmdutil.TokenRefreshOption(cfg, host, hc),
 			)
 
+			var asOf *string
+
+			if flagAsOf != "" {
+				if _, err := time.Parse(time.RFC3339, flagAsOf); err != nil {
+					return fmt.Errorf(
+						"--as-of must be RFC3339 (e.g. 2026-01-15T23:59:59Z): %w",
+						err,
+					)
+				}
+
+				asOf = &flagAsOf
+			}
+
 			data, err := client.Do(
 				viewQuery,
-				map[string]any{"id": args[0]},
+				map[string]any{"id": args[0], "asOf": asOf},
 			)
 			if err != nil {
 				return err
@@ -189,6 +206,12 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	flagOutput = cmdutil.AddOutputFlag(cmd)
+	cmd.Flags().StringVar(
+		&flagAsOf,
+		"as-of",
+		"",
+		"Reconstruct matrix cells as of this RFC3339 instant (omit for live tables)",
+	)
 
 	return cmd
 }

--- a/pkg/cmd/treatment-plan/list/list.go
+++ b/pkg/cmd/treatment-plan/list/list.go
@@ -23,6 +23,7 @@ package list
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.probo.inc/probo/pkg/cli/api"
@@ -40,6 +41,7 @@ query($id: ID!, $first: Int, $after: CursorKey, $orderBy: TreatmentPlanOrder, $f
           node {
             id
             treatment
+            category
             inherentRiskScore
             residualRiskScore
             netRiskScore
@@ -69,6 +71,7 @@ query($id: ID!, $first: Int, $after: CursorKey, $orderBy: TreatmentPlanOrder, $f
           node {
             id
             treatment
+            category
             inherentRiskScore
             residualRiskScore
             netRiskScore
@@ -88,16 +91,17 @@ query($id: ID!, $first: Int, $after: CursorKey, $orderBy: TreatmentPlanOrder, $f
 `
 
 const listByAnalysisQuery = `
-query($id: ID!, $first: Int, $after: CursorKey, $orderBy: TreatmentPlanOrder, $filter: TreatmentPlanFilter) {
+query($id: ID!, $first: Int, $after: CursorKey, $orderBy: TreatmentPlanOrder, $filter: TreatmentPlanFilter, $asOf: Datetime) {
   node(id: $id) {
     __typename
     ... on RiskAnalysis {
-      treatmentPlans(first: $first, after: $after, orderBy: $orderBy, filter: $filter) {
+      treatmentPlans(first: $first, after: $after, orderBy: $orderBy, filter: $filter, asOf: $asOf) {
         totalCount
         edges {
           node {
             id
             treatment
+            category
             inherentRiskScore
             residualRiskScore
             netRiskScore
@@ -119,12 +123,21 @@ query($id: ID!, $first: Int, $after: CursorKey, $orderBy: TreatmentPlanOrder, $f
 type treatmentPlan struct {
 	ID                string `json:"id"`
 	Treatment         string `json:"treatment"`
+	Category          string `json:"category"`
 	InherentRiskScore int    `json:"inherentRiskScore"`
 	ResidualRiskScore int    `json:"residualRiskScore"`
 	NetRiskScore      int    `json:"netRiskScore"`
 	Risk              struct {
 		Category string `json:"category"`
 	} `json:"risk"`
+}
+
+func (p treatmentPlan) tableCategory() string {
+	if p.Category != "" {
+		return p.Category
+	}
+
+	return p.Risk.Category
 }
 
 func NewCmdList(f *cmdutil.Factory) *cobra.Command {
@@ -138,6 +151,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 		flagScoreType    string
 		flagLikelihood   int
 		flagImpact       int
+		flagAsOf         string
 		flagOutput       *string
 	)
 
@@ -162,6 +176,10 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 
 			if flagRisk != "" && flagRiskAnalysis != "" {
 				return fmt.Errorf("pass only one of --risk and --risk-analysis")
+			}
+
+			if flagAsOf != "" && flagRiskAnalysis == "" {
+				return fmt.Errorf("--as-of requires --risk-analysis")
 			}
 
 			cfg, err := f.Config()
@@ -207,6 +225,17 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 
 			variables := map[string]any{
 				"id": parentID,
+			}
+
+			if flagAsOf != "" {
+				if _, err := time.Parse(time.RFC3339, flagAsOf); err != nil {
+					return fmt.Errorf(
+						"--as-of must be RFC3339 (e.g. 2026-01-15T23:59:59Z): %w",
+						err,
+					)
+				}
+
+				variables["asOf"] = flagAsOf
 			}
 
 			if flagOrderBy != "" {
@@ -294,7 +323,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				rows = append(rows, []string{
 					p.ID,
 					p.Treatment,
-					p.Risk.Category,
+					p.tableCategory(),
 					fmt.Sprintf("%d", p.InherentRiskScore),
 					fmt.Sprintf("%d", p.ResidualRiskScore),
 					fmt.Sprintf("%d", p.NetRiskScore),
@@ -327,6 +356,12 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagScoreType, "score-type", "", "Filter by matrix score type (INHERENT, NET, RESIDUAL)")
 	cmd.Flags().IntVar(&flagLikelihood, "likelihood", 0, "Filter by likelihood (with --score-type and --impact)")
 	cmd.Flags().IntVar(&flagImpact, "impact", 0, "Filter by impact (with --score-type and --likelihood)")
+	cmd.Flags().StringVar(
+		&flagAsOf,
+		"as-of",
+		"",
+		"Reconstruct plans as of this RFC3339 instant (requires --risk-analysis; omit for live tables)",
+	)
 	flagOutput = cmdutil.AddOutputFlag(cmd)
 
 	return cmd

--- a/pkg/cmd/treatment-plan/view/view.go
+++ b/pkg/cmd/treatment-plan/view/view.go
@@ -37,6 +37,7 @@ query($id: ID!) {
     ... on TreatmentPlan {
       id
       treatment
+      category
       inherentLikelihood
       inherentImpact
       inherentRiskScore
@@ -80,6 +81,7 @@ type viewResponse struct {
 		Typename           string `json:"__typename"`
 		ID                 string `json:"id"`
 		Treatment          string `json:"treatment"`
+		Category           string `json:"category"`
 		InherentLikelihood int    `json:"inherentLikelihood"`
 		InherentImpact     int    `json:"inherentImpact"`
 		InherentRiskScore  int    `json:"inherentRiskScore"`
@@ -183,6 +185,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Risk:"), p.Risk.ID)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Risk Analysis:"), p.RiskAnalysis.ID)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Treatment:"), p.Treatment)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Category:"), p.Category)
 			_, _ = fmt.Fprintf(out, "%s%s (%s)\n", label.Render("Owner:"), p.Owner.FullName, p.Owner.ID)
 
 			_, _ = fmt.Fprintln(out)

--- a/pkg/coredata/measure.go
+++ b/pkg/coredata/measure.go
@@ -63,12 +63,48 @@ func (m Measure) CursorKey(orderBy MeasureOrderField) page.CursorKey {
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
+// Deleted measures fall back to the latest measure event so as-of nested fields
+// can still authorize against the organization they belonged to.
 func (m *Measure) AuthorizationAttributes(
 	ctx context.Context,
 	conn pg.Querier,
 	resourceIDs []gid.GID,
 ) (policy.AttributesByID, error) {
-	q := `SELECT id, organization_id FROM measures WHERE id = ANY(@resource_ids::text[])`
+	q := `
+SELECT DISTINCT ON (id)
+	id,
+	organization_id
+FROM (
+	SELECT
+		id,
+		organization_id,
+		0 AS rank
+	FROM
+		measures
+	WHERE
+		id = ANY(@resource_ids::text[])
+	UNION ALL
+	SELECT
+		measure_id,
+		organization_id,
+		1 AS rank
+	FROM (
+		SELECT DISTINCT ON (measure_id)
+			measure_id,
+			organization_id
+		FROM
+			measure_events
+		WHERE
+			measure_id = ANY(@resource_ids::text[])
+		ORDER BY
+			measure_id,
+			created_at DESC
+	) events
+) candidates
+ORDER BY
+	id,
+	rank
+`
 
 	args := pgx.StrictNamedArgs{
 		"resource_ids": resourceIDs,
@@ -324,6 +360,179 @@ WHERE %s
 	*m = measures
 
 	return nil
+}
+
+func (m *Measures) LoadByIDsAsOf(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	measureIDs []gid.GID,
+	asOf time.Time,
+	cursor *page.Cursor[MeasureOrderField],
+	filter *MeasureFilter,
+) error {
+	if len(measureIDs) == 0 {
+		*m = nil
+		return nil
+	}
+
+	q := `
+WITH latest AS (
+	SELECT DISTINCT ON (measure_id)
+		tenant_id,
+		organization_id,
+		measure_id,
+		event_type,
+		name,
+		category,
+		state,
+		measure_created_at,
+		created_at
+	FROM
+		measure_events
+	WHERE
+		%s
+		AND measure_id = ANY(@measure_ids)
+		AND created_at < @as_of
+	ORDER BY
+		measure_id,
+		created_at DESC
+),
+msrs AS (
+	SELECT
+		latest.measure_id AS id,
+		latest.tenant_id,
+		latest.organization_id,
+		latest.category,
+		latest.name,
+		CAST(NULL AS text) AS description,
+		latest.state,
+		'' AS reference_id,
+		latest.measure_created_at AS created_at,
+		latest.created_at AS updated_at
+	FROM
+		latest
+	WHERE
+		latest.event_type <> @deleted
+)
+SELECT
+	id,
+	organization_id,
+	category,
+	name,
+	description,
+	state,
+	reference_id,
+	created_at,
+	updated_at
+FROM
+	msrs
+WHERE
+	%s
+	AND %s
+	AND %s
+`
+	q = fmt.Sprintf(
+		q,
+		scope.SQLFragment(),
+		scope.SQLFragment(),
+		filter.EventSQLFragment(),
+		cursor.SQLFragment(),
+	)
+
+	args := pgx.StrictNamedArgs{
+		"measure_ids": measureIDs,
+		"as_of":       asOf,
+		"deleted":     MeasureEventTypeDeleted,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query measures as of: %w", err)
+	}
+
+	measures, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[Measure])
+	if err != nil {
+		return fmt.Errorf("cannot collect measures as of: %w", err)
+	}
+
+	*m = measures
+
+	return nil
+}
+
+func (m *Measures) CountByIDsAsOf(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	measureIDs []gid.GID,
+	asOf time.Time,
+	filter *MeasureFilter,
+) (int, error) {
+	if len(measureIDs) == 0 {
+		return 0, nil
+	}
+
+	q := `
+WITH latest AS (
+	SELECT DISTINCT ON (measure_id)
+		tenant_id,
+		measure_id,
+		event_type,
+		name,
+		category,
+		state
+	FROM
+		measure_events
+	WHERE
+		%s
+		AND measure_id = ANY(@measure_ids)
+		AND created_at < @as_of
+	ORDER BY
+		measure_id,
+		created_at DESC
+),
+msrs AS (
+	SELECT
+		latest.measure_id AS id,
+		latest.tenant_id,
+		latest.name,
+		latest.category,
+		latest.state
+	FROM
+		latest
+	WHERE
+		latest.event_type <> @deleted
+)
+SELECT
+	COUNT(id)
+FROM
+	msrs
+WHERE
+	%s
+	AND %s
+`
+	q = fmt.Sprintf(q, scope.SQLFragment(), scope.SQLFragment(), filter.EventSQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"measure_ids": measureIDs,
+		"as_of":       asOf,
+		"deleted":     MeasureEventTypeDeleted,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+
+	row := conn.QueryRow(ctx, q, args)
+
+	var count int
+	if err := row.Scan(&count); err != nil {
+		return 0, fmt.Errorf("cannot scan measures as of count: %w", err)
+	}
+
+	return count, nil
 }
 
 func (m *Measures) CountByControlID(
@@ -817,9 +1026,16 @@ WHERE %s
 
 	maps.Copy(args, scope.SQLArguments())
 
-	_, err := conn.Exec(ctx, q, args)
+	result, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update measure: %w", err)
+	}
 
-	return err
+	if result.RowsAffected() == 0 {
+		return ErrResourceNotFound
+	}
+
+	return nil
 }
 
 func (m *Measure) Delete(

--- a/pkg/coredata/measure_event.go
+++ b/pkg/coredata/measure_event.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+type (
+	MeasureEvent struct {
+		OrganizationID   gid.GID          `db:"organization_id"`
+		MeasureID        gid.GID          `db:"measure_id"`
+		EventType        MeasureEventType `db:"event_type"`
+		Name             string           `db:"name"`
+		Category         string           `db:"category"`
+		State            MeasureState     `db:"state"`
+		MeasureCreatedAt time.Time        `db:"measure_created_at"`
+		CreatedAt        time.Time        `db:"created_at"`
+	}
+
+	MeasureEvents []*MeasureEvent
+)
+
+func NewMeasureEvent(
+	measure *Measure,
+	eventType MeasureEventType,
+	now time.Time,
+) *MeasureEvent {
+	return &MeasureEvent{
+		OrganizationID:   measure.OrganizationID,
+		MeasureID:        measure.ID,
+		EventType:        eventType,
+		Name:             measure.Name,
+		Category:         measure.Category,
+		State:            measure.State,
+		MeasureCreatedAt: measure.CreatedAt,
+		CreatedAt:        now,
+	}
+}
+
+func (e *MeasureEvent) Measure() *Measure {
+	return &Measure{
+		ID:             e.MeasureID,
+		OrganizationID: e.OrganizationID,
+		Category:       e.Category,
+		Name:           e.Name,
+		State:          e.State,
+		CreatedAt:      e.MeasureCreatedAt,
+		UpdatedAt:      e.CreatedAt,
+	}
+}
+
+func (e *MeasureEvent) Insert(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO
+    measure_events (
+        tenant_id,
+        organization_id,
+        measure_id,
+        event_type,
+        name,
+        category,
+        state,
+        measure_created_at,
+        created_at
+    )
+VALUES (
+    @tenant_id,
+    @organization_id,
+    @measure_id,
+    @event_type,
+    @name,
+    @category,
+    @state,
+    @measure_created_at,
+    @created_at
+);
+`
+
+	args := pgx.StrictNamedArgs{
+		"tenant_id":          scope.GetTenantID(),
+		"organization_id":    e.OrganizationID,
+		"measure_id":         e.MeasureID,
+		"event_type":         e.EventType,
+		"name":               e.Name,
+		"category":           e.Category,
+		"state":              e.State,
+		"measure_created_at": e.MeasureCreatedAt,
+		"created_at":         e.CreatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert measure event: %w", err)
+	}
+
+	return nil
+}
+
+func (es *MeasureEvents) LoadLatestByMeasureIDsAsOf(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	measureIDs []gid.GID,
+	asOf time.Time,
+	filter *MeasureFilter,
+) error {
+	if len(measureIDs) == 0 {
+		*es = nil
+		return nil
+	}
+
+	q := `
+SELECT
+    organization_id,
+    measure_id,
+    event_type,
+    name,
+    category,
+    state,
+    measure_created_at,
+    created_at
+FROM (
+    SELECT DISTINCT ON (measure_id)
+        organization_id,
+        measure_id,
+        event_type,
+        name,
+        category,
+        state,
+        measure_created_at,
+        created_at
+    FROM
+        measure_events
+    WHERE
+        %s
+        AND measure_id = ANY(@measure_ids)
+        AND created_at < @as_of
+    ORDER BY
+        measure_id,
+        created_at DESC
+) latest
+WHERE
+    event_type <> @deleted
+    AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.EventSQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"measure_ids": measureIDs,
+		"as_of":       asOf,
+		"deleted":     MeasureEventTypeDeleted,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query measure events: %w", err)
+	}
+
+	events, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[MeasureEvent])
+	if err != nil {
+		return fmt.Errorf("cannot collect measure events: %w", err)
+	}
+
+	*es = events
+
+	return nil
+}

--- a/pkg/coredata/measure_event_type.go
+++ b/pkg/coredata/measure_event_type.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata
+
+import (
+	"encoding"
+	"fmt"
+)
+
+type (
+	MeasureEventType string
+)
+
+const (
+	MeasureEventTypeCreated MeasureEventType = "CREATED"
+	MeasureEventTypeUpdated MeasureEventType = "UPDATED"
+	MeasureEventTypeDeleted MeasureEventType = "DELETED"
+)
+
+var (
+	_ fmt.Stringer             = MeasureEventType("")
+	_ encoding.TextMarshaler   = MeasureEventType("")
+	_ encoding.TextUnmarshaler = (*MeasureEventType)(nil)
+)
+
+func (v MeasureEventType) IsValid() bool {
+	switch v {
+	case
+		MeasureEventTypeCreated,
+		MeasureEventTypeUpdated,
+		MeasureEventTypeDeleted:
+		return true
+	}
+
+	return false
+}
+
+func (v MeasureEventType) String() string {
+	return string(v)
+}
+
+func (v MeasureEventType) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+func (v *MeasureEventType) UnmarshalText(text []byte) error {
+	val := MeasureEventType(text)
+	if !val.IsValid() {
+		return fmt.Errorf("invalid MeasureEventType value: %q", string(text))
+	}
+
+	*v = val
+
+	return nil
+}

--- a/pkg/coredata/measure_filter.go
+++ b/pkg/coredata/measure_filter.go
@@ -81,3 +81,37 @@ AND
 )
 	`
 }
+
+func (f *MeasureFilter) EventSQLFragment() string {
+	return `
+(
+	CASE
+		WHEN @query::text IS NULL OR @query::text = '' THEN
+			TRUE
+		ELSE
+			to_tsvector('simple', name) @@ (
+				SELECT to_tsquery('simple', string_agg(lexeme || ':*', ' & '))
+				FROM unnest(regexp_split_to_array(trim(@query), '\s+')) AS lexeme
+			)
+	END
+)
+AND
+(
+	CASE
+		WHEN @state::mitigation_state IS NULL THEN
+			TRUE
+		ELSE
+			state = @state::mitigation_state::text
+		END
+)
+AND
+(
+	CASE
+		WHEN @category::text IS NULL OR @category::text = '' THEN
+			TRUE
+		ELSE
+			category = @category::text
+	END
+)
+	`
+}

--- a/pkg/coredata/migrations/20260826T135100Z.sql
+++ b/pkg/coredata/migrations/20260826T135100Z.sql
@@ -1,0 +1,144 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+CREATE TYPE treatment_plan_event_type AS ENUM (
+    'CREATED',
+    'UPDATED',
+    'DELETED',
+    'MEASURE_LINKED',
+    'MEASURE_UNLINKED'
+);
+
+CREATE TABLE treatment_plan_events (
+    tenant_id TEXT NOT NULL,
+    organization_id TEXT NOT NULL REFERENCES organizations(id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    risk_analysis_id TEXT NOT NULL REFERENCES risk_analyses(id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    treatment_plan_id TEXT NOT NULL,
+    event_type treatment_plan_event_type NOT NULL,
+    risk_id TEXT NOT NULL REFERENCES risks(id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    owner_profile_id TEXT NOT NULL REFERENCES iam_membership_profiles(id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    treatment risk_treatment NOT NULL,
+    inherent_likelihood INTEGER NOT NULL,
+    inherent_impact INTEGER NOT NULL,
+    residual_likelihood INTEGER NOT NULL,
+    residual_impact INTEGER NOT NULL,
+    measure_ids TEXT[] NOT NULL,
+    category TEXT NOT NULL,
+    treatment_plan_created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    treatment_plan_updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE TYPE measure_event_type AS ENUM (
+    'CREATED',
+    'UPDATED',
+    'DELETED'
+);
+
+CREATE TABLE measure_events (
+    tenant_id TEXT NOT NULL,
+    organization_id TEXT NOT NULL REFERENCES organizations(id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    measure_id TEXT NOT NULL,
+    event_type measure_event_type NOT NULL,
+    name TEXT NOT NULL,
+    category TEXT NOT NULL,
+    state TEXT NOT NULL,
+    measure_created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+-- Seed current treatment plans and measures as CREATED events, the
+-- starting point for as-of reconstruction. History before this
+-- migration cannot be recovered.
+
+INSERT INTO treatment_plan_events (
+    tenant_id,
+    organization_id,
+    risk_analysis_id,
+    treatment_plan_id,
+    event_type,
+    risk_id,
+    owner_profile_id,
+    treatment,
+    inherent_likelihood,
+    inherent_impact,
+    residual_likelihood,
+    residual_impact,
+    measure_ids,
+    category,
+    treatment_plan_created_at,
+    treatment_plan_updated_at,
+    created_at
+)
+SELECT
+    tp.tenant_id,
+    tp.organization_id,
+    tp.risk_analysis_id,
+    tp.id,
+    'CREATED',
+    tp.risk_id,
+    tp.owner_profile_id,
+    tp.treatment,
+    tp.inherent_likelihood,
+    tp.inherent_impact,
+    tp.residual_likelihood,
+    tp.residual_impact,
+    COALESCE(
+        (
+            SELECT array_agg(tpm.measure_id ORDER BY tpm.measure_id)
+            FROM treatment_plans_measures tpm
+            WHERE tpm.treatment_plan_id = tp.id
+        ),
+        ARRAY[]::TEXT[]
+    ),
+    r.category,
+    tp.created_at,
+    tp.updated_at,
+    tp.created_at
+FROM treatment_plans tp
+INNER JOIN risks r ON r.id = tp.risk_id;
+
+INSERT INTO measure_events (
+    tenant_id,
+    organization_id,
+    measure_id,
+    event_type,
+    name,
+    category,
+    state,
+    measure_created_at,
+    created_at
+)
+SELECT
+    m.tenant_id,
+    m.organization_id,
+    m.id,
+    'CREATED',
+    m.name,
+    m.category,
+    m.state::text,
+    m.created_at,
+    m.created_at
+FROM measures m;

--- a/pkg/coredata/treatment_plan.go
+++ b/pkg/coredata/treatment_plan.go
@@ -188,6 +188,84 @@ LIMIT 1;
 	return nil
 }
 
+func (tp *TreatmentPlan) LoadByIDForUpdate(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	id gid.GID,
+) error {
+	q := `
+WITH locked AS (
+	SELECT
+		id,
+		tenant_id,
+		organization_id,
+		risk_id,
+		risk_analysis_id,
+		treatment,
+		owner_profile_id,
+		inherent_likelihood,
+		inherent_impact,
+		inherent_risk_score,
+		residual_likelihood,
+		residual_impact,
+		residual_risk_score,
+		created_at,
+		updated_at
+	FROM
+		treatment_plans
+	WHERE
+		%s
+		AND id = @id
+	LIMIT 1
+	FOR UPDATE
+)
+SELECT
+	locked.id,
+	locked.organization_id,
+	locked.risk_id,
+	locked.risk_analysis_id,
+	locked.treatment,
+	locked.owner_profile_id,
+	locked.inherent_likelihood,
+	locked.inherent_impact,
+	locked.inherent_risk_score,
+	locked.residual_likelihood,
+	locked.residual_impact,
+	locked.residual_risk_score,
+	locked.created_at,
+	locked.updated_at,
+	r.category
+FROM
+	locked
+INNER JOIN
+	risks r ON r.id = locked.risk_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": id}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query treatment plan for update: %w", err)
+	}
+
+	result, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TreatmentPlan])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect treatment plan: %w", err)
+	}
+
+	*tp = result
+
+	return nil
+}
+
 func (tps *TreatmentPlans) CountByOrganizationID(
 	ctx context.Context,
 	conn pg.Querier,
@@ -517,6 +595,321 @@ WHERE %s
 	return nil
 }
 
+func (tps *TreatmentPlans) CountByMeasureIDAsOf(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	measureID gid.GID,
+	asOf time.Time,
+	filter *TreatmentPlanFilter,
+) (int, error) {
+	q := `
+WITH candidates AS (
+	SELECT DISTINCT
+		treatment_plan_id
+	FROM
+		treatment_plan_events
+	WHERE
+		%s
+		AND created_at < @as_of
+		AND @measure_id::text = ANY(measure_ids)
+),
+latest AS (
+	SELECT DISTINCT ON (treatment_plan_id)
+		tenant_id,
+		organization_id,
+		risk_analysis_id,
+		treatment_plan_id,
+		event_type,
+		risk_id,
+		owner_profile_id,
+		treatment,
+		inherent_likelihood,
+		inherent_impact,
+		residual_likelihood,
+		residual_impact,
+		measure_ids,
+		category,
+		treatment_plan_created_at,
+		treatment_plan_updated_at,
+		created_at
+	FROM
+		treatment_plan_events
+	WHERE
+		%s
+		AND treatment_plan_id IN (SELECT treatment_plan_id FROM candidates)
+		AND created_at < @as_of
+	ORDER BY
+		treatment_plan_id,
+		created_at DESC
+),
+tps AS (
+	SELECT
+		latest.treatment_plan_id AS id,
+		latest.tenant_id,
+		latest.organization_id,
+		latest.risk_id,
+		latest.risk_analysis_id,
+		latest.treatment,
+		latest.owner_profile_id,
+		latest.inherent_likelihood,
+		latest.inherent_impact,
+		latest.inherent_likelihood * latest.inherent_impact AS inherent_risk_score,
+		latest.residual_likelihood,
+		latest.residual_impact,
+		latest.residual_likelihood * latest.residual_impact AS residual_risk_score,
+		latest.treatment_plan_created_at AS created_at,
+		latest.treatment_plan_updated_at AS updated_at,
+		latest.category,
+		latest.measure_ids
+	FROM
+		latest
+	WHERE
+		latest.event_type <> @deleted
+		AND @measure_id::text = ANY(latest.measure_ids)
+)
+SELECT
+	COUNT(id)
+FROM
+	tps
+WHERE
+	%s
+	AND (
+		CASE
+			WHEN @filter_score_type::text IS NULL
+				OR @filter_likelihood::int IS NULL
+				OR @filter_impact::int IS NULL
+			THEN TRUE
+			WHEN @filter_score_type::text = @filter_score_type_inherent::text THEN
+				inherent_likelihood = @filter_likelihood
+				AND inherent_impact = @filter_impact
+			WHEN @filter_score_type::text = @filter_score_type_residual::text THEN
+				residual_likelihood = @filter_likelihood
+				AND residual_impact = @filter_impact
+			WHEN @filter_score_type::text = @filter_score_type_net::text THEN
+				CASE
+					WHEN cardinality(measure_ids) > 0
+					AND NOT EXISTS (
+						SELECT 1
+						FROM unnest(measure_ids) AS mid
+						LEFT JOIN LATERAL (
+							SELECT latest_event.state
+							FROM (
+								SELECT me.state, me.event_type
+								FROM measure_events me
+								WHERE me.measure_id = mid
+									AND me.created_at < @as_of
+									AND me.tenant_id = tps.tenant_id
+								ORDER BY me.created_at DESC
+								LIMIT 1
+							) latest_event
+							WHERE latest_event.event_type <> @measure_deleted
+						) latest_state ON TRUE
+						WHERE latest_state.state IS DISTINCT FROM @filter_net_implemented::text
+					)
+					THEN
+						residual_likelihood = @filter_likelihood
+						AND residual_impact = @filter_impact
+					ELSE
+						inherent_likelihood = @filter_likelihood
+						AND inherent_impact = @filter_impact
+				END
+			ELSE TRUE
+		END
+	)
+`
+	q = fmt.Sprintf(q, scope.SQLFragment(), scope.SQLFragment(), scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"measure_id":      measureID,
+		"as_of":           asOf,
+		"deleted":         TreatmentPlanEventTypeDeleted,
+		"measure_deleted": MeasureEventTypeDeleted,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+
+	var count int
+	if err := conn.QueryRow(ctx, q, args).Scan(&count); err != nil {
+		return 0, fmt.Errorf("cannot count treatment plans as of: %w", err)
+	}
+
+	return count, nil
+}
+
+func (tps *TreatmentPlans) LoadByMeasureIDAsOf(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	measureID gid.GID,
+	asOf time.Time,
+	cursor *page.Cursor[TreatmentPlanOrderField],
+	filter *TreatmentPlanFilter,
+) error {
+	q := `
+WITH candidates AS (
+	SELECT DISTINCT
+		treatment_plan_id
+	FROM
+		treatment_plan_events
+	WHERE
+		%s
+		AND created_at < @as_of
+		AND @measure_id::text = ANY(measure_ids)
+),
+latest AS (
+	SELECT DISTINCT ON (treatment_plan_id)
+		tenant_id,
+		organization_id,
+		risk_analysis_id,
+		treatment_plan_id,
+		event_type,
+		risk_id,
+		owner_profile_id,
+		treatment,
+		inherent_likelihood,
+		inherent_impact,
+		residual_likelihood,
+		residual_impact,
+		measure_ids,
+		category,
+		treatment_plan_created_at,
+		treatment_plan_updated_at,
+		created_at
+	FROM
+		treatment_plan_events
+	WHERE
+		%s
+		AND treatment_plan_id IN (SELECT treatment_plan_id FROM candidates)
+		AND created_at < @as_of
+	ORDER BY
+		treatment_plan_id,
+		created_at DESC
+),
+tps AS (
+	SELECT
+		latest.treatment_plan_id AS id,
+		latest.tenant_id,
+		latest.organization_id,
+		latest.risk_id,
+		latest.risk_analysis_id,
+		latest.treatment,
+		latest.owner_profile_id,
+		latest.inherent_likelihood,
+		latest.inherent_impact,
+		latest.inherent_likelihood * latest.inherent_impact AS inherent_risk_score,
+		latest.residual_likelihood,
+		latest.residual_impact,
+		latest.residual_likelihood * latest.residual_impact AS residual_risk_score,
+		latest.treatment_plan_created_at AS created_at,
+		latest.treatment_plan_updated_at AS updated_at,
+		latest.category,
+		latest.measure_ids
+	FROM
+		latest
+	WHERE
+		latest.event_type <> @deleted
+		AND @measure_id::text = ANY(latest.measure_ids)
+)
+SELECT
+	id,
+	organization_id,
+	risk_id,
+	risk_analysis_id,
+	treatment,
+	owner_profile_id,
+	inherent_likelihood,
+	inherent_impact,
+	inherent_risk_score,
+	residual_likelihood,
+	residual_impact,
+	residual_risk_score,
+	created_at,
+	updated_at,
+	category
+FROM
+	tps
+WHERE
+	%s
+	AND (
+		CASE
+			WHEN @filter_score_type::text IS NULL
+				OR @filter_likelihood::int IS NULL
+				OR @filter_impact::int IS NULL
+			THEN TRUE
+			WHEN @filter_score_type::text = @filter_score_type_inherent::text THEN
+				inherent_likelihood = @filter_likelihood
+				AND inherent_impact = @filter_impact
+			WHEN @filter_score_type::text = @filter_score_type_residual::text THEN
+				residual_likelihood = @filter_likelihood
+				AND residual_impact = @filter_impact
+			WHEN @filter_score_type::text = @filter_score_type_net::text THEN
+				CASE
+					WHEN cardinality(measure_ids) > 0
+					AND NOT EXISTS (
+						SELECT 1
+						FROM unnest(measure_ids) AS mid
+						LEFT JOIN LATERAL (
+							SELECT latest_event.state
+							FROM (
+								SELECT me.state, me.event_type
+								FROM measure_events me
+								WHERE me.measure_id = mid
+									AND me.created_at < @as_of
+									AND me.tenant_id = tps.tenant_id
+								ORDER BY me.created_at DESC
+								LIMIT 1
+							) latest_event
+							WHERE latest_event.event_type <> @measure_deleted
+						) latest_state ON TRUE
+						WHERE latest_state.state IS DISTINCT FROM @filter_net_implemented::text
+					)
+					THEN
+						residual_likelihood = @filter_likelihood
+						AND residual_impact = @filter_impact
+					ELSE
+						inherent_likelihood = @filter_likelihood
+						AND inherent_impact = @filter_impact
+				END
+			ELSE TRUE
+		END
+	)
+	AND %s
+`
+
+	q = fmt.Sprintf(
+		q,
+		scope.SQLFragment(),
+		scope.SQLFragment(),
+		scope.SQLFragment(),
+		cursor.SQLFragment(),
+	)
+
+	args := pgx.StrictNamedArgs{
+		"measure_id":      measureID,
+		"as_of":           asOf,
+		"deleted":         TreatmentPlanEventTypeDeleted,
+		"measure_deleted": MeasureEventTypeDeleted,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query treatment plans as of: %w", err)
+	}
+
+	results, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[TreatmentPlan])
+	if err != nil {
+		return fmt.Errorf("cannot collect treatment plans as of: %w", err)
+	}
+
+	*tps = results
+
+	return nil
+}
+
 func (tps *TreatmentPlans) CountByRiskAnalysisID(
 	ctx context.Context,
 	conn pg.Querier,
@@ -621,13 +1014,305 @@ WHERE %s
 	return nil
 }
 
+func (tps *TreatmentPlans) CountByRiskAnalysisIDAsOf(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	riskAnalysisID gid.GID,
+	asOf time.Time,
+	filter *TreatmentPlanFilter,
+) (int, error) {
+	q := `
+WITH latest AS (
+	SELECT DISTINCT ON (treatment_plan_id)
+		tenant_id,
+		organization_id,
+		risk_analysis_id,
+		treatment_plan_id,
+		event_type,
+		risk_id,
+		owner_profile_id,
+		treatment,
+		inherent_likelihood,
+		inherent_impact,
+		residual_likelihood,
+		residual_impact,
+		measure_ids,
+		category,
+		treatment_plan_created_at,
+		treatment_plan_updated_at,
+		created_at
+	FROM
+		treatment_plan_events
+	WHERE
+		%s
+		AND risk_analysis_id = @risk_analysis_id
+		AND created_at < @as_of
+	ORDER BY
+		treatment_plan_id,
+		created_at DESC
+),
+tps AS (
+	SELECT
+		latest.treatment_plan_id AS id,
+		latest.tenant_id,
+		latest.organization_id,
+		latest.risk_id,
+		latest.risk_analysis_id,
+		latest.treatment,
+		latest.owner_profile_id,
+		latest.inherent_likelihood,
+		latest.inherent_impact,
+		latest.inherent_likelihood * latest.inherent_impact AS inherent_risk_score,
+		latest.residual_likelihood,
+		latest.residual_impact,
+		latest.residual_likelihood * latest.residual_impact AS residual_risk_score,
+		latest.treatment_plan_created_at AS created_at,
+		latest.treatment_plan_updated_at AS updated_at,
+		latest.category,
+		latest.measure_ids
+	FROM
+		latest
+	WHERE
+		latest.event_type <> @deleted
+)
+SELECT
+	COUNT(id)
+FROM
+	tps
+WHERE
+	%s
+	AND (
+		CASE
+			WHEN @filter_score_type::text IS NULL
+				OR @filter_likelihood::int IS NULL
+				OR @filter_impact::int IS NULL
+			THEN TRUE
+			WHEN @filter_score_type::text = @filter_score_type_inherent::text THEN
+				inherent_likelihood = @filter_likelihood
+				AND inherent_impact = @filter_impact
+			WHEN @filter_score_type::text = @filter_score_type_residual::text THEN
+				residual_likelihood = @filter_likelihood
+				AND residual_impact = @filter_impact
+			WHEN @filter_score_type::text = @filter_score_type_net::text THEN
+				CASE
+					WHEN cardinality(measure_ids) > 0
+					AND NOT EXISTS (
+						SELECT 1
+						FROM unnest(measure_ids) AS mid
+						LEFT JOIN LATERAL (
+							SELECT latest_event.state
+							FROM (
+								SELECT me.state, me.event_type
+								FROM measure_events me
+								WHERE me.measure_id = mid
+									AND me.created_at < @as_of
+									AND me.tenant_id = tps.tenant_id
+								ORDER BY me.created_at DESC
+								LIMIT 1
+							) latest_event
+							WHERE latest_event.event_type <> @measure_deleted
+						) latest_state ON TRUE
+						WHERE latest_state.state IS DISTINCT FROM @filter_net_implemented::text
+					)
+					THEN
+						residual_likelihood = @filter_likelihood
+						AND residual_impact = @filter_impact
+					ELSE
+						inherent_likelihood = @filter_likelihood
+						AND inherent_impact = @filter_impact
+				END
+			ELSE TRUE
+		END
+	)
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"risk_analysis_id": riskAnalysisID,
+		"as_of":            asOf,
+		"deleted":          TreatmentPlanEventTypeDeleted,
+		"measure_deleted":  MeasureEventTypeDeleted,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+
+	var count int
+	if err := conn.QueryRow(ctx, q, args).Scan(&count); err != nil {
+		return 0, fmt.Errorf("cannot count treatment plans as of: %w", err)
+	}
+
+	return count, nil
+}
+
+func (tps *TreatmentPlans) LoadByRiskAnalysisIDAsOf(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	riskAnalysisID gid.GID,
+	asOf time.Time,
+	cursor *page.Cursor[TreatmentPlanOrderField],
+	filter *TreatmentPlanFilter,
+) error {
+	q := `
+WITH latest AS (
+	SELECT DISTINCT ON (treatment_plan_id)
+		tenant_id,
+		organization_id,
+		risk_analysis_id,
+		treatment_plan_id,
+		event_type,
+		risk_id,
+		owner_profile_id,
+		treatment,
+		inherent_likelihood,
+		inherent_impact,
+		residual_likelihood,
+		residual_impact,
+		measure_ids,
+		category,
+		treatment_plan_created_at,
+		treatment_plan_updated_at,
+		created_at
+	FROM
+		treatment_plan_events
+	WHERE
+		%s
+		AND risk_analysis_id = @risk_analysis_id
+		AND created_at < @as_of
+	ORDER BY
+		treatment_plan_id,
+		created_at DESC
+),
+tps AS (
+	SELECT
+		latest.treatment_plan_id AS id,
+		latest.tenant_id,
+		latest.organization_id,
+		latest.risk_id,
+		latest.risk_analysis_id,
+		latest.treatment,
+		latest.owner_profile_id,
+		latest.inherent_likelihood,
+		latest.inherent_impact,
+		latest.inherent_likelihood * latest.inherent_impact AS inherent_risk_score,
+		latest.residual_likelihood,
+		latest.residual_impact,
+		latest.residual_likelihood * latest.residual_impact AS residual_risk_score,
+		latest.treatment_plan_created_at AS created_at,
+		latest.treatment_plan_updated_at AS updated_at,
+		latest.category,
+		latest.measure_ids
+	FROM
+		latest
+	WHERE
+		latest.event_type <> @deleted
+)
+SELECT
+	id,
+	organization_id,
+	risk_id,
+	risk_analysis_id,
+	treatment,
+	owner_profile_id,
+	inherent_likelihood,
+	inherent_impact,
+	inherent_risk_score,
+	residual_likelihood,
+	residual_impact,
+	residual_risk_score,
+	created_at,
+	updated_at,
+	category
+FROM
+	tps
+WHERE
+	%s
+	AND (
+		CASE
+			WHEN @filter_score_type::text IS NULL
+				OR @filter_likelihood::int IS NULL
+				OR @filter_impact::int IS NULL
+			THEN TRUE
+			WHEN @filter_score_type::text = @filter_score_type_inherent::text THEN
+				inherent_likelihood = @filter_likelihood
+				AND inherent_impact = @filter_impact
+			WHEN @filter_score_type::text = @filter_score_type_residual::text THEN
+				residual_likelihood = @filter_likelihood
+				AND residual_impact = @filter_impact
+			WHEN @filter_score_type::text = @filter_score_type_net::text THEN
+				CASE
+					WHEN cardinality(measure_ids) > 0
+					AND NOT EXISTS (
+						SELECT 1
+						FROM unnest(measure_ids) AS mid
+						LEFT JOIN LATERAL (
+							SELECT latest_event.state
+							FROM (
+								SELECT me.state, me.event_type
+								FROM measure_events me
+								WHERE me.measure_id = mid
+									AND me.created_at < @as_of
+									AND me.tenant_id = tps.tenant_id
+								ORDER BY me.created_at DESC
+								LIMIT 1
+							) latest_event
+							WHERE latest_event.event_type <> @measure_deleted
+						) latest_state ON TRUE
+						WHERE latest_state.state IS DISTINCT FROM @filter_net_implemented::text
+					)
+					THEN
+						residual_likelihood = @filter_likelihood
+						AND residual_impact = @filter_impact
+					ELSE
+						inherent_likelihood = @filter_likelihood
+						AND inherent_impact = @filter_impact
+				END
+			ELSE TRUE
+		END
+	)
+	AND %s
+`
+
+	q = fmt.Sprintf(
+		q,
+		scope.SQLFragment(),
+		scope.SQLFragment(),
+		cursor.SQLFragment(),
+	)
+
+	args := pgx.StrictNamedArgs{
+		"risk_analysis_id": riskAnalysisID,
+		"as_of":            asOf,
+		"deleted":          TreatmentPlanEventTypeDeleted,
+		"measure_deleted":  MeasureEventTypeDeleted,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query treatment plans as of: %w", err)
+	}
+
+	results, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[TreatmentPlan])
+	if err != nil {
+		return fmt.Errorf("cannot collect treatment plans as of: %w", err)
+	}
+
+	*tps = results
+
+	return nil
+}
+
 func (tps *TreatmentPlans) CountMatrixCellsByRiskAnalysisID(
 	ctx context.Context,
 	conn pg.Querier,
 	scope Scoper,
 	riskAnalysisID gid.GID,
 ) ([]*RiskAnalysisMatrixCell, error) {
-	implementedSQL := treatmentPlanAllMeasuresImplementedSQL()
 	q := `
 SELECT
 	@score_type_inherent::text AS score_type,
@@ -655,28 +1340,50 @@ UNION ALL
 
 SELECT
 	@score_type_net::text,
-	CASE
-		WHEN %s THEN residual_likelihood
-		ELSE inherent_likelihood
-	END,
-	CASE
-		WHEN %s THEN residual_impact
-		ELSE inherent_impact
-	END,
+	likelihood,
+	impact,
 	COUNT(*)::int
-FROM treatment_plans
-WHERE %s
-	AND risk_analysis_id = @risk_analysis_id
-GROUP BY 2, 3
+FROM (
+	SELECT
+		CASE
+			WHEN EXISTS (
+				SELECT 1
+				FROM treatment_plans_measures tpm
+				WHERE tpm.treatment_plan_id = treatment_plans.id
+			)
+			AND NOT EXISTS (
+				SELECT 1
+				FROM treatment_plans_measures tpm
+				INNER JOIN measures m ON m.id = tpm.measure_id
+				WHERE tpm.treatment_plan_id = treatment_plans.id
+					AND m.state::text IS DISTINCT FROM @filter_net_implemented::text
+			)
+			THEN residual_likelihood
+			ELSE inherent_likelihood
+		END AS likelihood,
+		CASE
+			WHEN EXISTS (
+				SELECT 1
+				FROM treatment_plans_measures tpm
+				WHERE tpm.treatment_plan_id = treatment_plans.id
+			)
+			AND NOT EXISTS (
+				SELECT 1
+				FROM treatment_plans_measures tpm
+				INNER JOIN measures m ON m.id = tpm.measure_id
+				WHERE tpm.treatment_plan_id = treatment_plans.id
+					AND m.state::text IS DISTINCT FROM @filter_net_implemented::text
+			)
+			THEN residual_impact
+			ELSE inherent_impact
+		END AS impact
+	FROM treatment_plans
+	WHERE %s
+		AND risk_analysis_id = @risk_analysis_id
+) net_scores
+GROUP BY likelihood, impact
 `
-	q = fmt.Sprintf(
-		q,
-		scope.SQLFragment(),
-		scope.SQLFragment(),
-		implementedSQL,
-		implementedSQL,
-		scope.SQLFragment(),
-	)
+	q = fmt.Sprintf(q, scope.SQLFragment(), scope.SQLFragment(), scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
 		"risk_analysis_id":       riskAnalysisID,

--- a/pkg/coredata/treatment_plan_event.go
+++ b/pkg/coredata/treatment_plan_event.go
@@ -1,0 +1,379 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+type (
+	TreatmentPlanEvent struct {
+		OrganizationID         gid.GID                `db:"organization_id"`
+		RiskAnalysisID         gid.GID                `db:"risk_analysis_id"`
+		TreatmentPlanID        gid.GID                `db:"treatment_plan_id"`
+		EventType              TreatmentPlanEventType `db:"event_type"`
+		RiskID                 gid.GID                `db:"risk_id"`
+		OwnerID                gid.GID                `db:"owner_profile_id"`
+		Treatment              RiskTreatment          `db:"treatment"`
+		InherentLikelihood     int                    `db:"inherent_likelihood"`
+		InherentImpact         int                    `db:"inherent_impact"`
+		ResidualLikelihood     int                    `db:"residual_likelihood"`
+		ResidualImpact         int                    `db:"residual_impact"`
+		MeasureIDs             []string               `db:"measure_ids"`
+		Category               string                 `db:"category"`
+		TreatmentPlanCreatedAt time.Time              `db:"treatment_plan_created_at"`
+		TreatmentPlanUpdatedAt time.Time              `db:"treatment_plan_updated_at"`
+		CreatedAt              time.Time              `db:"created_at"`
+	}
+
+	TreatmentPlanEvents []*TreatmentPlanEvent
+)
+
+func MeasureIDStrings(ids []gid.GID) []string {
+	if len(ids) == 0 {
+		return []string{}
+	}
+
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, id.String())
+	}
+
+	slices.Sort(out)
+
+	return out
+}
+
+func NewTreatmentPlanEvent(
+	tp *TreatmentPlan,
+	eventType TreatmentPlanEventType,
+	measureIDs []gid.GID,
+	now time.Time,
+) *TreatmentPlanEvent {
+	return &TreatmentPlanEvent{
+		OrganizationID:         tp.OrganizationID,
+		RiskAnalysisID:         tp.RiskAnalysisID,
+		TreatmentPlanID:        tp.ID,
+		EventType:              eventType,
+		RiskID:                 tp.RiskID,
+		OwnerID:                tp.OwnerID,
+		Treatment:              tp.Treatment,
+		InherentLikelihood:     tp.InherentLikelihood,
+		InherentImpact:         tp.InherentImpact,
+		ResidualLikelihood:     tp.ResidualLikelihood,
+		ResidualImpact:         tp.ResidualImpact,
+		MeasureIDs:             MeasureIDStrings(measureIDs),
+		Category:               tp.Category,
+		TreatmentPlanCreatedAt: tp.CreatedAt,
+		TreatmentPlanUpdatedAt: tp.UpdatedAt,
+		CreatedAt:              now,
+	}
+}
+
+func (e *TreatmentPlanEvent) LinkedMeasureIDs() ([]gid.GID, error) {
+	ids := make([]gid.GID, 0, len(e.MeasureIDs))
+	for _, raw := range e.MeasureIDs {
+		id, err := gid.ParseGID(raw)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse measure id %q: %w", raw, err)
+		}
+
+		ids = append(ids, id)
+	}
+
+	return ids, nil
+}
+
+func (e *TreatmentPlanEvent) TreatmentPlan() *TreatmentPlan {
+	return &TreatmentPlan{
+		ID:                 e.TreatmentPlanID,
+		OrganizationID:     e.OrganizationID,
+		RiskID:             e.RiskID,
+		RiskAnalysisID:     e.RiskAnalysisID,
+		Treatment:          e.Treatment,
+		OwnerID:            e.OwnerID,
+		InherentLikelihood: e.InherentLikelihood,
+		InherentImpact:     e.InherentImpact,
+		InherentRiskScore:  e.InherentLikelihood * e.InherentImpact,
+		ResidualLikelihood: e.ResidualLikelihood,
+		ResidualImpact:     e.ResidualImpact,
+		ResidualRiskScore:  e.ResidualLikelihood * e.ResidualImpact,
+		Category:           e.Category,
+		CreatedAt:          e.TreatmentPlanCreatedAt,
+		UpdatedAt:          e.TreatmentPlanUpdatedAt,
+	}
+}
+
+func (e *TreatmentPlanEvent) Insert(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO
+    treatment_plan_events (
+        tenant_id,
+        organization_id,
+        risk_analysis_id,
+        treatment_plan_id,
+        event_type,
+        risk_id,
+        owner_profile_id,
+        treatment,
+        inherent_likelihood,
+        inherent_impact,
+        residual_likelihood,
+        residual_impact,
+        measure_ids,
+        category,
+        treatment_plan_created_at,
+        treatment_plan_updated_at,
+        created_at
+    )
+VALUES (
+    @tenant_id,
+    @organization_id,
+    @risk_analysis_id,
+    @treatment_plan_id,
+    @event_type,
+    @risk_id,
+    @owner_profile_id,
+    @treatment,
+    @inherent_likelihood,
+    @inherent_impact,
+    @residual_likelihood,
+    @residual_impact,
+    @measure_ids,
+    @category,
+    @treatment_plan_created_at,
+    @treatment_plan_updated_at,
+    @created_at
+);
+`
+
+	args := pgx.StrictNamedArgs{
+		"tenant_id":                 scope.GetTenantID(),
+		"organization_id":           e.OrganizationID,
+		"risk_analysis_id":          e.RiskAnalysisID,
+		"treatment_plan_id":         e.TreatmentPlanID,
+		"event_type":                e.EventType,
+		"risk_id":                   e.RiskID,
+		"owner_profile_id":          e.OwnerID,
+		"treatment":                 e.Treatment,
+		"inherent_likelihood":       e.InherentLikelihood,
+		"inherent_impact":           e.InherentImpact,
+		"residual_likelihood":       e.ResidualLikelihood,
+		"residual_impact":           e.ResidualImpact,
+		"measure_ids":               e.MeasureIDs,
+		"category":                  e.Category,
+		"treatment_plan_created_at": e.TreatmentPlanCreatedAt,
+		"treatment_plan_updated_at": e.TreatmentPlanUpdatedAt,
+		"created_at":                e.CreatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert treatment plan event: %w", err)
+	}
+
+	return nil
+}
+
+func (es *TreatmentPlanEvents) LoadLatestByRiskAnalysisIDAsOf(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	riskAnalysisID gid.GID,
+	asOf time.Time,
+) error {
+	q := `
+SELECT
+    organization_id,
+    risk_analysis_id,
+    treatment_plan_id,
+    event_type,
+    risk_id,
+    owner_profile_id,
+    treatment,
+    inherent_likelihood,
+    inherent_impact,
+    residual_likelihood,
+    residual_impact,
+    measure_ids,
+    category,
+    treatment_plan_created_at,
+    treatment_plan_updated_at,
+    created_at
+FROM (
+    SELECT DISTINCT ON (treatment_plan_id)
+        organization_id,
+        risk_analysis_id,
+        treatment_plan_id,
+        event_type,
+        risk_id,
+        owner_profile_id,
+        treatment,
+        inherent_likelihood,
+        inherent_impact,
+        residual_likelihood,
+        residual_impact,
+        measure_ids,
+        category,
+        treatment_plan_created_at,
+        treatment_plan_updated_at,
+        created_at
+    FROM
+        treatment_plan_events
+    WHERE
+        %s
+        AND risk_analysis_id = @risk_analysis_id
+        AND created_at < @as_of
+    ORDER BY
+        treatment_plan_id,
+        created_at DESC
+) latest
+WHERE
+    event_type <> @deleted
+ORDER BY
+    treatment_plan_created_at ASC,
+    treatment_plan_id ASC
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"risk_analysis_id": riskAnalysisID,
+		"as_of":            asOf,
+		"deleted":          TreatmentPlanEventTypeDeleted,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query treatment plan events: %w", err)
+	}
+
+	events, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[TreatmentPlanEvent])
+	if err != nil {
+		return fmt.Errorf("cannot collect treatment plan events: %w", err)
+	}
+
+	*es = events
+
+	return nil
+}
+
+func (es *TreatmentPlanEvents) LoadLatestByTreatmentPlanIDsAsOf(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	riskAnalysisID gid.GID,
+	treatmentPlanIDs []gid.GID,
+	asOf time.Time,
+) error {
+	if len(treatmentPlanIDs) == 0 {
+		*es = nil
+		return nil
+	}
+
+	q := `
+SELECT
+    organization_id,
+    risk_analysis_id,
+    treatment_plan_id,
+    event_type,
+    risk_id,
+    owner_profile_id,
+    treatment,
+    inherent_likelihood,
+    inherent_impact,
+    residual_likelihood,
+    residual_impact,
+    measure_ids,
+    category,
+    treatment_plan_created_at,
+    treatment_plan_updated_at,
+    created_at
+FROM (
+    SELECT DISTINCT ON (treatment_plan_id)
+        organization_id,
+        risk_analysis_id,
+        treatment_plan_id,
+        event_type,
+        risk_id,
+        owner_profile_id,
+        treatment,
+        inherent_likelihood,
+        inherent_impact,
+        residual_likelihood,
+        residual_impact,
+        measure_ids,
+        category,
+        treatment_plan_created_at,
+        treatment_plan_updated_at,
+        created_at
+    FROM
+        treatment_plan_events
+    WHERE
+        %s
+        AND risk_analysis_id = @risk_analysis_id
+        AND treatment_plan_id = ANY(@treatment_plan_ids)
+        AND created_at < @as_of
+    ORDER BY
+        treatment_plan_id,
+        created_at DESC
+) latest
+WHERE
+    event_type <> @deleted
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"risk_analysis_id":   riskAnalysisID,
+		"treatment_plan_ids": treatmentPlanIDs,
+		"as_of":              asOf,
+		"deleted":            TreatmentPlanEventTypeDeleted,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query treatment plan events: %w", err)
+	}
+
+	events, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[TreatmentPlanEvent])
+	if err != nil {
+		return fmt.Errorf("cannot collect treatment plan events: %w", err)
+	}
+
+	*es = events
+
+	return nil
+}

--- a/pkg/coredata/treatment_plan_event_type.go
+++ b/pkg/coredata/treatment_plan_event_type.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata
+
+import (
+	"encoding"
+	"fmt"
+)
+
+type (
+	TreatmentPlanEventType string
+)
+
+const (
+	TreatmentPlanEventTypeCreated         TreatmentPlanEventType = "CREATED"
+	TreatmentPlanEventTypeUpdated         TreatmentPlanEventType = "UPDATED"
+	TreatmentPlanEventTypeDeleted         TreatmentPlanEventType = "DELETED"
+	TreatmentPlanEventTypeMeasureLinked   TreatmentPlanEventType = "MEASURE_LINKED"
+	TreatmentPlanEventTypeMeasureUnlinked TreatmentPlanEventType = "MEASURE_UNLINKED"
+)
+
+var (
+	_ fmt.Stringer             = TreatmentPlanEventType("")
+	_ encoding.TextMarshaler   = TreatmentPlanEventType("")
+	_ encoding.TextUnmarshaler = (*TreatmentPlanEventType)(nil)
+)
+
+func (v TreatmentPlanEventType) IsValid() bool {
+	switch v {
+	case
+		TreatmentPlanEventTypeCreated,
+		TreatmentPlanEventTypeUpdated,
+		TreatmentPlanEventTypeDeleted,
+		TreatmentPlanEventTypeMeasureLinked,
+		TreatmentPlanEventTypeMeasureUnlinked:
+		return true
+	}
+
+	return false
+}
+
+func (v TreatmentPlanEventType) String() string {
+	return string(v)
+}
+
+func (v TreatmentPlanEventType) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+func (v *TreatmentPlanEventType) UnmarshalText(text []byte) error {
+	val := TreatmentPlanEventType(text)
+	if !val.IsValid() {
+		return fmt.Errorf("invalid TreatmentPlanEventType value: %q", string(text))
+	}
+
+	*v = val
+
+	return nil
+}

--- a/pkg/coredata/treatment_plan_filter.go
+++ b/pkg/coredata/treatment_plan_filter.go
@@ -117,7 +117,23 @@ func (f *TreatmentPlanFilter) SQLFragment() string {
 			AND residual_impact = @filter_impact
 		WHEN @filter_score_type::text = @filter_score_type_net::text THEN
 			CASE
-				WHEN ` + treatmentPlanAllMeasuresImplementedSQL() + ` THEN
+				WHEN EXISTS (
+					SELECT 1
+					FROM treatment_plans_measures tpm
+					WHERE tpm.treatment_plan_id = id
+				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM treatment_plans_measures tpm
+					WHERE tpm.treatment_plan_id = id
+						AND EXISTS (
+							SELECT 1
+							FROM measures m
+							WHERE m.id = tpm.measure_id
+								AND m.state::text IS DISTINCT FROM @filter_net_implemented::text
+						)
+				)
+				THEN
 					residual_likelihood = @filter_likelihood
 					AND residual_impact = @filter_impact
 				ELSE
@@ -126,22 +142,5 @@ func (f *TreatmentPlanFilter) SQLFragment() string {
 			END
 		ELSE TRUE
 	END
-)`
-}
-
-func treatmentPlanAllMeasuresImplementedSQL() string {
-	return `(
-EXISTS (
-	SELECT 1
-	FROM treatment_plans_measures tpm
-	WHERE tpm.treatment_plan_id = id
-)
-AND NOT EXISTS (
-	SELECT 1
-	FROM treatment_plans_measures tpm
-	INNER JOIN measures m ON m.id = tpm.measure_id
-	WHERE tpm.treatment_plan_id = id
-		AND m.state IS DISTINCT FROM @filter_net_implemented
-)
 )`
 }

--- a/pkg/coredata/treatment_plan_measure.go
+++ b/pkg/coredata/treatment_plan_measure.go
@@ -96,7 +96,7 @@ func (tpm TreatmentPlanMeasure) Delete(
 	scope Scoper,
 	treatmentPlanID gid.GID,
 	measureID gid.GID,
-) error {
+) (bool, error) {
 	q := `
 DELETE
 FROM
@@ -115,12 +115,12 @@ WHERE
 	}
 	maps.Copy(args, scope.SQLArguments())
 
-	_, err := conn.Exec(ctx, q, args)
+	result, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		return fmt.Errorf("cannot delete treatment plan measure: %w", err)
+		return false, fmt.Errorf("cannot delete treatment plan measure: %w", err)
 	}
 
-	return nil
+	return result.RowsAffected() > 0, nil
 }
 
 func (tpms *TreatmentPlanMeasures) LoadByTreatmentPlanIDs(

--- a/pkg/probo/measure_service.go
+++ b/pkg/probo/measure_service.go
@@ -463,8 +463,25 @@ func (s MeasureService) Import(
 
 				importedMeasures = append(importedMeasures, measure)
 
+				originalID := measure.ID
 				if err := measure.Upsert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot upsert measure: %w", err)
+				}
+
+				eventType := coredata.MeasureEventTypeCreated
+				if originalID != measure.ID {
+					eventType = coredata.MeasureEventTypeUpdated
+				}
+
+				if err := insertMeasureEvent(
+					ctx,
+					tx,
+					scope,
+					measure,
+					eventType,
+					now,
+				); err != nil {
+					return fmt.Errorf("cannot record measure event: %w", err)
 				}
 
 				for j := range req.Measures[i].Tasks {
@@ -571,6 +588,10 @@ func (s MeasureService) Update(
 				return fmt.Errorf("cannot load measure: %w", err)
 			}
 
+			previousName := measure.Name
+			previousState := measure.State
+			previousCategory := measure.Category
+
 			if req.Name != nil {
 				measure.Name = *req.Name
 			}
@@ -591,6 +612,19 @@ func (s MeasureService) Update(
 
 			if err := measure.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update measure: %w", err)
+			}
+
+			if measure.Name != previousName || measure.State != previousState || measure.Category != previousCategory {
+				if err := insertMeasureEvent(
+					ctx,
+					conn,
+					scope,
+					measure,
+					coredata.MeasureEventTypeUpdated,
+					measure.UpdatedAt,
+				); err != nil {
+					return fmt.Errorf("cannot record measure event: %w", err)
+				}
 			}
 
 			return nil
@@ -645,6 +679,17 @@ func (s MeasureService) Create(
 				return fmt.Errorf("cannot insert measure: %w", err)
 			}
 
+			if err := insertMeasureEvent(
+				ctx,
+				conn,
+				scope,
+				measure,
+				coredata.MeasureEventTypeCreated,
+				now,
+			); err != nil {
+				return fmt.Errorf("cannot record measure event: %w", err)
+			}
+
 			return nil
 		},
 	)
@@ -661,6 +706,25 @@ func (s MeasureService) Delete(
 ) error {
 	return s.svc.pg.WithTx(ctx, func(ctx context.Context, conn pg.Tx) error {
 		measure := &coredata.Measure{}
+		if err := measure.LoadByID(ctx, conn, scope, measureID); err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil
+			}
+
+			return fmt.Errorf("cannot load measure: %w", err)
+		}
+
+		now := time.Now()
+		if err := insertMeasureEvent(
+			ctx,
+			conn,
+			scope,
+			measure,
+			coredata.MeasureEventTypeDeleted,
+			now,
+		); err != nil {
+			return fmt.Errorf("cannot record measure event: %w", err)
+		}
 
 		if err := measure.Delete(ctx, conn, scope, measureID); err != nil {
 			return fmt.Errorf("cannot delete measure: %w", err)
@@ -877,4 +941,20 @@ func (s MeasureService) DeleteDocumentMapping(
 	}
 
 	return measure, document, nil
+}
+
+func insertMeasureEvent(
+	ctx context.Context,
+	conn pg.Tx,
+	scope coredata.Scoper,
+	measure *coredata.Measure,
+	eventType coredata.MeasureEventType,
+	now time.Time,
+) error {
+	event := coredata.NewMeasureEvent(measure, eventType, now)
+	if err := event.Insert(ctx, conn, scope); err != nil {
+		return fmt.Errorf("cannot insert measure event: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/riskmanagement/as_of.go
+++ b/pkg/riskmanagement/as_of.go
@@ -1,0 +1,630 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package riskmanagement
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+)
+
+type (
+	RiskAnalysisMatrixEntry struct {
+		InherentLikelihood int
+		InherentImpact     int
+		NetLikelihood      int
+		NetImpact          int
+		ResidualLikelihood int
+		ResidualImpact     int
+	}
+
+	RiskAnalysisMatrixMeasure struct {
+		ID    gid.GID
+		Name  *string
+		State coredata.MeasureState
+	}
+
+	TreatmentPlansAsOfPage struct {
+		Page         *page.Page[*coredata.TreatmentPlan, coredata.TreatmentPlanOrderField]
+		TotalCount   int
+		ProgressByID map[gid.GID]TreatmentProgress
+		MeasuresByID map[gid.GID][]RiskAnalysisMatrixMeasure
+	}
+)
+
+func (s *Service) loadMatrixCellsAsOf(
+	ctx context.Context,
+	scope coredata.Scoper,
+	analysisID gid.GID,
+	asOf time.Time,
+) ([]*coredata.RiskAnalysisMatrixCell, error) {
+	var cells []*coredata.RiskAnalysisMatrixCell
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			analysis := &coredata.RiskAnalysis{}
+			if err := analysis.LoadByID(ctx, conn, scope, analysisID); err != nil {
+				return fmt.Errorf("cannot load risk analysis: %w", err)
+			}
+
+			folded, states, err := loadTreatmentPlansAsOf(ctx, conn, scope, analysisID, asOf)
+			if err != nil {
+				return fmt.Errorf("cannot load treatment plans as of: %w", err)
+			}
+
+			entries := make([]RiskAnalysisMatrixEntry, 0, len(folded))
+			for _, event := range folded {
+				measureIDs, err := event.LinkedMeasureIDs()
+				if err != nil {
+					return fmt.Errorf("cannot parse treatment plan measure ids: %w", err)
+				}
+
+				entries = append(
+					entries,
+					matrixEntryFromPlan(
+						event.TreatmentPlan(),
+						progressFromStates(measureIDs, states),
+					),
+				)
+			}
+
+			cells = cellsFromMatrixEntries(entries)
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load risk analysis matrix cells as of: %w", err)
+	}
+
+	return cells, nil
+}
+
+func loadTreatmentPlansAsOf(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	analysisID gid.GID,
+	asOf time.Time,
+) ([]*coredata.TreatmentPlanEvent, map[gid.GID]coredata.MeasureState, error) {
+	var events coredata.TreatmentPlanEvents
+	if err := events.LoadLatestByRiskAnalysisIDAsOf(ctx, conn, scope, analysisID, asOf); err != nil {
+		return nil, nil, fmt.Errorf("cannot load treatment plan events: %w", err)
+	}
+
+	measureIDs, err := uniqueEventMeasureIDs(events)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot collect treatment plan measure ids: %w", err)
+	}
+
+	measureEvents, err := loadMeasureEventsAsOf(ctx, conn, scope, measureIDs, asOf)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return events, measureStatesFromEvents(measureEvents), nil
+}
+
+func uniqueEventMeasureIDs(events []*coredata.TreatmentPlanEvent) ([]gid.GID, error) {
+	seen := make(map[gid.GID]struct{})
+	ids := make([]gid.GID, 0)
+
+	for _, event := range events {
+		measureIDs, err := event.LinkedMeasureIDs()
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse treatment plan measure ids: %w", err)
+		}
+
+		for _, measureID := range measureIDs {
+			if _, ok := seen[measureID]; ok {
+				continue
+			}
+
+			seen[measureID] = struct{}{}
+			ids = append(ids, measureID)
+		}
+	}
+
+	return ids, nil
+}
+
+func loadMeasureEventsAsOf(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	measureIDs []gid.GID,
+	asOf time.Time,
+) (coredata.MeasureEvents, error) {
+	var events coredata.MeasureEvents
+	if err := events.LoadLatestByMeasureIDsAsOf(
+		ctx,
+		conn,
+		scope,
+		measureIDs,
+		asOf,
+		coredata.NewMeasureFilter(nil, nil, nil),
+	); err != nil {
+		return nil, fmt.Errorf("cannot load measure events: %w", err)
+	}
+
+	return events, nil
+}
+
+func measureStatesFromEvents(events coredata.MeasureEvents) map[gid.GID]coredata.MeasureState {
+	states := make(map[gid.GID]coredata.MeasureState, len(events))
+	for _, event := range events {
+		states[event.MeasureID] = event.State
+	}
+
+	return states
+}
+
+func measureNamesFromEvents(events coredata.MeasureEvents) map[gid.GID]string {
+	names := make(map[gid.GID]string, len(events))
+	for _, event := range events {
+		names[event.MeasureID] = event.Name
+	}
+
+	return names
+}
+
+func progressFromStates(
+	measureIDs []gid.GID,
+	states map[gid.GID]coredata.MeasureState,
+) TreatmentProgress {
+	progress := TreatmentProgress{}
+
+	for _, measureID := range measureIDs {
+		progress.Total++
+
+		switch states[measureID] {
+		case coredata.MeasureStateImplemented:
+			progress.Done++
+		case coredata.MeasureStateInProgress:
+			progress.InProgress++
+		case coredata.MeasureStateNotImplemented:
+			progress.NotImplemented++
+		}
+	}
+
+	return progress
+}
+
+func matrixEntryFromPlan(
+	plan *coredata.TreatmentPlan,
+	progress TreatmentProgress,
+) RiskAnalysisMatrixEntry {
+	netLikelihood, netImpact, _ := NetScores(plan, progress)
+
+	return RiskAnalysisMatrixEntry{
+		InherentLikelihood: plan.InherentLikelihood,
+		InherentImpact:     plan.InherentImpact,
+		NetLikelihood:      netLikelihood,
+		NetImpact:          netImpact,
+		ResidualLikelihood: plan.ResidualLikelihood,
+		ResidualImpact:     plan.ResidualImpact,
+	}
+}
+
+func measuresFromIDs(
+	measureIDs []gid.GID,
+	names map[gid.GID]string,
+	states map[gid.GID]coredata.MeasureState,
+) []RiskAnalysisMatrixMeasure {
+	items := make([]RiskAnalysisMatrixMeasure, 0, len(measureIDs))
+	for _, measureID := range measureIDs {
+		item := RiskAnalysisMatrixMeasure{
+			ID:    measureID,
+			State: coredata.MeasureStateUnknown,
+		}
+		if name, ok := names[measureID]; ok {
+			item.Name = &name
+		}
+
+		if state, ok := states[measureID]; ok {
+			item.State = state
+		}
+
+		items = append(items, item)
+	}
+
+	slices.SortFunc(items, compareMatrixMeasures)
+
+	return items
+}
+
+func compareMatrixMeasures(a, b RiskAnalysisMatrixMeasure) int {
+	aName := ""
+	if a.Name != nil {
+		aName = *a.Name
+	}
+
+	bName := ""
+	if b.Name != nil {
+		bName = *b.Name
+	}
+
+	if cmp := cmp.Compare(aName, bName); cmp != 0 {
+		return cmp
+	}
+
+	return cmp.Compare(a.ID.String(), b.ID.String())
+}
+
+func cellsFromMatrixEntries(entries []RiskAnalysisMatrixEntry) []*coredata.RiskAnalysisMatrixCell {
+	type cellKey struct {
+		scoreType  coredata.TreatmentPlanScoreType
+		likelihood int
+		impact     int
+	}
+
+	counts := make(map[cellKey]int, len(entries)*3)
+	for _, entry := range entries {
+		counts[cellKey{coredata.TreatmentPlanScoreTypeInherent, entry.InherentLikelihood, entry.InherentImpact}]++
+		counts[cellKey{coredata.TreatmentPlanScoreTypeNet, entry.NetLikelihood, entry.NetImpact}]++
+		counts[cellKey{coredata.TreatmentPlanScoreTypeResidual, entry.ResidualLikelihood, entry.ResidualImpact}]++
+	}
+
+	cells := make([]*coredata.RiskAnalysisMatrixCell, 0, len(counts))
+	for key, count := range counts {
+		cells = append(cells, &coredata.RiskAnalysisMatrixCell{
+			Type:       key.scoreType,
+			Likelihood: key.likelihood,
+			Impact:     key.impact,
+			Count:      count,
+		})
+	}
+
+	slices.SortFunc(cells, func(a, b *coredata.RiskAnalysisMatrixCell) int {
+		if cmp := cmp.Compare(a.Type.String(), b.Type.String()); cmp != 0 {
+			return cmp
+		}
+
+		if cmp := cmp.Compare(a.Likelihood, b.Likelihood); cmp != 0 {
+			return cmp
+		}
+
+		return cmp.Compare(a.Impact, b.Impact)
+	})
+
+	return cells
+}
+
+func (s *Service) ListTreatmentPlansAsOf(
+	ctx context.Context,
+	scope coredata.Scoper,
+	analysisID gid.GID,
+	asOf time.Time,
+	cursor *page.Cursor[coredata.TreatmentPlanOrderField],
+	filter *coredata.TreatmentPlanFilter,
+	includeMeasures bool,
+) (*TreatmentPlansAsOfPage, error) {
+	filter, err := prepareTreatmentPlanFilter(filter)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list treatment plans as of: %w", err)
+	}
+
+	result := &TreatmentPlansAsOfPage{}
+
+	err = s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			analysis := &coredata.RiskAnalysis{}
+			if err := analysis.LoadByID(ctx, conn, scope, analysisID); err != nil {
+				return fmt.Errorf("cannot load risk analysis: %w", err)
+			}
+
+			var plans coredata.TreatmentPlans
+			if err := plans.LoadByRiskAnalysisIDAsOf(
+				ctx,
+				conn,
+				scope,
+				analysisID,
+				asOf,
+				cursor,
+				filter,
+			); err != nil {
+				return fmt.Errorf("cannot load treatment plans as of: %w", err)
+			}
+
+			total, err := plans.CountByRiskAnalysisIDAsOf(
+				ctx,
+				conn,
+				scope,
+				analysisID,
+				asOf,
+				filter,
+			)
+			if err != nil {
+				return fmt.Errorf("cannot count treatment plans as of: %w", err)
+			}
+
+			paged := page.NewPage(plans, cursor)
+
+			progressByID, measuresByID, err := loadAsOfPlanExtras(
+				ctx,
+				conn,
+				scope,
+				analysisID,
+				asOf,
+				paged.Data,
+				includeMeasures,
+			)
+			if err != nil {
+				return err
+			}
+
+			result.Page = paged
+			result.TotalCount = total
+			result.ProgressByID = progressByID
+			result.MeasuresByID = measuresByID
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list treatment plans as of: %w", err)
+	}
+
+	return result, nil
+}
+
+func (s *Service) ListTreatmentPlansForMeasureIDAsOf(
+	ctx context.Context,
+	scope coredata.Scoper,
+	measureID gid.GID,
+	asOf time.Time,
+	cursor *page.Cursor[coredata.TreatmentPlanOrderField],
+	filter *coredata.TreatmentPlanFilter,
+) (*TreatmentPlansAsOfPage, error) {
+	filter, err := prepareTreatmentPlanFilter(filter)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list treatment plans as of: %w", err)
+	}
+
+	result := &TreatmentPlansAsOfPage{}
+
+	err = s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var plans coredata.TreatmentPlans
+			if err := plans.LoadByMeasureIDAsOf(
+				ctx,
+				conn,
+				scope,
+				measureID,
+				asOf,
+				cursor,
+				filter,
+			); err != nil {
+				return fmt.Errorf("cannot load treatment plans as of: %w", err)
+			}
+
+			total, err := plans.CountByMeasureIDAsOf(
+				ctx,
+				conn,
+				scope,
+				measureID,
+				asOf,
+				filter,
+			)
+			if err != nil {
+				return fmt.Errorf("cannot count treatment plans as of: %w", err)
+			}
+
+			paged := page.NewPage(plans, cursor)
+			progressByID := make(map[gid.GID]TreatmentProgress, len(paged.Data))
+			byAnalysis := make(map[gid.GID][]*coredata.TreatmentPlan)
+
+			for _, plan := range paged.Data {
+				byAnalysis[plan.RiskAnalysisID] = append(byAnalysis[plan.RiskAnalysisID], plan)
+			}
+
+			for analysisID, group := range byAnalysis {
+				progress, _, err := loadAsOfPlanExtras(
+					ctx,
+					conn,
+					scope,
+					analysisID,
+					asOf,
+					group,
+					false,
+				)
+				if err != nil {
+					return err
+				}
+
+				maps.Copy(progressByID, progress)
+			}
+
+			result.Page = paged
+			result.TotalCount = total
+			result.ProgressByID = progressByID
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list measure treatment plans as of: %w", err)
+	}
+
+	return result, nil
+}
+
+func loadAsOfPlanExtras(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	analysisID gid.GID,
+	asOf time.Time,
+	plans []*coredata.TreatmentPlan,
+	includeMeasures bool,
+) (map[gid.GID]TreatmentProgress, map[gid.GID][]RiskAnalysisMatrixMeasure, error) {
+	progressByID := make(map[gid.GID]TreatmentProgress, len(plans))
+	measuresByID := make(map[gid.GID][]RiskAnalysisMatrixMeasure, len(plans))
+
+	if len(plans) == 0 {
+		return progressByID, measuresByID, nil
+	}
+
+	planIDs := make([]gid.GID, 0, len(plans))
+	for _, plan := range plans {
+		planIDs = append(planIDs, plan.ID)
+	}
+
+	var events coredata.TreatmentPlanEvents
+	if err := events.LoadLatestByTreatmentPlanIDsAsOf(
+		ctx,
+		conn,
+		scope,
+		analysisID,
+		planIDs,
+		asOf,
+	); err != nil {
+		return nil, nil, fmt.Errorf("cannot load treatment plan events: %w", err)
+	}
+
+	measureIDs, err := uniqueEventMeasureIDs(events)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot collect treatment plan measure ids: %w", err)
+	}
+
+	measureEvents, err := loadMeasureEventsAsOf(ctx, conn, scope, measureIDs, asOf)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	states := measureStatesFromEvents(measureEvents)
+
+	var names map[gid.GID]string
+	if includeMeasures {
+		names = measureNamesFromEvents(measureEvents)
+	}
+
+	for _, event := range events {
+		linked, err := event.LinkedMeasureIDs()
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot parse treatment plan measure ids: %w", err)
+		}
+
+		progressByID[event.TreatmentPlanID] = progressFromStates(linked, states)
+		if includeMeasures {
+			measuresByID[event.TreatmentPlanID] = measuresFromIDs(linked, names, states)
+		}
+	}
+
+	return progressByID, measuresByID, nil
+}
+
+func (s *Service) ListMeasuresAsOf(
+	ctx context.Context,
+	scope coredata.Scoper,
+	analysisID gid.GID,
+	planID gid.GID,
+	asOf time.Time,
+	cursor *page.Cursor[coredata.MeasureOrderField],
+	filter *coredata.MeasureFilter,
+) (*page.Page[*coredata.Measure, coredata.MeasureOrderField], int, error) {
+	if filter == nil {
+		filter = coredata.NewMeasureFilter(nil, nil, nil)
+	}
+
+	var (
+		paged *page.Page[*coredata.Measure, coredata.MeasureOrderField]
+		total int
+	)
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			analysis := &coredata.RiskAnalysis{}
+			if err := analysis.LoadByID(ctx, conn, scope, analysisID); err != nil {
+				return fmt.Errorf("cannot load risk analysis: %w", err)
+			}
+
+			var events coredata.TreatmentPlanEvents
+			if err := events.LoadLatestByTreatmentPlanIDsAsOf(
+				ctx,
+				conn,
+				scope,
+				analysisID,
+				[]gid.GID{planID},
+				asOf,
+			); err != nil {
+				return fmt.Errorf("cannot load treatment plan events: %w", err)
+			}
+
+			if len(events) == 0 {
+				paged = page.NewPage([]*coredata.Measure{}, cursor)
+				return nil
+			}
+
+			linked, err := events[0].LinkedMeasureIDs()
+			if err != nil {
+				return fmt.Errorf("cannot parse treatment plan measure ids: %w", err)
+			}
+
+			var measures coredata.Measures
+			if err := measures.LoadByIDsAsOf(
+				ctx,
+				conn,
+				scope,
+				linked,
+				asOf,
+				cursor,
+				filter,
+			); err != nil {
+				return fmt.Errorf("cannot load measures as of: %w", err)
+			}
+
+			count, err := measures.CountByIDsAsOf(
+				ctx,
+				conn,
+				scope,
+				linked,
+				asOf,
+				filter,
+			)
+			if err != nil {
+				return fmt.Errorf("cannot count measures as of: %w", err)
+			}
+
+			total = count
+			paged = page.NewPage(measures, cursor)
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("cannot list measures as of: %w", err)
+	}
+
+	return paged, total, nil
+}

--- a/pkg/riskmanagement/as_of_test.go
+++ b/pkg/riskmanagement/as_of_test.go
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package riskmanagement
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+func TestTreatmentPlanEvent_TreatmentPlan(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	planID := gid.New(tenantID, coredata.TreatmentPlanEntityType)
+	riskID := gid.New(tenantID, coredata.RiskEntityType)
+	ownerID := gid.New(tenantID, coredata.MembershipProfileEntityType)
+	measureID := gid.New(tenantID, coredata.MeasureEntityType)
+	analysisID := gid.New(tenantID, coredata.RiskAnalysisEntityType)
+	orgID := gid.New(tenantID, coredata.OrganizationEntityType)
+	createdAt := time.Unix(1_700_000_000, 0).UTC()
+	updatedAt := createdAt.Add(time.Hour)
+
+	tp := &coredata.TreatmentPlan{
+		ID:                 planID,
+		OrganizationID:     orgID,
+		RiskID:             riskID,
+		RiskAnalysisID:     analysisID,
+		Treatment:          coredata.RiskTreatmentMitigated,
+		OwnerID:            ownerID,
+		InherentLikelihood: 3,
+		InherentImpact:     5,
+		ResidualLikelihood: 1,
+		ResidualImpact:     2,
+		Category:           "Security",
+		CreatedAt:          createdAt,
+		UpdatedAt:          updatedAt,
+	}
+
+	event := coredata.NewTreatmentPlanEvent(
+		tp,
+		coredata.TreatmentPlanEventTypeUpdated,
+		[]gid.GID{measureID},
+		updatedAt,
+	)
+
+	assert.Equal(t, []string{measureID.String()}, event.MeasureIDs)
+	assert.Equal(t, "Security", event.Category)
+	linked, err := event.LinkedMeasureIDs()
+	require.NoError(t, err)
+	assert.Equal(t, []gid.GID{measureID}, linked)
+
+	reconstructed := event.TreatmentPlan()
+	assert.Equal(t, planID, reconstructed.ID)
+	assert.Equal(t, ownerID, reconstructed.OwnerID)
+	assert.Equal(t, 3, reconstructed.InherentLikelihood)
+	assert.Equal(t, 5, reconstructed.InherentImpact)
+	assert.Equal(t, 15, reconstructed.InherentRiskScore)
+	assert.Equal(t, 2, reconstructed.ResidualRiskScore)
+	assert.Equal(t, "Security", reconstructed.Category)
+	assert.Equal(t, createdAt, reconstructed.CreatedAt)
+	assert.Equal(t, updatedAt, reconstructed.UpdatedAt)
+
+	entry := matrixEntryFromPlan(
+		reconstructed,
+		progressFromStates(
+			linked,
+			map[gid.GID]coredata.MeasureState{
+				measureID: coredata.MeasureStateImplemented,
+			},
+		),
+	)
+	assert.Equal(t, 1, entry.NetLikelihood)
+	assert.Equal(t, 2, entry.NetImpact)
+}
+
+func TestTreatmentPlanEvent_TreatmentPlan_MeasureLinkedKeepsUpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	createdAt := time.Unix(1_700_000_000, 0).UTC()
+	updatedAt := createdAt.Add(time.Hour)
+	linkedAt := updatedAt.Add(time.Hour)
+	tp := &coredata.TreatmentPlan{
+		ID:                 gid.New(tenantID, coredata.TreatmentPlanEntityType),
+		OrganizationID:     gid.New(tenantID, coredata.OrganizationEntityType),
+		RiskID:             gid.New(tenantID, coredata.RiskEntityType),
+		RiskAnalysisID:     gid.New(tenantID, coredata.RiskAnalysisEntityType),
+		Treatment:          coredata.RiskTreatmentMitigated,
+		OwnerID:            gid.New(tenantID, coredata.MembershipProfileEntityType),
+		InherentLikelihood: 2,
+		InherentImpact:     3,
+		ResidualLikelihood: 1,
+		ResidualImpact:     1,
+		CreatedAt:          createdAt,
+		UpdatedAt:          updatedAt,
+	}
+
+	event := coredata.NewTreatmentPlanEvent(
+		tp,
+		coredata.TreatmentPlanEventTypeMeasureLinked,
+		nil,
+		linkedAt,
+	)
+	reconstructed := event.TreatmentPlan()
+
+	assert.Equal(t, createdAt, reconstructed.CreatedAt)
+	assert.Equal(t, updatedAt, reconstructed.UpdatedAt)
+}
+
+func TestTreatmentPlanEvent_LinkedMeasureIDs_Invalid(t *testing.T) {
+	t.Parallel()
+
+	event := &coredata.TreatmentPlanEvent{MeasureIDs: []string{"not-a-gid"}}
+	_, err := event.LinkedMeasureIDs()
+	require.Error(t, err)
+}
+
+func TestMeasureEvent_Measure(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	createdAt := time.Unix(1_700_000_000, 0).UTC()
+	updatedAt := createdAt.Add(time.Hour)
+	measure := &coredata.Measure{
+		ID:             gid.New(tenantID, coredata.MeasureEntityType),
+		OrganizationID: gid.New(tenantID, coredata.OrganizationEntityType),
+		Name:           "Access control",
+		Category:       "Access",
+		State:          coredata.MeasureStateImplemented,
+		CreatedAt:      createdAt,
+		UpdatedAt:      createdAt,
+	}
+
+	event := coredata.NewMeasureEvent(measure, coredata.MeasureEventTypeUpdated, updatedAt)
+	assert.Equal(t, measure.Name, event.Name)
+	assert.Equal(t, measure.Category, event.Category)
+	assert.Equal(t, measure.State, event.State)
+	assert.Equal(t, createdAt, event.MeasureCreatedAt)
+	assert.Equal(t, updatedAt, event.CreatedAt)
+
+	reconstructed := event.Measure()
+	assert.Equal(t, measure.ID, reconstructed.ID)
+	assert.Equal(t, measure.Name, reconstructed.Name)
+	assert.Equal(t, measure.Category, reconstructed.Category)
+	assert.Equal(t, measure.State, reconstructed.State)
+	assert.Equal(t, createdAt, reconstructed.CreatedAt)
+	assert.Equal(t, updatedAt, reconstructed.UpdatedAt)
+}
+
+func TestMeasureIDStrings_Empty(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{}, coredata.MeasureIDStrings(nil))
+	assert.Equal(t, []string{}, coredata.MeasureIDStrings([]gid.GID{}))
+}
+
+func TestProgressFromStates(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	doneID := gid.New(tenantID, coredata.MeasureEntityType)
+	openID := gid.New(tenantID, coredata.MeasureEntityType)
+
+	progress := progressFromStates(
+		[]gid.GID{doneID, openID},
+		map[gid.GID]coredata.MeasureState{
+			doneID: coredata.MeasureStateImplemented,
+			openID: coredata.MeasureStateNotStarted,
+		},
+	)
+
+	assert.Equal(t, 2, progress.Total)
+	assert.Equal(t, 1, progress.Done)
+}
+
+func TestProgressFromStates_MissingState(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	doneID := gid.New(tenantID, coredata.MeasureEntityType)
+	missingID := gid.New(tenantID, coredata.MeasureEntityType)
+
+	progress := progressFromStates(
+		[]gid.GID{doneID, missingID},
+		map[gid.GID]coredata.MeasureState{
+			doneID: coredata.MeasureStateImplemented,
+		},
+	)
+
+	assert.Equal(t, 2, progress.Total)
+	assert.Equal(t, 1, progress.Done)
+	assert.Equal(t, 0, progress.InProgress)
+	assert.Equal(t, 0, progress.NotImplemented)
+}
+
+func TestCellsFromMatrixEntries(t *testing.T) {
+	t.Parallel()
+
+	entries := []RiskAnalysisMatrixEntry{
+		{
+			InherentLikelihood: 4,
+			InherentImpact:     4,
+			NetLikelihood:      1,
+			NetImpact:          2,
+			ResidualLikelihood: 1,
+			ResidualImpact:     2,
+		},
+		{
+			InherentLikelihood: 4,
+			InherentImpact:     4,
+			NetLikelihood:      4,
+			NetImpact:          4,
+			ResidualLikelihood: 1,
+			ResidualImpact:     1,
+		},
+	}
+
+	cells := cellsFromMatrixEntries(entries)
+	require.Len(t, cells, 5)
+
+	countOf := func(scoreType coredata.TreatmentPlanScoreType, likelihood, impact int) int {
+		for _, cell := range cells {
+			if cell.Type == scoreType && cell.Likelihood == likelihood && cell.Impact == impact {
+				return cell.Count
+			}
+		}
+
+		return 0
+	}
+
+	assert.Equal(t, 2, countOf(coredata.TreatmentPlanScoreTypeInherent, 4, 4))
+	assert.Equal(t, 1, countOf(coredata.TreatmentPlanScoreTypeNet, 1, 2))
+	assert.Equal(t, 1, countOf(coredata.TreatmentPlanScoreTypeNet, 4, 4))
+	assert.Equal(t, 1, countOf(coredata.TreatmentPlanScoreTypeResidual, 1, 2))
+	assert.Equal(t, 1, countOf(coredata.TreatmentPlanScoreTypeResidual, 1, 1))
+}

--- a/pkg/riskmanagement/events.go
+++ b/pkg/riskmanagement/events.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package riskmanagement
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+func insertTreatmentPlanEvent(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	tp *coredata.TreatmentPlan,
+	eventType coredata.TreatmentPlanEventType,
+	measureIDs []gid.GID,
+	now time.Time,
+) error {
+	event := coredata.NewTreatmentPlanEvent(
+		tp,
+		eventType,
+		measureIDs,
+		now,
+	)
+
+	if err := event.Insert(ctx, tx, scope); err != nil {
+		return fmt.Errorf("cannot insert treatment plan event: %w", err)
+	}
+
+	return nil
+}
+
+func loadTreatmentPlanMeasureIDs(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	planID gid.GID,
+) ([]gid.GID, error) {
+	var mappings coredata.TreatmentPlanMeasures
+	if err := mappings.LoadByTreatmentPlanIDs(ctx, conn, scope, []gid.GID{planID}); err != nil {
+		return nil, fmt.Errorf("cannot load treatment plan measures: %w", err)
+	}
+
+	ids := make([]gid.GID, 0, len(mappings))
+	for _, mapping := range mappings {
+		ids = append(ids, mapping.MeasureID)
+	}
+
+	return ids, nil
+}

--- a/pkg/riskmanagement/fork.go
+++ b/pkg/riskmanagement/fork.go
@@ -571,6 +571,8 @@ func copyTreatmentPlans(
 	}
 
 	sourcePlanIDs := make([]gid.GID, 0, len(plans))
+	copiedPlans := make(map[gid.GID]*coredata.TreatmentPlan, len(plans))
+
 	for _, source := range plans {
 		copied := &coredata.TreatmentPlan{
 			ID:                 gid.New(scope.GetTenantID(), coredata.TreatmentPlanEntityType),
@@ -583,10 +585,12 @@ func copyTreatmentPlans(
 			InherentImpact:     source.InherentImpact,
 			ResidualLikelihood: source.ResidualLikelihood,
 			ResidualImpact:     source.ResidualImpact,
+			Category:           source.Category,
 			CreatedAt:          now,
 			UpdatedAt:          now,
 		}
 		idMap[source.ID] = copied.ID
+		copiedPlans[copied.ID] = copied
 		sourcePlanIDs = append(sourcePlanIDs, source.ID)
 
 		if err := copied.Insert(ctx, tx, scope); err != nil {
@@ -598,6 +602,8 @@ func copyTreatmentPlans(
 	if err := mappings.LoadByTreatmentPlanIDs(ctx, tx, scope, sourcePlanIDs); err != nil {
 		return fmt.Errorf("cannot load treatment plan measures: %w", err)
 	}
+
+	measureIDsByPlan := make(map[gid.GID][]gid.GID, len(copiedPlans))
 
 	for _, mapping := range mappings {
 		planID, err := remapID(idMap, mapping.TreatmentPlanID)
@@ -613,6 +619,22 @@ func copyTreatmentPlans(
 		}
 		if err := copied.Insert(ctx, tx, scope); err != nil {
 			return fmt.Errorf("cannot insert treatment plan measure: %w", err)
+		}
+
+		measureIDsByPlan[planID] = append(measureIDsByPlan[planID], copied.MeasureID)
+	}
+
+	for planID, copied := range copiedPlans {
+		if err := insertTreatmentPlanEvent(
+			ctx,
+			tx,
+			scope,
+			copied,
+			coredata.TreatmentPlanEventTypeCreated,
+			measureIDsByPlan[planID],
+			now,
+		); err != nil {
+			return fmt.Errorf("cannot record forked treatment plan created event: %w", err)
 		}
 	}
 

--- a/pkg/riskmanagement/treatment_plan.go
+++ b/pkg/riskmanagement/treatment_plan.go
@@ -22,6 +22,7 @@ package riskmanagement
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -280,12 +281,25 @@ func (s *Service) CreateTreatmentPlan(
 				InherentImpact:     req.InherentImpact,
 				ResidualLikelihood: residualLikelihood,
 				ResidualImpact:     residualImpact,
+				Category:           risk.Category,
 				CreatedAt:          now,
 				UpdatedAt:          now,
 			}
 
 			if err := tp.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert treatment plan: %w", err)
+			}
+
+			if err := insertTreatmentPlanEvent(
+				ctx,
+				tx,
+				scope,
+				tp,
+				coredata.TreatmentPlanEventTypeCreated,
+				nil,
+				now,
+			); err != nil {
+				return fmt.Errorf("cannot record treatment plan created event: %w", err)
 			}
 
 			return nil
@@ -336,7 +350,7 @@ func (s *Service) UpdateTreatmentPlan(
 	err := s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := tp.LoadByID(ctx, tx, scope, req.ID); err != nil {
+			if err := tp.LoadByIDForUpdate(ctx, tx, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load treatment plan: %w", err)
 			}
 
@@ -426,6 +440,23 @@ func (s *Service) UpdateTreatmentPlan(
 				return fmt.Errorf("cannot persist treatment plan: %w", err)
 			}
 
+			measureIDs, err := loadTreatmentPlanMeasureIDs(ctx, tx, scope, tp.ID)
+			if err != nil {
+				return fmt.Errorf("cannot load treatment plan measure ids: %w", err)
+			}
+
+			if err := insertTreatmentPlanEvent(
+				ctx,
+				tx,
+				scope,
+				tp,
+				coredata.TreatmentPlanEventTypeUpdated,
+				measureIDs,
+				tp.UpdatedAt,
+			); err != nil {
+				return fmt.Errorf("cannot record treatment plan updated event: %w", err)
+			}
+
 			return nil
 		},
 	)
@@ -441,6 +472,31 @@ func (s *Service) DeleteTreatmentPlan(ctx context.Context, scope coredata.Scoper
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			tp := &coredata.TreatmentPlan{}
+			if err := tp.LoadByIDForUpdate(ctx, tx, scope, id); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return nil
+				}
+
+				return fmt.Errorf("cannot load treatment plan: %w", err)
+			}
+
+			measureIDs, err := loadTreatmentPlanMeasureIDs(ctx, tx, scope, tp.ID)
+			if err != nil {
+				return fmt.Errorf("cannot load treatment plan measure ids: %w", err)
+			}
+
+			if err := insertTreatmentPlanEvent(
+				ctx,
+				tx,
+				scope,
+				tp,
+				coredata.TreatmentPlanEventTypeDeleted,
+				measureIDs,
+				time.Now(),
+			); err != nil {
+				return fmt.Errorf("cannot record treatment plan deleted event: %w", err)
+			}
+
 			if err := tp.Delete(ctx, tx, scope, id); err != nil {
 				return fmt.Errorf("cannot delete treatment plan row: %w", err)
 			}
@@ -669,7 +725,7 @@ func (s *Service) CreateMeasureMapping(
 	err := s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := tp.LoadByID(ctx, tx, scope, treatmentPlanID); err != nil {
+			if err := tp.LoadByIDForUpdate(ctx, tx, scope, treatmentPlanID); err != nil {
 				return fmt.Errorf("cannot load treatment plan: %w", err)
 			}
 
@@ -685,15 +741,33 @@ func (s *Service) CreateMeasureMapping(
 				return fmt.Errorf("cannot verify measure organization: %w", coredata.ErrResourceNotFound)
 			}
 
+			now := time.Now()
 			mapping := &coredata.TreatmentPlanMeasure{
 				TreatmentPlanID: tp.ID,
 				MeasureID:       measure.ID,
 				OrganizationID:  tp.OrganizationID,
-				CreatedAt:       time.Now(),
+				CreatedAt:       now,
 			}
 
 			if err := mapping.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert treatment plan measure: %w", err)
+			}
+
+			measureIDs, err := loadTreatmentPlanMeasureIDs(ctx, tx, scope, tp.ID)
+			if err != nil {
+				return fmt.Errorf("cannot load treatment plan measure ids: %w", err)
+			}
+
+			if err := insertTreatmentPlanEvent(
+				ctx,
+				tx,
+				scope,
+				tp,
+				coredata.TreatmentPlanEventTypeMeasureLinked,
+				measureIDs,
+				now,
+			); err != nil {
+				return fmt.Errorf("cannot record treatment plan measure linked event: %w", err)
 			}
 
 			return nil
@@ -718,7 +792,7 @@ func (s *Service) DeleteMeasureMapping(
 	err := s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := tp.LoadByID(ctx, tx, scope, treatmentPlanID); err != nil {
+			if err := tp.LoadByIDForUpdate(ctx, tx, scope, treatmentPlanID); err != nil {
 				return fmt.Errorf("cannot load treatment plan: %w", err)
 			}
 
@@ -727,8 +801,31 @@ func (s *Service) DeleteMeasureMapping(
 			}
 
 			mapping := coredata.TreatmentPlanMeasure{}
-			if err := mapping.Delete(ctx, tx, scope, tp.ID, measure.ID); err != nil {
+
+			deleted, err := mapping.Delete(ctx, tx, scope, tp.ID, measure.ID)
+			if err != nil {
 				return fmt.Errorf("cannot delete treatment plan measure: %w", err)
+			}
+
+			if !deleted {
+				return nil
+			}
+
+			measureIDs, err := loadTreatmentPlanMeasureIDs(ctx, tx, scope, tp.ID)
+			if err != nil {
+				return fmt.Errorf("cannot load treatment plan measure ids: %w", err)
+			}
+
+			if err := insertTreatmentPlanEvent(
+				ctx,
+				tx,
+				scope,
+				tp,
+				coredata.TreatmentPlanEventTypeMeasureUnlinked,
+				measureIDs,
+				time.Now(),
+			); err != nil {
+				return fmt.Errorf("cannot record treatment plan measure unlinked event: %w", err)
 			}
 
 			return nil
@@ -809,7 +906,17 @@ func (s *Service) GetRiskAnalysisMatrixCells(
 	ctx context.Context,
 	scope coredata.Scoper,
 	riskAnalysisID gid.GID,
+	asOf *time.Time,
 ) ([]*coredata.RiskAnalysisMatrixCell, error) {
+	if asOf != nil {
+		cells, err := s.loadMatrixCellsAsOf(ctx, scope, riskAnalysisID, *asOf)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get risk analysis matrix cells: %w", err)
+		}
+
+		return cells, nil
+	}
+
 	var counts []*coredata.RiskAnalysisMatrixCell
 
 	err := s.pg.WithConn(

--- a/pkg/server/api/console/v1/graphql/measure.graphql
+++ b/pkg/server/api/console/v1/graphql/measure.graphql
@@ -51,6 +51,7 @@ type Measure implements Node {
     name: String!
     description: String
     state: MeasureState!
+    asOf: Datetime
 
     evidences(
         first: Int
@@ -110,6 +111,7 @@ type Measure implements Node {
         before: CursorKey
         orderBy: TreatmentPlanOrder
         filter: TreatmentPlanFilter
+        asOf: Datetime
     ): TreatmentPlanConnection! @goField(forceResolver: true)
 
     createdAt: Datetime!
@@ -125,6 +127,7 @@ type MeasureConnection
     totalCount: Int! @goField(forceResolver: true)
     edges: [MeasureEdge!]!
     pageInfo: PageInfo!
+    asOf: Datetime
 }
 
 type MeasureEdge {

--- a/pkg/server/api/console/v1/graphql/risk_analysis.graphql
+++ b/pkg/server/api/console/v1/graphql/risk_analysis.graphql
@@ -221,9 +221,10 @@ type RiskAnalysis implements Node {
         before: CursorKey
         orderBy: TreatmentPlanOrder
         filter: TreatmentPlanFilter
+        asOf: Datetime
     ): TreatmentPlanConnection! @goField(forceResolver: true)
 
-    matrixCells: [RiskAnalysisMatrixCell!]!
+    matrixCells(asOf: Datetime): [RiskAnalysisMatrixCell!]!
         @goField(forceResolver: true)
 
     scenarioRisks(

--- a/pkg/server/api/console/v1/graphql/treatment_plan.graphql
+++ b/pkg/server/api/console/v1/graphql/treatment_plan.graphql
@@ -71,12 +71,19 @@ enum TreatmentPlanScoreType
 }
 
 input TreatmentPlanFilter {
-    "Score type of the matrix cell. Must be set together with likelihood and impact."
     scoreType: TreatmentPlanScoreType
-    "Likelihood axis of the cell. Must be set together with scoreType and impact."
     likelihood: Int
-    "Impact axis of the cell. Must be set together with scoreType and likelihood."
     impact: Int
+}
+
+type TreatmentPlanProgress
+    @goModel(
+        model: "go.probo.inc/probo/pkg/riskmanagement.TreatmentProgress"
+    ) {
+    done: Int!
+    inProgress: Int!
+    notImplemented: Int!
+    total: Int!
 }
 
 type TreatmentPlan implements Node {
@@ -88,9 +95,12 @@ type TreatmentPlan implements Node {
     residualLikelihood: Int!
     residualImpact: Int!
     residualRiskScore: Int!
+    category: String!
     netLikelihood: Int! @goField(forceResolver: true)
     netImpact: Int! @goField(forceResolver: true)
     netRiskScore: Int! @goField(forceResolver: true)
+    progress: TreatmentPlanProgress! @goField(forceResolver: true)
+    asOf: Datetime
 
     owner: Profile! @goField(forceResolver: true)
     risk: Risk! @goField(forceResolver: true)
@@ -104,6 +114,7 @@ type TreatmentPlan implements Node {
         before: CursorKey
         orderBy: MeasureOrder
         filter: MeasureFilter
+        asOf: Datetime
     ): MeasureConnection! @goField(forceResolver: true)
 
     createdAt: Datetime!

--- a/pkg/server/api/console/v1/measure_resolvers.go
+++ b/pkg/server/api/console/v1/measure_resolvers.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"time"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/coredata"
@@ -219,7 +220,11 @@ func (r *measureResolver) ThirdParties(ctx context.Context, obj *types.Measure, 
 }
 
 // TreatmentPlans is the resolver for the treatmentPlans field.
-func (r *measureResolver) TreatmentPlans(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TreatmentPlanOrderBy, filter *types.TreatmentPlanFilter) (*types.TreatmentPlanConnection, error) {
+func (r *measureResolver) TreatmentPlans(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TreatmentPlanOrderBy, filter *types.TreatmentPlanFilter, asOf *time.Time) (*types.TreatmentPlanConnection, error) {
+	if asOf == nil {
+		asOf = obj.AsOf
+	}
+
 	scope, err := r.authorize(ctx, obj.ID, riskmanagement.ActionTreatmentPlanList)
 	if err != nil {
 		return nil, err
@@ -244,6 +249,36 @@ func (r *measureResolver) TreatmentPlans(ctx context.Context, obj *types.Measure
 		planFilter = coredata.NewTreatmentPlanFilter(filter.ScoreType, filter.Likelihood, filter.Impact)
 	}
 
+	if asOf != nil {
+		asOfPage, err := r.riskManagement.ListTreatmentPlansForMeasureIDAsOf(
+			ctx,
+			scope,
+			obj.ID,
+			*asOf,
+			cursor,
+			planFilter,
+		)
+		if err != nil {
+			if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
+				return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
+			}
+
+			r.logger.ErrorCtx(ctx, "cannot list measure treatment plans as of", log.Error(err))
+
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		return types.NewTreatmentPlanConnectionAsOf(
+			asOfPage.Page,
+			r,
+			obj.ID,
+			planFilter,
+			*asOf,
+			asOfPage.TotalCount,
+			asOfPage.ProgressByID,
+		), nil
+	}
+
 	page, err := r.riskManagement.ListTreatmentPlansForMeasureID(ctx, scope, obj.ID, cursor, planFilter)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
@@ -260,11 +295,19 @@ func (r *measureResolver) TreatmentPlans(ctx context.Context, obj *types.Measure
 
 // Permission is the resolver for the permission field.
 func (r *measureResolver) Permission(ctx context.Context, obj *types.Measure, action string) (bool, error) {
+	if obj.AsOf != nil {
+		return false, nil
+	}
+
 	return r.Resolver.Permission(ctx, obj, action)
 }
 
 // TotalCount is the resolver for the totalCount field.
 func (r *measureConnectionResolver) TotalCount(ctx context.Context, obj *types.MeasureConnection) (int, error) {
+	if obj.AsOf != nil {
+		return obj.TotalCount, nil
+	}
+
 	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionMeasureList)
 	if err != nil {
 		return 0, err
@@ -423,6 +466,7 @@ func (r *mutationResolver) DeleteMeasure(ctx context.Context, input types.Delete
 
 	if err := r.probo.Measures.Delete(ctx, scope, input.MeasureID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete measure", log.Error(err))
+
 		return nil, gqlutils.Internal(ctx)
 	}
 

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -250,6 +250,14 @@ func (r *Resolver) treatmentPlanNetScores(
 	ctx context.Context,
 	obj *types.TreatmentPlan,
 ) (int, int, int, error) {
+	if obj.AsOf != nil {
+		if _, err := r.authorize(ctx, obj.RiskAnalysis.ID, riskmanagement.ActionTreatmentPlanList); err != nil {
+			return 0, 0, 0, err
+		}
+
+		return obj.NetLikelihood, obj.NetImpact, obj.NetRiskScore, nil
+	}
+
 	if _, err := r.authorize(ctx, obj.ID, riskmanagement.ActionTreatmentPlanGet); err != nil {
 		return 0, 0, 0, err
 	}

--- a/pkg/server/api/console/v1/risk_analysis_resolvers.go
+++ b/pkg/server/api/console/v1/risk_analysis_resolvers.go
@@ -8,6 +8,7 @@ package console_v1
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/vikstrous/dataloadgen"
 	"go.gearno.de/kit/log"
@@ -900,7 +901,7 @@ func (r *riskAnalysisResolver) Organization(ctx context.Context, obj *types.Risk
 }
 
 // TreatmentPlans is the resolver for the treatmentPlans field.
-func (r *riskAnalysisResolver) TreatmentPlans(ctx context.Context, obj *types.RiskAnalysis, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TreatmentPlanOrderBy, filter *types.TreatmentPlanFilter) (*types.TreatmentPlanConnection, error) {
+func (r *riskAnalysisResolver) TreatmentPlans(ctx context.Context, obj *types.RiskAnalysis, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TreatmentPlanOrderBy, filter *types.TreatmentPlanFilter, asOf *time.Time) (*types.TreatmentPlanConnection, error) {
 	scope, err := r.authorize(ctx, obj.ID, riskmanagement.ActionTreatmentPlanList)
 	if err != nil {
 		return nil, err
@@ -924,6 +925,41 @@ func (r *riskAnalysisResolver) TreatmentPlans(ctx context.Context, obj *types.Ri
 		planFilter = coredata.NewTreatmentPlanFilter(filter.ScoreType, filter.Likelihood, filter.Impact)
 	}
 
+	if asOf != nil {
+		asOfPage, err := r.riskManagement.ListTreatmentPlansAsOf(
+			ctx,
+			scope,
+			obj.ID,
+			*asOf,
+			cursor,
+			planFilter,
+			false,
+		)
+		if err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, gqlutils.NotFound(ctx, err)
+			}
+
+			if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
+				return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
+			}
+
+			r.logger.ErrorCtx(ctx, "cannot list treatment plans as of", log.Error(err))
+
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		return types.NewTreatmentPlanConnectionAsOf(
+			asOfPage.Page,
+			r,
+			obj.ID,
+			planFilter,
+			*asOf,
+			asOfPage.TotalCount,
+			asOfPage.ProgressByID,
+		), nil
+	}
+
 	p, err := r.riskManagement.ListTreatmentPlansForRiskAnalysisID(ctx, scope, obj.ID, cursor, planFilter)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
@@ -939,15 +975,20 @@ func (r *riskAnalysisResolver) TreatmentPlans(ctx context.Context, obj *types.Ri
 }
 
 // MatrixCells is the resolver for the matrixCells field.
-func (r *riskAnalysisResolver) MatrixCells(ctx context.Context, obj *types.RiskAnalysis) ([]*coredata.RiskAnalysisMatrixCell, error) {
+func (r *riskAnalysisResolver) MatrixCells(ctx context.Context, obj *types.RiskAnalysis, asOf *time.Time) ([]*coredata.RiskAnalysisMatrixCell, error) {
 	scope, err := r.authorize(ctx, obj.ID, riskmanagement.ActionTreatmentPlanList)
 	if err != nil {
 		return nil, err
 	}
 
-	counts, err := r.riskManagement.GetRiskAnalysisMatrixCells(ctx, scope, obj.ID)
+	counts, err := r.riskManagement.GetRiskAnalysisMatrixCells(ctx, scope, obj.ID, asOf)
 	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return nil, gqlutils.NotFound(ctx, err)
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot get treatment plan matrix cells", log.Error(err))
+
 		return nil, gqlutils.Internal(ctx)
 	}
 

--- a/pkg/server/api/console/v1/treatment_plan_resolvers.go
+++ b/pkg/server/api/console/v1/treatment_plan_resolvers.go
@@ -8,6 +8,7 @@ package console_v1
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/vikstrous/dataloadgen"
 	"go.gearno.de/kit/log"
@@ -199,8 +200,44 @@ func (r *treatmentPlanResolver) NetRiskScore(ctx context.Context, obj *types.Tre
 	return score, err
 }
 
+// Progress is the resolver for the progress field.
+func (r *treatmentPlanResolver) Progress(ctx context.Context, obj *types.TreatmentPlan) (*riskmanagement.TreatmentProgress, error) {
+	if obj.AsOf != nil {
+		if _, err := r.authorize(ctx, obj.RiskAnalysis.ID, riskmanagement.ActionTreatmentPlanList); err != nil {
+			return nil, err
+		}
+
+		if obj.Progress == nil {
+			return &riskmanagement.TreatmentProgress{}, nil
+		}
+
+		return obj.Progress, nil
+	}
+
+	if _, err := r.authorize(ctx, obj.ID, riskmanagement.ActionTreatmentPlanGet); err != nil {
+		return nil, err
+	}
+
+	loaders := dataloader.FromContext(ctx)
+
+	progress, err := loaders.TreatmentProgress.Load(ctx, obj.ID)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot get treatment plan progress", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return &progress, nil
+}
+
 // Owner is the resolver for the owner field.
 func (r *treatmentPlanResolver) Owner(ctx context.Context, obj *types.TreatmentPlan) (*types.Profile, error) {
+	if obj.AsOf != nil {
+		if _, err := r.authorize(ctx, obj.RiskAnalysis.ID, riskmanagement.ActionTreatmentPlanList); err != nil {
+			return nil, err
+		}
+	}
+
 	if _, err := r.authorize(ctx, obj.Owner.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
@@ -223,7 +260,15 @@ func (r *treatmentPlanResolver) Owner(ctx context.Context, obj *types.TreatmentP
 
 // Risk is the resolver for the risk field.
 func (r *treatmentPlanResolver) Risk(ctx context.Context, obj *types.TreatmentPlan) (*types.Risk, error) {
-	scope, err := r.authorize(ctx, obj.Risk.ID, probo.ActionRiskGet)
+	resourceID := obj.Risk.ID
+	action := probo.ActionRiskGet
+
+	if obj.AsOf != nil {
+		resourceID = obj.RiskAnalysis.ID
+		action = riskmanagement.ActionTreatmentPlanList
+	}
+
+	scope, err := r.authorize(ctx, resourceID, action)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +289,12 @@ func (r *treatmentPlanResolver) Risk(ctx context.Context, obj *types.TreatmentPl
 
 // RiskAnalysis is the resolver for the riskAnalysis field.
 func (r *treatmentPlanResolver) RiskAnalysis(ctx context.Context, obj *types.TreatmentPlan) (*types.RiskAnalysis, error) {
-	scope, err := r.authorize(ctx, obj.RiskAnalysis.ID, riskmanagement.ActionRiskAnalysisGet)
+	action := riskmanagement.ActionRiskAnalysisGet
+	if obj.AsOf != nil {
+		action = riskmanagement.ActionTreatmentPlanList
+	}
+
+	scope, err := r.authorize(ctx, obj.RiskAnalysis.ID, action)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +315,11 @@ func (r *treatmentPlanResolver) RiskAnalysis(ctx context.Context, obj *types.Tre
 
 // Organization is the resolver for the organization field.
 func (r *treatmentPlanResolver) Organization(ctx context.Context, obj *types.TreatmentPlan) (*types.Organization, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if obj.AsOf != nil {
+		if _, err := r.authorize(ctx, obj.RiskAnalysis.ID, riskmanagement.ActionTreatmentPlanList); err != nil {
+			return nil, err
+		}
+	} else if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -286,8 +340,20 @@ func (r *treatmentPlanResolver) Organization(ctx context.Context, obj *types.Tre
 }
 
 // Measures is the resolver for the measures field.
-func (r *treatmentPlanResolver) Measures(ctx context.Context, obj *types.TreatmentPlan, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error) {
-	scope, err := r.authorize(ctx, obj.ID, probo.ActionMeasureList)
+func (r *treatmentPlanResolver) Measures(ctx context.Context, obj *types.TreatmentPlan, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter, asOf *time.Time) (*types.MeasureConnection, error) {
+	if asOf == nil {
+		asOf = obj.AsOf
+	}
+
+	resourceID := obj.ID
+	action := probo.ActionMeasureList
+
+	if asOf != nil {
+		resourceID = obj.RiskAnalysis.ID
+		action = riskmanagement.ActionTreatmentPlanList
+	}
+
+	scope, err := r.authorize(ctx, resourceID, action)
 	if err != nil {
 		return nil, err
 	}
@@ -311,6 +377,31 @@ func (r *treatmentPlanResolver) Measures(ctx context.Context, obj *types.Treatme
 		measureFilter = coredata.NewMeasureFilter(filter.Query, filter.State, filter.Category)
 	}
 
+	if asOf != nil {
+		page, total, err := r.riskManagement.ListMeasuresAsOf(
+			ctx,
+			scope,
+			obj.RiskAnalysis.ID,
+			obj.ID,
+			*asOf,
+			cursor,
+			measureFilter,
+		)
+		if err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, gqlutils.NotFound(ctx, err)
+			}
+
+			r.logger.ErrorCtx(ctx, "cannot list treatment plan measures as of", log.Error(err))
+
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		connection := types.NewMeasureConnectionAsOf(page, r, obj.ID, measureFilter, *asOf, total)
+
+		return connection, nil
+	}
+
 	page, err := r.probo.Measures.ListForTreatmentPlanID(ctx, scope, obj.ID, cursor, measureFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list treatment plan measures", log.Error(err))
@@ -322,11 +413,19 @@ func (r *treatmentPlanResolver) Measures(ctx context.Context, obj *types.Treatme
 
 // Permission is the resolver for the permission field.
 func (r *treatmentPlanResolver) Permission(ctx context.Context, obj *types.TreatmentPlan, action string) (bool, error) {
+	if obj.AsOf != nil {
+		return false, nil
+	}
+
 	return r.Resolver.Permission(ctx, obj, action)
 }
 
 // TotalCount is the resolver for the totalCount field.
 func (r *treatmentPlanConnectionResolver) TotalCount(ctx context.Context, obj *types.TreatmentPlanConnection) (int, error) {
+	if obj.AsOf != nil {
+		return obj.TotalCount, nil
+	}
+
 	scope, err := r.authorize(ctx, obj.ParentID, riskmanagement.ActionTreatmentPlanList)
 	if err != nil {
 		return 0, err

--- a/pkg/server/api/console/v1/types/mesure.go
+++ b/pkg/server/api/console/v1/types/mesure.go
@@ -21,6 +21,8 @@
 package types
 
 import (
+	"time"
+
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
@@ -37,6 +39,7 @@ type (
 		Resolver any
 		ParentID gid.GID
 		Filters  *coredata.MeasureFilter
+		AsOf     *time.Time
 	}
 )
 
@@ -62,6 +65,33 @@ func NewMeasureConnection(
 	}
 }
 
+func NewMeasureConnectionAsOf(
+	p *page.Page[*coredata.Measure, coredata.MeasureOrderField],
+	parentType any,
+	parentID gid.GID,
+	filters *coredata.MeasureFilter,
+	asOf time.Time,
+	totalCount int,
+) *MeasureConnection {
+	edges := make([]*MeasureEdge, len(p.Data))
+	for i := range edges {
+		edges[i] = &MeasureEdge{
+			Cursor: p.Data[i].CursorKey(p.Cursor.OrderBy.Field),
+			Node:   NewMeasureAsOf(p.Data[i], asOf),
+		}
+	}
+
+	return &MeasureConnection{
+		Edges:      edges,
+		PageInfo:   *NewPageInfo(p),
+		Resolver:   parentType,
+		ParentID:   parentID,
+		Filters:    filters,
+		AsOf:       new(asOf),
+		TotalCount: totalCount,
+	}
+}
+
 func NewMeasureEdge(c *coredata.Measure, orderBy coredata.MeasureOrderField) *MeasureEdge {
 	return &MeasureEdge{
 		Cursor: c.CursorKey(orderBy),
@@ -79,4 +109,11 @@ func NewMeasure(c *coredata.Measure) *Measure {
 		CreatedAt:   c.CreatedAt,
 		UpdatedAt:   c.UpdatedAt,
 	}
+}
+
+func NewMeasureAsOf(c *coredata.Measure, asOf time.Time) *Measure {
+	measure := NewMeasure(c)
+	measure.AsOf = new(asOf)
+
+	return measure
 }

--- a/pkg/server/api/console/v1/types/treatment_plan.go
+++ b/pkg/server/api/console/v1/types/treatment_plan.go
@@ -21,9 +21,12 @@
 package types
 
 import (
+	"time"
+
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
+	"go.probo.inc/probo/pkg/riskmanagement"
 )
 
 type (
@@ -36,6 +39,7 @@ type (
 		Resolver   any
 		ParentID   gid.GID
 		Filters    *coredata.TreatmentPlanFilter
+		AsOf       *time.Time
 	}
 )
 
@@ -76,6 +80,7 @@ func NewTreatmentPlan(tp *coredata.TreatmentPlan) *TreatmentPlan {
 		ResidualLikelihood: tp.ResidualLikelihood,
 		ResidualImpact:     tp.ResidualImpact,
 		ResidualRiskScore:  tp.ResidualRiskScore,
+		Category:           tp.Category,
 		Risk: &Risk{
 			ID: tp.RiskID,
 		},
@@ -93,4 +98,47 @@ func NewTreatmentPlan(tp *coredata.TreatmentPlan) *TreatmentPlan {
 	}
 
 	return plan
+}
+
+func NewTreatmentPlanAsOf(
+	tp *coredata.TreatmentPlan,
+	asOf time.Time,
+	progress riskmanagement.TreatmentProgress,
+) *TreatmentPlan {
+	plan := NewTreatmentPlan(tp)
+	plan.AsOf = &asOf
+	plan.NetLikelihood, plan.NetImpact, plan.NetRiskScore = riskmanagement.NetScores(tp, progress)
+	plan.Progress = &progress
+
+	return plan
+}
+
+func NewTreatmentPlanConnectionAsOf(
+	p *page.Page[*coredata.TreatmentPlan, coredata.TreatmentPlanOrderField],
+	parentType any,
+	parentID gid.GID,
+	filters *coredata.TreatmentPlanFilter,
+	asOf time.Time,
+	totalCount int,
+	progressByID map[gid.GID]riskmanagement.TreatmentProgress,
+) *TreatmentPlanConnection {
+	edges := make([]*TreatmentPlanEdge, len(p.Data))
+	for i := range edges {
+		edges[i] = &TreatmentPlanEdge{
+			Cursor: p.Data[i].CursorKey(p.Cursor.OrderBy.Field),
+			Node:   NewTreatmentPlanAsOf(p.Data[i], asOf, progressByID[p.Data[i].ID]),
+		}
+	}
+
+	asOfCopy := asOf
+
+	return &TreatmentPlanConnection{
+		Edges:      edges,
+		PageInfo:   *NewPageInfo(p),
+		Resolver:   parentType,
+		ParentID:   parentID,
+		Filters:    filters,
+		AsOf:       &asOfCopy,
+		TotalCount: totalCount,
+	}
 }

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -6531,7 +6531,7 @@ func (r *Resolver) GetRiskAnalysisTool(ctx context.Context, req *mcp.CallToolReq
 		}
 	}
 
-	counts, err := r.riskManagement.GetRiskAnalysisMatrixCells(ctx, listScope, ra.ID)
+	counts, err := r.riskManagement.GetRiskAnalysisMatrixCells(ctx, listScope, ra.ID, input.AsOf)
 	if err != nil {
 		return nil, types.GetRiskAnalysisOutput{}, fmt.Errorf("failed to get risk analysis matrix cells: %w", err)
 	}
@@ -9122,6 +9122,16 @@ func (r *Resolver) ListTreatmentPlansTool(ctx context.Context, req *mcp.CallTool
 		}
 	}
 
+	if input.AsOf != nil && input.RiskAnalysisID == nil {
+		return nil, types.ListTreatmentPlansOutput{}, validator.ValidationErrors{
+			{
+				Field:   "as_of",
+				Code:    validator.ErrorCodeCustom,
+				Message: "can only be set together with risk_analysis_id",
+			},
+		}
+	}
+
 	scope, err := r.Authorize(ctx, input.OrganizationID, riskmanagement.ActionTreatmentPlanList)
 	if err != nil {
 		return nil, types.ListTreatmentPlansOutput{}, err
@@ -9154,6 +9164,25 @@ func (r *Resolver) ListTreatmentPlansTool(ctx context.Context, req *mcp.CallTool
 	switch {
 	case input.RiskID != nil:
 		p, err = r.riskManagement.ListTreatmentPlansForRiskID(ctx, scope, *input.RiskID, cursor, planFilter)
+	case input.RiskAnalysisID != nil && input.AsOf != nil:
+		asOfPage, listErr := r.riskManagement.ListTreatmentPlansAsOf(
+			ctx,
+			scope,
+			*input.RiskAnalysisID,
+			*input.AsOf,
+			cursor,
+			planFilter,
+			true,
+		)
+		if listErr != nil {
+			return nil, types.ListTreatmentPlansOutput{}, mapTreatmentPlanError(ctx, r.logger, "list", listErr)
+		}
+
+		return nil, types.NewListTreatmentPlansAsOfOutput(
+			asOfPage.Page,
+			asOfPage.ProgressByID,
+			asOfPage.MeasuresByID,
+		), nil
 	case input.RiskAnalysisID != nil:
 		p, err = r.riskManagement.ListTreatmentPlansForRiskAnalysisID(ctx, scope, *input.RiskAnalysisID, cursor, planFilter)
 	default:

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -2199,6 +2199,7 @@ components:
         - risk_id
         - risk_analysis_id
         - treatment
+        - category
         - inherent_likelihood
         - inherent_impact
         - inherent_risk_score
@@ -2231,6 +2232,9 @@ components:
         treatment:
           $ref: "#/components/schemas/RiskTreatment"
           description: Risk treatment
+        category:
+          type: string
+          description: Risk category stored on the treatment plan
         owner_id:
           $ref: "#/components/schemas/GID"
           description: Owner profile ID
@@ -2273,6 +2277,11 @@ components:
         measures_not_implemented:
           type: integer
           description: Number of not-implemented linked measures
+        measures:
+          type: array
+          description: Linked measures as of the requested instant. Present when listing with as_of.
+          items:
+            $ref: "#/components/schemas/TreatmentPlanMeasure"
         created_at:
           type: string
           format: date-time
@@ -2308,6 +2317,11 @@ components:
         filter:
           $ref: "#/components/schemas/TreatmentPlanFilter"
           description: Filter treatment plans by matrix cell. All three fields are required when set.
+        as_of:
+          type: string
+          format: date-time
+          go.probo.inc/mcpgen/type: time.Time
+          description: Reconstruct plans as of this instant. Only valid with risk_analysis_id. Omit to use live tables.
 
     ListTreatmentPlansOutput:
       type: object
@@ -2438,6 +2452,22 @@ components:
         deleted_treatment_plan_id:
           $ref: "#/components/schemas/GID"
           description: Deleted treatment plan ID
+
+    TreatmentPlanMeasure:
+      type: object
+      required:
+        - id
+        - state
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Measure ID
+        name:
+          type: string
+          description: Measure name. Absent when the measure has been deleted.
+        state:
+          $ref: "#/components/schemas/MeasureState"
+          description: Measure state as of the requested instant
 
     MeasureState:
       type: string
@@ -13789,6 +13819,11 @@ components:
         id:
           $ref: "#/components/schemas/GID"
           description: Risk analysis ID
+        as_of:
+          type: string
+          format: date-time
+          go.probo.inc/mcpgen/type: time.Time
+          description: Reconstruct matrix cells as of this instant. Omit to use live tables.
 
     GetRiskAnalysisOutput:
       type: object
@@ -18587,7 +18622,7 @@ tools:
       $ref: "#/components/schemas/ListRiskAnalysesOutput"
   - name: getRiskAnalysis
     title: Get Risk Analysis
-    description: Get a risk assessment by ID
+    description: Get a risk assessment by ID. Optionally reconstruct matrix cells as of a given instant.
     hints:
       readonly: true
       destructive: false

--- a/pkg/server/api/mcp/v1/types/treatment_plan.go
+++ b/pkg/server/api/mcp/v1/types/treatment_plan.go
@@ -36,6 +36,7 @@ func NewTreatmentPlan(tp *coredata.TreatmentPlan, progress riskmanagement.Treatm
 		RiskID:                 tp.RiskID,
 		RiskAnalysisID:         tp.RiskAnalysisID,
 		Treatment:              tp.Treatment,
+		Category:               tp.Category,
 		OwnerID:                tp.OwnerID,
 		InherentLikelihood:     tp.InherentLikelihood,
 		InherentImpact:         tp.InherentImpact,
@@ -55,12 +56,51 @@ func NewTreatmentPlan(tp *coredata.TreatmentPlan, progress riskmanagement.Treatm
 	}
 }
 
+func NewTreatmentPlanAsOf(
+	tp *coredata.TreatmentPlan,
+	progress riskmanagement.TreatmentProgress,
+	measures []riskmanagement.RiskAnalysisMatrixMeasure,
+) *TreatmentPlan {
+	plan := NewTreatmentPlan(tp, progress)
+	plan.Measures = newTreatmentPlanMeasures(measures)
+
+	return plan
+}
+
+func newTreatmentPlanMeasures(
+	measures []riskmanagement.RiskAnalysisMatrixMeasure,
+) []*TreatmentPlanMeasure {
+	items := make([]*TreatmentPlanMeasure, 0, len(measures))
+	for _, measure := range measures {
+		items = append(items, &TreatmentPlanMeasure{
+			ID:    measure.ID,
+			Name:  measure.Name,
+			State: measure.State,
+		})
+	}
+
+	return items
+}
+
 func NewListTreatmentPlansOutput(
 	p *page.Page[*coredata.TreatmentPlan, coredata.TreatmentPlanOrderField],
 	progressByID map[gid.GID]riskmanagement.TreatmentProgress,
 ) ListTreatmentPlansOutput {
+	return NewListTreatmentPlansAsOfOutput(p, progressByID, nil)
+}
+
+func NewListTreatmentPlansAsOfOutput(
+	p *page.Page[*coredata.TreatmentPlan, coredata.TreatmentPlanOrderField],
+	progressByID map[gid.GID]riskmanagement.TreatmentProgress,
+	measuresByID map[gid.GID][]riskmanagement.RiskAnalysisMatrixMeasure,
+) ListTreatmentPlansOutput {
 	items := make([]*TreatmentPlan, 0, len(p.Data))
 	for _, v := range p.Data {
+		if measuresByID != nil {
+			items = append(items, NewTreatmentPlanAsOf(v, progressByID[v.ID], measuresByID[v.ID]))
+			continue
+		}
+
 		items = append(items, NewTreatmentPlan(v, progressByID[v.ID]))
 	}
 


### PR DESCRIPTION
Pick a past date and see the heatmap, table,
and measures as they were. Each event stores
the full plan so as-of reads the latest row.
Owners and risks stay required; deleting
either while an event still references them
is restricted. Today stays on live data.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Risk analyses can now reconstruct their heatmap, treatment plans, and linked measure states at a chosen instant instead of always reading current tables. Live views stay unchanged; historical results are read-only, and owners and risks cannot be deleted while snapshots still reference them.

### Tests **`+1162`** **`-3`**

Covers matrix reconstruction, plan and measure history, forked plans, and access control for historical requests.

### Coredata **`+1816`** **`-32`**

Adds event snapshots, a migration, and historical filters and loaders for treatment plans and measures.

### GraphQL API **`+305`** **`-13`**

Exposes `asOf` on matrix cells, treatment plans, and measures, including historical plan category and progress.

### MCP **`+106`** **`-2`**

Adds `as_of` to risk-analysis and treatment-plan tools, returns historical categories and linked measures, and rejects invalid scopes.

### prb (CLI) **`+60`** **`-19`**

Adds `--as-of` to risk-analysis and treatment-plan commands and includes plan category in output.

### Service **`+910`** **`-4`**

Records plan and measure changes, reconstructs historical matrix data, and preserves plan categories and snapshots when forking.

### App: console **`+671`** **`-236`**

Adds localized As of controls, historical progress and measure views, and hides editing actions for read-only plans.

### Package: `n8n-node` **`+50`** **`-5`**

Adds As Of inputs for risk-analysis and scoped treatment-plan retrieval and returns plan category.

<sup>Written for commit e5374655f1980186a9ceeadbe3ebc4376dd32bcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



