### PR TITLE
Link the documented access-review connectors to their pages

### DIFF
--- a/e2e/console/connector_test.go
+++ b/e2e/console/connector_test.go
@@ -129,7 +129,23 @@ func TestAccessReviewDrivers(t *testing.T) {
 		assert.Equal(t, "https://www.probo.com/docs/product/access-review/anthropic", *url)
 	}
 
-	assert.Nil(t, docURLByProvider["BREX"], "BREX has no doc page, documentationUrl must be null")
+	// A slug that is not the lowercased enum is the case worth pinning: Cal.com
+	// publishes at /calcom, so deriving the URL from CAL_COM would 404.
+	if url := docURLByProvider["CAL_COM"]; assert.NotNil(t, url) {
+		assert.Equal(t, "https://www.probo.com/docs/product/access-review/calcom", *url)
+	}
+
+	// AWS carries the null case because it is the one provider that cannot
+	// acquire a doc page by being written: access review for it is not
+	// implemented, and the console still renders it as coming soon. Any
+	// provider picked here purely for being undocumented today gets documented
+	// eventually and breaks this assertion, as BREX did.
+	//
+	// Contains first: a bare Nil on a missing key passes whether or not the
+	// field is really null, which would let the null path rot unnoticed. AWS is
+	// a workload identity provider, so the catalog never skips it.
+	require.Contains(t, docURLByProvider, "AWS")
+	assert.Nil(t, docURLByProvider["AWS"], "AWS has no doc page, documentationUrl must be null")
 
 	t.Run("viewer can list access review drivers", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/connector/provider/authentik.go
+++ b/pkg/connector/provider/authentik.go
@@ -36,8 +36,9 @@ import (
 // password a service account is created with.
 func authentikRegistration() *Registration {
 	return &Registration{
-		Provider:    coredata.ConnectorProviderAuthentik,
-		DisplayName: "authentik",
+		Provider:         coredata.ConnectorProviderAuthentik,
+		DisplayName:      "authentik",
+		DocumentationURL: accessReviewDocsURL("authentik"),
 		APIKey: &APIKeyConfig{
 			ExtraSettings: []ExtraSetting{
 				{Key: "baseUrl", Label: "Base URL", Required: true},

--- a/pkg/connector/provider/brex.go
+++ b/pkg/connector/provider/brex.go
@@ -31,8 +31,9 @@ import (
 
 func brexRegistration() *Registration {
 	return &Registration{
-		Provider:    coredata.ConnectorProviderBrex,
-		DisplayName: "Brex",
+		Provider:         coredata.ConnectorProviderBrex,
+		DisplayName:      "Brex",
+		DocumentationURL: accessReviewDocsURL("brex"),
 		Endpoints: Endpoints{
 			Auth:  "https://accounts-api.brex.com/oauth2/default/v1/authorize",
 			Token: "https://accounts-api.brex.com/oauth2/default/v1/token",

--- a/pkg/connector/provider/calcom.go
+++ b/pkg/connector/provider/calcom.go
@@ -31,9 +31,10 @@ import (
 
 func calComRegistration() *Registration {
 	return &Registration{
-		Provider:    coredata.ConnectorProviderCalCom,
-		DisplayName: "Cal.com",
-		APIKey:      &APIKeyConfig{},
+		Provider:         coredata.ConnectorProviderCalCom,
+		DisplayName:      "Cal.com",
+		DocumentationURL: accessReviewDocsURL("calcom"),
+		APIKey:           &APIKeyConfig{},
 		Endpoints: Endpoints{
 			Auth:    "https://app.cal.com/auth/oauth2/authorize",
 			Token:   "https://api.cal.com/v2/auth/oauth2/token",

--- a/pkg/connector/provider/calendly.go
+++ b/pkg/connector/provider/calendly.go
@@ -31,9 +31,10 @@ import (
 
 func calendlyRegistration() *Registration {
 	return &Registration{
-		Provider:    coredata.ConnectorProviderCalendly,
-		DisplayName: "Calendly",
-		APIKey:      &APIKeyConfig{},
+		Provider:         coredata.ConnectorProviderCalendly,
+		DisplayName:      "Calendly",
+		DocumentationURL: accessReviewDocsURL("calendly"),
+		APIKey:           &APIKeyConfig{},
 		Endpoints: Endpoints{
 			Auth:    "https://auth.calendly.com/oauth/authorize",
 			Token:   "https://auth.calendly.com/oauth/token",

--- a/pkg/connector/provider/github.go
+++ b/pkg/connector/provider/github.go
@@ -32,8 +32,9 @@ import (
 
 func githubRegistration() *Registration {
 	return &Registration{
-		Provider:    coredata.ConnectorProviderGitHub,
-		DisplayName: "GitHub",
+		Provider:         coredata.ConnectorProviderGitHub,
+		DisplayName:      "GitHub",
+		DocumentationURL: accessReviewDocsURL("github"),
 		Endpoints: Endpoints{
 			Auth:  "https://github.com/login/oauth/authorize",
 			Token: "https://github.com/login/oauth/access_token",


### PR DESCRIPTION
> **Merge getprobo/probo.com#94 first.** This PR adds `DocumentationURL: accessReviewDocsURL("authentik")`, and `authentik.mdx` does not exist on the docs site's `v2` branch until that PR lands. Merging this first points the console at a 404. The other four slugs already have published pages, so authentik is the only order-sensitive one.

## Why

Every documented access-review connector should carry a `DocumentationURL` so the connections list can render a link to its setup guide (`ConnectorDocumentationLink` in `AccessReviewSourceProviderListItem.tsx`, fed by `ConnectorProviderInfo.documentationUrl`). Five connectors were missing it.

## What

| Connector | Page | Was |
| --- | --- | --- |
| authentik | `/docs/product/access-review/authentik` | No page, no link |
| Brex | `/docs/product/access-review/brex` | Page existed, no link |
| Cal.com | `/docs/product/access-review/calcom` | Page existed, no link |
| Calendly | `/docs/product/access-review/calendly` | Page existed, no link |
| GitHub | `/docs/product/access-review/github` | Page existed, no link |

Nuki already had its line and needed no change. That was the other half of the problem: `nuki.go` has pointed at `/docs/product/access-review/nuki` since it shipped, but the page did not exist, so the console linked to a 404. The companion PR adds it.

After this change, every connector with a published page carries its URL, and every `DocumentationURL` in the registry resolves to a real page.

Companion docs PR: https://github.com/getprobo/probo.com/pull/94

## The test this broke

`TestAccessReviewDrivers` pinned **BREX** as its example of a provider whose `documentationUrl` is null, so documenting Brex turned that assertion into a failure:

```
FAIL: TestAccessReviewDrivers  connector_test.go:132
  Expected nil, but got: (*string)(...)
  Messages: BREX has no doc page, documentationUrl must be null
```

**AWS** replaces it. Access review for AWS is not implemented and the console still renders it as coming soon, so it cannot acquire a page by someone writing one, which is exactly how BREX stopped qualifying. The assertion now does `require.Contains` before asserting null: a bare `assert.Nil` on an absent key passes whether or not the field is really null, so the null path could have rotted unnoticed. AWS is a workload identity provider, and `base_resolvers.go` never skips those from the catalog, so the key is always present.

**Cal.com** is pinned alongside Anthropic on the positive side. Its slug is `calcom` rather than the lowercased `CAL_COM`, so it is the case that would break first if a URL were ever derived from the provider name instead of passed explicitly.

## Verification

- `go build ./pkg/connector/...` passes
- `go test ./pkg/connector/provider/` passes
- `go vet ./e2e/console/` passes, `go test -c ./e2e/console/` compiles
- `gofmt` clean
- Rebased onto `main` (`e67775aac`); CI green including `test-e2e`

## Review note

gearnode's approval was given on `a7969a20a`, which contained only the authentik line. Five of the six files here postdate it, including the whole test change this PR is about. Worth a fresh look rather than merging on that approval.
