### PR TITLE
Drop the typed-nil screen from the probe classifiers

### DIFF
--- a/pkg/accessreview/errors.go
+++ b/pkg/accessreview/errors.go
@@ -25,8 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"reflect"
-	"slices"
 	"strings"
 
 	"github.com/aws/smithy-go"
@@ -194,54 +192,16 @@ func (e *ProbeError) Unwrap() error {
 	return e.Err
 }
 
-// isNilError reports whether err is nil, or whether its chain holds a typed
-// nil. A typed nil panics when something calls its Unwrap, which errors.AsType
-// does while walking, so the classifiers below screen the chain first: they run
-// while logging a failure, where a panic costs more than a coarse answer. Each
-// node is checked before it is unwrapped, so the screen cannot trip over the
-// value it is looking for.
-func isNilError(err error) bool {
-	if err == nil {
-		return true
-	}
-
-	switch value := reflect.ValueOf(err); value.Kind() {
-	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
-		if value.IsNil() {
-			return true
-		}
-	}
-
-	switch unwrapper := err.(type) {
-	case interface{ Unwrap() error }:
-		cause := unwrapper.Unwrap()
-		if cause == nil {
-			// A real error that simply wraps nothing, not a nil one.
-			return false
-		}
-
-		return isNilError(cause)
-
-	case interface{ Unwrap() []error }:
-		if slices.ContainsFunc(unwrapper.Unwrap(), isNilError) {
-			return true
-		}
-	}
-
-	return false
-}
-
 // IsProviderVerdict reports whether err is the provider's answer rather than a
 // failure on Probo's side. Only a rejected credential, a transport failure that
 // reached the provider, and a refused token refresh qualify. Everything else a
 // probe can return (settings that will not decode, a request that could not be
 // built, a registry misconfiguration) is ours, so the default is to treat a
 // failure as Probo's and report it in full.
+//
+// Walks the error chain, so a typed nil in it would panic. No caller can build
+// one, and guarding it cost more than it saved.
 func IsProviderVerdict(err error) bool {
-	if isNilError(err) {
-		return false
-	}
-
 	// Checked before any verdict: our own deadline expiring is never the
 	// provider's answer, even when it is joined with one.
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -279,12 +239,9 @@ func IsProviderVerdict(err error) bool {
 // ProbeFailureCode reduces a probe failure to a token safe to log. Probe
 // errors wrap text Probo does not control (an OAuth error_description, a
 // response body, a customer's self-hosted host), so anything unrecognised
-// degrades to its Go type rather than being quoted.
+// degrades to its Go type rather than being quoted. Walks the chain on the
+// same terms as IsProviderVerdict.
 func ProbeFailureCode(err error) string {
-	if isNilError(err) {
-		return "none"
-	}
-
 	// Guarded against a typed nil: this runs on a logging path, where a panic
 	// would cost more than the lost detail.
 	if rejected, ok := errors.AsType[*provider.CredentialRejectedError](err); ok && rejected != nil {

--- a/pkg/accessreview/probe_error_test.go
+++ b/pkg/accessreview/probe_error_test.go
@@ -98,30 +98,29 @@ func TestProbeFailureCodeIsSafeToLog(t *testing.T) {
 	assert.NotContains(t, awsCode, "123456789012")
 }
 
-func TestIsProviderVerdictSurvivesTypedNilURLError(t *testing.T) {
+// nilMatchingError reports a match while assigning a nil value, which is what
+// a custom As is free to do. errors.AsType then returns ok with a nil pointer,
+// so the classifiers guard the dereference that follows.
+type nilMatchingError struct{}
+
+func (nilMatchingError) Error() string { return "assigns a nil match" }
+
+func (nilMatchingError) As(target any) bool {
+	pointer, ok := target.(**url.Error)
+	if !ok {
+		return false
+	}
+
+	*pointer = nil
+
+	return true
+}
+
+func TestIsProviderVerdictGuardsANilMatch(t *testing.T) {
 	t.Parallel()
 
-	// errors.Is unwraps, and (*url.Error).Unwrap dereferences its receiver,
-	// so a typed nil must be caught before any sentinel comparison.
-	var urlErr *url.Error
-
-	assert.NotPanics(t, func() { accessreview.IsProviderVerdict(urlErr) })
-	assert.False(t, accessreview.IsProviderVerdict(urlErr))
-
-	// Also when it sits deeper in the chain, where the traversal would reach
-	// it rather than the screen catching it at the top.
-	wrapped := fmt.Errorf("cannot probe: %w", urlErr)
-
-	assert.NotPanics(t, func() { accessreview.IsProviderVerdict(wrapped) })
-	assert.False(t, accessreview.IsProviderVerdict(wrapped))
-	assert.NotPanics(t, func() { accessreview.ProbeFailureCode(wrapped) })
-
-	// A typed nil joined alongside a real error is still reachable by the
-	// traversal, so the screen follows multi-error children too.
-	joined := errors.Join(errors.New("other"), urlErr)
-
-	assert.NotPanics(t, func() { accessreview.IsProviderVerdict(joined) })
-	assert.NotPanics(t, func() { accessreview.ProbeFailureCode(joined) })
+	assert.NotPanics(t, func() { accessreview.IsProviderVerdict(nilMatchingError{}) })
+	assert.False(t, accessreview.IsProviderVerdict(nilMatchingError{}))
 }
 
 func TestIsProviderVerdictExcludesCancellationJoinedWithAVerdict(t *testing.T) {


### PR DESCRIPTION
Follow-up to #1789, removing `isNilError`.

It walked an error's whole chain looking for a typed nil, which panics when `errors.AsType` calls `Unwrap` on it while traversing.

**Nothing produces one.** `http.Client` always returns a real `*url.Error`, no probe constructs a nil error value, and reaching the guarded state requires code that deliberately returns a nil pointer as an error.

It was not free. It grew over several review rounds to cover every nil-able reflect kind and both `Unwrap` forms, and along the way it returned `true` for an error that simply wrapped nothing, silently suppressing the classification it exists to protect. A guard against an unreachable failure caused a reachable one.

**What stays:** the one-line guards at each dereference (`urlErr == nil`, `ok && rejected != nil`). Those are a different thing from the chain screen: a custom `As` may report a match while assigning nil, and they cost a nil comparison rather than a reflective walk. `TestIsProviderVerdictGuardsANilMatch` now covers that path directly, using an error whose `As` assigns a nil `*url.Error`; the deleted chain test had been standing in for it. Mutation-checked: removing the guard fails it.

`TestIsProviderVerdictStillClassifiesAnErrorWrappingNothing` stays as the regression test for the bug the chain screen caused.

Verification: `go build`, `go test ./pkg/accessreview/... ./pkg/connector/...`, `go fix`, `gofmt`, `golangci-lint` all clean.