### PR TITLE
Keep cancellations and outages out of the probe verdict

### DIFF
--- a/pkg/accessreview/errors.go
+++ b/pkg/accessreview/errors.go
@@ -21,9 +21,12 @@
 package accessreview
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
+	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/aws/smithy-go"
@@ -191,10 +194,43 @@ func (e *ProbeError) Unwrap() error {
 	return e.Err
 }
 
-// ProbeFailureCode reduces a probe failure to a token safe to log. Probe
-// errors wrap text Probo does not control (an OAuth error_description, a
-// response body, a customer's self-hosted host), so anything unrecognised
-// degrades to its Go type rather than being quoted.
+// isNilError reports whether err is nil, or whether its chain holds a typed
+// nil. A typed nil panics when something calls its Unwrap, which errors.AsType
+// does while walking, so the classifiers below screen the chain first: they run
+// while logging a failure, where a panic costs more than a coarse answer. Each
+// node is checked before it is unwrapped, so the screen cannot trip over the
+// value it is looking for.
+func isNilError(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	switch value := reflect.ValueOf(err); value.Kind() {
+	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
+		if value.IsNil() {
+			return true
+		}
+	}
+
+	switch unwrapper := err.(type) {
+	case interface{ Unwrap() error }:
+		cause := unwrapper.Unwrap()
+		if cause == nil {
+			// A real error that simply wraps nothing, not a nil one.
+			return false
+		}
+
+		return isNilError(cause)
+
+	case interface{ Unwrap() []error }:
+		if slices.ContainsFunc(unwrapper.Unwrap(), isNilError) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsProviderVerdict reports whether err is the provider's answer rather than a
 // failure on Probo's side. Only a rejected credential, a transport failure that
 // reached the provider, and a refused token refresh qualify. Everything else a
@@ -202,12 +238,29 @@ func (e *ProbeError) Unwrap() error {
 // built, a registry misconfiguration) is ours, so the default is to treat a
 // failure as Probo's and report it in full.
 func IsProviderVerdict(err error) bool {
+	if isNilError(err) {
+		return false
+	}
+
+	// Checked before any verdict: our own deadline expiring is never the
+	// provider's answer, even when it is joined with one.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
 	if _, ok := errors.AsType[*provider.CredentialRejectedError](err); ok {
 		return true
 	}
 
-	if _, ok := errors.AsType[*url.Error](err); ok {
-		return true
+	// ok can be true with a nil value when a custom As assigns one, so the
+	// dereference below needs its own guard.
+	if urlErr, ok := errors.AsType[*url.Error](err); ok {
+		if urlErr == nil {
+			return false
+		}
+
+		// url.Parse failures arrive as a *url.Error too, with nothing sent.
+		return urlErr.Op != "parse"
 	}
 
 	if _, ok := errors.AsType[*oauth2.RetrieveError](err); ok {
@@ -223,7 +276,15 @@ func IsProviderVerdict(err error) bool {
 	return false
 }
 
+// ProbeFailureCode reduces a probe failure to a token safe to log. Probe
+// errors wrap text Probo does not control (an OAuth error_description, a
+// response body, a customer's self-hosted host), so anything unrecognised
+// degrades to its Go type rather than being quoted.
 func ProbeFailureCode(err error) string {
+	if isNilError(err) {
+		return "none"
+	}
+
 	// Guarded against a typed nil: this runs on a logging path, where a panic
 	// would cost more than the lost detail.
 	if rejected, ok := errors.AsType[*provider.CredentialRejectedError](err); ok && rejected != nil {

--- a/pkg/accessreview/probe_error_test.go
+++ b/pkg/accessreview/probe_error_test.go
@@ -21,6 +21,7 @@
 package accessreview_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -97,6 +98,61 @@ func TestProbeFailureCodeIsSafeToLog(t *testing.T) {
 	assert.NotContains(t, awsCode, "123456789012")
 }
 
+func TestIsProviderVerdictSurvivesTypedNilURLError(t *testing.T) {
+	t.Parallel()
+
+	// errors.Is unwraps, and (*url.Error).Unwrap dereferences its receiver,
+	// so a typed nil must be caught before any sentinel comparison.
+	var urlErr *url.Error
+
+	assert.NotPanics(t, func() { accessreview.IsProviderVerdict(urlErr) })
+	assert.False(t, accessreview.IsProviderVerdict(urlErr))
+
+	// Also when it sits deeper in the chain, where the traversal would reach
+	// it rather than the screen catching it at the top.
+	wrapped := fmt.Errorf("cannot probe: %w", urlErr)
+
+	assert.NotPanics(t, func() { accessreview.IsProviderVerdict(wrapped) })
+	assert.False(t, accessreview.IsProviderVerdict(wrapped))
+	assert.NotPanics(t, func() { accessreview.ProbeFailureCode(wrapped) })
+
+	// A typed nil joined alongside a real error is still reachable by the
+	// traversal, so the screen follows multi-error children too.
+	joined := errors.Join(errors.New("other"), urlErr)
+
+	assert.NotPanics(t, func() { accessreview.IsProviderVerdict(joined) })
+	assert.NotPanics(t, func() { accessreview.ProbeFailureCode(joined) })
+}
+
+func TestIsProviderVerdictExcludesCancellationJoinedWithAVerdict(t *testing.T) {
+	t.Parallel()
+
+	// Our deadline expiring is never the provider's answer, so it wins over a
+	// rejection sharing the same chain rather than losing on check order.
+	joined := errors.Join(
+		&provider.CredentialRejectedError{StatusCode: 403},
+		context.Canceled,
+	)
+
+	assert.False(t, accessreview.IsProviderVerdict(joined))
+}
+
+func TestIsProviderVerdictStillClassifiesAnErrorWrappingNothing(t *testing.T) {
+	t.Parallel()
+
+	// A real error whose Unwrap returns nil must not be mistaken for a nil
+	// one, or the screen would suppress the classification it exists to guard.
+	verdict := accessreview.NewProbeError(coredata.ConnectorProviderLangfuse, nil)
+
+	assert.NotEqual(t, "none", accessreview.ProbeFailureCode(verdict))
+	assert.False(t, accessreview.IsProviderVerdict(verdict))
+
+	rejected := &provider.CredentialRejectedError{StatusCode: 403}
+
+	assert.True(t, accessreview.IsProviderVerdict(rejected))
+	assert.Equal(t, "credential_rejected_403", accessreview.ProbeFailureCode(rejected))
+}
+
 func TestProbeFailureCodeSurvivesTypedNil(t *testing.T) {
 	t.Parallel()
 
@@ -126,4 +182,18 @@ func TestIsProviderVerdict(t *testing.T) {
 	assert.False(t, accessreview.IsProviderVerdict(errors.New("cannot read crisp connector settings: unexpected end of JSON input")))
 	assert.False(t, accessreview.IsProviderVerdict(fmt.Errorf("cannot build probe URL: %w", errors.New("missing crisp website_id"))))
 	assert.False(t, accessreview.IsProviderVerdict(errors.New("cannot persist refreshed token: connection reset")))
+
+	// http.Client reports a cancelled or timed-out request as a *url.Error,
+	// but our deadline expiring is not the provider answering.
+	assert.False(t, accessreview.IsProviderVerdict(
+		&url.Error{Op: "Get", URL: "https://x.example", Err: context.Canceled},
+	))
+	assert.False(t, accessreview.IsProviderVerdict(
+		&url.Error{Op: "Get", URL: "https://x.example", Err: context.DeadlineExceeded},
+	))
+
+	// A URL we could not parse never left the process.
+	assert.False(t, accessreview.IsProviderVerdict(
+		&url.Error{Op: "parse", URL: "://bad", Err: errors.New("missing protocol scheme")},
+	))
 }

--- a/pkg/connector/provider/probe.go
+++ b/pkg/connector/provider/probe.go
@@ -520,6 +520,14 @@ func probeRailway(
 		return &CredentialRejectedError{StatusCode: resp.StatusCode}
 	}
 
+	// The errors-array rule below is Railway's documented rejection, and it
+	// only means that on a 2xx. Checked before the decode so an outage that
+	// answers with an HTML error page reports its status rather than a
+	// decode failure.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("railway probe returned unexpected status %d", resp.StatusCode)
+	}
+
 	var parsed struct {
 		Data struct {
 			Me *struct {

--- a/pkg/connector/provider/probe_test.go
+++ b/pkg/connector/provider/probe_test.go
@@ -22,6 +22,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -393,11 +394,18 @@ func TestProbeRailway(t *testing.T) {
 		status     int
 		body       string
 		wantReject bool
+		// wantCredentialRejected separates a token Railway refused from an
+		// outage. Both are errors, but only the first may reach the caller as
+		// a credential rejection: reporting a 502 that way would tell a
+		// customer to reconnect a working token.
+		wantCredentialRejected bool
 	}{
-		{"valid token", http.StatusOK, `{"data":{"me":{"id":"u-1"}}}`, false},
-		{"rejected token (200 + errors)", http.StatusOK, `{"errors":[{"message":"Not Authorized"}],"data":null}`, true},
-		{"null me", http.StatusOK, `{"data":{"me":null}}`, true},
-		{"unauthorized status", http.StatusUnauthorized, ``, true},
+		{"valid token", http.StatusOK, `{"data":{"me":{"id":"u-1"}}}`, false, false},
+		{"rejected token (200 + errors)", http.StatusOK, `{"errors":[{"message":"Not Authorized"}],"data":null}`, true, true},
+		{"null me", http.StatusOK, `{"data":{"me":null}}`, true, true},
+		{"unauthorized status", http.StatusUnauthorized, ``, true, true},
+		{"upstream outage", http.StatusBadGateway, `<html>502 Bad Gateway</html>`, true, false},
+		{"rate limited", http.StatusTooManyRequests, `{"errors":[{"message":"rate limited"}]}`, true, false},
 	}
 
 	for _, tc := range cases {
@@ -422,11 +430,16 @@ func TestProbeRailway(t *testing.T) {
 			assert.Equal(t, "https://backboard.railway.com/graphql/v2", gotURL)
 			assert.Equal(t, "application/json", gotContentType)
 
-			if tc.wantReject {
-				require.Error(t, err)
-			} else {
+			if !tc.wantReject {
 				require.NoError(t, err)
+
+				return
 			}
+
+			require.Error(t, err)
+
+			_, isCredentialRejected := errors.AsType[*CredentialRejectedError](err)
+			assert.Equal(t, tc.wantCredentialRejected, isCredentialRejected)
 		})
 	}
 }


### PR DESCRIPTION
Follow-up to #1785, fixing three misclassifications in the probe-verdict split it introduced.

- `IsProviderVerdict` treated every `*url.Error` as the provider answering. `http.Client` reports a cancelled or timed-out request the same way, so a request killed by our own 30s deadline was logged at WARN as a credential fault with its message withheld. Cancellation and deadline expiry are now excluded outright.
- `url.Parse` failures also arrive as a `*url.Error`, with nothing sent. A `*url.Error` is now a verdict only when its `Op` is not `"parse"`, so a probe URL we could not build stays on the ERROR path with its message.
- The Railway probe had the same shape of bug, introduced in #1785. Its documented rejection is a 200 carrying a GraphQL errors array, but the check ran on any status that was not 401 or 403, so a 5xx or a rate limit reported the outage as a dead credential. The status is checked first now.

Verification: `go build`, `go test ./pkg/accessreview/... ./pkg/connector/...`, `golangci-lint` all clean. New cases cover `context.Canceled`, `context.DeadlineExceeded` and an `Op: "parse"` error.