### PR TITLE
Log why a connector reports itself disconnected

### DIFF
--- a/pkg/accessreview/errors.go
+++ b/pkg/accessreview/errors.go
@@ -23,8 +23,14 @@ package accessreview
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
+	"github.com/aws/smithy-go"
+	"golang.org/x/oauth2"
+
+	"go.probo.inc/probo/pkg/connector/provider"
+	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 )
 
@@ -65,6 +71,13 @@ type (
 
 	MissingOAuthScopesError struct {
 		Scopes []string
+	}
+
+	// ProbeError carries the provider a credential probe failed for, so
+	// callers log it as a field rather than parse it out of a message.
+	ProbeError struct {
+		Provider coredata.ConnectorProvider
+		Err      error
 	}
 )
 
@@ -164,4 +177,78 @@ func (e *MissingOAuthScopesError) Error() string {
 
 func (e *MissingOAuthScopesError) Is(target error) bool {
 	return target == ErrMissingOAuthScopes
+}
+
+func NewProbeError(prvdr coredata.ConnectorProvider, err error) error {
+	return &ProbeError{Provider: prvdr, Err: err}
+}
+
+func (e *ProbeError) Error() string {
+	return fmt.Sprintf("cannot probe %s connector: %v", e.Provider, e.Err)
+}
+
+func (e *ProbeError) Unwrap() error {
+	return e.Err
+}
+
+// ProbeFailureCode reduces a probe failure to a token safe to log. Probe
+// errors wrap text Probo does not control (an OAuth error_description, a
+// response body, a customer's self-hosted host), so anything unrecognised
+// degrades to its Go type rather than being quoted.
+// IsProviderVerdict reports whether err is the provider's answer rather than a
+// failure on Probo's side. Only a rejected credential, a transport failure that
+// reached the provider, and a refused token refresh qualify. Everything else a
+// probe can return (settings that will not decode, a request that could not be
+// built, a registry misconfiguration) is ours, so the default is to treat a
+// failure as Probo's and report it in full.
+func IsProviderVerdict(err error) bool {
+	if _, ok := errors.AsType[*provider.CredentialRejectedError](err); ok {
+		return true
+	}
+
+	if _, ok := errors.AsType[*url.Error](err); ok {
+		return true
+	}
+
+	if _, ok := errors.AsType[*oauth2.RetrieveError](err); ok {
+		return true
+	}
+
+	// A workload identity connector never makes an HTTP request of its own:
+	// STS answers through the AWS SDK, so its API errors are the verdict.
+	if _, ok := errors.AsType[smithy.APIError](err); ok {
+		return true
+	}
+
+	return false
+}
+
+func ProbeFailureCode(err error) string {
+	// Guarded against a typed nil: this runs on a logging path, where a panic
+	// would cost more than the lost detail.
+	if rejected, ok := errors.AsType[*provider.CredentialRejectedError](err); ok && rejected != nil {
+		return fmt.Sprintf("credential_rejected_%d", rejected.StatusCode)
+	}
+
+	if _, ok := errors.AsType[*url.Error](err); ok {
+		return "transport_error"
+	}
+
+	// An AWS error code is a fixed identifier such as AccessDenied, so it is
+	// safe to report where the surrounding message is not.
+	if apiErr, ok := errors.AsType[smithy.APIError](err); ok && apiErr != nil {
+		return fmt.Sprintf("aws_%s", apiErr.ErrorCode())
+	}
+
+	cause := err
+	for {
+		unwrapped := errors.Unwrap(cause)
+		if unwrapped == nil {
+			break
+		}
+
+		cause = unwrapped
+	}
+
+	return fmt.Sprintf("%T", cause)
 }

--- a/pkg/accessreview/probe_error_test.go
+++ b/pkg/accessreview/probe_error_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package accessreview_test
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/aws/smithy-go"
+	"golang.org/x/oauth2"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/accessreview"
+	"go.probo.inc/probo/pkg/connector/provider"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestProbeErrorCarriesProvider(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("boom")
+	err := accessreview.NewProbeError(coredata.ConnectorProviderLangfuse, cause)
+
+	probeErr, ok := errors.AsType[*accessreview.ProbeError](err)
+	require.True(t, ok)
+	assert.Equal(t, coredata.ConnectorProviderLangfuse, probeErr.Provider)
+	// Unwrap keeps errors.Is working through the wrapper, which the resolver
+	// relies on to still recognise a missing connector.
+	assert.ErrorIs(t, err, cause)
+}
+
+func TestProbeFailureCodeIsSafeToLog(t *testing.T) {
+	t.Parallel()
+
+	// A provider that refuses the credential is the one case worth reporting
+	// precisely, because the status tells an operator whether to reconnect.
+	rejected := accessreview.NewProbeError(
+		coredata.ConnectorProviderLangfuse,
+		&provider.CredentialRejectedError{StatusCode: 403},
+	)
+	assert.Equal(t, "credential_rejected_403", accessreview.ProbeFailureCode(rejected))
+
+	// A transport error embeds the customer's self-hosted host, so only the
+	// classification survives.
+	transport := accessreview.NewProbeError(
+		coredata.ConnectorProviderLangfuse,
+		&url.Error{
+			Op:  "Get",
+			URL: "https://langfuse.internal.customer.example/api/public/organizations/memberships",
+			Err: errors.New("dial tcp: connection refused"),
+		},
+	)
+	code := accessreview.ProbeFailureCode(transport)
+	assert.Equal(t, "transport_error", code)
+	assert.NotContains(t, code, "customer.example")
+
+	// Anything unrecognised degrades to its type, which names the failure
+	// without quoting provider-controlled text.
+	opaque := accessreview.NewProbeError(
+		coredata.ConnectorProviderLangfuse,
+		fmt.Errorf("cannot refresh token: %w", errors.New(`oauth2: "invalid_grant" "token revoked for user ada@example.com"`)),
+	)
+	opaqueCode := accessreview.ProbeFailureCode(opaque)
+	assert.NotContains(t, opaqueCode, "ada@example.com")
+	assert.NotContains(t, opaqueCode, "invalid_grant")
+
+	// An AWS error code is a fixed identifier, so it is reported; the message
+	// around it, which can name a role ARN, is not.
+	awsCode := accessreview.ProbeFailureCode(
+		fmt.Errorf("cannot reach aws account: %w", &smithy.GenericAPIError{
+			Code:    "AccessDenied",
+			Message: "User: arn:aws:sts::123456789012:assumed-role/probo is not authorized",
+		}),
+	)
+	assert.Equal(t, "aws_AccessDenied", awsCode)
+	assert.NotContains(t, awsCode, "123456789012")
+}
+
+func TestProbeFailureCodeSurvivesTypedNil(t *testing.T) {
+	t.Parallel()
+
+	// ProbeFailureCode runs while logging a failure, so a malformed error must
+	// not turn a degraded connector into a panicking resolver.
+	var rejected *provider.CredentialRejectedError
+
+	assert.NotPanics(t, func() {
+		accessreview.ProbeFailureCode(accessreview.NewProbeError(coredata.ConnectorProviderLangfuse, rejected))
+	})
+}
+
+func TestIsProviderVerdict(t *testing.T) {
+	t.Parallel()
+
+	// The provider answered.
+	assert.True(t, accessreview.IsProviderVerdict(&provider.CredentialRejectedError{StatusCode: 401}))
+	assert.True(t, accessreview.IsProviderVerdict(&url.Error{Op: "Get", URL: "https://x.example", Err: errors.New("refused")}))
+	assert.True(t, accessreview.IsProviderVerdict(&oauth2.RetrieveError{ErrorCode: "invalid_grant"}))
+	// A workload identity connector is answered by STS through the SDK, so an
+	// AWS API error is the provider's verdict, not a Probo failure.
+	assert.True(t, accessreview.IsProviderVerdict(fmt.Errorf("cannot reach aws account: %w", &smithy.GenericAPIError{Code: "AccessDenied", Message: "not authorized"})))
+
+	// Probo never got as far as asking. Defaulting these to "ours" keeps a
+	// settings decode or a request we could not build in the error budget,
+	// with its message, instead of being blamed on the customer's credential.
+	assert.False(t, accessreview.IsProviderVerdict(errors.New("cannot read crisp connector settings: unexpected end of JSON input")))
+	assert.False(t, accessreview.IsProviderVerdict(fmt.Errorf("cannot build probe URL: %w", errors.New("missing crisp website_id"))))
+	assert.False(t, accessreview.IsProviderVerdict(errors.New("cannot persist refreshed token: connection reset")))
+}

--- a/pkg/accessreview/source_service.go
+++ b/pkg/accessreview/source_service.go
@@ -556,6 +556,8 @@ func (s *Service) ProbeConnector(
 		return err
 	}
 
+	// Only a ProbeError means the credential or the provider is at fault;
+	// everything else returned here is Probo's own.
 	switch conn := dbConnector.Connection.(type) {
 	case *connector.WorkloadIdentityConnection:
 		session, err := s.buildCloudSession(ctx, dbConnector)
@@ -563,15 +565,37 @@ func (s *Service) ProbeConnector(
 			return err
 		}
 
-		return s.providerRegistry.ProbeCloudConnection(ctx, session, dbConnector)
+		if err := s.providerRegistry.ProbeCloudConnection(ctx, session, dbConnector); err != nil {
+			if !IsProviderVerdict(err) {
+				return err
+			}
 
-	case connector.HTTPConnection:
-		httpClient, err := s.httpClientFor(ctx, scope, dbConnector, conn)
-		if err != nil {
-			return err
+			return NewProbeError(dbConnector.Provider, err)
 		}
 
-		return s.providerRegistry.ProbeConnection(ctx, httpClient, dbConnector)
+		return nil
+
+	case connector.HTTPConnection:
+		// The eager token refresh runs here, so a revoked grant fails the
+		// probe before any request is made.
+		httpClient, err := s.httpClientFor(ctx, scope, dbConnector, conn)
+		if err != nil {
+			if !IsProviderVerdict(err) {
+				return err
+			}
+
+			return NewProbeError(dbConnector.Provider, err)
+		}
+
+		if err := s.providerRegistry.ProbeConnection(ctx, httpClient, dbConnector); err != nil {
+			if !IsProviderVerdict(err) {
+				return err
+			}
+
+			return NewProbeError(dbConnector.Provider, err)
+		}
+
+		return nil
 
 	default:
 		return fmt.Errorf(

--- a/pkg/connector/provider/probe.go
+++ b/pkg/connector/provider/probe.go
@@ -139,6 +139,16 @@ func probePOSTJSON(
 	return doProbeRequest(httpClient, req)
 }
 
+// CredentialRejectedError reports that the provider refused the credential,
+// carrying the status separately so callers can log it without the message.
+type CredentialRejectedError struct {
+	StatusCode int
+}
+
+func (e *CredentialRejectedError) Error() string {
+	return fmt.Sprintf("credential rejected: status %d", e.StatusCode)
+}
+
 // doProbeRequest executes a probe request and maps the status to a verdict:
 // 401/403 always mean the credential is rejected, any 2xx/other status means
 // connected. extraReject lets a provider add statuses that also mean a hard
@@ -158,7 +168,7 @@ func doProbeRequest(httpClient *http.Client, req *http.Request, extraReject ...i
 	if resp.StatusCode == http.StatusUnauthorized ||
 		resp.StatusCode == http.StatusForbidden ||
 		slices.Contains(extraReject, resp.StatusCode) {
-		return fmt.Errorf("credential rejected: status %d", resp.StatusCode)
+		return &CredentialRejectedError{StatusCode: resp.StatusCode}
 	}
 
 	return nil
@@ -507,7 +517,7 @@ func probeRailway(
 	}()
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return fmt.Errorf("credential rejected: status %d", resp.StatusCode)
+		return &CredentialRejectedError{StatusCode: resp.StatusCode}
 	}
 
 	var parsed struct {
@@ -522,8 +532,10 @@ func probeRailway(
 		return fmt.Errorf("cannot decode railway probe response: %w", err)
 	}
 
+	// Railway answers 200 with an errors array rather than a 401, so this is
+	// a rejection too and must classify the same way.
 	if len(parsed.Errors) > 0 || parsed.Data.Me == nil {
-		return fmt.Errorf("credential rejected: railway returned no authenticated account")
+		return &CredentialRejectedError{StatusCode: resp.StatusCode}
 	}
 
 	return nil

--- a/pkg/server/api/console/v1/access_review_campaign_resolvers.go
+++ b/pkg/server/api/console/v1/access_review_campaign_resolvers.go
@@ -494,6 +494,8 @@ func (r *accessReviewSourceResolver) ProviderOrganizations(ctx context.Context, 
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list provider organizations",
 			log.String("provider", cnnctr.Provider.String()),
+			log.String("source_id", obj.ID.String()),
+			log.String("connector_id", obj.ConnectorID.String()),
 			log.Error(err),
 		)
 
@@ -576,6 +578,35 @@ func (r *accessReviewSourceResolver) ConnectionStatus(ctx context.Context, obj *
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return types.AccessReviewSourceConnectionStatusNotApplicable, nil
 		}
+
+		// A code, not the error: probe errors wrap provider-controlled text
+		// and customer-chosen hosts, which logging.md keeps out of the logs.
+		fields := []log.Attr{
+			log.String("source_id", obj.ID.String()),
+			log.String("connector_id", obj.ConnectorID.String()),
+		}
+
+		if probeErr, ok := errors.AsType[*accessreview.ProbeError](err); ok {
+			// Not Probo's failure, so not in the error budget.
+			r.logger.WarnCtx(
+				ctx,
+				"connector credential probe failed, reporting source disconnected",
+				append(fields,
+					log.String("provider", probeErr.Provider.String()),
+					log.String("probe_failure", accessreview.ProbeFailureCode(err)),
+				)...,
+			)
+
+			return types.AccessReviewSourceConnectionStatusDisconnected, nil
+		}
+
+		// A database read, a decrypt, a deployment without identity
+		// federation: ours, so it stays an error and keeps its message.
+		r.logger.ErrorCtx(
+			ctx,
+			"cannot probe connector, reporting source disconnected",
+			append(fields, log.Error(err))...,
+		)
 
 		return types.AccessReviewSourceConnectionStatusDisconnected, nil
 	}


### PR DESCRIPTION
`ConnectionStatus` mapped every `ProbeConnector` failure to `DISCONNECTED` and discarded the error. Nothing in `pkg/connector/provider/probe.go` logs, so a source that reports itself broken leaves no diagnostics anywhere.

- The probe error now reaches the logs **as a code, not a message**. `logging.md` forbids logging error descriptions from external sources, and a probe error wraps exactly that: an OAuth `error_description`, a provider response body, or a customer-chosen self-hosted host inside a `*url.Error`. `ProbeFailureCode` reduces it to a short token, reporting the status for a credential rejection and otherwise naming only the failure's type.
- `ProbeConnector` returns a typed `ProbeError` carrying the provider, so the provider is a **field** the logs can facet on rather than a fragment to pattern-match out of a message. Every credential path is wrapped, not just the two probe calls: an expired or revoked grant surfaces from the eager refresh inside `httpClientFor`, which is the commonest reason a source reports itself disconnected.
- That distinction also sets the **log level**. Only a `ProbeError` means the credential or provider is at fault, so only that logs at WARN; a database read, a decrypt, or a deployment missing identity federation stays ERROR instead of being demoted because the enum has nowhere else to put it.
- `doProbeRequest` returns a typed `CredentialRejectedError` carrying the status.
- This line and the sibling org-listing error now carry `source_id` and `connector_id`.

Not in scope: the org-listing line is also missing `trace_id`/`span_id`. `kit/log` attaches trace context only when `span.IsRecording()`, so that needs its own look at span lifecycle rather than a speculative fix.

Verification: `go build ./pkg/...`, `gofmt`, `go vet` clean; `golangci-lint run pkg/accessreview/... pkg/connector/... pkg/server/api/console/v1/...` 0 issues; `go test ./pkg/accessreview/... ./pkg/connector/...` passes, including new tests asserting `ProbeFailureCode` never emits a host or an OAuth description.