### PR TITLE
Allow organization deletion with related rows

### DIFF
--- a/e2e/console/organization_relations_test.go
+++ b/e2e/console/organization_relations_test.go
@@ -35,25 +35,34 @@ import (
 // covered here.
 
 type organizationRelationGraph struct {
-	orgID                string
-	ownerProfileID       string
-	contextProduct       string
-	frameworkID          string
-	controlID            string
-	measureID            string
-	taskID               string
-	soaID                string
-	assetID              string
-	datumID              string
-	documentID           string
-	auditID              string
-	findingID            string
-	processingActivityID string
-	compliancePortalID   string
-	thirdPartyID         string
-	riskID               string
-	riskAnalysisID       string
-	riskScenarioID       string
+	orgID                  string
+	ownerProfileID         string
+	contextProduct         string
+	frameworkID            string
+	controlID              string
+	measureID              string
+	taskID                 string
+	soaID                  string
+	assetID                string
+	datumID                string
+	documentID             string
+	auditID                string
+	findingID              string
+	processingActivityID   string
+	compliancePortalID     string
+	thirdPartyID           string
+	riskID                 string
+	riskAnalysisID         string
+	riskScenarioID         string
+	treatmentPlanID        string
+	obligationID           string
+	aiSystemID             string
+	businessFunctionID     string
+	deviceID               string
+	cookieBannerID         string
+	accessReviewSourceID   string
+	accessReviewCampaignID string
+	logoFileID             string
 }
 
 func populateOrganizationRelationGraph(
@@ -84,6 +93,7 @@ func populateOrganizationRelationGraph(
 	}, &struct{}{})
 	require.NoError(t, err)
 
+	g.logoFileID = createOrganizationRelationLogo(t, owner)
 	g.frameworkID = factory.NewFramework(owner).
 		WithName(marker + " framework").
 		Create()
@@ -112,6 +122,13 @@ func populateOrganizationRelationGraph(
 	g.documentID = factory.NewDocument(owner).
 		WithTitle(marker + " document").
 		Create()
+	approveTestDocument(t, owner, g.documentID)
+	requestDocumentSignature(
+		t,
+		owner,
+		latestDocumentVersionID(t, owner, g.documentID),
+		g.ownerProfileID,
+	)
 	g.auditID = factory.NewAudit(owner, g.frameworkID).
 		WithName(marker + " audit").
 		Create()
@@ -125,7 +142,10 @@ func populateOrganizationRelationGraph(
 	)
 	g.thirdPartyID = factory.CreateThirdParty(
 		owner,
-		factory.Attrs{"name": marker + " third party"},
+		factory.Attrs{
+			"name":             marker + " third party",
+			"administratorIds": []string{g.ownerProfileID},
+		},
 	)
 	g.riskID = factory.NewRisk(owner).
 		WithName(marker + " risk").
@@ -145,8 +165,97 @@ func populateOrganizationRelationGraph(
 		scopeID,
 		factory.Attrs{"name": marker + " scenario"},
 	)
+	factory.LinkRiskAnalysisScenarioRisk(owner, g.riskScenarioID, g.riskID)
+	g.treatmentPlanID = factory.CreateTreatmentPlan(
+		owner,
+		g.riskID,
+		g.riskAnalysisID,
+		factory.Attrs{"ownerId": g.ownerProfileID},
+	)
+	g.obligationID = createOrganizationRelationObligation(
+		t,
+		owner,
+		g.ownerProfileID,
+		marker+" obligation",
+	)
+	g.aiSystemID = createOrganizationRelationAiSystem(
+		t,
+		owner,
+		g.ownerProfileID,
+		marker+" ai system",
+	)
+	g.businessFunctionID = createOrganizationRelationBusinessFunction(
+		t,
+		owner,
+		g.ownerProfileID,
+		marker+" business function",
+	)
+	g.deviceID = createOrganizationRelationDevice(t, owner, g.ownerProfileID)
+	g.cookieBannerID = factory.NewCookieBanner(owner).
+		WithName(marker + " banner").
+		Create()
+	g.accessReviewSourceID = factory.NewAccessReviewSource(owner, g.orgID).
+		WithName(marker + " source").
+		Create()
+	g.accessReviewCampaignID = factory.NewAccessReviewCampaign(owner, g.orgID).
+		WithName(marker + " campaign").
+		WithAccessReviewSourceIDs([]string{g.accessReviewSourceID}).
+		Create()
 
 	return g
+}
+
+func createOrganizationRelationLogo(t *testing.T, owner *testutil.Client) string {
+	t.Helper()
+
+	pngContent := []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+		0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41,
+		0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+		0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00,
+		0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+		0x42, 0x60, 0x82,
+	}
+
+	var result struct {
+		UpdateOrganization struct {
+			Organization struct {
+				Logo *struct {
+					ID string `json:"id"`
+				} `json:"logo"`
+			} `json:"organization"`
+		} `json:"updateOrganization"`
+	}
+
+	err := owner.ExecuteConnectWithFile(
+		`
+			mutation($input: UpdateOrganizationInput!) {
+				updateOrganization(input: $input) {
+					organization { logo { id } }
+				}
+			}
+		`,
+		map[string]any{
+			"input": map[string]any{
+				"organizationId": owner.GetOrganizationID().String(),
+				"logoFile":       nil,
+			},
+		},
+		"input.logoFile",
+		testutil.UploadFile{
+			Filename:    "org-relations-logo.png",
+			ContentType: "image/png",
+			Content:     pngContent,
+		},
+		&result,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result.UpdateOrganization.Organization.Logo)
+
+	return result.UpdateOrganization.Organization.Logo.ID
 }
 
 func createOrganizationRelationAsset(
@@ -227,6 +336,151 @@ func createOrganizationRelationFinding(
 	return result.CreateFinding.FindingEdge.Node.ID
 }
 
+func createOrganizationRelationObligation(
+	t *testing.T,
+	owner *testutil.Client,
+	ownerProfileID, requirement string,
+) string {
+	t.Helper()
+
+	var result struct {
+		CreateObligation struct {
+			ObligationEdge struct {
+				Node struct {
+					ID string `json:"id"`
+				} `json:"node"`
+			} `json:"obligationEdge"`
+		} `json:"createObligation"`
+	}
+
+	err := owner.Execute(`
+		mutation($input: CreateObligationInput!) {
+			createObligation(input: $input) {
+				obligationEdge { node { id } }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"requirement":    requirement,
+			"status":         "NON_COMPLIANT",
+			"type":           "LEGAL",
+			"ownerId":        ownerProfileID,
+		},
+	}, &result)
+	require.NoError(t, err)
+
+	return result.CreateObligation.ObligationEdge.Node.ID
+}
+
+func createOrganizationRelationAiSystem(
+	t *testing.T,
+	owner *testutil.Client,
+	ownerProfileID, name string,
+) string {
+	t.Helper()
+
+	var result struct {
+		CreateAiSystem struct {
+			AiSystemEdge struct {
+				Node struct {
+					ID string `json:"id"`
+				} `json:"node"`
+			} `json:"aiSystemEdge"`
+		} `json:"createAiSystem"`
+	}
+
+	err := owner.Execute(`
+		mutation($input: CreateAiSystemInput!) {
+			createAiSystem(input: $input) {
+				aiSystemEdge { node { id } }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"organizationId":     owner.GetOrganizationID().String(),
+			"name":               name,
+			"status":             "ACTIVE",
+			"riskClassification": "MINIMAL",
+			"ownerId":            ownerProfileID,
+		},
+	}, &result)
+	require.NoError(t, err)
+
+	return result.CreateAiSystem.AiSystemEdge.Node.ID
+}
+
+func createOrganizationRelationBusinessFunction(
+	t *testing.T,
+	owner *testutil.Client,
+	ownerProfileID, name string,
+) string {
+	t.Helper()
+
+	var result struct {
+		CreateBusinessFunction struct {
+			BusinessFunctionEdge struct {
+				Node struct {
+					ID string `json:"id"`
+				} `json:"node"`
+			} `json:"businessFunctionEdge"`
+		} `json:"createBusinessFunction"`
+	}
+
+	err := owner.Execute(`
+		mutation($input: CreateBusinessFunctionInput!) {
+			createBusinessFunction(input: $input) {
+				businessFunctionEdge { node { id } }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"name":           name,
+			"classification": "CRITICAL",
+			"mtdMinutes":     240,
+			"rtoMinutes":     120,
+			"rpoMinutes":     60,
+			"ownerId":        ownerProfileID,
+		},
+	}, &result)
+	require.NoError(t, err)
+
+	return result.CreateBusinessFunction.BusinessFunctionEdge.Node.ID
+}
+
+func createOrganizationRelationDevice(
+	t *testing.T,
+	owner *testutil.Client,
+	ownerProfileID string,
+) string {
+	t.Helper()
+
+	var result struct {
+		CreateDevice struct {
+			Device struct {
+				ID string `json:"id"`
+			} `json:"device"`
+		} `json:"createDevice"`
+	}
+
+	err := owner.Execute(`
+		mutation($input: CreateDeviceInput!) {
+			createDevice(input: $input) {
+				device { id }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"ownerId":        ownerProfileID,
+		},
+	}, &result)
+	require.NoError(t, err)
+
+	return result.CreateDevice.Device.ID
+}
+
 func TestOrganization_Relations(t *testing.T) {
 	t.Parallel()
 
@@ -243,6 +497,7 @@ func TestOrganization_Relations(t *testing.T) {
 		{name: "AuditsFindings", run: orgRelationsAuditsFindings},
 		{name: "PrivacyPortalThirdParties", run: orgRelationsPrivacyPortalThirdParties},
 		{name: "RiskPortfolio", run: orgRelationsRiskPortfolio},
+		{name: "OwnedPrivacyAndReviews", run: orgRelationsOwnedPrivacyAndReviews},
 	}
 
 	for _, tc := range cases {
@@ -280,6 +535,9 @@ func orgRelationsContextProfilesPermission(
 					} `json:"node"`
 				} `json:"edges"`
 			} `json:"profiles"`
+			Logo *struct {
+				ID string `json:"id"`
+			} `json:"logo"`
 			CanCreateFramework bool `json:"canCreateFramework"`
 			CanListRisks       bool `json:"canListRisks"`
 		} `json:"node"`
@@ -301,6 +559,7 @@ func orgRelationsContextProfilesPermission(
 						totalCount
 						edges { node { id } }
 					}
+					logo { id }
 					canCreateFramework: permission(action: "core:framework:create")
 					canListRisks: permission(action: "risk-management:risk:list")
 				}
@@ -321,6 +580,8 @@ func orgRelationsContextProfilesPermission(
 
 	profileIDs := collectRelationNodeIDs(result.Node.Profiles.Edges)
 	assert.True(t, profileIDs[g.ownerProfileID], "profiles must include owner membership")
+	require.NotNil(t, result.Node.Logo)
+	assert.Equal(t, g.logoFileID, result.Node.Logo.ID)
 	assert.True(t, result.Node.CanCreateFramework)
 	assert.True(t, result.Node.CanListRisks)
 }
@@ -858,4 +1119,144 @@ func orgRelationsRiskPortfolio(
 	require.NoError(t, err)
 	assert.Equal(t, g.orgID, riskReverse.Node.Organization.ID)
 	assert.True(t, riskReverse.Node.CanUpdate)
+}
+
+func orgRelationsOwnedPrivacyAndReviews(
+	t *testing.T,
+	owner *testutil.Client,
+	g organizationRelationGraph,
+) {
+	var result struct {
+		Node struct {
+			Obligations struct {
+				TotalCount int `json:"totalCount"`
+				Edges      []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"obligations"`
+			BusinessFunctions struct {
+				TotalCount int `json:"totalCount"`
+				Edges      []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"businessFunctions"`
+			AiSystems struct {
+				TotalCount int `json:"totalCount"`
+				Edges      []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"aiSystems"`
+			Devices struct {
+				TotalCount int `json:"totalCount"`
+				Edges      []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"devices"`
+			TreatmentPlans struct {
+				TotalCount int `json:"totalCount"`
+				Edges      []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"treatmentPlans"`
+			CookieBanners struct {
+				TotalCount int `json:"totalCount"`
+				Edges      []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"cookieBanners"`
+			AccessReviewSources struct {
+				TotalCount int `json:"totalCount"`
+				Edges      []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"accessReviewSources"`
+			AccessReviewCampaigns struct {
+				TotalCount int `json:"totalCount"`
+				Edges      []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"accessReviewCampaigns"`
+		} `json:"node"`
+	}
+
+	err := owner.Execute(`
+		query($id: ID!) {
+			node(id: $id) {
+				... on Organization {
+					obligations(first: 50) {
+						totalCount
+						edges { node { id } }
+					}
+					businessFunctions(first: 50) {
+						totalCount
+						edges { node { id } }
+					}
+					aiSystems(first: 50) {
+						totalCount
+						edges { node { id } }
+					}
+					devices(first: 50) {
+						totalCount
+						edges { node { id } }
+					}
+					treatmentPlans(first: 50) {
+						totalCount
+						edges { node { id } }
+					}
+					cookieBanners(first: 50) {
+						totalCount
+						edges { node { id } }
+					}
+					accessReviewSources(first: 50) {
+						totalCount
+						edges { node { id } }
+					}
+					accessReviewCampaigns(first: 50) {
+						totalCount
+						edges { node { id } }
+					}
+				}
+			}
+		}
+	`, map[string]any{"id": g.orgID}, &result)
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, result.Node.Obligations.TotalCount, 1)
+	assert.True(t, collectRelationNodeIDs(result.Node.Obligations.Edges)[g.obligationID])
+	assert.GreaterOrEqual(t, result.Node.BusinessFunctions.TotalCount, 1)
+	assert.True(t, collectRelationNodeIDs(result.Node.BusinessFunctions.Edges)[g.businessFunctionID])
+	assert.GreaterOrEqual(t, result.Node.AiSystems.TotalCount, 1)
+	assert.True(t, collectRelationNodeIDs(result.Node.AiSystems.Edges)[g.aiSystemID])
+	assert.GreaterOrEqual(t, result.Node.Devices.TotalCount, 1)
+	assert.True(t, collectRelationNodeIDs(result.Node.Devices.Edges)[g.deviceID])
+	assert.GreaterOrEqual(t, result.Node.TreatmentPlans.TotalCount, 1)
+	assert.True(t, collectRelationNodeIDs(result.Node.TreatmentPlans.Edges)[g.treatmentPlanID])
+	assert.GreaterOrEqual(t, result.Node.CookieBanners.TotalCount, 1)
+	assert.True(t, collectRelationNodeIDs(result.Node.CookieBanners.Edges)[g.cookieBannerID])
+	assert.GreaterOrEqual(t, result.Node.AccessReviewSources.TotalCount, 1)
+	assert.True(
+		t,
+		collectRelationNodeIDs(result.Node.AccessReviewSources.Edges)[g.accessReviewSourceID],
+	)
+	assert.GreaterOrEqual(t, result.Node.AccessReviewCampaigns.TotalCount, 1)
+	assert.True(
+		t,
+		collectRelationNodeIDs(result.Node.AccessReviewCampaigns.Edges)[g.accessReviewCampaignID],
+	)
 }

--- a/e2e/console/organization_test.go
+++ b/e2e/console/organization_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
 	"go.probo.inc/probo/e2e/internal/testutil"
 )
 
@@ -147,4 +148,76 @@ func TestOrganization_Get(t *testing.T) {
 
 	assert.Equal(t, owner.GetOrganizationID().String(), result.Node.ID)
 	assert.NotEmpty(t, result.Node.Name)
+}
+
+func TestOrganization_Delete(t *testing.T) {
+	t.Parallel()
+
+	const deleteMutation = `
+		mutation DeleteOrganization($input: DeleteOrganizationInput!) {
+			deleteOrganization(input: $input) {
+				deletedOrganizationId
+			}
+		}
+	`
+
+	t.Run("owner can delete an organization with related records", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		orgID := owner.GetOrganizationID().String()
+
+		graph := populateOrganizationRelationGraph(t, owner)
+
+		var result struct {
+			DeleteOrganization struct {
+				DeletedOrganizationID string `json:"deletedOrganizationId"`
+			} `json:"deleteOrganization"`
+		}
+
+		err := owner.ExecuteConnect(deleteMutation, map[string]any{
+			"input": map[string]any{
+				"organizationId": orgID,
+			},
+		}, &result)
+		require.NoError(t, err)
+		assert.Equal(t, orgID, result.DeleteOrganization.DeletedOrganizationID)
+		factory.RequireFileSoftDeleted(t, graph.logoFileID)
+
+		err = owner.ExecuteConnectShouldFail(`
+			query GetOrganization($id: ID!) {
+				node(id: $id) {
+					... on Organization {
+						id
+					}
+				}
+			}
+		`, map[string]any{"id": orgID})
+		require.Error(t, err)
+	})
+
+	t.Run("admin cannot delete", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		admin := testutil.NewClientInOrg(t, testutil.RoleAdmin, owner)
+
+		err := admin.ExecuteConnectShouldFail(deleteMutation, map[string]any{
+			"input": map[string]any{
+				"organizationId": owner.GetOrganizationID().String(),
+			},
+		})
+		testutil.RequireForbiddenError(t, err)
+	})
+
+	t.Run("viewer cannot delete", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+		err := viewer.ExecuteConnectShouldFail(deleteMutation, map[string]any{
+			"input": map[string]any{
+				"organizationId": owner.GetOrganizationID().String(),
+			},
+		})
+		testutil.RequireForbiddenError(t, err)
+	})
 }

--- a/e2e/internal/factory/factory.go
+++ b/e2e/internal/factory/factory.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/stretchr/testify/require"
@@ -306,6 +307,29 @@ ON CONFLICT DO NOTHING
 		return err
 	})
 	require.NoError(t, err, "test setup: cannot inject cross-tenant third party administrator")
+}
+
+func RequireFileSoftDeleted(t *testing.T, fileID string) {
+	t.Helper()
+
+	var deletedAt *time.Time
+
+	err := test.PGClient(t).WithConn(
+		context.Background(),
+		func(ctx context.Context, conn pg.Querier) error {
+			return conn.QueryRow(
+				ctx,
+				`
+SELECT deleted_at
+FROM files
+WHERE id = $1
+`,
+				fileID,
+			).Scan(&deletedAt)
+		},
+	)
+	require.NoError(t, err, "cannot load file deleted_at")
+	require.NotNil(t, deletedAt, "file %s must be soft-deleted", fileID)
 }
 
 func CreateFramework(c *testutil.Client, attrs ...Attrs) string {

--- a/pkg/coredata/ai_system.go
+++ b/pkg/coredata/ai_system.go
@@ -574,3 +574,29 @@ func aiSystemCompanyRolesToStrings(roles []AiSystemCompanyRole) []string {
 
 	return result
 }
+
+func (c *AiSystems) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM ai_systems
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete ai systems: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/asset.go
+++ b/pkg/coredata/asset.go
@@ -659,3 +659,29 @@ WHERE
 
 	return nil
 }
+
+func (c *Assets) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM assets
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete assets: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/business_function.go
+++ b/pkg/coredata/business_function.go
@@ -539,3 +539,29 @@ WHERE
 
 	return nil
 }
+
+func (c *BusinessFunctions) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM business_functions
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete business functions: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/datum.go
+++ b/pkg/coredata/datum.go
@@ -493,3 +493,29 @@ WHERE
 
 	return nil
 }
+
+func (c *Data) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM data
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete data: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/device.go
+++ b/pkg/coredata/device.go
@@ -996,3 +996,29 @@ WHERE
 
 	return result.RowsAffected(), nil
 }
+
+func (c *Devices) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM devices
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete devices: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/document_version_approval_decision.go
+++ b/pkg/coredata/document_version_approval_decision.go
@@ -786,3 +786,29 @@ WHERE
 
 	return count, nil
 }
+
+func (c *DocumentVersionApprovalDecisions) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM document_version_approval_decisions
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete document version approval decisions: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/document_version_signature.go
+++ b/pkg/coredata/document_version_signature.go
@@ -1118,3 +1118,29 @@ WHERE
 
 	return count, nil
 }
+
+func (c *DocumentVersionSignatures) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM document_version_signatures
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete document version signatures: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/file.go
+++ b/pkg/coredata/file.go
@@ -383,3 +383,32 @@ WHERE %s
 
 	return err
 }
+
+func (f *Files) SoftDeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+UPDATE files
+SET
+    deleted_at = NOW()
+WHERE
+    %s
+    AND organization_id = @organization_id
+    AND deleted_at IS NULL
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot soft delete files: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/finding.go
+++ b/pkg/coredata/finding.go
@@ -673,3 +673,29 @@ WHERE
 
 	return nil
 }
+
+func (c *Findings) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM findings
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete findings: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/migrations/20260902T113433Z.sql
+++ b/pkg/coredata/migrations/20260902T113433Z.sql
@@ -1,0 +1,100 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TABLE iam_membership_profiles
+    DROP CONSTRAINT iam_membership_profiles_organization_id_fkey;
+ALTER TABLE iam_membership_profiles
+    ADD CONSTRAINT iam_membership_profiles_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE;
+
+ALTER TABLE audit_log_entries
+    DROP CONSTRAINT audit_log_entries_organization_id_fkey;
+ALTER TABLE audit_log_entries
+    ADD CONSTRAINT audit_log_entries_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE;
+
+ALTER TABLE cookie_banner_translations
+    DROP CONSTRAINT cookie_banner_translations_organization_id_fkey;
+ALTER TABLE cookie_banner_translations
+    ADD CONSTRAINT cookie_banner_translations_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE;
+
+ALTER TABLE access_review_sources
+    DROP CONSTRAINT access_review_sources_organization_id_fkey;
+ALTER TABLE access_review_sources
+    ADD CONSTRAINT access_review_sources_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE;
+
+ALTER TABLE access_review_campaigns
+    DROP CONSTRAINT access_review_campaigns_organization_id_fkey;
+ALTER TABLE access_review_campaigns
+    ADD CONSTRAINT access_review_campaigns_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE;
+
+ALTER TABLE access_review_entries
+    DROP CONSTRAINT access_review_entries_organization_id_fkey;
+ALTER TABLE access_review_entries
+    ADD CONSTRAINT access_review_entries_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE;
+
+ALTER TABLE access_review_entry_decision_history
+    DROP CONSTRAINT access_review_entry_decision_history_organization_id_fkey;
+ALTER TABLE access_review_entry_decision_history
+    ADD CONSTRAINT access_review_entry_decision_history_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE;
+
+ALTER TABLE access_review_campaign_sources
+    DROP CONSTRAINT access_review_campaign_sources_organization_id_fkey;
+ALTER TABLE access_review_campaign_sources
+    ADD CONSTRAINT access_review_campaign_sources_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE;
+
+ALTER TABLE access_review_campaign_source_fetch_attempts
+    DROP CONSTRAINT access_review_campaign_source_fetch_attemp_organization_id_fkey;
+ALTER TABLE access_review_campaign_source_fetch_attempts
+    ADD CONSTRAINT access_review_campaign_source_fetch_attemp_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE;

--- a/pkg/coredata/obligation.go
+++ b/pkg/coredata/obligation.go
@@ -725,3 +725,29 @@ WHERE
 
 	return nil
 }
+
+func (c *Obligations) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM obligations
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete obligations: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/processing_activities.go
+++ b/pkg/coredata/processing_activities.go
@@ -633,3 +633,29 @@ WHERE
 
 	return nil
 }
+
+func (c *ProcessingActivities) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM processing_activities
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete processing activities: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/risk_analysis_scenario_risk.go
+++ b/pkg/coredata/risk_analysis_scenario_risk.go
@@ -270,3 +270,35 @@ WHERE
 
 	return count, nil
 }
+
+func (srs *RiskAnalysisScenarioRisks) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM risk_analysis_scenario_risks
+WHERE
+	%s
+	AND risk_id IN (
+		SELECT id
+		FROM risks
+		WHERE
+			%s
+			AND organization_id = @organization_id
+	)
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete risk analysis scenario risks: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/statement_of_applicability.go
+++ b/pkg/coredata/statement_of_applicability.go
@@ -376,3 +376,29 @@ WHERE
 
 	return nil
 }
+
+func (c *StatementsOfApplicability) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM statements_of_applicability
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete statements of applicability: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/third_party_administrator.go
+++ b/pkg/coredata/third_party_administrator.go
@@ -198,3 +198,29 @@ WHEN NOT MATCHED BY SOURCE
 
 	return nil
 }
+
+func (c *ThirdPartyAdministrators) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM third_party_administrators
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete third party administrators: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/treatment_plan.go
+++ b/pkg/coredata/treatment_plan.go
@@ -1540,3 +1540,29 @@ DELETE FROM treatment_plans WHERE %s AND id = @id
 
 	return nil
 }
+
+func (c *TreatmentPlans) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM treatment_plans
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete treatment plans: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/treatment_plan_event.go
+++ b/pkg/coredata/treatment_plan_event.go
@@ -377,3 +377,29 @@ WHERE
 
 	return nil
 }
+
+func (c *TreatmentPlanEvents) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM treatment_plan_events
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete treatment plan events: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -926,6 +926,10 @@ func (s *OrganizationService) DeleteOrganization(ctx context.Context, organizati
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
+			if err := deleteOrganizationDependencies(ctx, tx, scope, organizationID); err != nil {
+				return fmt.Errorf("cannot delete organization dependencies: %w", err)
+			}
+
 			err = organization.Delete(ctx, tx, organizationID)
 			if err != nil {
 				return fmt.Errorf("cannot delete organization: %w", err)
@@ -934,6 +938,84 @@ func (s *OrganizationService) DeleteOrganization(ctx context.Context, organizati
 			return nil
 		},
 	)
+}
+
+func deleteOrganizationDependencies(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	organizationID gid.GID,
+) error {
+	// These tables restrict deleting a membership profile that still owns
+	// them, or a risk that is still linked to a scenario. They must be
+	// removed before organizations cascade-deletes those rows.
+	if err := new(coredata.TreatmentPlanEvents).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete treatment plan events: %w", err)
+	}
+
+	if err := new(coredata.TreatmentPlans).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete treatment plans: %w", err)
+	}
+
+	if err := new(coredata.RiskAnalysisScenarioRisks).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete risk analysis scenario risks: %w", err)
+	}
+
+	if err := new(coredata.DocumentVersionApprovalDecisions).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete document version approval decisions: %w", err)
+	}
+
+	if err := new(coredata.DocumentVersionSignatures).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete document version signatures: %w", err)
+	}
+
+	if err := new(coredata.ThirdPartyAdministrators).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete third party administrators: %w", err)
+	}
+
+	if err := new(coredata.Assets).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete assets: %w", err)
+	}
+
+	if err := new(coredata.Data).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete data: %w", err)
+	}
+
+	if err := new(coredata.Devices).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete devices: %w", err)
+	}
+
+	if err := new(coredata.Obligations).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete obligations: %w", err)
+	}
+
+	if err := new(coredata.ProcessingActivities).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete processing activities: %w", err)
+	}
+
+	if err := new(coredata.StatementsOfApplicability).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete statements of applicability: %w", err)
+	}
+
+	if err := new(coredata.AiSystems).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete ai systems: %w", err)
+	}
+
+	if err := new(coredata.BusinessFunctions).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete business functions: %w", err)
+	}
+
+	if err := new(coredata.Findings).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete findings: %w", err)
+	}
+
+	// files.organization_id has no foreign key, so they cannot cascade
+	// from the organization delete.
+	if err := new(coredata.Files).SoftDeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot soft delete files: %w", err)
+	}
+
+	return nil
 }
 
 func (s *OrganizationService) CreateUser(ctx context.Context, scope coredata.Scoper, req *CreateUserRequest) (*coredata.MembershipProfile, error) {


### PR DESCRIPTION
Deleting an organization failed when related rows still referenced it, or when profile-owner RESTRICT constraints fired while cascading membership profiles.

Missing organization_id foreign keys now cascade on update and delete. The IAM service still deletes rows that restrict on membership-profile owners before removing the organization. The e2e graph seeds those owned and cascading relations. Profile-owner RESTRICT is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deleting an organization previously failed when related rows still referenced it. Organization-owned foreign keys now cascade on delete and update, the IAM service removes the rows that would otherwise block the cascade, and files are soft-deleted since they have no organization FK. Only owners can delete an organization with related records.

### Tests **`+518`** **`-20`**

- Seeds the relation graph with additional owned, signed, and cascading records, including a logo file.
- Adds a delete test: an owner can delete an organization with related rows and the logo file is soft-deleted, while admins and viewers cannot.

### Coredata **`+525`** **`-0`**

- Adds scoped `DeleteByOrganizationID` to every owned coredata type, plus `SoftDeleteByOrganizationID` for files.
- The migration switches `organization_id` foreign keys on membership profiles, audit log entries, cookie banner translations, and access review tables to cascade on delete and update.

### Service **`+82`** **`-0`**

- `DeleteOrganization` deletes records that reference membership-profile owners or scenario-linked risks before removing the organization, then soft-deletes files; profile-owner RESTRICT constraints stay in place.

<sup>Written for commit a305c28990558314c477172b119e6d06fd30207c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

