### PR TITLE
Improve AWS access-review names, root email, and docs

### DIFF
--- a/apps/console/src/pages/organizations/access-reviews/connections/CreateAwsAccessReviewSourcePage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/connections/CreateAwsAccessReviewSourcePage.tsx
@@ -45,6 +45,7 @@ import {
   ActionSplitButton,
   type ActionSplitButtonAction,
 } from "../_components/ActionSplitButton";
+import { ConnectorDocumentationLink } from "../dialogs/_components/ConnectorDocumentationLink";
 import {
   AWS_IAM_ROLE_ARN_PATTERN,
   awsAccessReviewSourceName,
@@ -64,6 +65,7 @@ export const createAwsAccessReviewSourcePageQuery = graphql`
     accessReviewDrivers {
       provider
       displayName
+      documentationUrl
     }
     organization: node(id: $organizationId) {
       __typename
@@ -376,15 +378,21 @@ export function CreateAwsAccessReviewSourcePage({
             </Field>
           ))}
 
-          <div className="flex items-center justify-end gap-2">
-            <Button variant="secondary" asChild>
-              <Link to={`/organizations/${organizationId}/access-reviews/connections`}>
-                {t("createAwsAccessReviewSourcePage.actions.back")}
-              </Link>
-            </Button>
-            <Button disabled={!roleArnValid || isCreating} type="submit">
-              {t("createAwsAccessReviewSourcePage.actions.connect")}
-            </Button>
+          <div className="flex items-center justify-between gap-2">
+            <ConnectorDocumentationLink
+              url={awsDriver.documentationUrl}
+              variant="button"
+            />
+            <div className="flex items-center justify-end gap-2">
+              <Button variant="secondary" asChild>
+                <Link to={`/organizations/${organizationId}/access-reviews/connections`}>
+                  {t("createAwsAccessReviewSourcePage.actions.back")}
+                </Link>
+              </Button>
+              <Button disabled={!roleArnValid || isCreating} type="submit">
+                {t("createAwsAccessReviewSourcePage.actions.connect")}
+              </Button>
+            </div>
           </div>
         </form>
       </Card>

--- a/apps/console/src/pages/organizations/access-reviews/dialogs/_lib/connectorSettings.ts
+++ b/apps/console/src/pages/organizations/access-reviews/dialogs/_lib/connectorSettings.ts
@@ -127,7 +127,7 @@ export function awsAccessReviewSourceName(
     return displayName;
   }
 
-  return `${displayName} ${accountID}`;
+  return `${displayName} / ${accountID}`;
 }
 
 export function mapClientCredentialsExtraSettingToField(

--- a/e2e/console/connector_test.go
+++ b/e2e/console/connector_test.go
@@ -156,16 +156,19 @@ func TestAccessReviewDrivers(t *testing.T) {
 		assert.Equal(t, "https://www.probo.com/docs/product/access-review/calcom", *url)
 	}
 
-	// AWS carries the null case because it is the one provider that cannot
-	// acquire a doc page by being written. Any provider picked here purely for
-	// being undocumented today gets documented eventually and breaks this
-	// assertion, as BREX did.
+	if url := docURLByProvider["AWS"]; assert.NotNil(t, url) {
+		assert.Equal(t, "https://www.probo.com/docs/product/access-review/aws", *url)
+	}
+
+	// Sentry carries the null case: it is an API-key provider, so the catalog
+	// never skips it, and it still has no page. A provider picked here purely
+	// for being undocumented today gets documented eventually and breaks this
+	// assertion, as BREX and AWS did.
 	//
 	// Contains first: a bare Nil on a missing key passes whether or not the
-	// field is really null, which would let the null path rot unnoticed. E2E
-	// enables identity federation, so AWS is in the catalog.
-	require.Contains(t, docURLByProvider, "AWS")
-	assert.Nil(t, docURLByProvider["AWS"], "AWS has no doc page, documentationUrl must be null")
+	// field is really null, which would let the null path rot unnoticed.
+	require.Contains(t, docURLByProvider, "SENTRY")
+	assert.Nil(t, docURLByProvider["SENTRY"], "SENTRY has no doc page, documentationUrl must be null")
 
 	t.Run("viewer can list access review drivers", func(t *testing.T) {
 		t.Parallel()

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.57.3
 	github.com/aws/aws-sdk-go-v2/service/iam v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.42.0
+	github.com/aws/aws-sdk-go-v2/service/organizations v1.58.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.2
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.44.6
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.73.6

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.38 h1:gX8B8y3Ho30B1
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.38/go.mod h1:l5WblZlcmGPe4/O7JY2HO25Z+xqTBvyfTyFbRMf8gYw=
 github.com/aws/aws-sdk-go-v2/service/kms v1.52.0 h1:QNtg+Mtj1zmepk568+UKBD5DFfqh+ESTUUqQT27JkQc=
 github.com/aws/aws-sdk-go-v2/service/kms v1.52.0/go.mod h1:Y0+uxvxz6ib4KktRdK0V4X45Vcs/JyYoz8H71pO8xeI=
+github.com/aws/aws-sdk-go-v2/service/organizations v1.58.0 h1:3h6IMGQTd5DqUGoDX6GZZasQRE6KpYx8+z+9Tb5Ezwc=
+github.com/aws/aws-sdk-go-v2/service/organizations v1.58.0/go.mod h1:gDvnnHT8O9vj1zHOa1ApHdmGhOTKTC9mvZP03f0m6y8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.107.2 h1:GNU0/xtPEXMKilJZ/a8BedeuQnvu+Usi6qVm9EFfncc=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.107.2/go.mod h1:4jYWUecEsQtE73jPl7p3jrbYXH5ffcR4gegyCygagfg=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.44.6 h1:64ww9Pr4QuBPNe1aK9YeVDAUa35S/ykdl0Xb0chc7HI=

--- a/pkg/accessreview/drivers/aws.go
+++ b/pkg/accessreview/drivers/aws.go
@@ -96,14 +96,16 @@ func (d *AWSDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
 
 // iamUserRecord maps one IAM user.
 //
-// Email stays empty: an IAM user has no email attribute, and inventing one from
-// the user name would create an identity that matches the wrong human during
-// reconciliation. Active follows the credential report (console password or an
-// access key), not an IAM enabled/disabled flag — IAM has none.
+// Email is empty for IAM users: they have no email attribute, and inventing
+// one from the user name would match the wrong human during reconciliation.
+// Root may carry the Organizations account email. Active follows the
+// credential report (console password or an access key), not an IAM
+// enabled/disabled flag — IAM has none.
 func iamUserRecord(user iamUser) AccountRecord {
 	grants := slices.Concat(user.Groups, user.AttachedPolicies, user.InlinePolicies)
 
 	return AccountRecord{
+		Email:       user.Email,
 		FullName:    user.Name,
 		Roles:       grants,
 		IsAdmin:     awsIsAdmin(user, grants),

--- a/pkg/accessreview/drivers/aws_iam.go
+++ b/pkg/accessreview/drivers/aws_iam.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/awsx/arn"
 	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
@@ -63,6 +64,7 @@ type (
 	iamUser struct {
 		ARN              string
 		Name             string
+		Email            string
 		Groups           []string
 		AttachedPolicies []string
 		InlinePolicies   []string
@@ -139,7 +141,43 @@ func listIAMUsers(ctx context.Context, session *cloudaws.Session, logger *log.Lo
 		root = rootIdentity(session.Partition(), session.AccountID())
 	}
 
+	email, err := accountEmail(ctx, session)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, err
+		}
+
+		logger.WarnCtx(
+			ctx,
+			"cannot read aws account email, reporting root email unknown",
+			log.Error(err),
+		)
+	} else {
+		root.Email = email
+	}
+
 	return append(users, root), nil
+}
+
+// accountEmail is the Organizations email of this session's account, which
+// is the root sign-in address. A standalone account, or a member role that
+// cannot call Organizations, has no email to report.
+func accountEmail(ctx context.Context, session *cloudaws.Session) (string, error) {
+	out, err := organizations.NewFromConfig(session.Config()).DescribeAccount(
+		ctx,
+		&organizations.DescribeAccountInput{
+			AccountId: aws.String(session.AccountID()),
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("cannot describe the aws account: %w", err)
+	}
+
+	if out.Account == nil {
+		return "", nil
+	}
+
+	return aws.ToString(out.Account.Email), nil
 }
 
 // listAuthorizationDetails walks iam:GetAccountAuthorizationDetails, filtered

--- a/pkg/accessreview/drivers/aws_test.go
+++ b/pkg/accessreview/drivers/aws_test.go
@@ -110,6 +110,7 @@ func TestAWSDriver(t *testing.T) {
 
 	root := byID["arn:aws:iam::123456789012:root"]
 	assert.Equal(t, "<root_account>", root.FullName)
+	assert.Equal(t, "root@example.com", root.Email)
 	assert.Equal(t, coredata.MFAStatusDisabled, root.MFAStatus)
 	assert.Equal(t, coredata.AccessReviewEntryAuthMethodPassword, root.AuthMethod)
 	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, root.AccountType)
@@ -119,6 +120,30 @@ func TestAWSDriver(t *testing.T) {
 	assert.True(t, *root.Active)
 	require.NotNil(t, root.LastLogin)
 	assert.True(t, root.LastLogin.Equal(time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)))
+}
+
+func TestAWSDriver_LeavesRootEmailEmptyWhenOrganizationsDenied(t *testing.T) {
+	t.Parallel()
+
+	rec := newAWSRecorder(t, "testdata/aws_organizations_denied")
+	session := newAWSTestSession(t, rec)
+
+	records, err := NewAWSDriver(session, log.NewLogger(log.WithName("test"))).ListAccounts(context.Background())
+	require.NoError(t, err)
+
+	var root AccountRecord
+
+	for _, record := range records {
+		if record.ExternalID == "arn:aws:iam::123456789012:root" {
+			root = record
+			break
+		}
+	}
+
+	assert.Equal(t, "<root_account>", root.FullName)
+	assert.Empty(t, root.Email)
+	require.NotNil(t, root.IsAdmin)
+	assert.True(t, *root.IsAdmin)
 }
 
 func TestAWSDriver_KeepsIAMWhenLaterSSOAdminDenied(t *testing.T) {
@@ -191,6 +216,7 @@ func TestIAMUserRecord_MapsBareRootAsAdminWithUnknownSignals(t *testing.T) {
 
 	assert.Equal(t, rootUser, record.FullName)
 	assert.Equal(t, "arn:aws:iam::123456789012:root", record.ExternalID)
+	assert.Empty(t, record.Email)
 	require.NotNil(t, record.IsAdmin)
 	assert.True(t, *record.IsAdmin)
 	assert.Nil(t, record.Active)
@@ -205,12 +231,14 @@ func TestIAMUserRecord_MapsRootAsAdmin(t *testing.T) {
 		iamUser{
 			ARN:           "arn:aws:iam::123456789012:root",
 			Name:          rootUser,
+			Email:         "root@example.com",
 			MFAEnabled:    new(false),
 			ConsoleAccess: new(true),
 		},
 	)
 
 	assert.Equal(t, rootUser, record.FullName)
+	assert.Equal(t, "root@example.com", record.Email)
 	require.NotNil(t, record.IsAdmin)
 	assert.True(t, *record.IsAdmin)
 	require.NotNil(t, record.Active)
@@ -356,6 +384,17 @@ func TestPickAWSInstanceName(t *testing.T) {
 			},
 		)
 	}
+}
+
+func TestAccountEmail_ReadsOrganizationsEmail(t *testing.T) {
+	t.Parallel()
+
+	rec := newAWSRecorder(t, "testdata/aws_account_email")
+	session := newAWSTestSession(t, rec)
+
+	email, err := accountEmail(context.Background(), session)
+	require.NoError(t, err)
+	assert.Equal(t, "root@example.com", email)
 }
 
 func TestAWSNameResolver_UsesAccountName(t *testing.T) {

--- a/pkg/accessreview/drivers/testdata/aws_account_email.yaml
+++ b/pkg/accessreview/drivers/testdata/aws_account_email.yaml
@@ -1,0 +1,30 @@
+---
+# Hand-authored Organizations cassette. Never recorded against a live
+# account. DescribeAccount is AWS JSON and is matched by host and
+# X-Amz-Target (see awsAPIMatcher).
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: organizations.us-east-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - AWSOrganizationsV20161128.DescribeAccount
+        url: https://organizations.us-east-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"Account":{"Id":"123456789012","Arn":"arn:aws:organizations::123456789012:account/o-example/123456789012","Email":"root@example.com","Name":"acme-prod","Status":"ACTIVE"}}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms

--- a/pkg/accessreview/drivers/testdata/aws_organizations_denied.yaml
+++ b/pkg/accessreview/drivers/testdata/aws_organizations_denied.yaml
@@ -1,10 +1,7 @@
 ---
-# Hand-authored AWS cassette. Never recorded against a live account: SigV4
-# headers and credentials are not present. IAM Query interactions are matched
-# by host and Action; Organizations and Identity Center by host and
-# X-Amz-Target (see awsAPIMatcher). Synthetic IAM users: alice (console
-# admin with MFA), ci-deploy (access-key service account), and the account
-# root. ListInstances is empty so this account degrades to IAM only.
+# IAM identities of testdata/aws.yaml, then DescribeAccount reports the
+# account is not in an organization. ListAccounts must keep the root
+# identity with an empty email instead of aborting the fetch.
 version: 2
 interactions:
     - id: 0
@@ -96,12 +93,14 @@ interactions:
         proto_minor: 1
         content_length: -1
         uncompressed: true
-        body: '{"Account":{"Id":"123456789012","Arn":"arn:aws:organizations::123456789012:account/o-example/123456789012","Email":"root@example.com","Name":"acme-prod","Status":"ACTIVE"}}'
+        body: '{"__type":"AWSOrganizationsNotInUseException","Message":"Your account is not a member of an organization."}'
         headers:
             Content-Type:
                 - application/x-amz-json-1.1
-        status: 200 OK
-        code: 200
+            X-Amzn-Errortype:
+                - AWSOrganizationsNotInUseException
+        status: 400 Bad Request
+        code: 400
         duration: 1ms
     - id: 4
       request:

--- a/pkg/accessreview/drivers/testdata/aws_sso_admin_denied.yaml
+++ b/pkg/accessreview/drivers/testdata/aws_sso_admin_denied.yaml
@@ -81,6 +81,30 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
+        host: organizations.us-east-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - AWSOrganizationsV20161128.DescribeAccount
+        url: https://organizations.us-east-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"Account":{"Id":"123456789012","Arn":"arn:aws:organizations::123456789012:account/o-example/123456789012","Email":"root@example.com","Name":"acme-prod","Status":"ACTIVE"}}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
         host: sso.us-east-1.amazonaws.com
         headers:
             X-Amz-Target:
@@ -100,7 +124,7 @@ interactions:
         status: 200 OK
         code: 200
         duration: 1ms
-    - id: 4
+    - id: 5
       request:
         proto: HTTP/1.1
         proto_major: 1

--- a/pkg/accessreview/drivers/vcr_test.go
+++ b/pkg/accessreview/drivers/vcr_test.go
@@ -168,9 +168,9 @@ func newAWSRecorder(t *testing.T, cassettePath string) *recorder.Recorder {
 }
 
 // awsAPIMatcher matches AWS SDK POSTs without relying on SigV4 headers or
-// byte-for-byte bodies. IAM Query is identified by form Action; SSO Admin
-// and Identity Store use AWS JSON and are identified by X-Amz-Target;
-// Account Management is REST-JSON and is identified by path.
+// byte-for-byte bodies. IAM Query is identified by form Action; SSO Admin,
+// Identity Store, and Organizations use AWS JSON and are identified by
+// X-Amz-Target; Account Management is REST-JSON and is identified by path.
 func awsAPIMatcher(r *http.Request, i cassette.Request) bool {
 	if r.Method != i.Method {
 		return false

--- a/pkg/accessreview/source_name_worker.go
+++ b/pkg/accessreview/source_name_worker.go
@@ -232,7 +232,7 @@ func (h *sourceNameHandler) Process(ctx context.Context, source coredata.AccessR
 	}
 
 	displayName := h.providerRegistry.ProviderDisplayName(dbConnector.Provider)
-	newName := displayName + " " + instanceName
+	newName := displayName + " / " + instanceName
 
 	h.logger.InfoCtx(
 		ctx,

--- a/pkg/connector/provider/aws.go
+++ b/pkg/connector/provider/aws.go
@@ -42,8 +42,9 @@ import (
 // check, so there is no grant readback beside Probe.
 func awsRegistration() *Registration {
 	return &Registration{
-		Provider:    coredata.ConnectorProviderAWS,
-		DisplayName: "Amazon Web Services",
+		Provider:         coredata.ConnectorProviderAWS,
+		DisplayName:      "Amazon Web Services",
+		DocumentationURL: accessReviewDocsURL("aws"),
 		// See Registration.EndpointOverrideUnsupported: the AWS SDK resolves every host it dials from the session's region and partition, so there is no host in Endpoints for an override to move.
 		EndpointOverrideUnsupported: "the AWS SDK resolves its own endpoints from the session region, not from values in Endpoints",
 		WorkloadIdentity: &WorkloadIdentityConfig{

--- a/pkg/connector/provider/aws_test.go
+++ b/pkg/connector/provider/aws_test.go
@@ -95,6 +95,7 @@ func TestAWSRegistration(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Equal(t, "Amazon Web Services", reg.DisplayName)
+	assert.Equal(t, "https://www.probo.com/docs/product/access-review/aws", reg.DocumentationURL)
 	assert.True(t, reg.SupportsWorkloadIdentity())
 	assert.False(t, reg.SupportsAPIKey())
 	assert.False(t, reg.IsManagedAPIKey())


### PR DESCRIPTION
## Summary
- Source names now use a slash between the provider label and the
  account (`Amazon Web Services / 123456789012`), so the split is
  scannable in the worker and the AWS create-flow placeholder.
- The AWS root identity gets the Organizations account email from
  `DescribeAccount` when the audit role can call it. Standalone
  accounts and AccessDenied stay empty. IAM users still have no email.
- The AWS connector now exposes the `/aws` setup guide on the provider
  catalog and the AWS create page.

## Test plan
- [ ] Connect or refresh an AWS source and confirm the name is
      `Amazon Web Services / <account name or id>`
- [ ] Start a campaign against an Organizations-backed account and
      confirm the root row shows the account email
- [ ] Repeat on a standalone account, or with Organizations denied,
      and confirm the root email stays empty
- [ ] Open the AWS card in the provider catalog and the AWS create
      page and confirm both show a Documentation link to `/aws`