### PR TITLE
List Identity Center users without grants

### DIFF
--- a/cmd/probod/CHANGELOG.md
+++ b/cmd/probod/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `probod` (the server, including the bundled `@probo/conso
 
 ## Unreleased
 
+### Fixed
+
+- AWS access review now includes Identity Center users with no permission-set assignment on the connected account (empty roles). Still no Organizations walk and no cross-account assignment listing
+
 ## [0.275.0] - 2026-09-02
 
 ### Changed

--- a/pkg/accessreview/drivers/aws_identity_center.go
+++ b/pkg/accessreview/drivers/aws_identity_center.go
@@ -49,9 +49,9 @@ const (
 )
 
 type (
-	// identityCenterUser is one Identity Center principal assigned to the
-	// connected AWS account, joined from permission-set assignments and the
-	// identity store.
+	// identityCenterUser is one Identity Center principal from the identity
+	// store. Grants are the permission sets and groups assigned to this
+	// session's account; they are empty when the user has no assignment here.
 	identityCenterUser struct {
 		ID          string
 		ARN         string
@@ -183,8 +183,8 @@ func identityCenterAccessDenied(err error) bool {
 	}
 }
 
-// listIdentityCenterUsers returns Identity Center users assigned to this
-// session's account.
+// listIdentityCenterUsers returns Identity Center users in the identity
+// store, with grants for assignments on this session's account.
 //
 // Discovery walks Identity Center regions until ListInstances returns an
 // instance. AccessDenied on ListInstances, or any non-cancel error talking
@@ -294,11 +294,7 @@ func listIdentityCenterUsersInRegions(
 		return nil, err
 	}
 
-	if len(grants) == 0 {
-		return nil, nil
-	}
-
-	users, err := listAssignedIdentityStoreUsers(ctx, store, instance.storeID, grants)
+	users, err := listIdentityStoreUsers(ctx, store, instance.storeID, grants)
 	if err != nil {
 		return nil, err
 	}
@@ -657,7 +653,7 @@ func listIdentityCenterGroupMembers(
 	return nil, fmt.Errorf("cannot list all iam identity center group memberships: %w", ErrPaginationLimitReached)
 }
 
-func listAssignedIdentityStoreUsers(
+func listIdentityStoreUsers(
 	ctx context.Context,
 	client *identitystore.Client,
 	storeID string,
@@ -668,7 +664,7 @@ func listAssignedIdentityStoreUsers(
 		&identitystore.ListUsersInput{IdentityStoreId: aws.String(storeID)},
 	)
 
-	users := make([]identityCenterUser, 0, len(grants))
+	var users []identityCenterUser
 
 	for range maxPaginationPages {
 		if !paginator.HasMorePages() {
@@ -682,30 +678,42 @@ func listAssignedIdentityStoreUsers(
 
 		for _, user := range page.Users {
 			userID := aws.ToString(user.UserId)
-
-			grant, ok := grants[userID]
-			if !ok {
+			if userID == "" {
 				continue
 			}
 
-			users = append(
-				users,
-				identityCenterUser{
-					ID:          userID,
-					UserName:    aws.ToString(user.UserName),
-					DisplayName: aws.ToString(user.DisplayName),
-					Email:       identityCenterEmail(user.Emails, aws.ToString(user.UserName)),
-					Title:       aws.ToString(user.Title),
-					Grants:      slices.Compact(slices.Sorted(slices.Values(grant.names))),
-					Admin:       grant.admin,
-					Status:      user.UserStatus,
-					CreatedAt:   user.CreatedAt,
-				},
-			)
+			listed := identityCenterUser{
+				ID:          userID,
+				UserName:    aws.ToString(user.UserName),
+				DisplayName: aws.ToString(user.DisplayName),
+				Email:       identityCenterEmail(user.Emails, aws.ToString(user.UserName)),
+				Title:       aws.ToString(user.Title),
+				Status:      user.UserStatus,
+				CreatedAt:   user.CreatedAt,
+			}
+
+			if grant, ok := grants[userID]; ok {
+				listed.Grants = slices.Compact(slices.Sorted(slices.Values(grant.names)))
+				listed.Admin = grant.admin
+			}
+
+			users = append(users, listed)
 		}
 	}
 
 	return nil, fmt.Errorf("cannot list all iam identity store users: %w", ErrPaginationLimitReached)
+}
+
+func identityCenterAssignedUsers(users []identityCenterUser) []identityCenterUser {
+	assigned := make([]identityCenterUser, 0, len(users))
+
+	for _, user := range users {
+		if len(user.Grants) > 0 {
+			assigned = append(assigned, user)
+		}
+	}
+
+	return assigned
 }
 
 func addIdentityCenterGrant(
@@ -802,10 +810,10 @@ func identityCenterActive(status istypes.UserStatus) *bool {
 	}
 }
 
-// identityCenterUserRecord maps one Identity Center user assigned to the
-// connected account. MFA and last login come from registered devices and
-// CloudTrail UserAuthentication when those calls succeed. Active follows
-// UserStatus when the store reports it.
+// identityCenterUserRecord maps one Identity Center user. MFA and last
+// login come from registered devices and CloudTrail UserAuthentication
+// when those calls succeed. Active follows UserStatus when the store
+// reports it.
 func identityCenterUserRecord(user identityCenterUser) AccountRecord {
 	return AccountRecord{
 		Email:       user.Email,

--- a/pkg/accessreview/drivers/aws_identity_center_activity.go
+++ b/pkg/accessreview/drivers/aws_identity_center_activity.go
@@ -130,7 +130,7 @@ func enrichIdentityCenterActivity(
 		ctx,
 		identitystore.NewFromConfig(cfg),
 		instance.storeID,
-		users,
+		identityCenterAssignedUsers(users),
 	)
 	if errors.Is(deviceErr, context.Canceled) {
 		return deviceErr

--- a/pkg/accessreview/drivers/aws_identity_center_test.go
+++ b/pkg/accessreview/drivers/aws_identity_center_test.go
@@ -92,7 +92,7 @@ func TestListIdentityCenterUsers_FindsInstanceOutsideSessionRegion(t *testing.T)
 		[]string{cloudaws.DefaultCommercialRegion, "eu-west-1"},
 	)
 	require.NoError(t, err)
-	require.Len(t, users, 2)
+	require.Len(t, users, 3)
 
 	records := make([]AccountRecord, 0, len(users))
 	for _, user := range users {
@@ -120,6 +120,11 @@ func TestListIdentityCenterUsers_FindsInstanceOutsideSessionRegion(t *testing.T)
 	assert.Equal(t, coredata.MFAStatusEnabled, bob.MFAStatus)
 	require.NotNil(t, bob.LastLogin)
 	assert.True(t, bob.LastLogin.Equal(time.Unix(1786752000, 0).UTC()))
+
+	dave := byID["arn:aws:identitystore::123456789012:user/33333333-3333-3333-3333-333333333333"]
+	assert.Equal(t, "Dave Unused", dave.FullName)
+	assert.Empty(t, dave.Roles)
+	assert.Nil(t, dave.IsAdmin)
 }
 
 func TestListIdentityCenterUsers_ListsDirectAndGroupAssignments(t *testing.T) {
@@ -130,7 +135,7 @@ func TestListIdentityCenterUsers_ListsDirectAndGroupAssignments(t *testing.T) {
 
 	users, err := listIdentityCenterUsers(context.Background(), session, log.NewLogger(log.WithName("test")))
 	require.NoError(t, err)
-	require.Len(t, users, 2)
+	require.Len(t, users, 3)
 
 	records := make([]AccountRecord, 0, len(users))
 	for _, user := range users {
@@ -171,8 +176,16 @@ func TestListIdentityCenterUsers_ListsDirectAndGroupAssignments(t *testing.T) {
 	require.NotNil(t, carol.LastLogin)
 	assert.True(t, carol.LastLogin.Equal(time.Unix(1782864000, 0).UTC()))
 
-	_, unused := byID["arn:aws:identitystore::123456789012:user/33333333-3333-3333-3333-333333333333"]
-	assert.False(t, unused)
+	dave := byID["arn:aws:identitystore::123456789012:user/33333333-3333-3333-3333-333333333333"]
+	assert.Equal(t, "Dave Unused", dave.FullName)
+	assert.Equal(t, "dave@example.com", dave.Email)
+	assert.Empty(t, dave.Roles)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodSSO, dave.AuthMethod)
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, dave.AccountType)
+	assert.Equal(t, coredata.MFAStatusUnknown, dave.MFAStatus)
+	assert.Nil(t, dave.IsAdmin)
+	assert.Nil(t, dave.Active)
+	assert.Nil(t, dave.LastLogin)
 }
 
 func TestListIdentityCenterUsers_DegradesWhenActivityDenied(t *testing.T) {
@@ -183,7 +196,7 @@ func TestListIdentityCenterUsers_DegradesWhenActivityDenied(t *testing.T) {
 
 	users, err := listIdentityCenterUsers(context.Background(), session, log.NewLogger(log.WithName("test")))
 	require.NoError(t, err)
-	require.Len(t, users, 2)
+	require.Len(t, users, 3)
 
 	records := make([]AccountRecord, 0, len(users))
 	for _, user := range users {
@@ -323,6 +336,22 @@ func TestIdentityCenterUserRecord_LeavesUnknownSignalsNil(t *testing.T) {
 	assert.Equal(t, coredata.MFAStatusUnknown, record.MFAStatus)
 	assert.Nil(t, record.Active)
 	assert.Nil(t, record.IsAdmin)
+}
+
+func TestIdentityCenterAssignedUsers_DropsEmptyGrants(t *testing.T) {
+	t.Parallel()
+
+	assigned := identityCenterAssignedUsers(
+		[]identityCenterUser{
+			{ID: "bob", Grants: []string{"AdministratorAccess"}},
+			{ID: "dave"},
+			{ID: "carol", Grants: []string{"ReadOnlyAccess"}},
+		},
+	)
+
+	require.Len(t, assigned, 2)
+	assert.Equal(t, "bob", assigned[0].ID)
+	assert.Equal(t, "carol", assigned[1].ID)
 }
 
 func TestIdentityCenterIsAdmin_TreatsSSOAdministratorAccessAsAdmin(t *testing.T) {

--- a/pkg/accessreview/drivers/testdata/aws_identity_center.yaml
+++ b/pkg/accessreview/drivers/testdata/aws_identity_center.yaml
@@ -6,9 +6,10 @@
 # (AdministratorAccess, then ReadOnlyAccess), ListManagedPolicies for
 # ReadOnlyAccess only (the admin name short-circuits), ListAccountAssignments
 # for each set, DescribeGroup, ListGroupMemberships, ListUsers,
-# LookupEvents, ListMfaDevicesForUser for Bob then Carol.
+# LookupEvents, ListMfaDevicesForUser for Bob then Carol (assigned users).
 # Bob is assigned AdministratorAccess directly. Carol reaches ReadOnlyAccess
-# through the Engineers group. Dave is in the store with no assignment.
+# through the Engineers group. Dave is in the store with no assignment and
+# is listed with empty grants; MFA devices are not looked up for him.
 # Bob last logged in with TOTP and has a virtual MFA device. Carol's last
 # login is password-only and she has no registered device.
 version: 2

--- a/pkg/accessreview/drivers/testdata/aws_identity_center_activity_denied.yaml
+++ b/pkg/accessreview/drivers/testdata/aws_identity_center_activity_denied.yaml
@@ -1,6 +1,6 @@
 ---
 # Same Identity Center listing as testdata/aws_identity_center.yaml, then
-# LookupEvents and ListMfaDevicesForUser are denied. Assigned users must
+# LookupEvents and ListMfaDevicesForUser are denied. Store users must
 # still be returned with MFA and last login unknown.
 version: 2
 interactions:

--- a/pkg/accessreview/drivers/testdata/aws_identity_center_eu_west_1.yaml
+++ b/pkg/accessreview/drivers/testdata/aws_identity_center_eu_west_1.yaml
@@ -3,8 +3,9 @@
 # account. Interactions are matched by host and X-Amz-Target (see
 # awsAPIMatcher) and consumed in call order when the target repeats.
 # Call order: ListInstances empty in us-east-1, then the usual walk in
-# eu-west-1, then LookupEvents and ListMfaDevicesForUser in eu-west-1.
-# Same principals and activity as testdata/aws_identity_center.yaml.
+# eu-west-1, then LookupEvents and ListMfaDevicesForUser in eu-west-1
+# for assigned users. Same principals and activity as
+# testdata/aws_identity_center.yaml, including Dave with no assignment.
 version: 2
 interactions:
     - id: 0


### PR DESCRIPTION
The AWS driver kept only users with a permission-set assignment on the connected account. IdP-provisioned and manually created store users with no grants never appeared in the campaign.

List every identity-store user and report empty roles when they have no assignment here. Skip MFA device lookup for those users so a large unused directory stays inside the fetch budget. There is still no Organizations walk.