### PR TITLE
Improve identity center discovery

### DIFF
--- a/cmd/probod/CHANGELOG.md
+++ b/cmd/probod/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `probod` (the server, including the bundled `@probo/conso
 
 ## Unreleased
 
+- AWS Identity Center discovery now walks Identity Center regions until `ListInstances` returns an instance, instead of only the session region (`us-east-1` on commercial AWS). IAM-only degrade remains when no instance exists, `ListInstances` is AccessDenied, or the role cannot finish the SSO Admin walk.
+
 ## [0.274.2] - 2026-09-02
 
 ### Fixed

--- a/pkg/accessreview/drivers/aws.go
+++ b/pkg/accessreview/drivers/aws.go
@@ -40,14 +40,14 @@ const (
 
 // AWSDriver lists the identities of the one AWS account the connector
 // names: IAM users, plus Identity Center users assigned to that account
-// when an instance is visible in the session region. One connector
+// when an instance is visible in an Identity Center region. One connector
 // produces one source, the same as GitHub, so roles need no account
-// qualification. Member-account connectors, instances hosted in another
-// region, and a role that cannot finish the SSO Admin walk degrade to
-// IAM only.
+// qualification. Member-account connectors and a role that cannot finish
+// the SSO Admin walk degrade to IAM only.
 type AWSDriver struct {
-	session *cloudaws.Session
-	logger  *log.Logger
+	session   *cloudaws.Session
+	logger    *log.Logger
+	icRegions []string
 }
 
 var _ Driver = (*AWSDriver)(nil)
@@ -56,6 +56,14 @@ var _ Driver = (*AWSDriver)(nil)
 // connected account.
 func NewAWSDriver(session *cloudaws.Session, logger *log.Logger) *AWSDriver {
 	return &AWSDriver{session: session, logger: logger}
+}
+
+func (d *AWSDriver) identityCenterSearchRegions() []string {
+	if len(d.icRegions) > 0 {
+		return d.icRegions
+	}
+
+	return identityCenterRegions(d.session.Partition(), d.session.Config().Region)
 }
 
 func (d *AWSDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
@@ -69,7 +77,12 @@ func (d *AWSDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
 		records = append(records, iamUserRecord(user))
 	}
 
-	icUsers, err := listIdentityCenterUsers(ctx, d.session, d.logger)
+	icUsers, err := listIdentityCenterUsersInRegions(
+		ctx,
+		d.session,
+		d.logger,
+		d.identityCenterSearchRegions(),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot list identity center identities of the aws account: %w", err)
 	}

--- a/pkg/accessreview/drivers/aws_identity_center.go
+++ b/pkg/accessreview/drivers/aws_identity_center.go
@@ -22,6 +22,7 @@ package drivers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -32,6 +33,7 @@ import (
 	istypes "github.com/aws/aws-sdk-go-v2/service/identitystore/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
 	ssotypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
+	"github.com/aws/smithy-go"
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/awsx/arn"
 	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
@@ -66,6 +68,7 @@ type (
 	identityCenterInstance struct {
 		arn     string
 		storeID string
+		region  string
 	}
 
 	identityCenterPermissionSet struct {
@@ -80,22 +83,129 @@ type (
 	}
 )
 
+// identityCenterCommercialRegions is every commercial Region where an
+// organization can host IAM Identity Center, default-enabled homes first.
+// https://docs.aws.amazon.com/singlesignon/latest/userguide/regions.html
+var (
+	identityCenterCommercialRegions = []string{
+		"us-east-1",
+		"us-east-2",
+		"us-west-2",
+		"eu-west-1",
+		"eu-central-1",
+		"us-west-1",
+		"eu-west-2",
+		"eu-west-3",
+		"eu-north-1",
+		"ap-northeast-1",
+		"ap-northeast-2",
+		"ap-northeast-3",
+		"ap-southeast-1",
+		"ap-southeast-2",
+		"ap-south-1",
+		"sa-east-1",
+		"ca-central-1",
+		"af-south-1",
+		"ap-east-1",
+		"ap-east-2",
+		"ap-south-2",
+		"ap-southeast-3",
+		"ap-southeast-4",
+		"ap-southeast-5",
+		"ap-southeast-6",
+		"ap-southeast-7",
+		"ca-west-1",
+		"eu-south-1",
+		"eu-south-2",
+		"eu-central-2",
+		"il-central-1",
+		"me-south-1",
+		"me-central-1",
+		"mx-central-1",
+	}
+
+	identityCenterGovRegions = []string{
+		"us-gov-west-1",
+		"us-gov-east-1",
+	}
+)
+
+// identityCenterRegions is the ListInstances search order: the session
+// region first, then the rest of the partition's Identity Center regions.
+func identityCenterRegions(partition, preferred string) []string {
+	var rest []string
+
+	switch partition {
+	case cloudaws.GovPartition:
+		rest = identityCenterGovRegions
+	case cloudaws.ChinaPartition:
+		if preferred == "" {
+			return nil
+		}
+
+		return []string{preferred}
+	default:
+		rest = identityCenterCommercialRegions
+	}
+
+	regions := make([]string, 0, len(rest)+1)
+	if preferred != "" {
+		regions = append(regions, preferred)
+	}
+
+	for _, region := range rest {
+		if region == preferred {
+			continue
+		}
+
+		regions = append(regions, region)
+	}
+
+	return regions
+}
+
+func identityCenterAccessDenied(err error) bool {
+	apiErr, ok := errors.AsType[smithy.APIError](err)
+	if !ok || apiErr == nil {
+		return false
+	}
+
+	switch apiErr.ErrorCode() {
+	case "AccessDenied", "AccessDeniedException", "UnauthorizedException":
+		return true
+	default:
+		return false
+	}
+}
+
 // listIdentityCenterUsers returns Identity Center users assigned to this
 // session's account.
 //
-// SSO Admin degrades: an empty ListInstances, or any non-cancel error talking
-// to SSO Admin (discovery or a later read), means this account does not
-// expose a usable instance in the session region (a member account, a custom
-// role without the needed sso:*, or an instance hosted elsewhere). The IAM
-// walk still stands. Identity-store failures fail the fetch.
+// Discovery walks Identity Center regions until ListInstances returns an
+// instance. AccessDenied on ListInstances, or any non-cancel error talking
+// to SSO Admin after discovery, degrades to IAM-only (a member account, a
+// custom role without the needed sso:*, or no instance at all). Identity
+// store failures fail the fetch.
 func listIdentityCenterUsers(
 	ctx context.Context,
 	session *cloudaws.Session,
 	logger *log.Logger,
 ) ([]identityCenterUser, error) {
-	sso := ssoadmin.NewFromConfig(session.Config())
+	return listIdentityCenterUsersInRegions(
+		ctx,
+		session,
+		logger,
+		identityCenterRegions(session.Partition(), session.Config().Region),
+	)
+}
 
-	instance, err := discoverIdentityCenter(ctx, sso)
+func listIdentityCenterUsersInRegions(
+	ctx context.Context,
+	session *cloudaws.Session,
+	logger *log.Logger,
+	regions []string,
+) ([]identityCenterUser, error) {
+	instance, err := discoverIdentityCenter(ctx, session, logger, regions)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil, err
@@ -113,6 +223,10 @@ func listIdentityCenterUsers(
 	if instance.arn == "" {
 		return nil, nil
 	}
+
+	cfg := session.Config()
+	cfg.Region = instance.region
+	sso := ssoadmin.NewFromConfig(cfg)
 
 	sets, err := listIdentityCenterPermissionSets(ctx, sso, instance.arn)
 	if err != nil {
@@ -169,7 +283,7 @@ func listIdentityCenterUsers(
 		}
 	}
 
-	store := identitystore.NewFromConfig(session.Config())
+	store := identitystore.NewFromConfig(cfg)
 
 	if err := expandIdentityCenterGroupAssignments(ctx, store, instance.storeID, groups, grants); err != nil {
 		return nil, err
@@ -192,6 +306,51 @@ func listIdentityCenterUsers(
 }
 
 func discoverIdentityCenter(
+	ctx context.Context,
+	session *cloudaws.Session,
+	logger *log.Logger,
+	regions []string,
+) (identityCenterInstance, error) {
+	sessionRegion := session.Config().Region
+
+	for _, region := range regions {
+		cfg := session.Config()
+		cfg.Region = region
+		client := ssoadmin.NewFromConfig(cfg)
+
+		instance, err := listIdentityCenterInstances(ctx, client)
+		if err != nil {
+			if ctx.Err() != nil {
+				return identityCenterInstance{}, err
+			}
+
+			if identityCenterAccessDenied(err) {
+				return identityCenterInstance{}, err
+			}
+
+			continue
+		}
+
+		if instance.arn == "" {
+			continue
+		}
+
+		instance.region = region
+		if region != sessionRegion {
+			logger.InfoCtx(
+				ctx,
+				"discovered iam identity center in a non-session region",
+				log.String("region", region),
+			)
+		}
+
+		return instance, nil
+	}
+
+	return identityCenterInstance{}, nil
+}
+
+func listIdentityCenterInstances(
 	ctx context.Context,
 	client *ssoadmin.Client,
 ) (identityCenterInstance, error) {

--- a/pkg/accessreview/drivers/aws_identity_center_test.go
+++ b/pkg/accessreview/drivers/aws_identity_center_test.go
@@ -22,6 +22,7 @@ package drivers
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -29,8 +30,90 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.gearno.de/kit/log"
+	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
 	"go.probo.inc/probo/pkg/coredata"
 )
+
+func TestIdentityCenterRegions_PutsPreferredFirst(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"commercial preferred is first and unique",
+		func(t *testing.T) {
+			t.Parallel()
+
+			regions := identityCenterRegions(cloudaws.CommercialPartition, "eu-west-1")
+			require.NotEmpty(t, regions)
+			assert.Equal(t, "eu-west-1", regions[0])
+
+			sorted := slices.Clone(regions)
+			slices.Sort(sorted)
+			assert.Equal(t, sorted, slices.Compact(slices.Clone(sorted)))
+			assert.Contains(t, regions, "us-east-1")
+			assert.Contains(t, regions, "eu-central-1")
+		},
+	)
+
+	t.Run(
+		"govcloud preferred is first",
+		func(t *testing.T) {
+			t.Parallel()
+
+			regions := identityCenterRegions(cloudaws.GovPartition, cloudaws.DefaultGovRegion)
+			require.Equal(t, []string{cloudaws.DefaultGovRegion, "us-gov-east-1"}, regions)
+		},
+	)
+
+	t.Run(
+		"china is preferred only",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(
+				t,
+				[]string{cloudaws.DefaultChinaRegion},
+				identityCenterRegions(cloudaws.ChinaPartition, cloudaws.DefaultChinaRegion),
+			)
+			assert.Empty(t, identityCenterRegions(cloudaws.ChinaPartition, ""))
+		},
+	)
+}
+
+func TestListIdentityCenterUsers_FindsInstanceOutsideSessionRegion(t *testing.T) {
+	t.Parallel()
+
+	rec := newAWSRecorder(t, "testdata/aws_identity_center_eu_west_1")
+	session := newAWSTestSession(t, rec)
+
+	users, err := listIdentityCenterUsersInRegions(
+		context.Background(),
+		session,
+		log.NewLogger(log.WithName("test")),
+		[]string{cloudaws.DefaultCommercialRegion, "eu-west-1"},
+	)
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+
+	records := make([]AccountRecord, 0, len(users))
+	for _, user := range users {
+		records = append(records, identityCenterUserRecord(user))
+	}
+
+	byID := make(map[string]AccountRecord, len(records))
+	for _, record := range records {
+		byID[record.ExternalID] = record
+	}
+
+	bob := byID["arn:aws:identitystore::123456789012:user/11111111-1111-1111-1111-111111111111"]
+	assert.Equal(t, "Bob Admin", bob.FullName)
+	assert.Equal(t, []string{"AdministratorAccess"}, bob.Roles)
+	require.NotNil(t, bob.IsAdmin)
+	assert.True(t, *bob.IsAdmin)
+
+	carol := byID["arn:aws:identitystore::123456789012:user/22222222-2222-2222-2222-222222222222"]
+	assert.Equal(t, "Carol Engineer", carol.FullName)
+	assert.ElementsMatch(t, []string{"Engineers", "ReadOnlyAccess"}, carol.Roles)
+}
 
 func TestListIdentityCenterUsers_ListsDirectAndGroupAssignments(t *testing.T) {
 	t.Parallel()

--- a/pkg/accessreview/drivers/aws_test.go
+++ b/pkg/accessreview/drivers/aws_test.go
@@ -69,7 +69,10 @@ func TestAWSDriver(t *testing.T) {
 	rec := newAWSRecorder(t, "testdata/aws")
 	session := newAWSTestSession(t, rec)
 
-	records, err := NewAWSDriver(session, log.NewLogger(log.WithName("test"))).ListAccounts(context.Background())
+	driver := NewAWSDriver(session, log.NewLogger(log.WithName("test")))
+	driver.icRegions = []string{cloudaws.DefaultCommercialRegion}
+
+	records, err := driver.ListAccounts(context.Background())
 	require.NoError(t, err)
 	require.Len(t, records, 3)
 

--- a/pkg/accessreview/drivers/testdata/aws_identity_center_eu_west_1.yaml
+++ b/pkg/accessreview/drivers/testdata/aws_identity_center_eu_west_1.yaml
@@ -1,0 +1,272 @@
+---
+# Hand-authored Identity Center cassette. Never recorded against a live
+# account. Interactions are matched by host and X-Amz-Target (see
+# awsAPIMatcher) and consumed in call order when the target repeats.
+# Call order: ListInstances empty in us-east-1, then the usual walk in
+# eu-west-1. Same principals as testdata/aws_identity_center.yaml.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: sso.us-east-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - SWBExternalService.ListInstances
+        url: https://sso.us-east-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"Instances":[]}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: sso.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - SWBExternalService.ListInstances
+        url: https://sso.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"Instances":[{"InstanceArn":"arn:aws:sso:::instance/ssoins-example","IdentityStoreId":"d-1234567890"}]}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: sso.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - SWBExternalService.ListPermissionSets
+        url: https://sso.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"PermissionSets":["arn:aws:sso:::permissionSet/ssoins-example/ps-admin","arn:aws:sso:::permissionSet/ssoins-example/ps-readonly"]}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: sso.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - SWBExternalService.DescribePermissionSet
+        url: https://sso.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"PermissionSet":{"Name":"AdministratorAccess","PermissionSetArn":"arn:aws:sso:::permissionSet/ssoins-example/ps-admin"}}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: sso.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - SWBExternalService.DescribePermissionSet
+        url: https://sso.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"PermissionSet":{"Name":"ReadOnlyAccess","PermissionSetArn":"arn:aws:sso:::permissionSet/ssoins-example/ps-readonly"}}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: sso.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - SWBExternalService.ListManagedPoliciesInPermissionSet
+        url: https://sso.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"AttachedManagedPolicies":[{"Name":"ReadOnlyAccess","Arn":"arn:aws:iam::aws:policy/ReadOnlyAccess"}]}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: sso.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - SWBExternalService.ListAccountAssignments
+        url: https://sso.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"AccountAssignments":[{"AccountId":"123456789012","PermissionSetArn":"arn:aws:sso:::permissionSet/ssoins-example/ps-admin","PrincipalId":"11111111-1111-1111-1111-111111111111","PrincipalType":"USER"}]}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: sso.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - SWBExternalService.ListAccountAssignments
+        url: https://sso.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"AccountAssignments":[{"AccountId":"123456789012","PermissionSetArn":"arn:aws:sso:::permissionSet/ssoins-example/ps-readonly","PrincipalId":"44444444-4444-4444-4444-444444444444","PrincipalType":"GROUP"}]}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: identitystore.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - AWSIdentityStore.DescribeGroup
+        url: https://identitystore.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"GroupId":"44444444-4444-4444-4444-444444444444","IdentityStoreId":"d-1234567890","DisplayName":"Engineers"}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: identitystore.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - AWSIdentityStore.ListGroupMemberships
+        url: https://identitystore.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"GroupMemberships":[{"IdentityStoreId":"d-1234567890","GroupId":"44444444-4444-4444-4444-444444444444","MemberId":{"UserId":"22222222-2222-2222-2222-222222222222"}}]}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: identitystore.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - AWSIdentityStore.ListUsers
+        url: https://identitystore.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"Users":[{"UserId":"11111111-1111-1111-1111-111111111111","IdentityStoreId":"d-1234567890","UserName":"bob","DisplayName":"Bob Admin","Title":"Security Lead","UserStatus":"ENABLED","CreatedAt":1767225600,"Emails":[{"Primary":true,"Value":"bob@example.com"}]},{"UserId":"22222222-2222-2222-2222-222222222222","IdentityStoreId":"d-1234567890","UserName":"carol@example.com","DisplayName":"Carol Engineer","UserStatus":"ENABLED"},{"UserId":"33333333-3333-3333-3333-333333333333","IdentityStoreId":"d-1234567890","UserName":"dave","DisplayName":"Dave Unused","Emails":[{"Primary":true,"Value":"dave@example.com"}]}]}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms

--- a/pkg/connector/provider/aws.go
+++ b/pkg/connector/provider/aws.go
@@ -43,7 +43,7 @@ import (
 func awsRegistration() *Registration {
 	return &Registration{
 		Provider:    coredata.ConnectorProviderAWS,
-		DisplayName: "AWS",
+		DisplayName: "Amazon Web Services",
 		// See Registration.EndpointOverrideUnsupported: the AWS SDK resolves every host it dials from the session's region and partition, so there is no host in Endpoints for an override to move.
 		EndpointOverrideUnsupported: "the AWS SDK resolves its own endpoints from the session region, not from values in Endpoints",
 		WorkloadIdentity: &WorkloadIdentityConfig{

--- a/pkg/connector/provider/aws_test.go
+++ b/pkg/connector/provider/aws_test.go
@@ -94,7 +94,7 @@ func TestAWSRegistration(t *testing.T) {
 	reg, ok := r.Get(coredata.ConnectorProviderAWS)
 	require.True(t, ok)
 
-	assert.Equal(t, "AWS", reg.DisplayName)
+	assert.Equal(t, "Amazon Web Services", reg.DisplayName)
 	assert.True(t, reg.SupportsWorkloadIdentity())
 	assert.False(t, reg.SupportsAPIKey())
 	assert.False(t, reg.IsManagedAPIKey())


### PR DESCRIPTION
ListInstances is regional. The session stays on us-east-1 for
    STS, so an instance in another home region looked like none
    and the review dropped to IAM-only users.

Walk Identity Center regions until one returns an instance,
    then pin SSO Admin and Identity Store to that region. Empty
    or unsupported regions continue; AccessDenied still degrades
    to IAM-only.