### PR TITLE
Show the document title in the browser tab

### DIFF
--- a/apps/console/src/pages/organizations/documents/DocumentLayout.tsx
+++ b/apps/console/src/pages/organizations/documents/DocumentLayout.tsx
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import { usePageTitle } from "@probo/hooks";
 import { Badge, Button, IconUpload, PageHeader, TabBadge, TabLink, Tabs } from "@probo/ui";
 import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -42,6 +43,7 @@ export const documentLayoutQuery = graphql`
       ... on DocumentVersion {
         id
         status
+        title
         ...DocumentTitleFormFragment
         ...DocumentActionsDropdown_versionFragment
         ...DocumentDetailsCard_versionFragment
@@ -86,6 +88,7 @@ export const documentLayoutQuery = graphql`
             node {
               id
               status
+              title
               ...DocumentTitleFormFragment
               ...DocumentActionsDropdown_versionFragment
               ...DocumentDetailsCard_versionFragment
@@ -157,6 +160,8 @@ export function DocumentLayout(props: { queryRef: PreloadedQuery<DocumentLayoutQ
   const hasApprovals = lastQuorum != null;
 
   const currentTab = location.pathname.split("/").at(-1);
+
+  usePageTitle(currentVersion.title);
 
   // For changes on the current version (type, classification, title, content).
   // Refreshes layout data but does NOT remount the editor.


### PR DESCRIPTION
Every document tab rendered under `DocumentLayout` (description, controls, approvals, signatures) kept the static `Probo Console` title from `index.html`, so several documents open at once are indistinguishable in the browser tab strip.

`DocumentLayout` now calls the existing `usePageTitle` hook with the current version's title, matching what the risk, measure, third-party and campaign detail pages already do. The title comes from the version already loaded by `DocumentLayoutQuery`, so no extra request — just `title` added to the two `DocumentVersion` selections.

Verified: `make relay`, `npm run check -w @probo/console`, `eslint` on the changed file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets the browser tab title to the current document's title for every tab rendered under `DocumentLayout`, so several open documents are no longer indistinguishable in the tab strip. The title comes from the version already loaded by the query, so no extra request is needed.

### App: console **`+5`** **`-0`**

- Calls `usePageTitle` with the current version's title and adds `title` to the two `DocumentVersion` selections.

<sup>Written for commit c39dcee133f85e64e80bbab465419487469f0e76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

