### PR TITLE
Display continuity metrics in hours

### DIFF
--- a/apps/console/src/pages/organizations/businessFunctions/_components/BusinessFunctionListItem.tsx
+++ b/apps/console/src/pages/organizations/businessFunctions/_components/BusinessFunctionListItem.tsx
@@ -41,6 +41,7 @@ import { useMutation } from "#/lib/relay/useMutation";
 import {
   businessFunctionListConnectionFilters,
   BusinessFunctionsConnectionKey,
+  formatContinuityMinutes,
   getClassificationLabel,
   getClassificationVariant,
 } from "../_lib/businessFunctionHelpers";
@@ -163,9 +164,9 @@ export function BusinessFunctionListItem({
           {getClassificationLabel(businessFunction.classification, t, "businessFunctionsPage")}
         </Badge>
       </Td>
-      <Td>{businessFunction.mtdMinutes}</Td>
-      <Td>{businessFunction.rtoMinutes}</Td>
-      <Td>{businessFunction.rpoMinutes}</Td>
+      <Td>{formatContinuityMinutes(businessFunction.mtdMinutes, t)}</Td>
+      <Td>{formatContinuityMinutes(businessFunction.rtoMinutes, t)}</Td>
+      <Td>{formatContinuityMinutes(businessFunction.rpoMinutes, t)}</Td>
       <Td>{businessFunction.owner?.fullName || "-"}</Td>
       <Td>
         <EntityBadgeList

--- a/apps/console/src/pages/organizations/businessFunctions/_lib/businessFunctionHelpers.ts
+++ b/apps/console/src/pages/organizations/businessFunctions/_lib/businessFunctionHelpers.ts
@@ -83,6 +83,25 @@ export function durationMinutesHelperText(
   return t(`${prefix}.fields.durationHelper`);
 }
 
+type DurationTranslator = (key: string, options?: { count?: number }) => string;
+
+export function formatContinuityMinutes(
+  minutes: number,
+  t: DurationTranslator,
+): string {
+  const totalMinutes = Number.isFinite(minutes) ? Math.max(0, Math.trunc(minutes)) : 0;
+  const hours = Math.floor(totalMinutes / 60);
+  const remainingMinutes = totalMinutes % 60;
+
+  if (hours > 0 && remainingMinutes > 0) {
+    return `${t("duration.hour", { count: hours })}, ${t("duration.min", { count: remainingMinutes })}`;
+  }
+  if (hours > 0) {
+    return t("duration.hour", { count: hours });
+  }
+  return t("duration.min", { count: remainingMinutes });
+}
+
 export const BusinessFunctionsConnectionKey = "BusinessFunctionsPage_businessFunctions";
 
 export const emptyBusinessFunctionFilter = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- convert business function MTD values from minutes to hours in the registry
- convert RTO and RPO values from minutes to hours in the same table
- keep API storage and edit forms in minutes

## Testing
- `npm -w @probo/console run check`
- `npm -w @probo/console run build`

## Issue
- ENG-809
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-809](https://linear.app/probo/issue/ENG-809/display-mtd-rto-and-rpo-in-hours)

<div><a href="https://cursor.com/agents/bc-3356417b-e338-4515-9183-a68943e9a00a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3356417b-e338-4515-9183-a68943e9a00a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Displays business continuity metrics (MTD, RTO, RPO) in hours and minutes on the business function list instead of raw minutes, addressing ENG-809. API storage and edit forms continue to use minutes, so only the list display changes.

### App: console **`+23`** **`-3`**

- Adds `formatContinuityMinutes` to convert minutes into localized hours and remaining minutes (e.g., "1 hour, 30 min").
- Uses it for the MTD, RTO, and RPO cells on the business function list.

<sup>Written for commit dd8904fd64126bde1747bb0b3bd7adec83fab1ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

