### PR TITLE
Wrap name and period in the risk analysis list

### DIFF
--- a/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysesPage.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysesPage.tsx
@@ -142,10 +142,10 @@ export default function RiskAnalysesPage({ queryRef }: RiskAnalysesPageProps) {
       <SortableTable {...pagination} refetch={refetch}>
         <Thead>
           <Tr>
-            <SortableTh field="NAME">
+            <SortableTh field="NAME" className="w-72 min-w-48">
               {t("riskAnalysesPage.columns.name")}
             </SortableTh>
-            <Th>{t("riskAnalysesPage.columns.description")}</Th>
+            <Th className="w-full">{t("riskAnalysesPage.columns.description")}</Th>
             <Th>{t("riskAnalysesPage.columns.period")}</Th>
             <Th>{t("riskAnalysesPage.columns.matrixSize")}</Th>
             <SortableTh field="CREATED_AT">

--- a/apps/console/src/pages/organizations/risks/risk-analyses/_components/RiskAnalysisListItem.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/_components/RiskAnalysisListItem.tsx
@@ -67,13 +67,30 @@ export function RiskAnalysisListItem({
     <Tr
       to={`/organizations/${organizationId}/risk-management/risk-analyses/${riskAnalysis.id}/treatment-plans`}
     >
-      <Td className="w-px whitespace-nowrap font-medium">{riskAnalysis.name}</Td>
-      <Td className="text-txt-secondary max-w-md">
-        {riskAnalysis.description || "—"}
+      <Td className="w-72 min-w-48 max-w-72 font-medium wrap-break-word">
+        {riskAnalysis.name}
       </Td>
-      <Td className="w-px whitespace-nowrap text-txt-secondary">
+      <Td className="min-w-64 w-full text-txt-secondary">
+        <span className="line-clamp-2" title={riskAnalysis.description ?? undefined}>
+          {riskAnalysis.description || "—"}
+        </span>
+      </Td>
+      <Td className="whitespace-nowrap text-txt-secondary">
         {riskAnalysis.period
-          ? `${riskAnalysis.period.start ? dateFormat(i18n.language, riskAnalysis.period.start) : "—"} – ${riskAnalysis.period.end ? dateFormat(i18n.language, riskAnalysis.period.end) : "—"}`
+          ? (
+              <span className="flex flex-col">
+                <span>
+                  {riskAnalysis.period.start
+                    ? dateFormat(i18n.language, riskAnalysis.period.start)
+                    : "—"}
+                </span>
+                <span>
+                  {riskAnalysis.period.end
+                    ? dateFormat(i18n.language, riskAnalysis.period.end)
+                    : "—"}
+                </span>
+              </span>
+            )
           : "—"}
       </Td>
       <Td className="w-px whitespace-nowrap text-txt-secondary">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [ENG-799](https://linear.app/getprobo/issue/ENG-799): long **Name** and **Period** values in the risk analysis table no longer stay on a single non-wrapping line and steal width from **Description**.

- Name wraps within a pinned narrower column (`w-72`) instead of shrink-to-fit + `whitespace-nowrap`
- Period stacks start and end on two intact lines instead of one long date range
- Description takes the remaining width and clamps to two lines, with the full text on hover

[Risk analysis table with wrapping name/period and truncated description](https://cursor.com/agents/bc-8b3f96b0-7168-4ca1-bc2f-a2ef256660e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frisk_analysis_table_balanced_columns.webp)

[risk_analysis_table_final_layout.mp4](https://cursor.com/agents/bc-8b3f96b0-7168-4ca1-bc2f-a2ef256660e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frisk_analysis_table_final_layout.mp4)

[Full description shown in hover tooltip](https://cursor.com/agents/bc-8b3f96b0-7168-4ca1-bc2f-a2ef256660e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frisk_analysis_table_description_tooltip.webp)

## Test plan

- [x] Open Risk management → Risk analyses with a mix of short and long names
- [x] Confirm long names wrap onto a few lines and the Name column stays narrower than before
- [x] Confirm period ranges show start and end on two lines without breaking mid-date
- [x] Confirm long descriptions are truncated after two lines and the full text appears in the `title` tooltip
- [x] Confirm matrix size, created date, and row actions are unchanged


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-799](https://linear.app/probo/issue/ENG-799/improve-risk-analysis-table-column-handling)

<div><a href="https://cursor.com/agents/bc-8b3f96b0-7168-4ca1-bc2f-a2ef256660e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b3f96b0-7168-4ca1-bc2f-a2ef256660e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ENG-799: long Name and Period values in the risk analysis table no longer stay on one line and steal width from Description. Name wraps within a pinned-width column, Period stacks start and end on two intact lines, and Description takes the remaining space, clamped to two lines with a hover tooltip.

### App: console **`+24`** **`-7`**

- Gives Name a pinned preferred width so long titles wrap onto a few lines instead of many skinny ones.
- Stacks Period start and end on two separate lines instead of a single long range.
- Lets Description take the remaining width and clamps it to two lines with a `title` tooltip.

<sup>Written for commit 7805ccf24c7af293ffed693265a05825518a8e42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

