### PR TITLE
Sanitize generated document content before insert

### DIFF
--- a/e2e/console/finding_publish_test.go
+++ b/e2e/console/finding_publish_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.probo.inc/probo/e2e/internal/testutil"
+	"go.probo.inc/probo/pkg/prosemirror"
 )
 
 func TestFinding_PublishFindingList(t *testing.T) {
@@ -116,6 +117,10 @@ func TestFinding_PublishFindingList(t *testing.T) {
 			assert.Equal(t, 0, ver.Minor)
 			assert.Contains(t, ver.Content, "Purpose")
 			assert.Contains(t, ver.Content, "Test Finding")
+
+			// The stored content is sanitized before insert, so it must be a
+			// parseable ProseMirror document rooted at a "doc" node.
+			require.NoError(t, prosemirror.ValidateDocumentContentJSON(ver.Content))
 		},
 	)
 

--- a/pkg/probo/generated_document_service.go
+++ b/pkg/probo/generated_document_service.go
@@ -4062,6 +4062,13 @@ func (s *GeneratedDocumentService) publishOrRequestApproval(
 		}
 	}
 
+	content, err := prosemirror.SanitizeDocumentJSON(version.Content)
+	if err != nil {
+		return fmt.Errorf("cannot sanitize generated document content: %w", err)
+	}
+
+	version.Content = content
+
 	if err := version.Insert(ctx, tx, scope); err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			switch previousVersion.Status {

--- a/pkg/probo/generated_documents_render_test.go
+++ b/pkg/probo/generated_documents_render_test.go
@@ -1,0 +1,446 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package probo_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/docgen"
+	"go.probo.inc/probo/pkg/probo"
+	"go.probo.inc/probo/pkg/prosemirror"
+)
+
+// hostileText exercises the template escaping every generated document relies
+// on: a double quote, a backslash, a control character and an HTML tag all
+// break the emitted JSON if a field is interpolated unescaped.
+const hostileText = "quote \" backslash \\ newline \n tag <script> ampersand &"
+
+func TestBuildDocuments_ProduceParseableProseMirror(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		build func() (string, error)
+	}{
+		{
+			name: "data list",
+			build: func() (string, error) {
+				return probo.BuildDataListDocument(
+					docgen.DataListData{
+						Title:            hostileText,
+						OrganizationName: hostileText,
+						TotalData:        1,
+						Rows: []docgen.DataListRow{
+							{
+								Name:           hostileText,
+								Classification: hostileText,
+								Owner:          hostileText,
+								ThirdParties:   hostileText,
+							},
+						},
+					},
+				)
+			},
+		},
+		{
+			name: "asset list",
+			build: func() (string, error) {
+				return probo.BuildAssetListDocument(
+					docgen.AssetListData{
+						Title:            hostileText,
+						OrganizationName: hostileText,
+						TotalAssets:      1,
+						Rows: []docgen.AssetListRow{
+							{
+								Name:            hostileText,
+								AssetType:       hostileText,
+								Amount:          1,
+								DataTypesStored: hostileText,
+								Owner:           hostileText,
+								ThirdParties:    hostileText,
+							},
+						},
+					},
+				)
+			},
+		},
+		{
+			name: "statement of applicability",
+			build: func() (string, error) {
+				return probo.BuildStatementOfApplicabilityDocument(
+					docgen.StatementOfApplicabilityData{
+						Title:            hostileText,
+						OrganizationName: hostileText,
+						TotalControls:    1,
+						Rows: []docgen.SOARow{
+							{
+								FrameworkName:  hostileText,
+								ControlSection: hostileText,
+								ControlName:    hostileText,
+								Applicability:  hostileText,
+								Justification:  hostileText,
+								MaturityLevel:  hostileText,
+							},
+						},
+					},
+				)
+			},
+		},
+		{
+			name: "finding list",
+			build: func() (string, error) {
+				return probo.BuildFindingListDocument(
+					docgen.FindingListData{
+						Title:            hostileText,
+						OrganizationName: hostileText,
+						TotalFindings:    1,
+						Rows: []docgen.FindingListRow{
+							{
+								ReferenceID:        hostileText,
+								Kind:               hostileText,
+								Description:        hostileText,
+								Source:             hostileText,
+								IdentifiedOn:       hostileText,
+								RootCause:          hostileText,
+								CorrectiveAction:   hostileText,
+								EffectivenessCheck: hostileText,
+								Status:             hostileText,
+								Priority:           hostileText,
+								Owner:              hostileText,
+								DueDate:            hostileText,
+							},
+						},
+					},
+				)
+			},
+		},
+		{
+			name: "business function list",
+			build: func() (string, error) {
+				return probo.BuildBusinessFunctionListDocument(
+					docgen.BusinessFunctionListData{
+						Title:                  hostileText,
+						OrganizationName:       hostileText,
+						TotalBusinessFunctions: 1,
+						Rows: []docgen.BusinessFunctionListRow{
+							{
+								ReferenceID:    hostileText,
+								Name:           hostileText,
+								Classification: hostileText,
+								Notes:          hostileText,
+								Owner:          hostileText,
+							},
+						},
+					},
+				)
+			},
+		},
+		{
+			name: "ai system list",
+			build: func() (string, error) {
+				return probo.BuildAiSystemListDocument(
+					docgen.AiSystemListData{
+						Title:            hostileText,
+						OrganizationName: hostileText,
+						TotalAiSystems:   1,
+						Rows: []docgen.AiSystemListRow{
+							{
+								Name:               hostileText,
+								Version:            hostileText,
+								CompanyRoles:       hostileText,
+								Status:             hostileText,
+								Owner:              hostileText,
+								Purpose:            hostileText,
+								RiskClassification: hostileText,
+								Notes:              hostileText,
+							},
+						},
+					},
+				)
+			},
+		},
+		{
+			name: "obligation list",
+			build: func() (string, error) {
+				return probo.BuildObligationListDocument(
+					docgen.ObligationListData{
+						Title:            hostileText,
+						OrganizationName: hostileText,
+						TotalObligations: 1,
+						Rows: []docgen.ObligationListRow{
+							{
+								Area:                   hostileText,
+								Source:                 hostileText,
+								Requirement:            hostileText,
+								ActionsToBeImplemented: hostileText,
+								Status:                 hostileText,
+								Type:                   hostileText,
+								Regulator:              hostileText,
+								Owner:                  hostileText,
+								DueDate:                hostileText,
+							},
+						},
+					},
+				)
+			},
+		},
+		{
+			name: "processing activity list",
+			build: func() (string, error) {
+				return probo.BuildProcessingActivityListDocument(
+					docgen.ProcessingActivityListData{
+						Title:                     hostileText,
+						OrganizationName:          hostileText,
+						TotalProcessingActivities: 1,
+						Rows: []docgen.ProcessingActivityListRow{
+							{
+								Name:                 hostileText,
+								Purpose:              hostileText,
+								Role:                 hostileText,
+								DataSubjectCategory:  hostileText,
+								PersonalDataCategory: hostileText,
+								LawfulBasis:          hostileText,
+								Recipients:           hostileText,
+								Location:             hostileText,
+								RetentionPeriod:      hostileText,
+								SecurityMeasures:     hostileText,
+							},
+						},
+					},
+				)
+			},
+		},
+		{
+			name: "data protection impact assessment list",
+			build: func() (string, error) {
+				return probo.BuildDataProtectionImpactAssessmentListDocument(
+					docgen.DataProtectionImpactAssessmentListData{
+						Title:                                hostileText,
+						OrganizationName:                     hostileText,
+						TotalDataProtectionImpactAssessments: 1,
+						Rows: []docgen.DataProtectionImpactAssessmentListRow{
+							{
+								ProcessingActivityName:      hostileText,
+								Description:                 hostileText,
+								NecessityAndProportionality: hostileText,
+								PotentialRisk:               hostileText,
+								Mitigations:                 hostileText,
+								ResidualRisk:                hostileText,
+							},
+						},
+					},
+				)
+			},
+		},
+		{
+			name: "transfer impact assessment list",
+			build: func() (string, error) {
+				return probo.BuildTransferImpactAssessmentListDocument(
+					docgen.TransferImpactAssessmentListData{
+						Title:                          hostileText,
+						OrganizationName:               hostileText,
+						TotalTransferImpactAssessments: 1,
+						Rows: []docgen.TransferImpactAssessmentListRow{
+							{
+								ProcessingActivityName: hostileText,
+								DataSubjects:           hostileText,
+								Transfer:               hostileText,
+								LegalMechanism:         hostileText,
+								LocalLawRisk:           hostileText,
+								SupplementaryMeasures:  hostileText,
+							},
+						},
+					},
+				)
+			},
+		},
+		{
+			name: "third party list",
+			build: func() (string, error) {
+				return probo.BuildThirdPartyListDocument(
+					docgen.ThirdPartyListData{
+						Title:             hostileText,
+						OrganizationName:  hostileText,
+						TotalThirdParties: 1,
+						Rows: []docgen.ThirdPartyListRow{
+							{
+								Name:        hostileText,
+								LegalName:   hostileText,
+								Description: hostileText,
+								Category:    hostileText,
+								Services: []docgen.ThirdPartyListService{
+									{Name: hostileText, Description: hostileText},
+								},
+								Contacts: []docgen.ThirdPartyListContact{
+									{FullName: hostileText, Email: hostileText, Phone: hostileText, Role: hostileText},
+								},
+								RiskAnalyses: []docgen.ThirdPartyListRiskAssessment{
+									{
+										AssessedAt:      hostileText,
+										ExpiresAt:       hostileText,
+										DataSensitivity: hostileText,
+										BusinessImpact:  hostileText,
+										Notes:           "# Heading\n\nBody with a \"quote\" and <tag>.\n",
+									},
+								},
+								ComplianceReports: []docgen.ThirdPartyListComplianceReport{
+									{ReportName: hostileText, ReportDate: hostileText, ValidUntil: hostileText},
+								},
+							},
+						},
+					},
+				)
+			},
+		},
+		{
+			name: "risk list",
+			build: func() (string, error) {
+				return probo.BuildRiskListDocument(
+					docgen.RiskListData{
+						Title:            hostileText,
+						OrganizationName: hostileText,
+						TotalRisks:       1,
+						Rows: []docgen.RiskListRow{
+							{
+								Name:               hostileText,
+								Description:        hostileText,
+								Category:           hostileText,
+								Treatment:          hostileText,
+								Owner:              hostileText,
+								InherentLikelihood: hostileText,
+								InherentImpact:     hostileText,
+								InherentRiskScore:  hostileText,
+								ResidualLikelihood: hostileText,
+								ResidualImpact:     hostileText,
+								ResidualRiskScore:  hostileText,
+								Note:               hostileText,
+							},
+						},
+					},
+				)
+			},
+		},
+		{
+			name: "tracker policy",
+			build: func() (string, error) {
+				return probo.BuildTrackerPolicyDocument(
+					docgen.TrackerPolicyData{
+						OrganizationName:  hostileText,
+						WebsiteOrigin:     hostileText,
+						PrivacyPolicyURL:  hostileText,
+						ConsentExpiryDays: 180,
+						Categories: []docgen.TrackerPolicyCategory{
+							{
+								Name:        hostileText,
+								Description: hostileText,
+								Necessary:   true,
+								Trackers: []docgen.TrackerPolicyTracker{
+									{Name: hostileText, Type: hostileText, Purpose: hostileText, Duration: hostileText},
+								},
+							},
+						},
+						ThirdParties: []docgen.TrackerPolicyThirdParty{
+							{Name: hostileText, Description: hostileText, PrivacyPolicyURL: hostileText},
+						},
+					},
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				content, err := tt.build()
+				require.NoError(t, err)
+
+				require.NoError(t, prosemirror.ValidateDocumentContentJSON(content))
+			},
+		)
+	}
+}
+
+func TestBuildDocuments_EmptyDataProducesParseableProseMirror(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		build func() (string, error)
+	}{
+		{"data list", func() (string, error) {
+			return probo.BuildDataListDocument(docgen.DataListData{})
+		}},
+		{"asset list", func() (string, error) {
+			return probo.BuildAssetListDocument(docgen.AssetListData{})
+		}},
+		{"statement of applicability", func() (string, error) {
+			return probo.BuildStatementOfApplicabilityDocument(docgen.StatementOfApplicabilityData{})
+		}},
+		{"finding list", func() (string, error) {
+			return probo.BuildFindingListDocument(docgen.FindingListData{})
+		}},
+		{"business function list", func() (string, error) {
+			return probo.BuildBusinessFunctionListDocument(docgen.BusinessFunctionListData{})
+		}},
+		{"ai system list", func() (string, error) {
+			return probo.BuildAiSystemListDocument(docgen.AiSystemListData{})
+		}},
+		{"obligation list", func() (string, error) {
+			return probo.BuildObligationListDocument(docgen.ObligationListData{})
+		}},
+		{"processing activity list", func() (string, error) {
+			return probo.BuildProcessingActivityListDocument(docgen.ProcessingActivityListData{})
+		}},
+		{"data protection impact assessment list", func() (string, error) {
+			return probo.BuildDataProtectionImpactAssessmentListDocument(docgen.DataProtectionImpactAssessmentListData{})
+		}},
+		{"transfer impact assessment list", func() (string, error) {
+			return probo.BuildTransferImpactAssessmentListDocument(docgen.TransferImpactAssessmentListData{})
+		}},
+		{"third party list", func() (string, error) {
+			return probo.BuildThirdPartyListDocument(docgen.ThirdPartyListData{})
+		}},
+		{"risk list", func() (string, error) {
+			return probo.BuildRiskListDocument(docgen.RiskListData{})
+		}},
+		{"tracker policy", func() (string, error) {
+			return probo.BuildTrackerPolicyDocument(docgen.TrackerPolicyData{})
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				content, err := tt.build()
+				require.NoError(t, err)
+
+				require.NoError(t, prosemirror.ValidateDocumentContentJSON(content))
+			},
+		)
+	}
+}


### PR DESCRIPTION
Section 1 of #1820.

## What

Call `prosemirror.SanitizeDocumentJSON` in `publishOrRequestApproval` immediately before `version.Insert(...)`.

## Why

The generated document path never validated the ProseMirror JSON it persisted. `pkg/probo/generated_document_service.go` makes no `validator.` calls, and 10 of the 13 files in `pkg/probo/templates/` are `.json.tmpl` emitting ProseMirror JSON straight from template text. Content reached `version.Insert` exactly as rendered. The authored path already sanitizes on both of its write paths, at `document_service.go:702` and `:968`.

Malformed content therefore failed soft rather than loudly. `docgen.ProseMirrorJSONToHTML` (`pkg/docgen/generator.go:599`) falls back to `<p>{escaped raw JSON}</p>` when `prosemirror.Parse` fails, so a broken register renders as escaped garbage in the exported PDF and errors nowhere an operator would look.

`publishOrRequestApproval` is the single choke point all 13 publishers route through, so one call covers every generated document.

## Why `SanitizeDocumentJSON` and not `ValidateDocumentContentJSON`

`SanitizeDocumentJSON` calls the same `parseDocRoot`, so it *is* the validation, and it additionally rewrites unsafe link `href` and image `src` attributes. It is also the identical helper the authored path uses, so both paths now converge on one definition of acceptable content.

## Two things a reviewer will reasonably ask

**Why is `ProseMirrorDocumentMaxTextLength` not applied here?** Deliberate. That 200,000-character cap is authored-path request validation. Real generated registers exceed it — the one that prompted this work measures 205,990 characters and publishes fine today — so enforcing it on this path would be a breaking regression for existing deployments. The check added here is structural, not length-based.

**Can sanitizing reject content that is valid today?** No. `prosemirror.Node.Attrs` is a `json.RawMessage` (`pkg/prosemirror/node.go:42`), so the round-trip is lossless for table `colwidth` and heading `level`, and `Parse` has no node-type whitelist. Anything that parses today still parses and re-serialises unchanged.

## Tests

New `pkg/probo/generated_documents_render_test.go` (`package probo_test`, DB-free, `t.Parallel()` throughout): a table test over all 13 exported `Build*Document` functions asserting `prosemirror.ValidateDocumentContentJSON` on the output, in two passes — one with populated rows and one with zero-value data for the empty-state branches.

Every string field in the populated pass is fed the same hostile fixture (a double quote, a backslash, a raw newline, an HTML tag and an ampersand), so the test exercises the `json` escaping the templates depend on rather than just re-asserting well-formed output. I verified it bites: replacing a single `{{json .ReferenceID}}` with `"{{.ReferenceID}}"` in `finding_list.json.tmpl` fails the finding subtest with a parse error.

`e2e/console/finding_publish_test.go` gains one assertion that the stored `ver.Content` is a parseable document. The other 19 publish suites passing unchanged is the backward-compatibility proof.

## Verification

- `make fix` and `make lint` — Go side clean, 0 issues. (`lint-js` OOMs on my machine, unrelated to this Go-only change.)
- `make test` — 5443 tests, 5 skipped, 0 failures.
- `make build`, then the full `./e2e/internal/... ./e2e/console/...` run — 2000 tests, 2 skipped, 0 failures attributable to this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generated documents were persisted without validation, so malformed ProseMirror JSON rendered as escaped garbage in exported PDFs instead of failing loudly. `publishOrRequestApproval` now sanitizes content through `prosemirror.SanitizeDocumentJSON` — the same helper the authored path uses — before `version.Insert`, covering all 13 publishers through one choke point. The 200,000-character length cap is deliberately not applied since real generated registers exceed it.

### Tests **`+451`** **`-0`**

New `pkg/probo/generated_documents_render_test.go` table-tests all 13 `Build*Document` functions, asserting parseable output with hostile text (quotes, backslashes, newlines, HTML tags) and with empty data. `e2e/console/finding_publish_test.go` now asserts the stored version content parses; the other 19 publish suites passing unchanged prove backward compatibility.

### Service **`+7`** **`-0`**

Runs `version.Content` through `prosemirror.SanitizeDocumentJSON` before `version.Insert` in `publishOrRequestApproval`. The round-trip is lossless for content that parses today (`Node.Attrs` is a `json.RawMessage`), so nothing valid is rejected.

<sup>Written for commit 5f16462cffa52016c40f353d5bfd83a1b2a222e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

