### PR TITLE
Omit empty n8n user-list filter values

### DIFF
--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -1113,6 +1113,7 @@ func TestUser_List_N8nNodeQuery(t *testing.T) {
 		t.Parallel()
 
 		var result n8nListUsersResult
+
 		err := owner.ExecuteConnect(
 			n8nListUsersQuery,
 			map[string]any{
@@ -1125,6 +1126,7 @@ func TestUser_List_N8nNodeQuery(t *testing.T) {
 		require.GreaterOrEqual(t, len(result.Node.Profiles.Edges), 2)
 
 		foundOwner := false
+
 		for _, edge := range result.Node.Profiles.Edges {
 			assert.NotEmpty(t, edge.Node.ID)
 			assert.NotEmpty(t, edge.Node.FullName)
@@ -1133,10 +1135,12 @@ func TestUser_List_N8nNodeQuery(t *testing.T) {
 			assert.NotEmpty(t, edge.Node.State)
 			assert.Equal(t, owner.GetOrganizationID().String(), edge.Node.Organization.ID)
 			assert.NotEmpty(t, edge.Node.Membership.Role)
+
 			if edge.Node.Membership.Role == "OWNER" {
 				foundOwner = true
 			}
 		}
+
 		assert.True(t, foundOwner, "expected the creating owner in the n8n list payload")
 	})
 
@@ -1161,6 +1165,7 @@ func TestUser_List_N8nNodeQuery(t *testing.T) {
 		t.Parallel()
 
 		var result n8nListUsersResult
+
 		err := owner.ExecuteConnect(
 			n8nListUsersQuery,
 			map[string]any{
@@ -1174,6 +1179,7 @@ func TestUser_List_N8nNodeQuery(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.NotEmpty(t, result.Node.Profiles.Edges)
+
 		for _, edge := range result.Node.Profiles.Edges {
 			assert.Equal(t, "ACTIVE", edge.Node.State)
 		}

--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -1031,3 +1031,151 @@ func TestUser_List(t *testing.T) {
 
 	assert.GreaterOrEqual(t, result.Node.Profiles.TotalCount, 3, "Should have at least 3 members")
 }
+
+// n8nListUsersQuery is the GraphQL document sent by the n8n User → List
+// operation. Keep it in lockstep with
+// packages/n8n-node/nodes/Probo/actions/user/listUsers.operation.ts.
+const n8nListUsersQuery = `
+	query ListUsers($organizationId: ID!, $first: Int, $after: CursorKey, $orderBy: ProfileOrder, $filter: ProfileFilter) {
+		node(id: $organizationId) {
+			... on Organization {
+				profiles(first: $first, after: $after, orderBy: $orderBy, filter: $filter) {
+					edges {
+						node {
+							id
+							fullName
+							emailAddress
+							source
+							state
+							additionalEmailAddresses
+							kind
+							position
+							contract {
+								start
+								end
+							}
+							createdAt
+							updatedAt
+							organization { id name }
+							membership { id role createdAt }
+						}
+					}
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+				}
+			}
+		}
+	}
+`
+
+type n8nListUsersResult struct {
+	Node struct {
+		Profiles struct {
+			Edges []struct {
+				Node struct {
+					ID           string  `json:"id"`
+					FullName     string  `json:"fullName"`
+					EmailAddress string  `json:"emailAddress"`
+					Source       string  `json:"source"`
+					State        string  `json:"state"`
+					Kind         *string `json:"kind"`
+					Organization struct {
+						ID   string `json:"id"`
+						Name string `json:"name"`
+					} `json:"organization"`
+					Membership struct {
+						ID   string `json:"id"`
+						Role string `json:"role"`
+					} `json:"membership"`
+				} `json:"node"`
+			} `json:"edges"`
+			PageInfo struct {
+				HasNextPage bool    `json:"hasNextPage"`
+				EndCursor   *string `json:"endCursor"`
+			} `json:"pageInfo"`
+		} `json:"profiles"`
+	} `json:"node"`
+}
+
+// TestUser_List_N8nNodeQuery is a non-regression test for ENG-798: the n8n
+// User → List operation failed with HTTP 422 after ProfileFilter.states became
+// a multi-value enum. An empty States control in n8n 2.x can yield [""], which
+// GraphQL rejects. The node must omit that filter; the query itself must stay
+// valid against the Connect schema, including Period contract fields.
+func TestUser_List_N8nNodeQuery(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	testutil.NewClientInOrg(t, testutil.RoleEmployee, owner)
+
+	t.Run("lists users with the n8n selection set", func(t *testing.T) {
+		t.Parallel()
+
+		var result n8nListUsersResult
+		err := owner.ExecuteConnect(
+			n8nListUsersQuery,
+			map[string]any{
+				"organizationId": owner.GetOrganizationID().String(),
+				"first":          100,
+			},
+			&result,
+		)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(result.Node.Profiles.Edges), 2)
+
+		foundOwner := false
+		for _, edge := range result.Node.Profiles.Edges {
+			assert.NotEmpty(t, edge.Node.ID)
+			assert.NotEmpty(t, edge.Node.FullName)
+			assert.NotEmpty(t, edge.Node.EmailAddress)
+			assert.NotEmpty(t, edge.Node.Source)
+			assert.NotEmpty(t, edge.Node.State)
+			assert.Equal(t, owner.GetOrganizationID().String(), edge.Node.Organization.ID)
+			assert.NotEmpty(t, edge.Node.Membership.Role)
+			if edge.Node.Membership.Role == "OWNER" {
+				foundOwner = true
+			}
+		}
+		assert.True(t, foundOwner, "expected the creating owner in the n8n list payload")
+	})
+
+	t.Run("rejects an empty string in states", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := owner.DoConnect(
+			n8nListUsersQuery,
+			map[string]any{
+				"organizationId": owner.GetOrganizationID().String(),
+				"first":          100,
+				"filter": map[string]any{
+					"states": []string{""},
+				},
+			},
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ProfileState")
+	})
+
+	t.Run("filters by a valid state", func(t *testing.T) {
+		t.Parallel()
+
+		var result n8nListUsersResult
+		err := owner.ExecuteConnect(
+			n8nListUsersQuery,
+			map[string]any{
+				"organizationId": owner.GetOrganizationID().String(),
+				"first":          100,
+				"filter": map[string]any{
+					"states": []string{"ACTIVE"},
+				},
+			},
+			&result,
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, result.Node.Profiles.Edges)
+		for _, edge := range result.Node.Profiles.Edges {
+			assert.Equal(t, "ACTIVE", edge.Node.State)
+		}
+	})
+}

--- a/packages/n8n-node/CHANGELOG.md
+++ b/packages/n8n-node/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the `@probo/n8n-nodes-probo` package will be documented i
 
 ## Unreleased
 
+### Fixed
+
+- User `List` no longer sends empty or unknown `States` / `Role` / `Type`
+  values. n8n 2.x can yield `[""]` from an untouched multi-select, which the
+  API rejects with HTTP 422 and blocked workflows that list users to send
+  policies to new employees
+
 ## [0.223.0] - 2026-08-27
 
 ### Added

--- a/packages/n8n-node/nodes/Probo/GenericFunctions.ts
+++ b/packages/n8n-node/nodes/Probo/GenericFunctions.ts
@@ -30,6 +30,72 @@ import { NodeApiError } from 'n8n-workflow';
 
 import { version } from '../../package.json';
 
+function graphqlErrorMessages(errors: IDataObject[]): string {
+	return errors
+		.map((err) => (typeof err.message === 'string' && err.message) || JSON.stringify(err))
+		.join('; ');
+}
+
+function graphqlErrorsFromUnknown(
+	value: unknown,
+	seen: Set<unknown> = new Set(),
+): IDataObject[] | undefined {
+	if (!value || typeof value !== 'object' || seen.has(value)) {
+		return undefined;
+	}
+
+	seen.add(value);
+
+	const record = value as IDataObject;
+	if (Array.isArray(record.errors)) {
+		return record.errors as IDataObject[];
+	}
+
+	for (const key of ['data', 'body', 'response', 'error', 'cause'] as const) {
+		const nested = graphqlErrorsFromUnknown(record[key], seen);
+		if (nested) {
+			return nested;
+		}
+	}
+
+	return undefined;
+}
+
+function graphqlErrorMessagesFromHttpError(error: unknown): string | undefined {
+	const errors = graphqlErrorsFromUnknown(error);
+	if (!errors || errors.length === 0) {
+		return undefined;
+	}
+
+	return graphqlErrorMessages(errors);
+}
+
+function httpCodeFromError(error: unknown): string | undefined {
+	if (!error || typeof error !== 'object') {
+		return undefined;
+	}
+
+	const record = error as IDataObject;
+	if (typeof record.httpCode === 'string' || typeof record.httpCode === 'number') {
+		return String(record.httpCode);
+	}
+
+	if (typeof record.status === 'number' || typeof record.status === 'string') {
+		return String(record.status);
+	}
+
+	const response = record.response as IDataObject | undefined;
+	if (typeof response?.status === 'number' || typeof response?.status === 'string') {
+		return String(response.status);
+	}
+
+	if (typeof response?.statusCode === 'number' || typeof response?.statusCode === 'string') {
+		return String(response.statusCode);
+	}
+
+	return undefined;
+}
+
 type ApiRequestFn = (
 	this: IExecuteFunctions | IHookFunctions,
 	query: string,
@@ -69,17 +135,22 @@ async function proboGraphqlRequest(
 		);
 
 		if (response.errors && Array.isArray(response.errors) && response.errors.length > 0) {
-			const errorMessages = response.errors.map((err: IDataObject) =>
-				err.message || JSON.stringify(err)
-			).join('; ');
 			throw new NodeApiError(this.getNode(), {
-				message: `GraphQL errors: ${errorMessages}`,
+				message: `GraphQL errors: ${graphqlErrorMessages(response.errors)}`,
 				httpCode: '200',
 			} as JsonObject);
 		}
 
 		return response;
 	} catch (error) {
+		const graphqlMessage = graphqlErrorMessagesFromHttpError(error);
+		if (graphqlMessage) {
+			throw new NodeApiError(this.getNode(), {
+				message: `GraphQL errors: ${graphqlMessage}`,
+				httpCode: httpCodeFromError(error) ?? '422',
+			} as JsonObject);
+		}
+
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}
 }
@@ -250,17 +321,22 @@ export async function proboApiMultipartRequest(
 		);
 
 		if (response.errors && Array.isArray(response.errors) && response.errors.length > 0) {
-			const errorMessages = response.errors.map((err: IDataObject) =>
-				err.message || JSON.stringify(err)
-			).join('; ');
 			throw new NodeApiError(this.getNode(), {
-				message: `GraphQL errors: ${errorMessages}`,
+				message: `GraphQL errors: ${graphqlErrorMessages(response.errors)}`,
 				httpCode: '200',
 			} as JsonObject);
 		}
 
 		return response;
 	} catch (error) {
+		const graphqlMessage = graphqlErrorMessagesFromHttpError(error);
+		if (graphqlMessage) {
+			throw new NodeApiError(this.getNode(), {
+				message: `GraphQL errors: ${graphqlMessage}`,
+				httpCode: httpCodeFromError(error) ?? '422',
+			} as JsonObject);
+		}
+
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}
 }

--- a/packages/n8n-node/nodes/Probo/actions/user/listUsers.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/user/listUsers.operation.ts
@@ -26,6 +26,34 @@ import type {
 } from 'n8n-workflow';
 import { proboConnectApiRequestAllItems } from '../../GenericFunctions';
 
+const profileStates = new Set(['ACTIVE', 'DEACTIVATED', 'PENDING']);
+const membershipRoles = new Set([
+	'ADMIN',
+	'AUDITOR',
+	'COMPLIANCE_PORTAL_ACCESS_MANAGER',
+	'COMPLIANCE_PORTAL_MANAGER',
+	'EMPLOYEE',
+	'OWNER',
+	'VIEWER',
+]);
+const profileKinds = new Set(['CONTRACTOR', 'EMPLOYEE', 'SERVICE_ACCOUNT']);
+
+function stringList(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		return value.filter((item): item is string => typeof item === 'string');
+	}
+
+	if (typeof value === 'string' && value !== '') {
+		return [value];
+	}
+
+	return [];
+}
+
+function allowedValues(value: unknown, allowed: Set<string>): string[] {
+	return stringList(value).filter((item) => allowed.has(item));
+}
+
 export const description: INodeProperties[] = [
 	{
 		displayName: 'Organization ID',
@@ -154,9 +182,9 @@ export async function execute(
 	const returnAll = this.getNodeParameter('returnAll', itemIndex) as boolean;
 	const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
 	const query = this.getNodeParameter('query', itemIndex, '') as string;
-	const state = this.getNodeParameter('state', itemIndex, []) as string[];
-	const role = this.getNodeParameter('role', itemIndex, '') as string;
-	const kind = this.getNodeParameter('kind', itemIndex, '') as string;
+	const states = allowedValues(this.getNodeParameter('state', itemIndex, []), profileStates);
+	const [role] = allowedValues(this.getNodeParameter('role', itemIndex, ''), membershipRoles);
+	const [kind] = allowedValues(this.getNodeParameter('kind', itemIndex, ''), profileKinds);
 
 	const gqlQuery = `
 		query ListUsers($organizationId: ID!, $first: Int, $after: CursorKey, $orderBy: ProfileOrder, $filter: ProfileFilter) {
@@ -197,8 +225,8 @@ export async function execute(
 	if (query) {
 		filter.query = query;
 	}
-	if (state.length > 0) {
-		filter.states = state;
+	if (states.length > 0) {
+		filter.states = states;
 	}
 	if (role) {
 		filter.role = role;

--- a/pkg/server/api/connect/v1/n8n_list_users_query_test.go
+++ b/pkg/server/api/connect/v1/n8n_list_users_query_test.go
@@ -97,6 +97,6 @@ func TestN8nListUsersQuery_ValidatesAgainstConnectSchema(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	errs := validator.Validate(schema, query)
+	errs := validator.ValidateWithRules(schema, query, nil)
 	assert.Empty(t, errs, errs.Error())
 }

--- a/pkg/server/api/connect/v1/n8n_list_users_query_test.go
+++ b/pkg/server/api/connect/v1/n8n_list_users_query_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package connect_v1_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/parser"
+	"github.com/vektah/gqlparser/v2/validator"
+)
+
+// Keep this document identical to the query in
+// packages/n8n-node/nodes/Probo/actions/user/listUsers.operation.ts.
+const n8nListUsersQuery = `
+	query ListUsers($organizationId: ID!, $first: Int, $after: CursorKey, $orderBy: ProfileOrder, $filter: ProfileFilter) {
+		node(id: $organizationId) {
+			... on Organization {
+				profiles(first: $first, after: $after, orderBy: $orderBy, filter: $filter) {
+					edges {
+						node {
+							id
+							fullName
+							emailAddress
+							source
+							state
+							additionalEmailAddresses
+							kind
+							position
+							contract {
+								start
+								end
+							}
+							createdAt
+							updatedAt
+							organization { id name }
+							membership { id role createdAt }
+						}
+					}
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+				}
+			}
+		}
+	}
+`
+
+func TestN8nListUsersQuery_ValidatesAgainstConnectSchema(t *testing.T) {
+	t.Parallel()
+
+	sources := []string{
+		"schema.graphql",
+		"../../../gqlutils/directives/authentication/schema.graphql",
+		"../../../gqlutils/directives/session/schema.graphql",
+	}
+
+	astSources := make([]*ast.Source, 0, len(sources))
+	for _, path := range sources {
+		schemaSource, err := os.ReadFile(path)
+		require.NoError(t, err, "read %s", path)
+		astSources = append(astSources, &ast.Source{
+			Name:  path,
+			Input: string(schemaSource),
+		})
+	}
+
+	schema, err := gqlparser.LoadSchema(astSources...)
+	require.NoError(t, err)
+
+	query, err := parser.ParseQuery(&ast.Source{
+		Name:  "listUsers.operation.ts",
+		Input: n8nListUsersQuery,
+	})
+	require.NoError(t, err)
+
+	errs := validator.Validate(schema, query)
+	assert.Empty(t, errs, errs.Error())
+}

--- a/pkg/server/api/connect/v1/n8n_list_users_query_test.go
+++ b/pkg/server/api/connect/v1/n8n_list_users_query_test.go
@@ -22,6 +22,7 @@ package connect_v1_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,16 +73,24 @@ const n8nListUsersQuery = `
 func TestN8nListUsersQuery_ValidatesAgainstConnectSchema(t *testing.T) {
 	t.Parallel()
 
-	sources := []string{
-		"schema.graphql",
+	// schema.graphql is a generated merge (gitignored). Load the same
+	// committed sources gqlgen.yaml uses so CI can run this without Relay.
+	sources, err := filepath.Glob("graphql/*.graphql")
+	require.NoError(t, err)
+	require.NotEmpty(t, sources)
+
+	sources = append(
+		sources,
 		"../../../gqlutils/directives/authentication/schema.graphql",
 		"../../../gqlutils/directives/session/schema.graphql",
-	}
+	)
 
 	astSources := make([]*ast.Source, 0, len(sources))
+
 	for _, path := range sources {
 		schemaSource, err := os.ReadFile(path)
 		require.NoError(t, err, "read %s", path)
+
 		astSources = append(astSources, &ast.Source{
 			Name:  path,
 			Input: string(schemaSource),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes ENG-798: the n8n User → List operation failed with HTTP 422 (“Your request is invalid or could not be processed by the service”) since 26 Aug, blocking automatic send-policy workflows for new employees.

## Cause

Two stacked GraphQL validation failures (gqlgen returns HTTP 422 for both):

1. **26 Aug (Period deploy).** `ee56c4224` landed on main at 16:29 CEST and replaced `contractStartDate` / `contractEndDate` with `contract { start end }`. n8n **0.222.0** (released that morning) still requested the old fields, so List users started failing the same day the reporter last had a working run (beginning of that week). **0.223.0** (27 Aug) already uses `Period`.

2. **Empty States on 0.223.0 + n8n 2.x.** An untouched States multi-select can yield `[""]`. The node forwarded that as `ProfileFilter.states`, which fails `ProfileState` enum coercion. The Linear screenshot shows States left at the “Select” placeholder — this is the remaining 422 after 0.223.0. The same class of problem applies to Role and Type when they are empty or stale (`INACTIVE` after the pending/deactivated split).

## Fix

- Drop blank and unknown States / Role / Type values before calling Connect
- Surface GraphQL error messages from HTTP 422 responses instead of n8n’s generic “request is invalid” text
- Keep the List users document on the Connect `Period` contract fields
- Add a Connect schema validation test for the n8n List users document
- Add an e2e contract test that runs the n8n query (success path, valid `states`, and the `[""]` rejection)

## Tests

- `go test ./pkg/server/api/connect/v1 -run TestN8nListUsersQuery_ValidatesAgainstConnectSchema` — pass
- `make test-e2e E2E_TEST_FLAGS='-run TestUser_List_N8nNodeQuery'` — 4/4 pass

## How to verify

1. Install the node from this branch (or the next `@probo/n8n-nodes-probo` release after 0.223.0)
2. Run User → List with Organization ID set, Return All on, States / Role / Type left at their defaults
3. The node should return `{ users: [...] }` instead of 422

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-798](https://linear.app/probo/issue/ENG-798/fix-n8n-list-user-node-failing-with-422)

<div><a href="https://cursor.com/agents/bc-faaf89d1-d05f-4ac4-b5c4-3f9235b9f4e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-faaf89d1-d05f-4ac4-b5c4-3f9235b9f4e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes [ENG-798](https://linear.app/probo/issue/ENG-798/fix-n8n-list-user-node-failing-with-422): the n8n User → List node fails with HTTP 422 when States, Role, or Type carry empty or outdated values, blocking workflows that list users to send policies to new employees. The node now omits those values before calling Connect, and 422 responses surface the real GraphQL error in n8n instead of a generic message.

### Tests **`+265`** **`-0`**

- e2e test runs the node's exact query for the success path, a valid `states` filter, and the `[""]` rejection.
- Schema validation test keeps the node's query in sync with the Connect schema, loading the committed `graphql/*.graphql` sources because the generated merge is gitignored.

### Package: n8n-node **`+124`** **`-13`**

- n8n 2.x leaves `[""]` in the untouched States multi-select, and Role/Type can hold `INACTIVE` after the pending/deactivated split — both are rejected by the API.

<sup>Written for commit 7ac6b5a1d8ac7001d8cd2e68cabea5a82ec65b16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

