### PR TITLE
Add backlog, canceled, and duplicate task states

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -766,14 +766,14 @@
       "timeEstimate": { "label": "Time estimate" },
       "deadline": { "label": "Deadline" }
     },
-    "states": { "todo": "To do", "inProgress": "In progress", "done": "Done" },
+    "states": { "backlog": "Backlog", "todo": "To do", "inProgress": "In progress", "done": "Done", "canceled": "Canceled", "duplicate": "Duplicate" },
     "priorities": { "urgent": "Urgent", "high": "High", "medium": "Medium", "low": "Low" },
     "messages": { "created": "Task created successfully.", "updated": "Task updated successfully." },
     "errors": { "create": "Failed to create task", "update": "Failed to update task" },
     "actions": { "create": "Create task", "update": "Update task" }
   },
   "tasksCard": {
-    "states": { "all": "All", "todo": "To do", "inProgress": "In progress", "done": "Done" },
+    "states": { "all": "All", "backlog": "Backlog", "todo": "To do", "inProgress": "In progress", "done": "Done", "canceled": "Canceled", "duplicate": "Duplicate" },
     "empty": "No tasks",
     "error": { "title": "Error", "reorder": "Failed to reorder task." },
     "dragInstructions": {
@@ -781,7 +781,7 @@
       "state": "Drag and drop to reorder tasks"
     },
     "deleteConfirmation": "Are you sure you want to delete this task?",
-    "actions": { "moveToInProgress": "Move to In progress", "moveToDone": "Move to Done", "edit": "Edit", "delete": "Delete" }
+    "actions": { "moveToTodo": "Move to To do", "moveToInProgress": "Move to In progress", "moveToDone": "Move to Done", "edit": "Edit", "delete": "Delete" }
   },
   "deleteTrustCenterReferenceDialog": {
     "title": "Delete Reference",

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -1297,7 +1297,10 @@
     "states": {
       "todo": "À faire",
       "inProgress": "En cours",
-      "done": "Terminé"
+      "done": "Terminé",
+      "backlog": "Backlog",
+      "canceled": "Annulé",
+      "duplicate": "Doublon"
     },
     "priorities": {
       "urgent": "Urgente",
@@ -1323,7 +1326,10 @@
       "all": "Toutes",
       "todo": "À faire",
       "inProgress": "En cours",
-      "done": "Terminé"
+      "done": "Terminé",
+      "backlog": "Backlog",
+      "canceled": "Annulé",
+      "duplicate": "Doublon"
     },
     "empty": "Aucune tâche",
     "error": {
@@ -1336,6 +1342,7 @@
     },
     "deleteConfirmation": "Voulez-vous vraiment supprimer cette tâche ?",
     "actions": {
+      "moveToTodo": "Déplacer vers À faire",
       "moveToInProgress": "Déplacer vers En cours",
       "moveToDone": "Déplacer vers Terminé",
       "edit": "Modifier",

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -1297,7 +1297,10 @@
     "states": {
       "todo": "Te doen",
       "inProgress": "In uitvoering",
-      "done": "Voltooid"
+      "done": "Voltooid",
+      "backlog": "Backlog",
+      "canceled": "Geannuleerd",
+      "duplicate": "Duplicaat"
     },
     "priorities": {
       "urgent": "Urgent",
@@ -1323,7 +1326,10 @@
       "all": "Alle",
       "todo": "Te doen",
       "inProgress": "In uitvoering",
-      "done": "Voltooid"
+      "done": "Voltooid",
+      "backlog": "Backlog",
+      "canceled": "Geannuleerd",
+      "duplicate": "Duplicaat"
     },
     "empty": "Geen taken",
     "error": {
@@ -1336,6 +1342,7 @@
     },
     "deleteConfirmation": "Weet u zeker dat u deze taak wilt verwijderen?",
     "actions": {
+      "moveToTodo": "Verplaatsen naar Te doen",
       "moveToInProgress": "Verplaatsen naar In uitvoering",
       "moveToDone": "Verplaatsen naar Voltooid",
       "edit": "Bewerken",

--- a/apps/console/src/components/tasks/TaskFormDialog.tsx
+++ b/apps/console/src/components/tasks/TaskFormDialog.tsx
@@ -99,12 +99,13 @@ export const taskUpdateMutation = graphql`
   }
 `;
 
-export const taskStates = ["TODO", "IN_PROGRESS", "DONE"] as const;
+export const taskStates = ["BACKLOG", "TODO", "IN_PROGRESS", "DONE", "CANCELED", "DUPLICATE"] as const;
 export const taskPriorities = ["URGENT", "HIGH", "MEDIUM", "LOW"] as const;
 
 const createTaskSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional().nullable(),
+  state: z.enum(taskStates),
   priority: z.enum(taskPriorities),
   timeEstimate: z.string().optional().nullable(),
   assignedToId: z.string().optional().nullable(),
@@ -217,6 +218,7 @@ export default function TaskFormDialog(props: Props) {
             organizationId,
             name: data.name,
             description: data.description || null,
+            state: "state" in data ? data.state : undefined,
             priority: data.priority,
             timeEstimate: data.timeEstimate || null,
             deadline: formatDatetime(data.deadline) ?? null,
@@ -271,42 +273,58 @@ export default function TaskFormDialog(props: Props) {
           {/* Properties form */}
           <div className="py-5 px-6 bg-subtle">
             <Label>{t("taskFormDialog.properties")}</Label>
-            {isUpdating && (
-              <PropertyRow
-                label={t("taskFormDialog.fields.state.label")}
-                error={"state" in formState.errors ? formState.errors.state?.message : undefined}
-              >
-                <Controller
-                  name="state"
-                  control={control}
-                  render={({ field }) => (
-                    <Select
-                      value={field.value}
-                      onValueChange={field.onChange}
-                    >
-                      <Option value="TODO">
-                        <span className="flex items-center gap-2">
-                          <TaskStateIcon state="TODO" />
-                          {t("taskFormDialog.states.todo")}
-                        </span>
-                      </Option>
-                      <Option value="IN_PROGRESS">
-                        <span className="flex items-center gap-2">
-                          <TaskStateIcon state="IN_PROGRESS" />
-                          {t("taskFormDialog.states.inProgress")}
-                        </span>
-                      </Option>
-                      <Option value="DONE">
-                        <span className="flex items-center gap-2">
-                          <TaskStateIcon state="DONE" />
-                          {t("taskFormDialog.states.done")}
-                        </span>
-                      </Option>
-                    </Select>
-                  )}
-                />
-              </PropertyRow>
-            )}
+            <PropertyRow
+              label={t("taskFormDialog.fields.state.label")}
+              error={"state" in formState.errors ? formState.errors.state?.message : undefined}
+            >
+              <Controller
+                name="state"
+                control={control}
+                render={({ field }) => (
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                  >
+                    <Option value="BACKLOG">
+                      <span className="flex items-center gap-2">
+                        <TaskStateIcon state="BACKLOG" />
+                        {t("taskFormDialog.states.backlog")}
+                      </span>
+                    </Option>
+                    <Option value="TODO">
+                      <span className="flex items-center gap-2">
+                        <TaskStateIcon state="TODO" />
+                        {t("taskFormDialog.states.todo")}
+                      </span>
+                    </Option>
+                    <Option value="IN_PROGRESS">
+                      <span className="flex items-center gap-2">
+                        <TaskStateIcon state="IN_PROGRESS" />
+                        {t("taskFormDialog.states.inProgress")}
+                      </span>
+                    </Option>
+                    <Option value="DONE">
+                      <span className="flex items-center gap-2">
+                        <TaskStateIcon state="DONE" />
+                        {t("taskFormDialog.states.done")}
+                      </span>
+                    </Option>
+                    <Option value="CANCELED">
+                      <span className="flex items-center gap-2">
+                        <TaskStateIcon state="CANCELED" />
+                        {t("taskFormDialog.states.canceled")}
+                      </span>
+                    </Option>
+                    <Option value="DUPLICATE">
+                      <span className="flex items-center gap-2">
+                        <TaskStateIcon state="DUPLICATE" />
+                        {t("taskFormDialog.states.duplicate")}
+                      </span>
+                    </Option>
+                  </Select>
+                )}
+              />
+            </PropertyRow>
             <PropertyRow
               label={t("taskFormDialog.fields.priority.label")}
               error={formState.errors.priority?.message}

--- a/apps/console/src/components/tasks/TasksCard.tsx
+++ b/apps/console/src/components/tasks/TasksCard.tsx
@@ -27,6 +27,7 @@ import {
   IconCircleCheck,
   IconCircleProgress,
   IconPencil,
+  IconRadioUnchecked,
   IconTrashCan,
   PriorityLevel,
   TabBadge,
@@ -64,10 +65,13 @@ import type {
 import type { TasksCardOrganizationQuery } from "#/__generated__/core/TasksCardOrganizationQuery.graphql";
 import TaskFormDialog, {
   taskPriorities,
+  taskStates,
   taskUpdateMutation,
 } from "#/components/tasks/TaskFormDialog";
 import { updateStoreCounter } from "#/hooks/useMutationWithIncrement";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
+
+type TaskState = (typeof taskStates)[number];
 
 function resolveDropPriority(
   dragged: TaskPriority,
@@ -206,9 +210,12 @@ export function TasksCard({ tasks, connectionId, canReorder, refetch }: Props) {
   };
 
   const stateHashes = [
+    { hash: "backlog", label: t("tasksCard.states.backlog"), state: "BACKLOG" },
     { hash: "todo", label: t("tasksCard.states.todo"), state: "TODO" },
     { hash: "in-progress", label: t("tasksCard.states.inProgress"), state: "IN_PROGRESS" },
     { hash: "done", label: t("tasksCard.states.done"), state: "DONE" },
+    { hash: "canceled", label: t("tasksCard.states.canceled"), state: "CANCELED" },
+    { hash: "duplicate", label: t("tasksCard.states.duplicate"), state: "DUPLICATE" },
   ] as const;
 
   const hashes = [
@@ -319,7 +326,7 @@ export function TasksCard({ tasks, connectionId, canReorder, refetch }: Props) {
 
     // Determine if state changed (All tab cross-section drop).
     const newState = targetState && targetState !== draggedTask.state
-      ? targetState as "TODO" | "IN_PROGRESS" | "DONE"
+      ? targetState as TaskState
       : undefined;
 
     // Only change priority for same-state reorder, never for cross-section drops.
@@ -390,7 +397,7 @@ export function TasksCard({ tasks, connectionId, canReorder, refetch }: Props) {
 
   const displayTasks = applyPreviewOrder(filteredTasks);
 
-  const renderTaskRow = (node: (typeof tasks)[number]["node"], sectionState?: "TODO" | "IN_PROGRESS" | "DONE") => {
+  const renderTaskRow = (node: (typeof tasks)[number]["node"], sectionState?: TaskState) => {
     const task = readTask(node);
     return (
       <TaskRow
@@ -475,7 +482,7 @@ export function TasksCard({ tasks, connectionId, canReorder, refetch }: Props) {
 type TaskRowProps = {
   fKey: TasksCard_TaskRowFragment$key | TaskFormDialogFragment$key;
   connectionId: string;
-  sectionState?: "TODO" | "IN_PROGRESS" | "DONE";
+  sectionState?: TaskState;
   canDrag?: boolean;
   isDragging?: boolean;
   isGhost?: boolean;
@@ -538,11 +545,12 @@ function TaskRow(props: TaskRowProps) {
   const displayState = props.sectionState ?? task.state;
 
   const nextStepConfig: Record<string, {
-    state: "IN_PROGRESS" | "DONE";
+    state: TaskState;
     label: string;
     icon: typeof IconCircleProgress;
     className: string;
   }> = {
+    BACKLOG: { state: "TODO", label: t("tasksCard.actions.moveToTodo"), icon: IconRadioUnchecked, className: "text-txt-quaternary" },
     TODO: { state: "IN_PROGRESS", label: t("tasksCard.actions.moveToInProgress"), icon: IconCircleProgress, className: "text-txt-warning" },
     IN_PROGRESS: { state: "DONE", label: t("tasksCard.actions.moveToDone"), icon: IconCircleCheck, className: "text-txt-accent" },
   };

--- a/e2e/console/task_test.go
+++ b/e2e/console/task_test.go
@@ -41,6 +41,7 @@ func TestTask_Create(t *testing.T) {
 					node {
 						id
 						name
+						state
 					}
 				}
 			}
@@ -51,8 +52,9 @@ func TestTask_Create(t *testing.T) {
 		CreateTask struct {
 			TaskEdge struct {
 				Node struct {
-					ID   string `json:"id"`
-					Name string `json:"name"`
+					ID    string `json:"id"`
+					Name  string `json:"name"`
+					State string `json:"state"`
 				} `json:"node"`
 			} `json:"taskEdge"`
 		} `json:"createTask"`
@@ -72,6 +74,7 @@ func TestTask_Create(t *testing.T) {
 	task := result.CreateTask.TaskEdge.Node
 	assert.NotEmpty(t, task.ID)
 	assert.Equal(t, "Owner Task", task.Name)
+	assert.Equal(t, "TODO", task.State)
 }
 
 func TestTask_CreateWithoutMeasure(t *testing.T) {
@@ -327,12 +330,53 @@ func TestTask_StateEnum(t *testing.T) {
 		Create()
 
 	states := []string{
+		"BACKLOG",
 		"TODO",
 		"IN_PROGRESS",
 		"DONE",
+		"CANCELED",
+		"DUPLICATE",
 	}
 
 	for _, state := range states {
+		t.Run("create with state "+state, func(t *testing.T) {
+			query := `
+				mutation CreateTask($input: CreateTaskInput!) {
+					createTask(input: $input) {
+						taskEdge {
+							node {
+								id
+								state
+							}
+						}
+					}
+				}
+			`
+
+			var result struct {
+				CreateTask struct {
+					TaskEdge struct {
+						Node struct {
+							ID    string `json:"id"`
+							State string `json:"state"`
+						} `json:"node"`
+					} `json:"taskEdge"`
+				} `json:"createTask"`
+			}
+
+			err := owner.Execute(query, map[string]any{
+				"input": map[string]any{
+					"organizationId": owner.GetOrganizationID().String(),
+					"measureId":      measureID,
+					"name":           "Create State " + state,
+					"priority":       "MEDIUM",
+					"state":          state,
+				},
+			}, &result)
+			require.NoError(t, err, "State %s should be valid on create", state)
+			assert.Equal(t, state, result.CreateTask.TaskEdge.Node.State)
+		})
+
 		t.Run("update to state "+state, func(t *testing.T) {
 			taskID := factory.NewTask(owner, measureID).
 				WithName("State Test " + state).

--- a/packages/n8n-node/nodes/Probo/actions/task/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/task/create.operation.ts
@@ -77,6 +77,45 @@ export const description: INodeProperties[] = [
 		description: 'The description of the task',
 	},
 	{
+		displayName: 'State',
+		name: 'state',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: ['task'],
+				operation: ['create'],
+			},
+		},
+		options: [
+			{
+				name: 'Backlog',
+				value: 'BACKLOG',
+			},
+			{
+				name: 'Canceled',
+				value: 'CANCELED',
+			},
+			{
+				name: 'Done',
+				value: 'DONE',
+			},
+			{
+				name: 'Duplicate',
+				value: 'DUPLICATE',
+			},
+			{
+				name: 'In Progress',
+				value: 'IN_PROGRESS',
+			},
+			{
+				name: 'Todo',
+				value: 'TODO',
+			},
+		],
+		default: 'TODO',
+		description: 'The state of the task',
+	},
+	{
 		displayName: 'Priority',
 		name: 'priority',
 		type: 'options',
@@ -156,6 +195,7 @@ export async function execute(
 	const measureId = this.getNodeParameter('measureId', itemIndex, '') as string;
 	const name = this.getNodeParameter('name', itemIndex) as string;
 	const description = this.getNodeParameter('description', itemIndex, '') as string;
+	const state = this.getNodeParameter('state', itemIndex, '') as string;
 	const priority = this.getNodeParameter('priority', itemIndex, '') as string;
 	const timeEstimate = this.getNodeParameter('timeEstimate', itemIndex, '') as string;
 	const assignedToId = this.getNodeParameter('assignedToId', itemIndex, '') as string;
@@ -187,6 +227,7 @@ export async function execute(
 			name,
 			...(measureId && { measureId }),
 			...(description && { description }),
+			...(state && { state }),
 			...(priority && { priority }),
 			...(timeEstimate && { timeEstimate }),
 			...(assignedToId && { assignedToId }),

--- a/packages/n8n-node/nodes/Probo/actions/task/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/task/update.operation.ts
@@ -78,16 +78,28 @@ export const description: INodeProperties[] = [
 				value: '',
 			},
 			{
-				name: 'Todo',
-				value: 'TODO',
+				name: 'Backlog',
+				value: 'BACKLOG',
+			},
+			{
+				name: 'Canceled',
+				value: 'CANCELED',
+			},
+			{
+				name: 'Done',
+				value: 'DONE',
+			},
+			{
+				name: 'Duplicate',
+				value: 'DUPLICATE',
 			},
 			{
 				name: 'In Progress',
 				value: 'IN_PROGRESS',
 			},
 			{
-				name: 'Done',
-				value: 'DONE',
+				name: 'Todo',
+				value: 'TODO',
 			},
 		],
 		default: '',

--- a/packages/ui/src/Atoms/Icons/IconCircleSlashes.tsx
+++ b/packages/ui/src/Atoms/Icons/IconCircleSlashes.tsx
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,50 +18,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { Meta, StoryObj } from "@storybook/react";
+import type { IconProps } from "./type";
 
-import { TaskStateIcon } from "./TaskStateIcon";
-
-export default {
-  title: "Atoms/TaskStateIcon",
-  component: TaskStateIcon,
-  argTypes: {},
-} satisfies Meta<typeof TaskStateIcon>;
-
-type Story = StoryObj<typeof TaskStateIcon>;
-
-export const Backlog: Story = {
-  args: {
-    state: "BACKLOG",
-  },
-};
-
-export const Default: Story = {
-  args: {
-    state: "TODO",
-  },
-};
-
-export const InProgress: Story = {
-  args: {
-    state: "IN_PROGRESS",
-  },
-};
-
-export const Done: Story = {
-  args: {
-    state: "DONE",
-  },
-};
-
-export const Canceled: Story = {
-  args: {
-    state: "CANCELED",
-  },
-};
-
-export const Duplicate: Story = {
-  args: {
-    state: "DUPLICATE",
-  },
-};
+export function IconCircleSlashes({ size = 24, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" className={className} xmlns="http://www.w3.org/2000/svg">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2ZM6.343 13.98L7.687 15.323L15.323 7.687L13.98 6.343L6.343 13.98ZM8.677 16.313L10.02 17.657L17.657 10.02L16.313 8.677L8.677 16.313Z"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/Atoms/Icons/TaskStateIcon.tsx
+++ b/packages/ui/src/Atoms/Icons/TaskStateIcon.tsx
@@ -18,21 +18,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import { CircleDashedIcon } from "@phosphor-icons/react";
+
 import { IconCircleCheck } from "./IconCircleCheck";
 import { IconCircleProgress } from "./IconCircleProgress";
+import { IconCircleSlashes } from "./IconCircleSlashes";
+import { IconCircleX } from "./IconCircleX";
 import { IconRadioUnchecked } from "./IconRadioUnchecked";
 
+export type TaskState = "BACKLOG" | "TODO" | "IN_PROGRESS" | "DONE" | "CANCELED" | "DUPLICATE";
+
 type Props = {
-  state: "TODO" | "IN_PROGRESS" | "DONE";
+  state: TaskState;
 };
 
 export function TaskStateIcon({ state }: Props) {
   switch (state) {
+    case "BACKLOG":
+      return <CircleDashedIcon size={16} className="text-txt-quaternary" />;
     case "TODO":
       return <IconRadioUnchecked size={16} className="text-txt-quaternary" />;
     case "IN_PROGRESS":
       return <IconCircleProgress size={16} className="text-txt-warning" />;
     case "DONE":
       return <IconCircleCheck size={16} className="text-txt-accent" />;
+    case "CANCELED":
+      return <IconCircleX size={16} className="text-txt-danger" />;
+    case "DUPLICATE":
+      return <IconCircleSlashes size={16} className="text-txt-tertiary" />;
   }
 }

--- a/packages/ui/src/Atoms/Icons/index.tsx
+++ b/packages/ui/src/Atoms/Icons/index.tsx
@@ -25,6 +25,7 @@ export { IconBell2 } from "./IconBell2";
 export { IconMedal } from "./IconMedal";
 export { IconMail } from "./IconMail";
 export { IconArrowInbox1 } from "./IconArrowInbox1";
+export { IconCircleSlashes } from "./IconCircleSlashes";
 export { IconCircleX } from "./IconCircleX";
 export { IconFire3 } from "./IconFire3";
 export { IconMagnifyingGlass } from "./IconMagnifyingGlass";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -67,6 +67,7 @@ export { ControlItem } from "./Atoms/ControlItem/ControlItem";
 export { InfiniteScrollTrigger } from "./Atoms/InfiniteScrollTrigger/InfiniteScrollTrigger";
 export { PriorityLevel } from "./Atoms/PriorityLevel/PriorityLevel";
 export { TaskStateIcon } from "./Atoms/Icons/TaskStateIcon";
+export type { TaskState } from "./Atoms/Icons/TaskStateIcon";
 export { Checkbox } from "./Atoms/Checkbox/Checkbox";
 export { Toggle } from "./Atoms/Toggle/Toggle";
 export {

--- a/pkg/cmd/cmdutil/flags.go
+++ b/pkg/cmd/cmdutil/flags.go
@@ -26,12 +26,28 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/coredata"
 )
 
 const (
 	OutputJSON  = "json"
 	OutputTable = "table"
 )
+
+func TaskStates() []string {
+	states := coredata.TaskStates()
+
+	out := make([]string, len(states))
+	for i, state := range states {
+		out[i] = state.String()
+	}
+
+	return out
+}
+
+func TaskStateFlagUsage() string {
+	return "Task state: " + strings.Join(TaskStates(), ", ")
+}
 
 // AddOutputFlag registers --output / -o on cmd and returns a pointer to the
 // value. The default is "table". Callers should call ValidateOutputFlag early

--- a/pkg/cmd/task/create/create.go
+++ b/pkg/cmd/task/create/create.go
@@ -63,6 +63,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 		flagOrg          string
 		flagName         string
 		flagDescription  string
+		flagState        string
 		flagPriority     string
 		flagMeasure      string
 		flagTimeEstimate string
@@ -146,6 +147,14 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				input["description"] = flagDescription
 			}
 
+			if flagState != "" {
+				if err := cmdutil.ValidateEnum("state", flagState, cmdutil.TaskStates()); err != nil {
+					return err
+				}
+
+				input["state"] = flagState
+			}
+
 			if flagPriority != "" {
 				input["priority"] = flagPriority
 			}
@@ -194,6 +203,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
 	cmd.Flags().StringVar(&flagName, "name", "", "Task name (required)")
 	cmd.Flags().StringVar(&flagDescription, "description", "", "Task description")
+	cmd.Flags().StringVar(&flagState, "state", "", cmdutil.TaskStateFlagUsage())
 	cmd.Flags().StringVar(&flagPriority, "priority", "", "Task priority: URGENT, HIGH, MEDIUM, LOW")
 	cmd.Flags().StringVar(&flagMeasure, "measure", "", "Measure ID")
 	cmd.Flags().StringVar(&flagTimeEstimate, "time-estimate", "", "Time estimate")

--- a/pkg/cmd/task/update/update.go
+++ b/pkg/cmd/task/update/update.go
@@ -101,6 +101,10 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if cmd.Flags().Changed("state") {
+				if err := cmdutil.ValidateEnum("state", flagState, cmdutil.TaskStates()); err != nil {
+					return err
+				}
+
 				input["state"] = flagState
 			}
 
@@ -163,7 +167,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVar(&flagName, "name", "", "Task name")
 	cmd.Flags().StringVar(&flagDescription, "description", "", "Task description")
-	cmd.Flags().StringVar(&flagState, "state", "", "Task state: TODO, IN_PROGRESS, DONE")
+	cmd.Flags().StringVar(&flagState, "state", "", cmdutil.TaskStateFlagUsage())
 	cmd.Flags().StringVar(&flagPriority, "priority", "", "Task priority: URGENT, HIGH, MEDIUM, LOW")
 	cmd.Flags().StringVar(&flagTimeEstimate, "time-estimate", "", "Time estimate")
 	cmd.Flags().StringVar(&flagDeadline, "deadline", "", "Deadline")

--- a/pkg/coredata/migrations/20260828T133808Z.sql
+++ b/pkg/coredata/migrations/20260828T133808Z.sql
@@ -1,0 +1,23 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TYPE task_state ADD VALUE 'BACKLOG' BEFORE 'TODO';
+ALTER TYPE task_state ADD VALUE 'CANCELED';
+ALTER TYPE task_state ADD VALUE 'DUPLICATE';

--- a/pkg/coredata/task_state.go
+++ b/pkg/coredata/task_state.go
@@ -30,9 +30,12 @@ type (
 )
 
 const (
+	TaskStateBacklog    TaskState = "BACKLOG"
 	TaskStateTodo       TaskState = "TODO"
 	TaskStateInProgress TaskState = "IN_PROGRESS"
 	TaskStateDone       TaskState = "DONE"
+	TaskStateCanceled   TaskState = "CANCELED"
+	TaskStateDuplicate  TaskState = "DUPLICATE"
 )
 
 var (
@@ -43,18 +46,24 @@ var (
 
 func TaskStates() []TaskState {
 	return []TaskState{
+		TaskStateBacklog,
 		TaskStateTodo,
 		TaskStateInProgress,
 		TaskStateDone,
+		TaskStateCanceled,
+		TaskStateDuplicate,
 	}
 }
 
 func (v TaskState) IsValid() bool {
 	switch v {
 	case
+		TaskStateBacklog,
 		TaskStateTodo,
 		TaskStateInProgress,
-		TaskStateDone:
+		TaskStateDone,
+		TaskStateCanceled,
+		TaskStateDuplicate:
 		return true
 	}
 

--- a/pkg/probo/task_service.go
+++ b/pkg/probo/task_service.go
@@ -44,6 +44,7 @@ type (
 		MeasureID      *gid.GID
 		Name           string
 		Description    *string
+		State          *coredata.TaskState
 		Priority       coredata.TaskPriority
 		TimeEstimate   *time.Duration
 		AssignedToID   *gid.GID
@@ -71,6 +72,7 @@ func (ctr *CreateTaskRequest) Validate() error {
 	v.Check(ctr.MeasureID, "measure_id", validator.GID(coredata.MeasureEntityType))
 	v.Check(ctr.Name, "name", validator.SafeTextNoNewLine(TitleMaxLength))
 	v.Check(ctr.Description, "description", validator.SafeText(ContentMaxLength))
+	v.Check(ctr.State, "state", validator.OneOfSlice(coredata.TaskStates()))
 	v.Check(ctr.Priority, "priority", validator.Required(), validator.OneOfSlice(coredata.TaskPriorities()))
 	v.Check(ctr.TimeEstimate, "time_estimate", validator.RangeDuration(0, 1000*time.Hour))
 	v.Check(ctr.AssignedToID, "assigned_to_id", validator.GID(coredata.MembershipProfileEntityType))
@@ -110,6 +112,11 @@ func (s TaskService) Create(
 		return nil, fmt.Errorf("cannot generate reference id: %w", err)
 	}
 
+	state := coredata.TaskStateTodo
+	if req.State != nil {
+		state = *req.State
+	}
+
 	task := &coredata.Task{
 		ID:             taskID,
 		OrganizationID: req.OrganizationID,
@@ -120,7 +127,7 @@ func (s TaskService) Create(
 		TimeEstimate:   req.TimeEstimate,
 		AssignedToID:   req.AssignedToID,
 		Deadline:       req.Deadline,
-		State:          coredata.TaskStateTodo,
+		State:          state,
 		ReferenceID:    "custom-task-" + referenceID.String(),
 		CreatedAt:      now,
 		UpdatedAt:      now,

--- a/pkg/server/api/console/v1/graphql/task.graphql
+++ b/pkg/server/api/console/v1/graphql/task.graphql
@@ -1,7 +1,10 @@
 enum TaskState @goModel(model: "go.probo.inc/probo/pkg/coredata.TaskState") {
+    BACKLOG @goEnum(value: "go.probo.inc/probo/pkg/coredata.TaskStateBacklog")
     TODO @goEnum(value: "go.probo.inc/probo/pkg/coredata.TaskStateTodo")
     IN_PROGRESS @goEnum(value: "go.probo.inc/probo/pkg/coredata.TaskStateInProgress")
     DONE @goEnum(value: "go.probo.inc/probo/pkg/coredata.TaskStateDone")
+    CANCELED @goEnum(value: "go.probo.inc/probo/pkg/coredata.TaskStateCanceled")
+    DUPLICATE @goEnum(value: "go.probo.inc/probo/pkg/coredata.TaskStateDuplicate")
 }
 
 enum TaskPriority
@@ -91,6 +94,7 @@ input CreateTaskInput {
     measureId: ID
     name: String!
     description: String
+    state: TaskState
     priority: TaskPriority!
     timeEstimate: Duration
     assignedToId: ID

--- a/pkg/server/api/console/v1/task_resolvers.go
+++ b/pkg/server/api/console/v1/task_resolvers.go
@@ -36,6 +36,7 @@ func (r *mutationResolver) CreateTask(ctx context.Context, input types.CreateTas
 			OrganizationID: input.OrganizationID,
 			Name:           input.Name,
 			Description:    input.Description,
+			State:          input.State,
 			Priority:       input.Priority,
 			TimeEstimate:   input.TimeEstimate,
 			AssignedToID:   input.AssignedToID,

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2133,6 +2133,7 @@ func (r *Resolver) AddTaskTool(ctx context.Context, req *mcp.CallToolRequest, in
 			MeasureID:      input.MeasureID,
 			Name:           input.Name,
 			Description:    input.Description,
+			State:          input.State,
 			Priority:       priority,
 			TimeEstimate:   input.TimeEstimate,
 			Deadline:       input.Deadline,

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -6871,9 +6871,12 @@ components:
     TaskState:
       type: string
       enum:
+        - BACKLOG
         - TODO
         - IN_PROGRESS
         - DONE
+        - CANCELED
+        - DUPLICATE
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.TaskState
 
     TaskOrderField:
@@ -7069,6 +7072,10 @@ components:
             - type: "null"
               description: Not assigned
           description: Assigned to person ID
+        state:
+          $ref: "#/components/schemas/TaskState"
+          description: Task state (defaults to TODO if not specified)
+          default: TODO
         priority:
           $ref: "#/components/schemas/TaskPriority"
           description: Task priority level (defaults to MEDIUM if not specified)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `BACKLOG`, `CANCELED`, and `DUPLICATE` task states across storage, APIs, clients, and the UI. New tasks still default to `TODO` when no state is supplied, while callers can now create or update tasks in any state.

### Tests **`+46`** **`-2`**

Creates tasks in every supported state and confirms the default `TODO` state when none is given.

### Coredata **`+33`** **`-1`**

Adds the new enum values via migration and validates them alongside the existing states.

### GraphQL API **`+5`** **`-0`**

Exposes the new states and accepts an optional `state` on task creation.

### MCP **`+8`** **`-0`**

Adds the new states and a `state` input to the create-task tool schema and resolver.

### prb (CLI) **`+31`** **`-1`**

Adds a `--state` flag to task create, validates state on create and update, and generates flag help from the enum.

### Service **`+8`** **`-1`**

Passes an optional task state through validation and keeps `TODO` as the fallback.

### App: console **`+88`** **`-48`**

Shows all six states in task forms and board columns, adds the state selector to create, and adds a Backlog-to-To-do quick move with English, French, and Dutch translations.

### Package: ui **`+66`** **`-1`**

Adds icons, the exported `TaskState` type, and Storybook stories for the new states.

### Package: n8n-node **`+57`** **`-4`**

Adds the new states to task create and update options.

<sup>Written for commit 34562bae8520ff62c45eb6000556103693f53a8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

