### PR TITLE
Show precise SCIM event timestamps

### DIFF
--- a/apps/console/src/pages/iam/organizations/auth/scim/_components/SCIMEventListItem.tsx
+++ b/apps/console/src/pages/iam/organizations/auth/scim/_components/SCIMEventListItem.tsx
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { dateFormat } from "@probo/i18n";
+import { dateTimeFormat } from "@probo/i18n";
 import { Badge, IconChevronDown, IconChevronRight, Td, Tr } from "@probo/ui";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -26,6 +26,16 @@ import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
 import type { SCIMEventListItemFragment$key } from "#/__generated__/iam/SCIMEventListItemFragment.graphql";
+
+const scimEventDateFormat = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  weekday: "short",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+} as const;
 
 const SCIMEventListItemFragment = graphql`
   fragment SCIMEventListItemFragment on SCIMEvent {
@@ -95,7 +105,11 @@ export function SCIMEventListItem(props: {
               : (
                   <IconChevronRight size={16} className="text-txt-secondary" />
                 )}
-            {dateFormat(i18n.language, event.createdAt)}
+            {dateTimeFormat(
+              i18n.language,
+              event.createdAt,
+              scimEventDateFormat,
+            )}
           </div>
         </Td>
         <Td>{getMethodBadge(event.method)}</Td>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- show hours, minutes, and seconds on SCIM provisioning events
- retain locale-aware date and time formatting

## Testing
- pending post-rebase console validation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6321c4dc-9157-4b8d-93d6-6cf2d511d8ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6321c4dc-9157-4b8d-93d6-6cf2d511d8ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
SCIM provisioning event timestamps in the console now show hours, minutes, and seconds instead of only the date. Locale-aware date and time formatting is preserved.

### App: console **`+16`** **`-2`**

Switches the SCIM event list item to `dateTimeFormat` with a custom option set that includes the time.

<sup>Written for commit 9c0f45916b5c872d82ef50372a6b3ede53418ac7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

