### PR TITLE
Accept .log files as Measure evidence

### DIFF
--- a/packages/helpers/src/fileAccept.ts
+++ b/packages/helpers/src/fileAccept.ts
@@ -39,7 +39,7 @@ export const acceptPresentation = {
 
 export const acceptText = {
   "text/markdown": [".md"],
-  "text/plain": [".txt"],
+  "text/plain": [".txt", ".log"],
   "text/x-log": [".log"],
   "text/uri-list": [".uri"],
   "text/uri-list; charset=utf-8": [".uri"],

--- a/pkg/filevalidation/validator.go
+++ b/pkg/filevalidation/validator.go
@@ -70,7 +70,7 @@ var FileTypes = []FileType{
 
 	// Text types
 	{MimeType: "text/markdown", Extensions: []string{".md"}, Category: CategoryText},
-	{MimeType: "text/plain", Extensions: []string{".txt"}, Category: CategoryText},
+	{MimeType: "text/plain", Extensions: []string{".txt", ".log"}, Category: CategoryText},
 	{MimeType: "text/x-log", Extensions: []string{".log"}, Category: CategoryText},
 	{MimeType: "text/uri-list", Extensions: []string{".uri"}, Category: CategoryText},
 	{MimeType: "text/uri-list; charset=utf-8", Extensions: []string{".uri"}, Category: CategoryText},

--- a/pkg/filevalidation/validator_test.go
+++ b/pkg/filevalidation/validator_test.go
@@ -189,6 +189,22 @@ func TestValidate(t *testing.T) {
 			shouldError: false,
 		},
 		{
+			name:        "Log file with browser text/plain MIME",
+			validator:   NewValidator(WithCategories(CategoryText)),
+			filename:    "auth.log",
+			contentType: "text/plain",
+			fileSize:    1024,
+			shouldError: false,
+		},
+		{
+			name:        "Log file with text/x-log MIME",
+			validator:   NewValidator(WithCategories(CategoryText)),
+			filename:    "auth.log",
+			contentType: "text/x-log",
+			fileSize:    1024,
+			shouldError: false,
+		},
+		{
 			name:        "Valid with multiple categories",
 			validator:   NewValidator(WithCategories(CategoryImage, CategoryDocument)),
 			filename:    "test.jpg",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [ENG-800](https://linear.app/probo/issue/ENG-800/access-log-files-for-measurement-evidence).

`.log` was already listed as `text/x-log`, but browsers report log files as `text/plain`. The dropzone and backend validator required an exact MIME/extension pair, so uploads failed.

This change allows `text/plain` for `.log` next to the existing `text/x-log` mapping.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-800](https://linear.app/probo/issue/ENG-800/access-log-files-for-measurement-evidence)

<div><a href="https://cursor.com/agents/bc-d9b9147b-d906-4cb3-83c6-8a2a27d07e72?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9b9147b-d906-4cb3-83c6-8a2a27d07e72&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes [ENG-800](https://linear.app/probo/issue/ENG-800/access-log-files-for-measurement-evidence). `.log` files failed to upload as Measure evidence because browsers report them as `text/plain`, while the backend validator and dropzone helpers only accepted `text/x-log`. Both MIME types are now accepted for `.log` uploads.

### Tests **`+16`**

- Adds unit tests covering `.log` with both `text/plain` and `text/x-log` MIME types.

### Service **`+1`** **`-1`**

- Adds `.log` to the `text/plain` extension list in the backend file validator.

### Package: helpers **`+1`** **`-1`**

- Adds `.log` to the `text/plain` accept map in `fileAccept.ts`.

<sup>Written for commit 66090d29c3ae77646e2bbcf02d1c4aba530d7e8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

