### PR TITLE
Fill Identity Center MFA and last login

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.3.13
 	github.com/aws/aws-sdk-go-v2/service/account v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.57.3
+	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/iam v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.58.0

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/aws/aws-sdk-go-v2/service/account v1.39.0 h1:qFq5cqivuaypTfmNUteSQXW7
 github.com/aws/aws-sdk-go-v2/service/account v1.39.0/go.mod h1:/6l8GO1Mf2ywirWh1SrlxHbqS7YzuZC6+K14nXl9K78=
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.57.3 h1:owjauLAE3bW8PZDN1xLo9B/JQ0sbUCNFoNhkXCSNri0=
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.57.3/go.mod h1:dn4LwmeCdEtY0vnHnFz48VtLf+9GFnnjRvS7su00tt0=
+github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.57.1 h1:5XlIVn2Z60K3GkDz/Ktjtiuy1Ck2xSdcO57ZVjKBojA=
+github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.57.1/go.mod h1:WbDasAgg1UxPx3TjF9wsbDKCXTcI4jsB5synkB8CCB8=
 github.com/aws/aws-sdk-go-v2/service/iam v1.59.2 h1:An/8OH+HhHxKar6bDa8v1ITiG7V3/lU+TwErOzzCm1M=
 github.com/aws/aws-sdk-go-v2/service/iam v1.59.2/go.mod h1:gQRbwtyMFDBnV/58n5bVWmZi50c7H2HN/+ikrW876So=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.42.0 h1:VbS7xQeUpRv3jc182zlu1SnY3HZtMcyX/eUo5KOF4Nk=

--- a/pkg/accessreview/drivers/aws_identity_center.go
+++ b/pkg/accessreview/drivers/aws_identity_center.go
@@ -63,6 +63,11 @@ type (
 		Admin       bool
 		Status      istypes.UserStatus
 		CreatedAt   *time.Time
+
+		// MFAEnabled and LastLogin are filled after listing, from registered
+		// MFA devices and CloudTrail UserAuthentication. Nil is no signal.
+		MFAEnabled *bool
+		LastLogin  *time.Time
 	}
 
 	identityCenterInstance struct {
@@ -300,6 +305,22 @@ func listIdentityCenterUsersInRegions(
 
 	for i := range users {
 		users[i].ARN = identityCenterUserARN(session.Partition(), session.AccountID(), users[i].ID)
+	}
+
+	if len(users) == 0 {
+		return users, nil
+	}
+
+	if err := enrichIdentityCenterActivity(ctx, session, instance, users); err != nil {
+		if ctx.Err() != nil {
+			return nil, err
+		}
+
+		logger.WarnCtx(
+			ctx,
+			"cannot enrich identity center activity, reporting mfa and last login unknown",
+			log.Error(err),
+		)
 	}
 
 	return users, nil
@@ -782,8 +803,9 @@ func identityCenterActive(status istypes.UserStatus) *bool {
 }
 
 // identityCenterUserRecord maps one Identity Center user assigned to the
-// connected account. MFA and last login stay unknown: Identity Store has no
-// public API for either. Active follows UserStatus when the store reports it.
+// connected account. MFA and last login come from registered devices and
+// CloudTrail UserAuthentication when those calls succeed. Active follows
+// UserStatus when the store reports it.
 func identityCenterUserRecord(user identityCenterUser) AccountRecord {
 	return AccountRecord{
 		Email:       user.Email,
@@ -792,9 +814,10 @@ func identityCenterUserRecord(user identityCenterUser) AccountRecord {
 		Roles:       user.Grants,
 		IsAdmin:     identityCenterIsAdmin(user),
 		Active:      identityCenterActive(user.Status),
-		MFAStatus:   coredata.MFAStatusUnknown,
+		MFAStatus:   awsMFAStatus(user.MFAEnabled),
 		AuthMethod:  coredata.AccessReviewEntryAuthMethodSSO,
 		AccountType: coredata.AccessReviewEntryAccountTypeUser,
+		LastLogin:   user.LastLogin,
 		CreatedAt:   user.CreatedAt,
 		ExternalID:  user.ARN,
 	}

--- a/pkg/accessreview/drivers/aws_identity_center_activity.go
+++ b/pkg/accessreview/drivers/aws_identity_center_activity.go
@@ -1,0 +1,427 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudtrail"
+	cttypes "github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
+	"github.com/aws/aws-sdk-go-v2/service/identitystore"
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
+)
+
+const (
+	// identityCenterLoginLookback is CloudTrail Event History's retention.
+	// Older Identity Center sign-ins are invisible, not absent.
+	identityCenterLoginLookback = 90 * 24 * time.Hour
+
+	identityCenterUserAuthentication = "UserAuthentication"
+	identityStoreMFATarget           = "AWSIdentityStore.ListMfaDevicesForUser"
+)
+
+type (
+	identityCenterLogin struct {
+		at      time.Time
+		usedMFA bool
+	}
+
+	identityCenterCloudTrailEvent struct {
+		UserIdentity struct {
+			OnBehalfOf struct {
+				UserID string `json:"userId"`
+			} `json:"onBehalfOf"`
+			AdditionalEventData identityCenterCredentialData `json:"additionalEventData"`
+		} `json:"userIdentity"`
+		AdditionalEventData identityCenterCredentialData `json:"additionalEventData"`
+	}
+
+	identityCenterCredentialData struct {
+		CredentialType string `json:"CredentialType"`
+	}
+
+	listMfaDevicesOutput struct {
+		MfaDevices []json.RawMessage `json:"MfaDevices"`
+		MFADevices []json.RawMessage `json:"MFADevices"`
+		Devices    []json.RawMessage `json:"Devices"`
+	}
+
+	awsJSONError struct {
+		code    string
+		message string
+	}
+
+	setListMfaDevicesTarget struct{}
+
+	listMfaDevicesDeserializer struct {
+		out *listMfaDevicesOutput
+	}
+)
+
+var _ smithy.APIError = awsJSONError{}
+
+func (e awsJSONError) Error() string {
+	if e.message == "" {
+		return e.code
+	}
+
+	return e.code + ": " + e.message
+}
+
+func (e awsJSONError) ErrorCode() string {
+	return e.code
+}
+
+func (e awsJSONError) ErrorMessage() string {
+	return e.message
+}
+
+func (e awsJSONError) ErrorFault() smithy.ErrorFault {
+	return smithy.FaultClient
+}
+
+func (o listMfaDevicesOutput) hasDevice() bool {
+	return len(o.MfaDevices) > 0 || len(o.MFADevices) > 0 || len(o.Devices) > 0
+}
+
+func enrichIdentityCenterActivity(
+	ctx context.Context,
+	session *cloudaws.Session,
+	instance identityCenterInstance,
+	users []identityCenterUser,
+) error {
+	cfg := session.Config()
+	cfg.Region = instance.region
+
+	logins, loginErr := lookupIdentityCenterLogins(ctx, cloudtrail.NewFromConfig(cfg), users)
+	if errors.Is(loginErr, context.Canceled) {
+		return loginErr
+	}
+
+	devices, deviceErr := listIdentityCenterMFADevices(
+		ctx,
+		identitystore.NewFromConfig(cfg),
+		instance.storeID,
+		users,
+	)
+	if errors.Is(deviceErr, context.Canceled) {
+		return deviceErr
+	}
+
+	applyIdentityCenterActivity(users, logins, devices)
+
+	if loginErr != nil {
+		return loginErr
+	}
+
+	return deviceErr
+}
+
+func lookupIdentityCenterLogins(
+	ctx context.Context,
+	client *cloudtrail.Client,
+	users []identityCenterUser,
+) (map[string]identityCenterLogin, error) {
+	wanted := make(map[string]struct{}, len(users))
+	for _, user := range users {
+		if user.ID != "" {
+			wanted[user.ID] = struct{}{}
+		}
+	}
+
+	if len(wanted) == 0 {
+		return nil, nil
+	}
+
+	now := time.Now().UTC()
+	paginator := cloudtrail.NewLookupEventsPaginator(
+		client,
+		&cloudtrail.LookupEventsInput{
+			StartTime: aws.Time(now.Add(-identityCenterLoginLookback)),
+			EndTime:   aws.Time(now),
+			LookupAttributes: []cttypes.LookupAttribute{
+				{
+					AttributeKey:   cttypes.LookupAttributeKeyEventName,
+					AttributeValue: aws.String(identityCenterUserAuthentication),
+				},
+			},
+		},
+	)
+
+	found := make(map[string]identityCenterLogin, len(wanted))
+
+	for range maxPaginationPages {
+		if !paginator.HasMorePages() {
+			return found, nil
+		}
+
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return found, fmt.Errorf("cannot look up identity center sign-in events: %w", err)
+		}
+
+		for _, event := range page.Events {
+			userID, usedMFA, ok := parseIdentityCenterLoginEvent(aws.ToString(event.CloudTrailEvent))
+			if !ok {
+				continue
+			}
+
+			if _, want := wanted[userID]; !want {
+				continue
+			}
+
+			if _, seen := found[userID]; seen {
+				continue
+			}
+
+			if event.EventTime == nil {
+				continue
+			}
+
+			found[userID] = identityCenterLogin{at: event.EventTime.UTC(), usedMFA: usedMFA}
+			if len(found) == len(wanted) {
+				return found, nil
+			}
+		}
+	}
+
+	return found, fmt.Errorf(
+		"cannot look up all identity center sign-in events: %w",
+		ErrPaginationLimitReached,
+	)
+}
+
+func parseIdentityCenterLoginEvent(raw string) (string, bool, bool) {
+	if raw == "" {
+		return "", false, false
+	}
+
+	var event identityCenterCloudTrailEvent
+	if err := json.Unmarshal([]byte(raw), &event); err != nil {
+		return "", false, false
+	}
+
+	userID := event.UserIdentity.OnBehalfOf.UserID
+	if userID == "" {
+		return "", false, false
+	}
+
+	credentialType := event.AdditionalEventData.CredentialType
+	if credentialType == "" {
+		credentialType = event.UserIdentity.AdditionalEventData.CredentialType
+	}
+
+	return userID, identityCenterCredentialUsedMFA(credentialType), true
+}
+
+func identityCenterCredentialUsedMFA(credentialType string) bool {
+	for part := range strings.SplitSeq(credentialType, ",") {
+		switch strings.ToUpper(strings.TrimSpace(part)) {
+		case "TOTP", "WEBAUTHN":
+			return true
+		}
+	}
+
+	return false
+}
+
+func listIdentityCenterMFADevices(
+	ctx context.Context,
+	client *identitystore.Client,
+	storeID string,
+	users []identityCenterUser,
+) (map[string]bool, error) {
+	hasDevice := make(map[string]bool)
+
+	for _, user := range users {
+		if user.ID == "" {
+			continue
+		}
+
+		found, err := listMfaDevicesForUser(ctx, client, storeID, user.ID)
+		if err != nil {
+			return hasDevice, err
+		}
+
+		if found {
+			hasDevice[user.ID] = true
+		}
+	}
+
+	return hasDevice, nil
+}
+
+func applyIdentityCenterActivity(
+	users []identityCenterUser,
+	logins map[string]identityCenterLogin,
+	hasDevice map[string]bool,
+) {
+	for i := range users {
+		if login, ok := logins[users[i].ID]; ok {
+			users[i].LastLogin = new(login.at)
+			if login.usedMFA {
+				users[i].MFAEnabled = new(true)
+			}
+		}
+
+		if hasDevice[users[i].ID] {
+			users[i].MFAEnabled = new(true)
+		}
+	}
+}
+
+// listMfaDevicesForUser retargets DescribeUser: same IdentityStoreId and
+// UserId body, no public MFA API, so the identitystore client still signs.
+func listMfaDevicesForUser(
+	ctx context.Context,
+	client *identitystore.Client,
+	storeID string,
+	userID string,
+) (bool, error) {
+	var devices listMfaDevicesOutput
+
+	_, err := client.DescribeUser(
+		ctx,
+		&identitystore.DescribeUserInput{
+			IdentityStoreId: aws.String(storeID),
+			UserId:          aws.String(userID),
+		},
+		withListMfaDevicesForUser(&devices),
+	)
+	if err != nil {
+		return false, fmt.Errorf("cannot list identity center mfa devices of a user: %w", err)
+	}
+
+	return devices.hasDevice(), nil
+}
+
+func withListMfaDevicesForUser(out *listMfaDevicesOutput) func(*identitystore.Options) {
+	return func(o *identitystore.Options) {
+		o.APIOptions = append(
+			o.APIOptions,
+			func(stack *middleware.Stack) error {
+				if err := stack.Serialize.Add(&setListMfaDevicesTarget{}, middleware.After); err != nil {
+					return err
+				}
+
+				if _, err := stack.Deserialize.Remove("OperationDeserializer"); err != nil {
+					return err
+				}
+
+				return stack.Deserialize.Add(
+					&listMfaDevicesDeserializer{out: out},
+					middleware.After,
+				)
+			},
+		)
+	}
+}
+
+func (*setListMfaDevicesTarget) ID() string {
+	return "ListMfaDevicesForUserTarget"
+}
+
+func (*setListMfaDevicesTarget) HandleSerialize(
+	ctx context.Context,
+	in middleware.SerializeInput,
+	next middleware.SerializeHandler,
+) (middleware.SerializeOutput, middleware.Metadata, error) {
+	if req, ok := in.Request.(*smithyhttp.Request); ok {
+		req.Header.Set("X-Amz-Target", identityStoreMFATarget)
+	}
+
+	return next.HandleSerialize(ctx, in)
+}
+
+func (*listMfaDevicesDeserializer) ID() string {
+	return "OperationDeserializer"
+}
+
+func (m *listMfaDevicesDeserializer) HandleDeserialize(
+	ctx context.Context,
+	in middleware.DeserializeInput,
+	next middleware.DeserializeHandler,
+) (middleware.DeserializeOutput, middleware.Metadata, error) {
+	out, metadata, err := next.HandleDeserialize(ctx, in)
+	if err != nil {
+		return out, metadata, err
+	}
+
+	response, ok := out.RawResponse.(*smithyhttp.Response)
+	if !ok || response == nil {
+		return out, metadata, fmt.Errorf("cannot decode identity center mfa devices of a user: unknown response")
+	}
+
+	payload, err := io.ReadAll(response.Body)
+	if err != nil {
+		return out, metadata, fmt.Errorf("cannot read identity center mfa devices of a user: %w", err)
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return out, metadata, parseAWSJSONError(payload)
+	}
+
+	if err := json.Unmarshal(payload, m.out); err != nil {
+		return out, metadata, fmt.Errorf("cannot decode identity center mfa devices of a user: %w", err)
+	}
+
+	out.Result = &identitystore.DescribeUserOutput{}
+
+	return out, metadata, nil
+}
+
+func parseAWSJSONError(payload []byte) error {
+	var body struct {
+		Type    string `json:"__type"`
+		Message string `json:"message"`
+		Alt     string `json:"Message"`
+	}
+
+	if err := json.Unmarshal(payload, &body); err != nil {
+		return awsJSONError{code: "UnknownError"}
+	}
+
+	code := body.Type
+	if i := strings.LastIndex(code, "#"); i >= 0 {
+		code = code[i+1:]
+	}
+
+	if code == "" {
+		code = "UnknownError"
+	}
+
+	message := body.Message
+	if message == "" {
+		message = body.Alt
+	}
+
+	return awsJSONError{code: code, message: message}
+}

--- a/pkg/accessreview/drivers/aws_identity_center_activity_test.go
+++ b/pkg/accessreview/drivers/aws_identity_center_activity_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIdentityCenterLoginEvent(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"reads user id and totp from additional event data",
+		func(t *testing.T) {
+			t.Parallel()
+
+			userID, usedMFA, ok := parseIdentityCenterLoginEvent(
+				`{"userIdentity":{"onBehalfOf":{"userId":"11111111-1111-1111-1111-111111111111"}},"additionalEventData":{"CredentialType":"PASSWORD,TOTP"}}`,
+			)
+			require.True(t, ok)
+			assert.Equal(t, "11111111-1111-1111-1111-111111111111", userID)
+			assert.True(t, usedMFA)
+		},
+	)
+
+	t.Run(
+		"treats password-only as no mfa signal",
+		func(t *testing.T) {
+			t.Parallel()
+
+			userID, usedMFA, ok := parseIdentityCenterLoginEvent(
+				`{"userIdentity":{"onBehalfOf":{"userId":"carol"}},"additionalEventData":{"CredentialType":"PASSWORD"}}`,
+			)
+			require.True(t, ok)
+			assert.Equal(t, "carol", userID)
+			assert.False(t, usedMFA)
+		},
+	)
+
+	t.Run(
+		"reads webauthn from user identity additional data",
+		func(t *testing.T) {
+			t.Parallel()
+
+			userID, usedMFA, ok := parseIdentityCenterLoginEvent(
+				`{"userIdentity":{"onBehalfOf":{"userId":"bob"},"additionalEventData":{"CredentialType":"WEBAUTHN"}}}`,
+			)
+			require.True(t, ok)
+			assert.Equal(t, "bob", userID)
+			assert.True(t, usedMFA)
+		},
+	)
+
+	t.Run(
+		"rejects missing user id",
+		func(t *testing.T) {
+			t.Parallel()
+
+			_, _, ok := parseIdentityCenterLoginEvent(`{"additionalEventData":{"CredentialType":"TOTP"}}`)
+			assert.False(t, ok)
+		},
+	)
+
+	t.Run(
+		"rejects invalid json",
+		func(t *testing.T) {
+			t.Parallel()
+
+			_, _, ok := parseIdentityCenterLoginEvent(`{`)
+			assert.False(t, ok)
+		},
+	)
+}
+
+func TestIdentityCenterCredentialUsedMFA(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, identityCenterCredentialUsedMFA("PASSWORD,TOTP"))
+	assert.True(t, identityCenterCredentialUsedMFA("webauthn"))
+	assert.False(t, identityCenterCredentialUsedMFA("PASSWORD"))
+	assert.False(t, identityCenterCredentialUsedMFA("EXTERNAL_IDP"))
+	assert.False(t, identityCenterCredentialUsedMFA("EMAIL_OTP"))
+	assert.False(t, identityCenterCredentialUsedMFA(""))
+}
+
+func TestApplyIdentityCenterActivity(t *testing.T) {
+	t.Parallel()
+
+	lastLogin := time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC)
+	users := []identityCenterUser{
+		{ID: "bob"},
+		{ID: "carol"},
+		{ID: "dave"},
+	}
+
+	applyIdentityCenterActivity(
+		users,
+		map[string]identityCenterLogin{
+			"bob":   {at: lastLogin, usedMFA: true},
+			"carol": {at: lastLogin, usedMFA: false},
+		},
+		map[string]bool{"dave": true},
+	)
+
+	require.NotNil(t, users[0].LastLogin)
+	assert.True(t, users[0].LastLogin.Equal(lastLogin))
+	require.NotNil(t, users[0].MFAEnabled)
+	assert.True(t, *users[0].MFAEnabled)
+
+	require.NotNil(t, users[1].LastLogin)
+	assert.True(t, users[1].LastLogin.Equal(lastLogin))
+	assert.Nil(t, users[1].MFAEnabled)
+
+	assert.Nil(t, users[2].LastLogin)
+	require.NotNil(t, users[2].MFAEnabled)
+	assert.True(t, *users[2].MFAEnabled)
+}
+
+func TestApplyIdentityCenterActivity_DeviceOverridesPasswordLogin(t *testing.T) {
+	t.Parallel()
+
+	lastLogin := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	users := []identityCenterUser{{ID: "bob"}}
+
+	applyIdentityCenterActivity(
+		users,
+		map[string]identityCenterLogin{"bob": {at: lastLogin, usedMFA: false}},
+		map[string]bool{"bob": true},
+	)
+
+	require.NotNil(t, users[0].MFAEnabled)
+	assert.True(t, *users[0].MFAEnabled)
+	require.NotNil(t, users[0].LastLogin)
+}
+
+func TestListMfaDevicesOutput_HasDevice(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, listMfaDevicesOutput{}.hasDevice())
+	assert.True(t, listMfaDevicesOutput{MfaDevices: []json.RawMessage{[]byte(`{}`)}}.hasDevice())
+	assert.True(t, listMfaDevicesOutput{MFADevices: []json.RawMessage{[]byte(`{}`)}}.hasDevice())
+	assert.True(t, listMfaDevicesOutput{Devices: []json.RawMessage{[]byte(`{}`)}}.hasDevice())
+}
+
+func TestParseAWSJSONError(t *testing.T) {
+	t.Parallel()
+
+	err := parseAWSJSONError(
+		[]byte(`{"__type":"AccessDeniedException","Message":"not authorized"}`),
+	)
+	require.True(t, identityCenterAccessDenied(err))
+	assert.ErrorContains(t, err, "not authorized")
+}

--- a/pkg/accessreview/drivers/aws_identity_center_test.go
+++ b/pkg/accessreview/drivers/aws_identity_center_test.go
@@ -113,6 +113,13 @@ func TestListIdentityCenterUsers_FindsInstanceOutsideSessionRegion(t *testing.T)
 	carol := byID["arn:aws:identitystore::123456789012:user/22222222-2222-2222-2222-222222222222"]
 	assert.Equal(t, "Carol Engineer", carol.FullName)
 	assert.ElementsMatch(t, []string{"Engineers", "ReadOnlyAccess"}, carol.Roles)
+	assert.Equal(t, coredata.MFAStatusUnknown, carol.MFAStatus)
+	require.NotNil(t, carol.LastLogin)
+	assert.True(t, carol.LastLogin.Equal(time.Unix(1782864000, 0).UTC()))
+
+	assert.Equal(t, coredata.MFAStatusEnabled, bob.MFAStatus)
+	require.NotNil(t, bob.LastLogin)
+	assert.True(t, bob.LastLogin.Equal(time.Unix(1786752000, 0).UTC()))
 }
 
 func TestListIdentityCenterUsers_ListsDirectAndGroupAssignments(t *testing.T) {
@@ -142,26 +149,51 @@ func TestListIdentityCenterUsers_ListsDirectAndGroupAssignments(t *testing.T) {
 	assert.Equal(t, []string{"AdministratorAccess"}, bob.Roles)
 	assert.Equal(t, coredata.AccessReviewEntryAuthMethodSSO, bob.AuthMethod)
 	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, bob.AccountType)
-	assert.Equal(t, coredata.MFAStatusUnknown, bob.MFAStatus)
+	assert.Equal(t, coredata.MFAStatusEnabled, bob.MFAStatus)
 	require.NotNil(t, bob.IsAdmin)
 	assert.True(t, *bob.IsAdmin)
 	require.NotNil(t, bob.Active)
 	assert.True(t, *bob.Active)
 	require.NotNil(t, bob.CreatedAt)
 	assert.True(t, bob.CreatedAt.Equal(time.Unix(1767225600, 0).UTC()))
-	assert.Nil(t, bob.LastLogin)
+	require.NotNil(t, bob.LastLogin)
+	assert.True(t, bob.LastLogin.Equal(time.Unix(1786752000, 0).UTC()))
 
 	carol := byID["arn:aws:identitystore::123456789012:user/22222222-2222-2222-2222-222222222222"]
 	assert.Equal(t, "Carol Engineer", carol.FullName)
 	assert.Equal(t, "carol@example.com", carol.Email)
 	assert.ElementsMatch(t, []string{"Engineers", "ReadOnlyAccess"}, carol.Roles)
 	assert.Equal(t, coredata.AccessReviewEntryAuthMethodSSO, carol.AuthMethod)
+	assert.Equal(t, coredata.MFAStatusUnknown, carol.MFAStatus)
 	assert.Nil(t, carol.IsAdmin)
 	require.NotNil(t, carol.Active)
 	assert.True(t, *carol.Active)
+	require.NotNil(t, carol.LastLogin)
+	assert.True(t, carol.LastLogin.Equal(time.Unix(1782864000, 0).UTC()))
 
 	_, unused := byID["arn:aws:identitystore::123456789012:user/33333333-3333-3333-3333-333333333333"]
 	assert.False(t, unused)
+}
+
+func TestListIdentityCenterUsers_DegradesWhenActivityDenied(t *testing.T) {
+	t.Parallel()
+
+	rec := newAWSRecorder(t, "testdata/aws_identity_center_activity_denied")
+	session := newAWSTestSession(t, rec)
+
+	users, err := listIdentityCenterUsers(context.Background(), session, log.NewLogger(log.WithName("test")))
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+
+	records := make([]AccountRecord, 0, len(users))
+	for _, user := range users {
+		records = append(records, identityCenterUserRecord(user))
+	}
+
+	for _, record := range records {
+		assert.Equal(t, coredata.MFAStatusUnknown, record.MFAStatus)
+		assert.Nil(t, record.LastLogin)
+	}
 }
 
 func TestListIdentityCenterUsers_DegradesWhenLaterSSOAdminDenied(t *testing.T) {
@@ -235,6 +267,24 @@ func TestIdentityCenterUserRecord_MapsPrimaryEmailAndAdminName(t *testing.T) {
 	assert.Equal(t, &createdAt, record.CreatedAt)
 	assert.Nil(t, record.LastLogin)
 	assert.Equal(t, "arn:aws:identitystore::123456789012:user/bob", record.ExternalID)
+}
+
+func TestIdentityCenterUserRecord_MapsActivitySignals(t *testing.T) {
+	t.Parallel()
+
+	lastLogin := time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC)
+
+	record := identityCenterUserRecord(
+		identityCenterUser{
+			ARN:        "arn:aws:identitystore::123456789012:user/bob",
+			UserName:   "bob",
+			MFAEnabled: new(true),
+			LastLogin:  &lastLogin,
+		},
+	)
+
+	assert.Equal(t, coredata.MFAStatusEnabled, record.MFAStatus)
+	assert.Equal(t, &lastLogin, record.LastLogin)
 }
 
 func TestIdentityCenterUserRecord_FallsBackToUserNameEmailAndDisplayName(t *testing.T) {

--- a/pkg/accessreview/drivers/testdata/aws_identity_center_activity_denied.yaml
+++ b/pkg/accessreview/drivers/testdata/aws_identity_center_activity_denied.yaml
@@ -1,16 +1,7 @@
 ---
-# Hand-authored Identity Center cassette. Never recorded against a live
-# account. Interactions are matched by host and X-Amz-Target (see
-# awsAPIMatcher) and consumed in call order when the target repeats.
-# Call order: ListInstances, ListPermissionSets, DescribePermissionSet
-# (AdministratorAccess, then ReadOnlyAccess), ListManagedPolicies for
-# ReadOnlyAccess only (the admin name short-circuits), ListAccountAssignments
-# for each set, DescribeGroup, ListGroupMemberships, ListUsers,
-# LookupEvents, ListMfaDevicesForUser for Bob then Carol.
-# Bob is assigned AdministratorAccess directly. Carol reaches ReadOnlyAccess
-# through the Engineers group. Dave is in the store with no assignment.
-# Bob last logged in with TOTP and has a virtual MFA device. Carol's last
-# login is password-only and she has no registered device.
+# Same Identity Center listing as testdata/aws_identity_center.yaml, then
+# LookupEvents and ListMfaDevicesForUser are denied. Assigned users must
+# still be returned with MFA and last login unknown.
 version: 2
 interactions:
     - id: 0
@@ -270,12 +261,14 @@ interactions:
         proto_minor: 1
         content_length: -1
         uncompressed: true
-        body: '{"Events":[{"EventName":"UserAuthentication","EventTime":1786752000,"CloudTrailEvent":"{\"userIdentity\":{\"onBehalfOf\":{\"userId\":\"11111111-1111-1111-1111-111111111111\"}},\"additionalEventData\":{\"CredentialType\":\"PASSWORD,TOTP\"}}"},{"EventName":"UserAuthentication","EventTime":1782864000,"CloudTrailEvent":"{\"userIdentity\":{\"onBehalfOf\":{\"userId\":\"22222222-2222-2222-2222-222222222222\"}},\"additionalEventData\":{\"CredentialType\":\"PASSWORD\"}}"}]}'
+        body: '{"__type":"AccessDeniedException","Message":"not authorized to perform cloudtrail:LookupEvents"}'
         headers:
             Content-Type:
                 - application/x-amz-json-1.1
-        status: 200 OK
-        code: 200
+            X-Amzn-Errortype:
+                - AccessDeniedException
+        status: 400 Bad Request
+        code: 400
         duration: 1ms
     - id: 11
       request:
@@ -294,34 +287,12 @@ interactions:
         proto_minor: 1
         content_length: -1
         uncompressed: true
-        body: '{"MfaDevices":[{"DeviceId":"m-bob","DeviceType":"TOTP"}]}'
+        body: '{"__type":"AccessDeniedException","Message":"not authorized to perform sso-directory:ListMfaDevicesForUser"}'
         headers:
             Content-Type:
                 - application/x-amz-json-1.1
-        status: 200 OK
-        code: 200
-        duration: 1ms
-    - id: 12
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        host: identitystore.us-east-1.amazonaws.com
-        headers:
-            X-Amz-Target:
-                - AWSIdentityStore.ListMfaDevicesForUser
-        url: https://identitystore.us-east-1.amazonaws.com/
-        method: POST
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: -1
-        uncompressed: true
-        body: '{"MfaDevices":[]}'
-        headers:
-            Content-Type:
-                - application/x-amz-json-1.1
-        status: 200 OK
-        code: 200
+            X-Amzn-Errortype:
+                - AccessDeniedException
+        status: 400 Bad Request
+        code: 400
         duration: 1ms

--- a/pkg/accessreview/drivers/testdata/aws_identity_center_eu_west_1.yaml
+++ b/pkg/accessreview/drivers/testdata/aws_identity_center_eu_west_1.yaml
@@ -3,7 +3,8 @@
 # account. Interactions are matched by host and X-Amz-Target (see
 # awsAPIMatcher) and consumed in call order when the target repeats.
 # Call order: ListInstances empty in us-east-1, then the usual walk in
-# eu-west-1. Same principals as testdata/aws_identity_center.yaml.
+# eu-west-1, then LookupEvents and ListMfaDevicesForUser in eu-west-1.
+# Same principals and activity as testdata/aws_identity_center.yaml.
 version: 2
 interactions:
     - id: 0
@@ -264,6 +265,78 @@ interactions:
         content_length: -1
         uncompressed: true
         body: '{"Users":[{"UserId":"11111111-1111-1111-1111-111111111111","IdentityStoreId":"d-1234567890","UserName":"bob","DisplayName":"Bob Admin","Title":"Security Lead","UserStatus":"ENABLED","CreatedAt":1767225600,"Emails":[{"Primary":true,"Value":"bob@example.com"}]},{"UserId":"22222222-2222-2222-2222-222222222222","IdentityStoreId":"d-1234567890","UserName":"carol@example.com","DisplayName":"Carol Engineer","UserStatus":"ENABLED"},{"UserId":"33333333-3333-3333-3333-333333333333","IdentityStoreId":"d-1234567890","UserName":"dave","DisplayName":"Dave Unused","Emails":[{"Primary":true,"Value":"dave@example.com"}]}]}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: cloudtrail.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - CloudTrail_20131101.LookupEvents
+        url: https://cloudtrail.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"Events":[{"EventName":"UserAuthentication","EventTime":1786752000,"CloudTrailEvent":"{\"userIdentity\":{\"onBehalfOf\":{\"userId\":\"11111111-1111-1111-1111-111111111111\"}},\"additionalEventData\":{\"CredentialType\":\"PASSWORD,TOTP\"}}"},{"EventName":"UserAuthentication","EventTime":1782864000,"CloudTrailEvent":"{\"userIdentity\":{\"onBehalfOf\":{\"userId\":\"22222222-2222-2222-2222-222222222222\"}},\"additionalEventData\":{\"CredentialType\":\"PASSWORD\"}}"}]}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: identitystore.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - AWSIdentityStore.ListMfaDevicesForUser
+        url: https://identitystore.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"MfaDevices":[{"DeviceId":"m-bob","DeviceType":"TOTP"}]}'
+        headers:
+            Content-Type:
+                - application/x-amz-json-1.1
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: identitystore.eu-west-1.amazonaws.com
+        headers:
+            X-Amz-Target:
+                - AWSIdentityStore.ListMfaDevicesForUser
+        url: https://identitystore.eu-west-1.amazonaws.com/
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"MfaDevices":[]}'
         headers:
             Content-Type:
                 - application/x-amz-json-1.1


### PR DESCRIPTION
Identity Store does not expose these fields, so access reviews left SSO users as unknown. CloudTrail Event History supplies last login for the last 90 days, and registered MFA devices (or a TOTP/WebAuthn sign-in) mark MFA enabled. Enrichment failures keep the listed users and leave the missing signals unknown.