### PR TITLE
Add Tiptap to task descriptions and comments

### DIFF
--- a/apps/console/src/pages/organizations/tasks/_components/CreateTaskDialog.tsx
+++ b/apps/console/src/pages/organizations/tasks/_components/CreateTaskDialog.tsx
@@ -19,9 +19,9 @@
 // SOFTWARE.
 
 import { Form } from "@base-ui/react/form";
-import { PriorityLevel, TaskStateIcon } from "@probo/ui";
+import { PriorityLevel, RichEditor, TaskStateIcon } from "@probo/ui";
 import { Button } from "@probo/ui/src/v2/Button/Button";
-import { Dialog } from "@probo/ui/src/v2/Dialog/Dialog";
+import { Dialog, type DialogProps } from "@probo/ui/src/v2/Dialog/Dialog";
 import { DialogBody } from "@probo/ui/src/v2/Dialog/DialogBody";
 import { DialogClose } from "@probo/ui/src/v2/Dialog/DialogClose";
 import { DialogFooter } from "@probo/ui/src/v2/Dialog/DialogFooter";
@@ -30,7 +30,6 @@ import { DialogPopup } from "@probo/ui/src/v2/Dialog/DialogPopup";
 import { DialogTitle } from "@probo/ui/src/v2/Dialog/DialogTitle";
 import { DialogTrigger } from "@probo/ui/src/v2/Dialog/DialogTrigger";
 import { Field } from "@probo/ui/src/v2/form/Field";
-import { Textarea } from "@probo/ui/src/v2/form/Textarea";
 import { TextField } from "@probo/ui/src/v2/form/TextField";
 import { Select } from "@probo/ui/src/v2/Select/Select";
 import { SelectItem } from "@probo/ui/src/v2/Select/SelectItem";
@@ -40,6 +39,7 @@ import { SelectTrigger } from "@probo/ui/src/v2/Select/SelectTrigger";
 import { type ReactElement, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { isRichEditorContentEmpty } from "../_lib/richEditorContent";
 import type { TaskPriority, TaskState } from "../_lib/taskState";
 import {
   taskPriorities,
@@ -50,7 +50,19 @@ import { useCreateTask } from "../_lib/useCreateTask";
 import { createTaskDialog } from "../variants";
 
 const taskNameMaxLength = 1000;
-const taskDescriptionMaxLength = 5000;
+
+type DialogOpenChangeDetails = Parameters<
+  NonNullable<DialogProps["onOpenChange"]>
+>[1];
+
+function isRichEditorFloatingDismiss(details: DialogOpenChangeDetails) {
+  if (details.reason !== "outside-press" && details.reason !== "focus-out") {
+    return false;
+  }
+
+  const target = details.event.target;
+  return target instanceof Element && target.closest("[data-rich-editor-floating]") != null;
+}
 
 interface CreateTaskDialogProps {
   connectionId: string;
@@ -68,23 +80,30 @@ export function CreateTaskDialog({
   const { t } = useTranslation("organizations/tasks");
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
-  const [nameError, setNameError] = useState<string | null>(null);
-  const [description, setDescription] = useState("");
+  const [content, setContent] = useState("");
+  const [editorKey, setEditorKey] = useState(0);
+  const [errors, setErrors] = useState<Record<string, string>>({});
   const [state, setState] = useState<TaskState>("TODO");
   const [priority, setPriority] = useState<TaskPriority>("MEDIUM");
   const [createTask, isCreating] = useCreateTask();
   const bodyRef = useRef<HTMLDivElement>(null);
-  const { form, fields, value } = createTaskDialog();
+  const { form, fields, descriptionField, editor, value } = createTaskDialog();
 
   function reset() {
     setName("");
-    setNameError(null);
-    setDescription("");
+    setContent("");
+    setEditorKey(key => key + 1);
+    setErrors({});
     setState("TODO");
     setPriority("MEDIUM");
   }
 
-  function handleOpenChange(next: boolean) {
+  function handleOpenChange(next: boolean, details: DialogOpenChangeDetails) {
+    if (!next && isRichEditorFloatingDismiss(details)) {
+      details.cancel();
+      return;
+    }
+
     setOpen(next);
     if (!next) {
       reset();
@@ -94,15 +113,15 @@ export function CreateTaskDialog({
   function handleSubmit() {
     const nextName = name.trim();
     if (!nextName) {
-      setNameError(t("createDialog.errors.nameRequired"));
+      setErrors({ name: t("createDialog.errors.nameRequired") });
       return;
     }
-    setNameError(null);
+    setErrors({});
 
     void createTask(
       {
         name: nextName,
-        description: description.trim() || null,
+        content: isRichEditorContentEmpty(content) ? null : content,
         state,
         priority,
         measureId,
@@ -110,7 +129,8 @@ export function CreateTaskDialog({
       connectionId,
     ).then(
       () => {
-        handleOpenChange(false);
+        setOpen(false);
+        reset();
         onCompleted?.();
       },
       () => {
@@ -122,13 +142,13 @@ export function CreateTaskDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger render={children} />
-      <DialogPopup>
-        <Form className={form()} onFormSubmit={handleSubmit}>
+      <DialogPopup lockScroll>
+        <Form className={form()} errors={errors} onFormSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>{t("createDialog.title")}</DialogTitle>
           </DialogHeader>
           <DialogBody ref={bodyRef} className={fields()}>
-            <Field label={t("detailsPage.fields.name")} error={nameError}>
+            <Field label={t("detailsPage.fields.name")} error={errors.name}>
               <TextField
                 name="name"
                 required
@@ -139,20 +159,23 @@ export function CreateTaskDialog({
                 onValueChange={(next) => {
                   setName(next);
                   if (next.trim()) {
-                    setNameError(null);
+                    setErrors((current) => {
+                      const nextErrors = { ...current };
+                      delete nextErrors.name;
+                      return nextErrors;
+                    });
                   }
                 }}
               />
             </Field>
-            <Field label={t("detailsPage.fields.description")}>
-              <Textarea
-                name="description"
-                rows={4}
-                maxLength={taskDescriptionMaxLength}
-                value={description}
+            <Field className={descriptionField()} label={t("detailsPage.fields.description")}>
+              <RichEditor
+                key={editorKey}
+                className={editor()}
+                content={content}
                 disabled={isCreating}
-                placeholder={t("detailsPage.descriptionPlaceholder")}
-                onChange={event => setDescription(event.currentTarget.value)}
+                aria-label={t("detailsPage.fields.description")}
+                onChangeContent={setContent}
               />
             </Field>
             <Select

--- a/apps/console/src/pages/organizations/tasks/_components/TaskCommentDeleteDialog.tsx
+++ b/apps/console/src/pages/organizations/tasks/_components/TaskCommentDeleteDialog.tsx
@@ -30,18 +30,18 @@ import { DialogTitle } from "@probo/ui/src/v2/Dialog/DialogTitle";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
 
-import type { TaskCommentDeleteDialog_comment$key } from "#/__generated__/core/TaskCommentDeleteDialog_comment.graphql";
+import type { TaskCommentDeleteDialog_taskComment$key } from "#/__generated__/core/TaskCommentDeleteDialog_taskComment.graphql";
 
 import { useDeleteTaskComment } from "../_lib/useDeleteTaskComment";
 
 const taskCommentDeleteDialogFragment = graphql`
-  fragment TaskCommentDeleteDialog_comment on TaskComment {
+  fragment TaskCommentDeleteDialog_taskComment on TaskComment {
     id
   }
 `;
 
 interface TaskCommentDeleteDialogProps {
-  taskCommentKey: TaskCommentDeleteDialog_comment$key;
+  taskCommentKey: TaskCommentDeleteDialog_taskComment$key;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }

--- a/apps/console/src/pages/organizations/tasks/_components/TaskCommentEditor.tsx
+++ b/apps/console/src/pages/organizations/tasks/_components/TaskCommentEditor.tsx
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { RichEditor } from "@probo/ui";
+import { Field } from "@probo/ui/src/v2/form/Field";
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { graphql, useFragment } from "react-relay";
+
+import type { TaskCommentEditor_taskComment$key } from "#/__generated__/core/TaskCommentEditor_taskComment.graphql";
+
+import { richEditorContentTextLength } from "../_lib/richEditorContent";
+import { taskCommentMaxLength } from "../_lib/taskCommentMaxLength";
+import { useDebouncedSerializedFieldSave } from "../_lib/useSerializedFieldSave";
+import { useUpdateTaskComment } from "../_lib/useUpdateTaskComment";
+import { taskCommentEditor } from "../variants";
+
+const taskCommentSaveDelayMs = 1000;
+
+const taskCommentEditorFragment = graphql`
+  fragment TaskCommentEditor_taskComment on TaskComment {
+    id
+    content
+  }
+`;
+
+interface TaskCommentEditorProps {
+  taskCommentKey: TaskCommentEditor_taskComment$key;
+}
+
+export function TaskCommentEditor({ taskCommentKey }: TaskCommentEditorProps) {
+  const { t } = useTranslation("organizations/tasks");
+  const comment = useFragment(taskCommentEditorFragment, taskCommentKey);
+  const [updateTaskComment] = useUpdateTaskComment();
+  const saved = comment.content;
+  const [draft, setDraft] = useState(saved);
+  const [savedContent, setSavedContent] = useState(saved);
+  const [dirty, setDirty] = useState(false);
+  const [editorGeneration, setEditorGeneration] = useState(0);
+  const [error, setError] = useState<string | undefined>();
+
+  if (saved !== savedContent) {
+    setSavedContent(saved);
+    if (!dirty) {
+      setDraft(saved);
+      setEditorGeneration(generation => generation + 1);
+    }
+  }
+
+  const persist = useCallback(
+    async (value: string) => {
+      if (richEditorContentTextLength(value) > taskCommentMaxLength) {
+        setError(
+          t("detailsPage.comments.errors.contentTooLong", {
+            max: taskCommentMaxLength,
+          }),
+        );
+        return;
+      }
+
+      try {
+        await updateTaskComment(
+          {
+            variables: {
+              input: {
+                taskCommentId: comment.id,
+                content: value,
+              },
+            },
+          },
+        );
+        setDraft((current) => {
+          if (current === value) {
+            setDirty(false);
+            setError(undefined);
+            return value;
+          }
+          return current;
+        });
+      } catch {
+        setDraft((current) => {
+          if (current === value) {
+            setDirty(false);
+            setEditorGeneration(generation => generation + 1);
+            setError(t("detailsPage.comments.errors.update"));
+            return saved;
+          }
+          return current;
+        });
+      }
+    },
+    [comment.id, saved, t, updateTaskComment],
+  );
+  const persistDebounced = useDebouncedSerializedFieldSave(
+    persist,
+    taskCommentSaveDelayMs,
+  );
+
+  return (
+    <Field error={error}>
+      <RichEditor
+        key={editorGeneration}
+        className={taskCommentEditor()}
+        content={draft}
+        aria-label={t("detailsPage.comments.fields.comment")}
+        onChangeContent={(next) => {
+          setDirty(true);
+          setDraft(next);
+          if (richEditorContentTextLength(next) > taskCommentMaxLength) {
+            setError(
+              t("detailsPage.comments.errors.contentTooLong", {
+                max: taskCommentMaxLength,
+              }),
+            );
+            return;
+          }
+
+          setError(undefined);
+          persistDebounced.schedule(next);
+        }}
+        onBlur={() => {
+          persistDebounced.flush();
+        }}
+      />
+    </Field>
+  );
+}

--- a/apps/console/src/pages/organizations/tasks/_components/TaskCommentForm.tsx
+++ b/apps/console/src/pages/organizations/tasks/_components/TaskCommentForm.tsx
@@ -19,34 +19,44 @@
 // SOFTWARE.
 
 import { Form } from "@base-ui/react/form";
+import { RichEditor } from "@probo/ui";
 import { Button } from "@probo/ui/src/v2/Button/Button";
 import { Field } from "@probo/ui/src/v2/form/Field";
-import { Textarea } from "@probo/ui/src/v2/form/Textarea";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { isRichEditorContentEmpty, richEditorContentTextLength } from "../_lib/richEditorContent";
+import { taskCommentMaxLength } from "../_lib/taskCommentMaxLength";
 import { useCreateTaskComment } from "../_lib/useCreateTaskComment";
-import { taskCommentForm } from "../variants";
-
-const taskCommentMaxLength = 5000;
+import { taskCommentEditor, taskCommentForm } from "../variants";
 
 export function TaskCommentForm() {
   const { t } = useTranslation("organizations/tasks");
   const [createTaskComment, isCreating] = useCreateTaskComment();
-  const [description, setDescription] = useState("");
+  const [content, setContent] = useState("");
+  const [editorKey, setEditorKey] = useState(0);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const { root, actions } = taskCommentForm();
 
   function handleSubmit() {
-    const next = description.trim();
-    if (!next) {
-      setErrors({ description: t("detailsPage.comments.errors.descriptionRequired") });
+    if (isRichEditorContentEmpty(content)) {
+      setErrors({ content: t("detailsPage.comments.errors.contentRequired") });
       return;
     }
 
-    void createTaskComment(next).then(
+    if (richEditorContentTextLength(content) > taskCommentMaxLength) {
+      setErrors({
+        content: t("detailsPage.comments.errors.contentTooLong", {
+          max: taskCommentMaxLength,
+        }),
+      });
+      return;
+    }
+
+    void createTaskComment(content).then(
       () => {
-        setDescription("");
+        setContent("");
+        setEditorKey(key => key + 1);
         setErrors({});
       },
       () => {
@@ -56,21 +66,28 @@ export function TaskCommentForm() {
   }
 
   return (
-    <Form className={root()} errors={errors} onFormSubmit={handleSubmit}>
+    <Form className={root()} onFormSubmit={handleSubmit}>
       <Field
-        label={t("detailsPage.comments.fields.description")}
-        error={errors.description}
+        label={t("detailsPage.comments.fields.leaveAComment")}
+        error={errors.content}
       >
-        <Textarea
-          name="description"
-          rows={3}
-          required
-          maxLength={taskCommentMaxLength}
-          value={description}
+        <RichEditor
+          key={editorKey}
+          className={taskCommentEditor()}
+          content={content}
           disabled={isCreating}
-          placeholder={t("detailsPage.comments.placeholder")}
-          onChange={(event) => {
-            setDescription(event.currentTarget.value);
+          aria-label={t("detailsPage.comments.fields.leaveAComment")}
+          onChangeContent={(next) => {
+            setContent(next);
+            if (richEditorContentTextLength(next) > taskCommentMaxLength) {
+              setErrors({
+                content: t("detailsPage.comments.errors.contentTooLong", {
+                  max: taskCommentMaxLength,
+                }),
+              });
+              return;
+            }
+
             setErrors({});
           }}
         />

--- a/apps/console/src/pages/organizations/tasks/_components/TaskCommentListItem.tsx
+++ b/apps/console/src/pages/organizations/tasks/_components/TaskCommentListItem.tsx
@@ -19,86 +19,113 @@
 // SOFTWARE.
 
 import { TrashIcon, UserIcon } from "@phosphor-icons/react";
-import { dateTimeFormat } from "@probo/i18n";
+import { RichEditor } from "@probo/ui";
 import { Avatar } from "@probo/ui/src/v2/Avatar/Avatar";
+import { ErrorBoundary } from "@probo/ui/src/v2/ErrorBoundary/ErrorBoundary";
 import { IconButton } from "@probo/ui/src/v2/IconButton/IconButton";
-import { ListItem } from "@probo/ui/src/v2/List/ListItem";
-import { ListItemContent } from "@probo/ui/src/v2/List/ListItemContent";
 import { Text } from "@probo/ui/src/v2/typography/Text";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
 
-import type { TaskCommentListItem_comment$key } from "#/__generated__/core/TaskCommentListItem_comment.graphql";
+import type { TaskCommentListItem_taskComment$key } from "#/__generated__/core/TaskCommentListItem_taskComment.graphql";
 
-import { taskCommentListItem } from "../variants";
+import { taskCommentEditor, taskCommentListItem } from "../variants";
 
 import { TaskCommentDeleteDialog } from "./TaskCommentDeleteDialog";
+import { TaskCommentEditor } from "./TaskCommentEditor";
 
 const taskCommentListItemFragment = graphql`
-  fragment TaskCommentListItem_comment on TaskComment {
-    description
+  fragment TaskCommentListItem_taskComment on TaskComment {
+    content
     createdAt
     owner {
       fullName
     }
+    canUpdate: permission(action: "core:task-comment:update")
     canDelete: permission(action: "core:task-comment:delete")
-    ...TaskCommentDeleteDialog_comment
+    ...TaskCommentEditor_taskComment
+    ...TaskCommentDeleteDialog_taskComment
   }
 `;
 
 interface TaskCommentListItemProps {
-  taskCommentKey: TaskCommentListItem_comment$key;
+  taskCommentKey: TaskCommentListItem_taskComment$key;
 }
 
 export function TaskCommentListItem({ taskCommentKey }: TaskCommentListItemProps) {
   const { i18n, t } = useTranslation("organizations/tasks");
   const comment = useFragment(taskCommentListItemFragment, taskCommentKey);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const { header, description } = taskCommentListItem();
+  const { root, header, meta, content } = taskCommentListItem();
   const ownerInitial = comment.owner.fullName.charAt(0).toUpperCase();
+  const createdAt = new Intl.DateTimeFormat(i18n.language, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(new Date(comment.createdAt));
 
   return (
-    <ListItem>
-      <Avatar
-        size={2}
-        variant="soft"
-        color="gold"
-        radius="full"
-        fallback={ownerInitial || <UserIcon />}
-      />
-      <ListItemContent>
-        <div className={header()}>
+    <li className={root()}>
+      <div className={header()}>
+        <Avatar
+          size={2}
+          variant="soft"
+          color="gold"
+          radius="full"
+          fallback={ownerInitial || <UserIcon />}
+        />
+        <div className={meta()}>
           <Text size={2} weight="medium">
             {comment.owner.fullName}
           </Text>
           <Text size={1} color="faint">
-            {dateTimeFormat(i18n.language, comment.createdAt)}
+            {createdAt}
           </Text>
         </div>
-        <div className={description()}>
-          <Text size={2}>{comment.description}</Text>
-        </div>
-      </ListItemContent>
-      {comment.canDelete && (
-        <>
-          <IconButton
-            variant="ghost"
-            color="neutral"
-            aria-label={t("detailsPage.comments.actions.delete")}
-            onClick={() => {
-              setDeleteOpen(true);
-            }}
-          >
-            <TrashIcon />
-          </IconButton>
-          <TaskCommentDeleteDialog
-            taskCommentKey={comment}
-            open={deleteOpen}
-            onOpenChange={setDeleteOpen}
-          />
-        </>
-      )}
-    </ListItem>
+        {comment.canDelete && (
+          <>
+            <IconButton
+              variant="ghost"
+              color="neutral"
+              aria-label={t("detailsPage.comments.actions.delete")}
+              onClick={() => {
+                setDeleteOpen(true);
+              }}
+            >
+              <TrashIcon />
+            </IconButton>
+            <TaskCommentDeleteDialog
+              taskCommentKey={comment}
+              open={deleteOpen}
+              onOpenChange={setDeleteOpen}
+            />
+          </>
+        )}
+      </div>
+      <div className={content()}>
+        <ErrorBoundary
+          fallback={(
+            <Text size={2} color="faint">
+              {t("detailsPage.comments.errors.content")}
+            </Text>
+          )}
+        >
+          {comment.canUpdate
+            ? <TaskCommentEditor taskCommentKey={comment} />
+            : (
+                <RichEditor
+                  className={taskCommentEditor()}
+                  content={comment.content}
+                  disabled
+                  aria-label={t("detailsPage.comments.fields.comment")}
+                />
+              )}
+        </ErrorBoundary>
+      </div>
+    </li>
   );
 }

--- a/apps/console/src/pages/organizations/tasks/_components/TaskCommentsList.tsx
+++ b/apps/console/src/pages/organizations/tasks/_components/TaskCommentsList.tsx
@@ -19,7 +19,6 @@
 // SOFTWARE.
 
 import { Button } from "@probo/ui/src/v2/Button/Button";
-import { List } from "@probo/ui/src/v2/List/List";
 import { Heading } from "@probo/ui/src/v2/typography/Heading";
 import { useTranslation } from "react-i18next";
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay";
@@ -62,7 +61,7 @@ const taskCommentsListFragment = graphql`
       edges {
         node {
           id
-          ...TaskCommentListItem_comment
+          ...TaskCommentListItem_taskComment
         }
       }
     }
@@ -84,7 +83,7 @@ function TaskCommentsListContent({ taskKey }: TaskCommentsListContentProps) {
     TaskCommentsListRefetchQuery,
     TaskCommentsList_comments$key
   >(taskCommentsListFragment, taskKey);
-  const { root, header, actions } = taskCommentsSection();
+  const { root, header, actions, list } = taskCommentsSection();
   const comments = task.comments.edges.map(edge => edge.node);
 
   return (
@@ -111,14 +110,14 @@ function TaskCommentsListContent({ taskKey }: TaskCommentsListContentProps) {
       {comments.length === 0
         ? <TaskCommentsEmpty />
         : (
-            <List>
+            <ul className={list()}>
               {comments.map(comment => (
                 <TaskCommentListItem
                   key={comment.id}
                   taskCommentKey={comment}
                 />
               ))}
-            </List>
+            </ul>
           )}
       {task.canCreateComment && <TaskCommentForm />}
     </div>

--- a/apps/console/src/pages/organizations/tasks/_components/TaskCommentsSection.tsx
+++ b/apps/console/src/pages/organizations/tasks/_components/TaskCommentsSection.tsx
@@ -18,16 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { ListSkeleton } from "@probo/ui/src/v2/List/ListSkeleton";
-import { HeadingSkeleton } from "@probo/ui/src/v2/typography/HeadingSkeleton";
 import { Suspense } from "react";
 import { graphql, useFragment } from "react-relay";
 
 import type { TaskCommentsSection_task$key } from "#/__generated__/core/TaskCommentsSection_task.graphql";
 
-import { taskCommentsSection } from "../variants";
-
 import { TaskCommentsList } from "./TaskCommentsList";
+import { TaskCommentsSectionSkeleton } from "./TaskCommentsSectionSkeleton";
 
 const taskCommentsSectionFragment = graphql`
   fragment TaskCommentsSection_task on Task {
@@ -39,19 +36,6 @@ interface TaskCommentsSectionProps {
   taskKey: TaskCommentsSection_task$key;
 }
 
-function TaskCommentsSectionFallback() {
-  const { root, header } = taskCommentsSection();
-
-  return (
-    <div className={root()}>
-      <div className={header()}>
-        <HeadingSkeleton size={4} className="w-32" />
-      </div>
-      <ListSkeleton count={2} />
-    </div>
-  );
-}
-
 export function TaskCommentsSection({ taskKey }: TaskCommentsSectionProps) {
   const task = useFragment(taskCommentsSectionFragment, taskKey);
 
@@ -60,7 +44,7 @@ export function TaskCommentsSection({ taskKey }: TaskCommentsSectionProps) {
   }
 
   return (
-    <Suspense fallback={<TaskCommentsSectionFallback />}>
+    <Suspense fallback={<TaskCommentsSectionSkeleton />}>
       <TaskCommentsList />
     </Suspense>
   );

--- a/apps/console/src/pages/organizations/tasks/_components/TaskCommentsSectionSkeleton.tsx
+++ b/apps/console/src/pages/organizations/tasks/_components/TaskCommentsSectionSkeleton.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { HeadingSkeleton } from "@probo/ui/src/v2/typography/HeadingSkeleton";
+
+import { taskCommentsSection } from "../variants";
+
+export function TaskCommentsSectionSkeleton() {
+  const { root, header, list, titleSkeleton, itemSkeleton } = taskCommentsSection();
+
+  return (
+    <div className={root()}>
+      <div className={header()}>
+        <div className={titleSkeleton()}>
+          <HeadingSkeleton size={4} />
+        </div>
+      </div>
+      <div className={list()}>
+        <div className={itemSkeleton()} />
+        <div className={itemSkeleton()} />
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/tasks/_components/TaskDescriptionSection.tsx
+++ b/apps/console/src/pages/organizations/tasks/_components/TaskDescriptionSection.tsx
@@ -18,63 +18,79 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import { RichEditor } from "@probo/ui";
+import { ErrorBoundary } from "@probo/ui/src/v2/ErrorBoundary/ErrorBoundary";
 import { Text } from "@probo/ui/src/v2/typography/Text";
-import { useCallback, useState } from "react";
+import { type ErrorInfo, type ReactNode, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
 
 import type { TaskDescriptionSection_task$key } from "#/__generated__/core/TaskDescriptionSection_task.graphql";
 
+import { isRichEditorContentEmpty } from "../_lib/richEditorContent";
 import { useDebouncedSerializedFieldSave } from "../_lib/useSerializedFieldSave";
 import { useUpdateTask } from "../_lib/useUpdateTask";
 import { taskDescriptionSection } from "../variants";
 
-const taskDescriptionMaxLength = 5000;
 const taskDescriptionSaveDelayMs = 1000;
 
 const taskDescriptionSectionFragment = graphql`
   fragment TaskDescriptionSection_task on Task {
     id
-    description
+    content
     canUpdate: permission(action: "core:task:update")
   }
 `;
 
 interface TaskDescriptionSectionProps {
   taskKey: TaskDescriptionSection_task$key;
+  fallback?: ReactNode;
+  onError?: (error: unknown, info: ErrorInfo) => void;
 }
 
-export function TaskDescriptionSection({ taskKey }: TaskDescriptionSectionProps) {
+function normalizeContent(value: string) {
+  return isRichEditorContentEmpty(value) ? "" : value;
+}
+
+function TaskDescriptionSectionContent({
+  taskKey,
+}: {
+  taskKey: TaskDescriptionSection_task$key;
+}) {
   const { t } = useTranslation("organizations/tasks");
   const task = useFragment(taskDescriptionSectionFragment, taskKey);
   const [updateTask] = useUpdateTask();
-  const saved = task.description ?? "";
+  const saved = task.content;
   const [draft, setDraft] = useState(saved);
-  const [savedDescription, setSavedDescription] = useState(saved);
+  const [savedContent, setSavedContent] = useState(saved);
   const [dirty, setDirty] = useState(false);
+  const [editorGeneration, setEditorGeneration] = useState(0);
 
-  if (saved !== savedDescription) {
-    setSavedDescription(saved);
+  if (saved !== savedContent) {
+    setSavedContent(saved);
     if (!dirty) {
       setDraft(saved);
+      setEditorGeneration(generation => generation + 1);
     }
   }
 
   const persist = useCallback(
     async (value: string) => {
-      const next = value.trim();
+      const next = normalizeContent(value);
 
       try {
-        await updateTask({
-          variables: {
-            input: {
-              taskId: task.id,
-              description: next || null,
+        await updateTask(
+          {
+            variables: {
+              input: {
+                taskId: task.id,
+                content: next || null,
+              },
             },
           },
-        });
+        );
         setDraft((current) => {
-          if (current === value || current.trim() === next) {
+          if (current === value || normalizeContent(current) === next) {
             setDirty(false);
             return next;
           }
@@ -82,8 +98,9 @@ export function TaskDescriptionSection({ taskKey }: TaskDescriptionSectionProps)
         });
       } catch {
         setDraft((current) => {
-          if (current.trim() === next) {
+          if (normalizeContent(current) === next) {
             setDirty(false);
+            setEditorGeneration(generation => generation + 1);
             return saved;
           }
           return current;
@@ -96,21 +113,18 @@ export function TaskDescriptionSection({ taskKey }: TaskDescriptionSectionProps)
     persist,
     taskDescriptionSaveDelayMs,
   );
-  const { root, textarea } = taskDescriptionSection();
+  const { root, editor } = taskDescriptionSection();
 
   return (
     <div className={root()}>
       {task.canUpdate
         ? (
-            <textarea
-              className={textarea()}
-              rows={1}
-              value={draft}
-              maxLength={taskDescriptionMaxLength}
-              placeholder={t("detailsPage.descriptionPlaceholder")}
+            <RichEditor
+              key={editorGeneration}
+              className={editor()}
+              content={draft}
               aria-label={t("detailsPage.fields.description")}
-              onChange={(event) => {
-                const next = event.currentTarget.value;
+              onChangeContent={(next) => {
                 setDirty(true);
                 setDraft(next);
                 persistDebounced.schedule(next);
@@ -120,17 +134,41 @@ export function TaskDescriptionSection({ taskKey }: TaskDescriptionSectionProps)
               }}
             />
           )
-        : task.description
+        : isRichEditorContentEmpty(saved)
           ? (
-              <Text size={2} className="whitespace-pre-wrap wrap-break-word">
-                {task.description}
-              </Text>
-            )
-          : (
               <Text size={2} color="faint">
                 {t("detailsPage.noDescription")}
               </Text>
+            )
+          : (
+              <RichEditor
+                className={editor()}
+                content={saved}
+                disabled
+                aria-label={t("detailsPage.fields.description")}
+              />
             )}
     </div>
+  );
+}
+
+export function TaskDescriptionSection({
+  taskKey,
+  fallback,
+  onError,
+}: TaskDescriptionSectionProps) {
+  const { t } = useTranslation("organizations/tasks");
+
+  return (
+    <ErrorBoundary
+      fallback={fallback ?? (
+        <Text size={2} color="faint">
+          {t("detailsPage.errors.content")}
+        </Text>
+      )}
+      onError={onError}
+    >
+      <TaskDescriptionSectionContent taskKey={taskKey} />
+    </ErrorBoundary>
   );
 }

--- a/apps/console/src/pages/organizations/tasks/_lib/richEditorContent.ts
+++ b/apps/console/src/pages/organizations/tasks/_lib/richEditorContent.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+type JSONContent = {
+  type?: string;
+  text?: string;
+  content?: JSONContent[];
+};
+
+function isJSONContent(value: unknown): value is JSONContent {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (!("content" in value) || value.content === undefined) {
+    return true;
+  }
+
+  return Array.isArray(value.content) && value.content.every(isJSONContent);
+}
+
+function isDocContent(value: unknown): value is JSONContent {
+  return isJSONContent(value) && value.type === "doc";
+}
+
+function jsonContentHasText(node: JSONContent): boolean {
+  if (typeof node.text === "string" && node.text.trim().length > 0) {
+    return true;
+  }
+
+  return node.content?.some(jsonContentHasText) ?? false;
+}
+
+function isEmptyBlock(node: JSONContent): boolean {
+  switch (node.type) {
+    case "horizontalRule":
+    case "image":
+      return false;
+    case "hardBreak":
+      return true;
+    case "paragraph":
+    case "heading":
+    case "codeBlock":
+      return !jsonContentHasText(node);
+    case "blockquote":
+    case "bulletList":
+    case "orderedList":
+    case "listItem":
+    case "table":
+    case "tableRow":
+    case "tableHeader":
+    case "tableCell":
+      return (node.content ?? []).every(isEmptyBlock);
+    default:
+      return !jsonContentHasText(node);
+  }
+}
+
+function isEmptyDoc(node: JSONContent): boolean {
+  const content = node.content ?? [];
+  if (content.length === 0) {
+    return true;
+  }
+
+  return content.every(isEmptyBlock);
+}
+
+function parseDoc(content: string): JSONContent | null {
+  if (!content.trim()) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (isDocContent(parsed)) {
+      return parsed;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+export function isRichEditorContentEmpty(content: string): boolean {
+  const parsed = parseDoc(content);
+  if (parsed == null) {
+    return true;
+  }
+
+  return isEmptyDoc(parsed);
+}
+
+function jsonContentTextLength(node: JSONContent): number {
+  let length = typeof node.text === "string" ? [...node.text].length : 0;
+
+  for (const child of node.content ?? []) {
+    length += jsonContentTextLength(child);
+  }
+
+  return length;
+}
+
+export function richEditorContentTextLength(content: string): number {
+  const parsed = parseDoc(content);
+  if (parsed == null) {
+    return 0;
+  }
+
+  return jsonContentTextLength(parsed);
+}

--- a/apps/console/src/pages/organizations/tasks/_lib/taskCommentMaxLength.ts
+++ b/apps/console/src/pages/organizations/tasks/_lib/taskCommentMaxLength.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+export const taskCommentMaxLength = 5000;

--- a/apps/console/src/pages/organizations/tasks/_lib/useCreateTask.ts
+++ b/apps/console/src/pages/organizations/tasks/_lib/useCreateTask.ts
@@ -62,7 +62,7 @@ export function useCreateTask() {
   async function createTask(
     input: {
       name: string;
-      description?: string | null;
+      content?: string | null;
       state?: TaskState;
       priority: TaskPriority;
       measureId?: string | null;
@@ -83,7 +83,7 @@ export function useCreateTask() {
         input: {
           organizationId,
           name: input.name,
-          description: input.description || null,
+          content: input.content || null,
           state: input.state,
           priority: input.priority,
           measureId,

--- a/apps/console/src/pages/organizations/tasks/_lib/useCreateTaskComment.ts
+++ b/apps/console/src/pages/organizations/tasks/_lib/useCreateTaskComment.ts
@@ -36,7 +36,7 @@ const createTaskCommentMutation = graphql`
       taskCommentEdge @appendEdge(connections: $connections) {
         node {
           id
-          ...TaskCommentListItem_comment
+          ...TaskCommentListItem_taskComment
         }
       }
     }
@@ -55,7 +55,7 @@ export function useCreateTaskComment() {
       },
     );
 
-  async function createTaskCommentOnTask(description: string) {
+  async function createTaskCommentOnTask(content: string) {
     if (taskId == null) {
       throw new Error(":taskId missing in route params");
     }
@@ -64,7 +64,7 @@ export function useCreateTaskComment() {
       variables: {
         input: {
           taskId,
-          description,
+          content,
         },
         connections: [taskCommentsConnectionId(taskId)],
       },

--- a/apps/console/src/pages/organizations/tasks/_lib/useUpdateTask.ts
+++ b/apps/console/src/pages/organizations/tasks/_lib/useUpdateTask.ts
@@ -25,7 +25,7 @@ import { graphql } from "relay-runtime";
 import type { useUpdateTaskMutation } from "#/__generated__/core/useUpdateTaskMutation.graphql";
 import { updateStoreCounter } from "#/hooks/useMutationWithIncrement";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
-import { useMutation } from "#/lib/relay/useMutation";
+import { type MutationFeedback, useMutation } from "#/lib/relay/useMutation";
 
 import { moveTaskNodeSorted } from "./taskConnectionOrder";
 import {
@@ -71,7 +71,10 @@ export function useUpdateTask() {
     },
   );
 
-  function updateTask(config: UseMutationConfig<useUpdateTaskMutation>) {
+  function updateTask(
+    config: UseMutationConfig<useUpdateTaskMutation>,
+    feedback?: MutationFeedback,
+  ) {
     const previousMeasureId = linkedRecordId(
       relayEnv.getStore().getSource().get(config.variables.input.taskId),
       "measure",
@@ -103,7 +106,7 @@ export function useUpdateTask() {
         }
         config.updater?.(store, data);
       },
-    }).then((result) => {
+    }, feedback).then((result) => {
       if (measureChanged && previousMeasureId !== nextMeasureId) {
         if (previousMeasureId) {
           updateStoreCounter(relayEnv, previousMeasureId, "tasks(first:0)", -1);

--- a/apps/console/src/pages/organizations/tasks/_lib/useUpdateTaskComment.ts
+++ b/apps/console/src/pages/organizations/tasks/_lib/useUpdateTaskComment.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { useTranslation } from "react-i18next";
+import { graphql } from "react-relay";
+
+import type { useUpdateTaskCommentMutation } from "#/__generated__/core/useUpdateTaskCommentMutation.graphql";
+import { useMutation } from "#/lib/relay/useMutation";
+
+const updateTaskCommentMutation = graphql`
+  mutation useUpdateTaskCommentMutation($input: UpdateTaskCommentInput!) {
+    updateTaskComment(input: $input) {
+      taskComment {
+        ...TaskCommentListItem_taskComment
+      }
+    }
+  }
+`;
+
+export function useUpdateTaskComment() {
+  const { t } = useTranslation("organizations/tasks");
+
+  return useMutation<useUpdateTaskCommentMutation>(
+    updateTaskCommentMutation,
+    {
+      successMessage: t("detailsPage.comments.messages.updated"),
+      errorToast: t("detailsPage.comments.errors.update"),
+    },
+  );
+}

--- a/apps/console/src/pages/organizations/tasks/_locales/en-US.json
+++ b/apps/console/src/pages/organizations/tasks/_locales/en-US.json
@@ -4,7 +4,6 @@
     "empty": "—",
     "none": "None",
     "noDescription": "No description",
-    "descriptionPlaceholder": "Add a description",
     "unassigned": "Unassigned",
     "fields": {
       "name": "Name",
@@ -58,14 +57,15 @@
     },
     "errors": {
       "delete": "Failed to delete task",
-      "update": "Failed to update task"
+      "update": "Failed to update task",
+      "content": "Could not display this description"
     },
     "comments": {
       "title": "Comments",
       "empty": "No comments yet",
-      "placeholder": "Add a comment",
       "fields": {
-        "description": "Comment"
+        "comment": "Comment",
+        "leaveAComment": "Leave a comment"
       },
       "actions": {
         "submit": "Add comment",
@@ -79,12 +79,16 @@
       },
       "messages": {
         "created": "Comment added successfully.",
+        "updated": "Comment updated successfully.",
         "deleted": "Comment deleted successfully."
       },
       "errors": {
         "create": "Failed to add comment",
+        "update": "Failed to update comment",
         "delete": "Failed to delete comment",
-        "descriptionRequired": "Enter a comment"
+        "content": "Could not display this comment",
+        "contentRequired": "Enter a comment",
+        "contentTooLong": "Comment must be at most {{max}} characters"
       }
     }
   },

--- a/apps/console/src/pages/organizations/tasks/_locales/fr-FR.json
+++ b/apps/console/src/pages/organizations/tasks/_locales/fr-FR.json
@@ -4,7 +4,6 @@
     "empty": "—",
     "none": "Aucun",
     "noDescription": "Aucune description",
-    "descriptionPlaceholder": "Ajouter une description",
     "unassigned": "Non assigné",
     "fields": {
       "name": "Nom",
@@ -58,14 +57,15 @@
     },
     "errors": {
       "delete": "Échec de la suppression de la tâche",
-      "update": "Échec de la mise à jour de la tâche"
+      "update": "Échec de la mise à jour de la tâche",
+      "content": "Impossible d'afficher cette description"
     },
     "comments": {
       "title": "Commentaires",
       "empty": "Aucun commentaire pour le moment",
-      "placeholder": "Ajouter un commentaire",
       "fields": {
-        "description": "Commentaire"
+        "comment": "Commentaire",
+        "leaveAComment": "Laisser un commentaire"
       },
       "actions": {
         "submit": "Ajouter un commentaire",
@@ -79,12 +79,16 @@
       },
       "messages": {
         "created": "Commentaire ajouté avec succès.",
+        "updated": "Commentaire mis à jour avec succès.",
         "deleted": "Commentaire supprimé avec succès."
       },
       "errors": {
         "create": "Échec de l'ajout du commentaire",
+        "update": "Échec de la mise à jour du commentaire",
         "delete": "Échec de la suppression du commentaire",
-        "descriptionRequired": "Saisissez un commentaire"
+        "content": "Impossible d'afficher ce commentaire",
+        "contentRequired": "Saisissez un commentaire",
+        "contentTooLong": "Le commentaire ne doit pas dépasser {{max}} caractères"
       }
     }
   },

--- a/apps/console/src/pages/organizations/tasks/_locales/nl-NL.json
+++ b/apps/console/src/pages/organizations/tasks/_locales/nl-NL.json
@@ -4,7 +4,6 @@
     "empty": "—",
     "none": "Geen",
     "noDescription": "Geen beschrijving",
-    "descriptionPlaceholder": "Voeg een beschrijving toe",
     "unassigned": "Niet toegewezen",
     "fields": {
       "name": "Naam",
@@ -58,14 +57,15 @@
     },
     "errors": {
       "delete": "Verwijderen van taak mislukt",
-      "update": "Bijwerken van taak mislukt"
+      "update": "Bijwerken van taak mislukt",
+      "content": "Deze beschrijving kon niet worden weergegeven"
     },
     "comments": {
       "title": "Opmerkingen",
       "empty": "Nog geen opmerkingen",
-      "placeholder": "Voeg een opmerking toe",
       "fields": {
-        "description": "Opmerking"
+        "comment": "Opmerking",
+        "leaveAComment": "Laat een opmerking achter"
       },
       "actions": {
         "submit": "Opmerking toevoegen",
@@ -79,12 +79,16 @@
       },
       "messages": {
         "created": "Opmerking succesvol toegevoegd.",
+        "updated": "Opmerking succesvol bijgewerkt.",
         "deleted": "Opmerking succesvol verwijderd."
       },
       "errors": {
         "create": "Toevoegen van opmerking mislukt",
+        "update": "Bijwerken van opmerking mislukt",
         "delete": "Verwijderen van opmerking mislukt",
-        "descriptionRequired": "Voer een opmerking in"
+        "content": "Deze opmerking kon niet worden weergegeven",
+        "contentRequired": "Voer een opmerking in",
+        "contentTooLong": "Opmerking mag maximaal {{max}} tekens bevatten"
       }
     }
   },

--- a/apps/console/src/pages/organizations/tasks/variants.ts
+++ b/apps/console/src/pages/organizations/tasks/variants.ts
@@ -66,10 +66,7 @@ export const taskNameField = tv({
 export const taskDescriptionSection = tv({
   slots: {
     root: "min-w-0",
-    textarea: [
-      "w-full field-sizing-content resize-none overflow-hidden border-0 bg-transparent p-0 text-2 text-sand-12 outline-none",
-      "placeholder:text-sand-a9",
-    ],
+    editor: "min-h-40",
   },
 });
 
@@ -84,6 +81,9 @@ export const taskCommentsSection = tv({
     root: "flex min-w-0 flex-col gap-3",
     header: "flex items-center justify-between gap-3",
     actions: "flex justify-end",
+    list: "flex flex-col gap-4",
+    titleSkeleton: "w-32",
+    itemSkeleton: "h-24 animate-pulse rounded-2 bg-sand-3",
   },
 });
 
@@ -101,17 +101,28 @@ export const taskCommentForm = tv({
   },
 });
 
+export const taskCommentEditor = tv({
+  base: [
+    "flex-none! overflow-visible! bg-sand-1! py-3! pr-3! pl-14! shadow-2!",
+    "[&_.tiptap>p:first-child]:mt-0",
+  ],
+});
+
 export const taskCommentListItem = tv({
   slots: {
-    header: "flex flex-wrap items-baseline gap-x-2 gap-y-0.5",
-    description: "whitespace-pre-wrap wrap-break-word",
+    root: "flex flex-col gap-2",
+    header: "flex items-center gap-2",
+    meta: "flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2 gap-y-0.5",
+    content: "min-w-0",
   },
 });
 
 export const createTaskDialog = tv({
   slots: {
-    form: "flex flex-col gap-4",
-    fields: "flex flex-col gap-4",
+    form: "flex h-full min-h-0 flex-1 flex-col gap-4",
+    fields: "flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto",
+    descriptionField: "flex min-h-0 flex-1 flex-col",
+    editor: "min-h-80 py-3! [&_.tiptap]:min-h-full [&_.tiptap>p:first-child]:mt-0",
     value: "flex items-center gap-2",
   },
 });

--- a/e2e/console/task_comment_rbac_test.go
+++ b/e2e/console/task_comment_rbac_test.go
@@ -1,0 +1,383 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package console_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+func TestTaskComment_RBAC(t *testing.T) {
+	t.Parallel()
+
+	org := testutil.NewOrganizationRoles(t)
+	owner := org.Client(t, testutil.RoleOwner)
+	taskID := factory.NewTaskWithoutMeasure(owner).Create()
+
+	const updateMutation = `
+		mutation UpdateTaskComment($input: UpdateTaskCommentInput!) {
+			updateTaskComment(input: $input) {
+				taskComment { id }
+			}
+		}
+	`
+
+	const deleteMutation = `
+		mutation DeleteTaskComment($input: DeleteTaskCommentInput!) {
+			deleteTaskComment(input: $input) {
+				deletedTaskCommentId
+			}
+		}
+	`
+
+	t.Run(
+		"update",
+		func(t *testing.T) {
+			t.Parallel()
+
+			t.Run(
+				"author can update own comment",
+				func(t *testing.T) {
+					t.Parallel()
+
+					tests := []struct {
+						name       string
+						authorRole testutil.TestRole
+					}{
+						{name: "owner", authorRole: testutil.RoleOwner},
+						{name: "admin", authorRole: testutil.RoleAdmin},
+						{name: "viewer", authorRole: testutil.RoleViewer},
+					}
+
+					for _, tt := range tests {
+						t.Run(
+							tt.name,
+							func(t *testing.T) {
+								t.Parallel()
+
+								owner := org.Client(t, testutil.RoleOwner)
+								author := org.Client(t, tt.authorRole)
+								commentID := factory.NewTaskComment(owner, taskID).
+									WithContent("Own comment").
+									WithOwnerID(author.GetProfileID().String()).
+									Create()
+
+								_, err := author.Do(
+									updateMutation,
+									map[string]any{
+										"input": map[string]any{
+											"taskCommentId": commentID,
+											"content":       factory.ProseMirrorPlainText("Edited by author"),
+										},
+									},
+								)
+								require.NoError(t, err, "%s should update their own comment", tt.name)
+							},
+						)
+					}
+				},
+			)
+
+			t.Run(
+				"nobody can update another user's comment",
+				func(t *testing.T) {
+					t.Parallel()
+
+					tests := []struct {
+						name       string
+						actorRole  testutil.TestRole
+						authorRole testutil.TestRole
+					}{
+						{
+							name:       "admin cannot update owner comment",
+							actorRole:  testutil.RoleAdmin,
+							authorRole: testutil.RoleOwner,
+						},
+						{
+							name:       "owner cannot update admin comment",
+							actorRole:  testutil.RoleOwner,
+							authorRole: testutil.RoleAdmin,
+						},
+						{
+							name:       "viewer cannot update owner comment",
+							actorRole:  testutil.RoleViewer,
+							authorRole: testutil.RoleOwner,
+						},
+					}
+
+					for _, tt := range tests {
+						t.Run(
+							tt.name,
+							func(t *testing.T) {
+								t.Parallel()
+
+								owner := org.Client(t, testutil.RoleOwner)
+								author := org.Client(t, tt.authorRole)
+								actor := org.Client(t, tt.actorRole)
+								commentID := factory.NewTaskComment(owner, taskID).
+									WithContent("Someone else's comment").
+									WithOwnerID(author.GetProfileID().String()).
+									Create()
+
+								_, err := actor.Do(
+									updateMutation,
+									map[string]any{
+										"input": map[string]any{
+											"taskCommentId": commentID,
+											"content":       factory.ProseMirrorPlainText("Hijacked comment"),
+										},
+									},
+								)
+								testutil.RequireForbiddenError(t, err, tt.name)
+							},
+						)
+					}
+				},
+			)
+		},
+	)
+
+	t.Run(
+		"delete",
+		func(t *testing.T) {
+			t.Parallel()
+
+			t.Run(
+				"author can delete own comment",
+				func(t *testing.T) {
+					t.Parallel()
+
+					tests := []struct {
+						name       string
+						authorRole testutil.TestRole
+					}{
+						{name: "owner", authorRole: testutil.RoleOwner},
+						{name: "admin", authorRole: testutil.RoleAdmin},
+						{name: "viewer", authorRole: testutil.RoleViewer},
+					}
+
+					for _, tt := range tests {
+						t.Run(
+							tt.name,
+							func(t *testing.T) {
+								t.Parallel()
+
+								owner := org.Client(t, testutil.RoleOwner)
+								author := org.Client(t, tt.authorRole)
+								commentID := factory.NewTaskComment(owner, taskID).
+									WithContent("Deletable own comment").
+									WithOwnerID(author.GetProfileID().String()).
+									Create()
+
+								_, err := author.Do(
+									deleteMutation,
+									map[string]any{
+										"input": map[string]any{
+											"taskCommentId": commentID,
+										},
+									},
+								)
+								require.NoError(t, err, "%s should delete their own comment", tt.name)
+							},
+						)
+					}
+				},
+			)
+
+			t.Run(
+				"owner and admin can delete another user's comment",
+				func(t *testing.T) {
+					t.Parallel()
+
+					tests := []struct {
+						name      string
+						actorRole testutil.TestRole
+					}{
+						{name: "owner", actorRole: testutil.RoleOwner},
+						{name: "admin", actorRole: testutil.RoleAdmin},
+					}
+
+					for _, tt := range tests {
+						t.Run(
+							tt.name,
+							func(t *testing.T) {
+								t.Parallel()
+
+								owner := org.Client(t, testutil.RoleOwner)
+								viewer := org.Client(t, testutil.RoleViewer)
+								actor := org.Client(t, tt.actorRole)
+								commentID := factory.NewTaskComment(owner, taskID).
+									WithContent("Comment to moderate").
+									WithOwnerID(viewer.GetProfileID().String()).
+									Create()
+
+								_, err := actor.Do(
+									deleteMutation,
+									map[string]any{
+										"input": map[string]any{
+											"taskCommentId": commentID,
+										},
+									},
+								)
+								require.NoError(t, err, "%s should delete another user's comment", tt.name)
+							},
+						)
+					}
+				},
+			)
+
+			t.Run(
+				"viewer cannot delete another user's comment",
+				func(t *testing.T) {
+					t.Parallel()
+
+					owner := org.Client(t, testutil.RoleOwner)
+					viewer := org.Client(t, testutil.RoleViewer)
+					commentID := factory.NewTaskComment(owner, taskID).
+						WithContent("Owner comment").
+						Create()
+
+					_, err := viewer.Do(
+						deleteMutation,
+						map[string]any{
+							"input": map[string]any{
+								"taskCommentId": commentID,
+							},
+						},
+					)
+					testutil.RequireForbiddenError(t, err, "viewer cannot delete another user's comment")
+				},
+			)
+		},
+	)
+
+	t.Run(
+		"permission field",
+		func(t *testing.T) {
+			t.Parallel()
+
+			const permissionQuery = `
+				query($id: ID!) {
+					node(id: $id) {
+						... on TaskComment {
+							canUpdate: permission(action: "core:task-comment:update")
+							canDelete: permission(action: "core:task-comment:delete")
+						}
+					}
+				}
+			`
+
+			type permissionResult struct {
+				Node struct {
+					CanUpdate bool `json:"canUpdate"`
+					CanDelete bool `json:"canDelete"`
+				} `json:"node"`
+			}
+
+			owner := org.Client(t, testutil.RoleOwner)
+			admin := org.Client(t, testutil.RoleAdmin)
+			viewer := org.Client(t, testutil.RoleViewer)
+			ownerCommentID := factory.NewTaskComment(owner, taskID).
+				WithContent("Owner permission comment").
+				Create()
+			viewerCommentID := factory.NewTaskComment(owner, taskID).
+				WithContent("Viewer permission comment").
+				WithOwnerID(viewer.GetProfileID().String()).
+				Create()
+
+			t.Run(
+				"author can update and delete",
+				func(t *testing.T) {
+					t.Parallel()
+
+					var result permissionResult
+
+					err := owner.ForTest(t).Execute(
+						permissionQuery,
+						map[string]any{"id": ownerCommentID},
+						&result,
+					)
+					require.NoError(t, err)
+					assert.True(t, result.Node.CanUpdate)
+					assert.True(t, result.Node.CanDelete)
+				},
+			)
+
+			t.Run(
+				"admin cannot update another user's comment but can delete it",
+				func(t *testing.T) {
+					t.Parallel()
+
+					var result permissionResult
+
+					err := admin.ForTest(t).Execute(
+						permissionQuery,
+						map[string]any{"id": ownerCommentID},
+						&result,
+					)
+					require.NoError(t, err)
+					assert.False(t, result.Node.CanUpdate)
+					assert.True(t, result.Node.CanDelete)
+				},
+			)
+
+			t.Run(
+				"viewer can update and delete own comment",
+				func(t *testing.T) {
+					t.Parallel()
+
+					var result permissionResult
+
+					err := viewer.ForTest(t).Execute(
+						permissionQuery,
+						map[string]any{"id": viewerCommentID},
+						&result,
+					)
+					require.NoError(t, err)
+					assert.True(t, result.Node.CanUpdate)
+					assert.True(t, result.Node.CanDelete)
+				},
+			)
+
+			t.Run(
+				"viewer cannot update or delete another user's comment",
+				func(t *testing.T) {
+					t.Parallel()
+
+					var result permissionResult
+
+					err := viewer.ForTest(t).Execute(
+						permissionQuery,
+						map[string]any{"id": ownerCommentID},
+						&result,
+					)
+					require.NoError(t, err)
+					assert.False(t, result.Node.CanUpdate)
+					assert.False(t, result.Node.CanDelete)
+				},
+			)
+		},
+	)
+}

--- a/e2e/console/task_comment_test.go
+++ b/e2e/console/task_comment_test.go
@@ -42,7 +42,7 @@ func TestTaskComment_Create(t *testing.T) {
 				taskCommentEdge {
 					node {
 						id
-						description
+						content
 						owner {
 							id
 						}
@@ -56,9 +56,9 @@ func TestTaskComment_Create(t *testing.T) {
 		CreateTaskComment struct {
 			TaskCommentEdge struct {
 				Node struct {
-					ID          string `json:"id"`
-					Description string `json:"description"`
-					Owner       struct {
+					ID      string `json:"id"`
+					Content string `json:"content"`
+					Owner   struct {
 						ID string `json:"id"`
 					} `json:"owner"`
 				} `json:"node"`
@@ -68,15 +68,15 @@ func TestTaskComment_Create(t *testing.T) {
 
 	err := owner.Execute(query, map[string]any{
 		"input": map[string]any{
-			"taskId":      taskID,
-			"description": "First comment",
+			"taskId":  taskID,
+			"content": factory.ProseMirrorPlainText("First comment"),
 		},
 	}, &result)
 	require.NoError(t, err)
 
 	comment := result.CreateTaskComment.TaskCommentEdge.Node
 	assert.NotEmpty(t, comment.ID)
-	assert.Equal(t, "First comment", comment.Description)
+	factory.AssertProseMirrorPlainText(t, "First comment", comment.Content)
 	assert.Equal(t, owner.GetProfileID().String(), comment.Owner.ID)
 }
 
@@ -88,7 +88,7 @@ func TestTaskComment_CreateWithOwner(t *testing.T) {
 	ownerID := assignee.GetProfileID().String()
 
 	commentID := factory.NewTaskComment(owner, taskID).
-		WithDescription("Assigned comment").
+		WithContent("Assigned comment").
 		WithOwnerID(ownerID).
 		Create()
 
@@ -121,8 +121,8 @@ func TestTaskComment_ListOldestFirst(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 	taskID := factory.NewTaskWithoutMeasure(owner).Create()
-	firstID := factory.NewTaskComment(owner, taskID).WithDescription("Oldest comment").Create()
-	secondID := factory.NewTaskComment(owner, taskID).WithDescription("Newest comment").Create()
+	firstID := factory.NewTaskComment(owner, taskID).WithContent("Oldest comment").Create()
+	secondID := factory.NewTaskComment(owner, taskID).WithContent("Newest comment").Create()
 
 	query := `
 		query($id: ID!) {
@@ -133,7 +133,7 @@ func TestTaskComment_ListOldestFirst(t *testing.T) {
 						edges {
 							node {
 								id
-								description
+								content
 							}
 						}
 					}
@@ -148,8 +148,8 @@ func TestTaskComment_ListOldestFirst(t *testing.T) {
 				TotalCount int `json:"totalCount"`
 				Edges      []struct {
 					Node struct {
-						ID          string `json:"id"`
-						Description string `json:"description"`
+						ID      string `json:"id"`
+						Content string `json:"content"`
 					} `json:"node"`
 				} `json:"edges"`
 			} `json:"comments"`
@@ -162,23 +162,23 @@ func TestTaskComment_ListOldestFirst(t *testing.T) {
 	require.GreaterOrEqual(t, result.Node.Comments.TotalCount, 2)
 	require.GreaterOrEqual(t, len(result.Node.Comments.Edges), 2)
 	assert.Equal(t, firstID, result.Node.Comments.Edges[0].Node.ID)
-	assert.Equal(t, "Oldest comment", result.Node.Comments.Edges[0].Node.Description)
+	factory.AssertProseMirrorPlainText(t, "Oldest comment", result.Node.Comments.Edges[0].Node.Content)
 	assert.Equal(t, secondID, result.Node.Comments.Edges[1].Node.ID)
-	assert.Equal(t, "Newest comment", result.Node.Comments.Edges[1].Node.Description)
+	factory.AssertProseMirrorPlainText(t, "Newest comment", result.Node.Comments.Edges[1].Node.Content)
 }
 
 func TestTaskComment_Update(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 	taskID := factory.NewTaskWithoutMeasure(owner).Create()
-	commentID := factory.NewTaskComment(owner, taskID).WithDescription("Original comment").Create()
+	commentID := factory.NewTaskComment(owner, taskID).WithContent("Original comment").Create()
 
 	query := `
 		mutation UpdateTaskComment($input: UpdateTaskCommentInput!) {
 			updateTaskComment(input: $input) {
 				taskComment {
 					id
-					description
+					content
 				}
 			}
 		}
@@ -187,8 +187,8 @@ func TestTaskComment_Update(t *testing.T) {
 	var result struct {
 		UpdateTaskComment struct {
 			TaskComment struct {
-				ID          string `json:"id"`
-				Description string `json:"description"`
+				ID      string `json:"id"`
+				Content string `json:"content"`
 			} `json:"taskComment"`
 		} `json:"updateTaskComment"`
 	}
@@ -196,13 +196,96 @@ func TestTaskComment_Update(t *testing.T) {
 	err := owner.Execute(query, map[string]any{
 		"input": map[string]any{
 			"taskCommentId": commentID,
-			"description":   "Updated comment",
+			"content":       factory.ProseMirrorPlainText("Updated comment"),
 		},
 	}, &result)
 	require.NoError(t, err)
 
 	assert.Equal(t, commentID, result.UpdateTaskComment.TaskComment.ID)
-	assert.Equal(t, "Updated comment", result.UpdateTaskComment.TaskComment.Description)
+	factory.AssertProseMirrorPlainText(t, "Updated comment", result.UpdateTaskComment.TaskComment.Content)
+}
+
+func TestTaskComment_OmittableContent(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	taskID := factory.NewTaskWithoutMeasure(owner).Create()
+
+	const query = `
+		mutation UpdateTaskComment($input: UpdateTaskCommentInput!) {
+			updateTaskComment(input: $input) {
+				taskComment {
+					id
+					content
+				}
+			}
+		}
+	`
+
+	t.Run("clear content saves empty document", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			content any
+		}{
+			{name: "null", content: nil},
+			{name: "empty string", content: ""},
+			{name: "empty document", content: factory.ProseMirrorPlainText("")},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				commentID := factory.NewTaskComment(owner, taskID).
+					WithContent("Initial comment").
+					Create()
+
+				var result struct {
+					UpdateTaskComment struct {
+						TaskComment struct {
+							ID      string `json:"id"`
+							Content string `json:"content"`
+						} `json:"taskComment"`
+					} `json:"updateTaskComment"`
+				}
+
+				err := owner.Execute(query, map[string]any{
+					"input": map[string]any{
+						"taskCommentId": commentID,
+						"content":       tt.content,
+					},
+				}, &result)
+				require.NoError(t, err)
+				factory.AssertProseMirrorPlainText(t, "", result.UpdateTaskComment.TaskComment.Content)
+			})
+		}
+	})
+
+	t.Run("update without content preserves value", func(t *testing.T) {
+		t.Parallel()
+
+		commentID := factory.NewTaskComment(owner, taskID).
+			WithContent("Should persist").
+			Create()
+
+		var result struct {
+			UpdateTaskComment struct {
+				TaskComment struct {
+					ID      string `json:"id"`
+					Content string `json:"content"`
+				} `json:"taskComment"`
+			} `json:"updateTaskComment"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"taskCommentId": commentID,
+			},
+		}, &result)
+		require.NoError(t, err)
+		factory.AssertProseMirrorPlainText(t, "Should persist", result.UpdateTaskComment.TaskComment.Content)
+	})
 }
 
 func TestTaskComment_Delete(t *testing.T) {
@@ -252,8 +335,8 @@ func TestTaskComment_ViewerCannotCreate(t *testing.T) {
 
 	_, err := viewer.Do(query, map[string]any{
 		"input": map[string]any{
-			"taskId":      taskID,
-			"description": "Viewer comment",
+			"taskId":  taskID,
+			"content": factory.ProseMirrorPlainText("Viewer comment"),
 		},
 	})
 	testutil.RequireForbiddenError(t, err, "viewer cannot create task comments")
@@ -280,32 +363,32 @@ func TestTaskComment_CreateValidation(t *testing.T) {
 		wantErrorContains string
 	}{
 		{
-			name: "empty description",
+			name: "empty content",
 			input: map[string]any{
-				"description": "",
+				"content": "",
 			},
-			wantErrorContains: "description",
+			wantErrorContains: "content",
 		},
 		{
 			name: "HTML injection",
 			input: map[string]any{
-				"description": "<script>xss</script>",
+				"content": "<script>xss</script>",
 			},
-			wantErrorContains: "HTML",
+			wantErrorContains: "ProseMirror document",
 		},
 		{
 			name: "control char",
 			input: map[string]any{
-				"description": "Test\x00",
+				"content": "Test\x00",
 			},
-			wantErrorContains: "control",
+			wantErrorContains: "ProseMirror document",
 		},
 		{
 			name: "max length",
 			input: map[string]any{
-				"description": strings.Repeat("c", 5001),
+				"content": factory.ProseMirrorPlainText(strings.Repeat("c", 5001)),
 			},
-			wantErrorContains: "description",
+			wantErrorContains: "at most",
 		},
 	}
 
@@ -345,8 +428,8 @@ func TestTaskComment_AuditorCannotAccess(t *testing.T) {
 
 		_, err := auditor.Do(query, map[string]any{
 			"input": map[string]any{
-				"taskId":      taskID,
-				"description": "Auditor comment",
+				"taskId":  taskID,
+				"content": factory.ProseMirrorPlainText("Auditor comment"),
 			},
 		})
 		testutil.RequireForbiddenError(t, err, "auditor cannot create task comments")
@@ -381,7 +464,7 @@ func TestTaskComment_AuditorCannotAccess(t *testing.T) {
 				node(id: $id) {
 					... on TaskComment {
 						id
-						description
+						content
 					}
 				}
 			}
@@ -403,7 +486,7 @@ func TestTaskComment_ViewerCanList(t *testing.T) {
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 	viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
 	taskID := factory.NewTaskWithoutMeasure(owner).Create()
-	commentID := factory.NewTaskComment(owner, taskID).WithDescription("Visible comment").Create()
+	commentID := factory.NewTaskComment(owner, taskID).WithContent("Visible comment").Create()
 
 	query := `
 		query($id: ID!) {
@@ -413,7 +496,7 @@ func TestTaskComment_ViewerCanList(t *testing.T) {
 						edges {
 							node {
 								id
-								description
+								content
 							}
 						}
 					}
@@ -427,8 +510,8 @@ func TestTaskComment_ViewerCanList(t *testing.T) {
 			Comments struct {
 				Edges []struct {
 					Node struct {
-						ID          string `json:"id"`
-						Description string `json:"description"`
+						ID      string `json:"id"`
+						Content string `json:"content"`
 					} `json:"node"`
 				} `json:"edges"`
 			} `json:"comments"`
@@ -440,7 +523,7 @@ func TestTaskComment_ViewerCanList(t *testing.T) {
 
 	require.NotEmpty(t, result.Node.Comments.Edges)
 	assert.Equal(t, commentID, result.Node.Comments.Edges[0].Node.ID)
-	assert.Equal(t, "Visible comment", result.Node.Comments.Edges[0].Node.Description)
+	factory.AssertProseMirrorPlainText(t, "Visible comment", result.Node.Comments.Edges[0].Node.Content)
 }
 
 func TestTaskComment_TenantIsolation(t *testing.T) {
@@ -459,7 +542,7 @@ func TestTaskComment_TenantIsolation(t *testing.T) {
 				node(id: $id) {
 					... on TaskComment {
 						id
-						description
+						content
 					}
 				}
 			}
@@ -467,8 +550,7 @@ func TestTaskComment_TenantIsolation(t *testing.T) {
 
 		var result struct {
 			Node *struct {
-				ID          string `json:"id"`
-				Description string `json:"description"`
+				ID string `json:"id"`
 			} `json:"node"`
 		}
 
@@ -490,7 +572,7 @@ func TestTaskComment_TenantIsolation(t *testing.T) {
 		_, err := org2Owner.Do(query, map[string]any{
 			"input": map[string]any{
 				"taskCommentId": commentID,
-				"description":   "Hijacked comment",
+				"content":       factory.ProseMirrorPlainText("Hijacked comment"),
 			},
 		})
 		require.Error(t, err)

--- a/e2e/console/task_test.go
+++ b/e2e/console/task_test.go
@@ -65,7 +65,7 @@ func TestTask_Create(t *testing.T) {
 			"organizationId": owner.GetOrganizationID().String(),
 			"measureId":      measureID,
 			"name":           "Owner Task",
-			"description":    "Created by owner",
+			"content":        factory.ProseMirrorPlainText("Created by owner"),
 			"priority":       "MEDIUM",
 		},
 	}, &result)
@@ -115,7 +115,7 @@ func TestTask_CreateWithoutMeasure(t *testing.T) {
 		"input": map[string]any{
 			"organizationId": owner.GetOrganizationID().String(),
 			"name":           "Task without measure",
-			"description":    "Created without a measure",
+			"content":        factory.ProseMirrorPlainText("Created without a measure"),
 			"priority":       "HIGH",
 		},
 	}, &result)
@@ -133,7 +133,7 @@ func TestTask_Update(t *testing.T) {
 	measureID := factory.NewMeasure(owner).Create()
 	taskID := factory.NewTask(owner, measureID).
 		WithName("Task to Update").
-		WithDescription("Original description").
+		WithContent("Original description").
 		Create()
 
 	query := `
@@ -158,9 +158,9 @@ func TestTask_Update(t *testing.T) {
 
 	err := owner.Execute(query, map[string]any{
 		"input": map[string]any{
-			"taskId":      taskID,
-			"name":        "Updated by Owner",
-			"description": "Owner updated this",
+			"taskId":  taskID,
+			"name":    "Updated by Owner",
+			"content": factory.ProseMirrorPlainText("Owner updated this"),
 		},
 	}, &result)
 	require.NoError(t, err)
@@ -433,7 +433,7 @@ func TestTask_SubResolvers(t *testing.T) {
 					... on Task {
 						id
 						name
-						description
+						content
 						state
 					}
 				}
@@ -442,10 +442,10 @@ func TestTask_SubResolvers(t *testing.T) {
 
 		var result struct {
 			Node struct {
-				ID          string  `json:"id"`
-				Name        string  `json:"name"`
-				Description *string `json:"description"`
-				State       string  `json:"state"`
+				ID      string  `json:"id"`
+				Name    string  `json:"name"`
+				Content *string `json:"content"`
+				State   string  `json:"state"`
 			} `json:"node"`
 		}
 
@@ -579,7 +579,7 @@ func TestTask_InvalidID(t *testing.T) {
 	})
 }
 
-func TestTask_OmittableDescription(t *testing.T) {
+func TestTask_OmittableContent(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 
@@ -589,16 +589,16 @@ func TestTask_OmittableDescription(t *testing.T) {
 
 	taskID := factory.NewTask(owner, measureID).
 		WithName("Description Test Task").
-		WithDescription("Initial description").
+		WithContent("Initial description").
 		Create()
 
-	t.Run("set description", func(t *testing.T) {
+	t.Run("set content", func(t *testing.T) {
 		query := `
 			mutation UpdateTask($input: UpdateTaskInput!) {
 				updateTask(input: $input) {
 					task {
 						id
-						description
+						content
 					}
 				}
 			}
@@ -607,30 +607,30 @@ func TestTask_OmittableDescription(t *testing.T) {
 		var result struct {
 			UpdateTask struct {
 				Task struct {
-					ID          string  `json:"id"`
-					Description *string `json:"description"`
+					ID      string  `json:"id"`
+					Content *string `json:"content"`
 				} `json:"task"`
 			} `json:"updateTask"`
 		}
 
 		err := owner.Execute(query, map[string]any{
 			"input": map[string]any{
-				"taskId":      taskID,
-				"description": "Updated description",
+				"taskId":  taskID,
+				"content": factory.ProseMirrorPlainText("Updated description"),
 			},
 		}, &result)
 		require.NoError(t, err)
-		require.NotNil(t, result.UpdateTask.Task.Description)
-		assert.Equal(t, "Updated description", *result.UpdateTask.Task.Description)
+		require.NotNil(t, result.UpdateTask.Task.Content)
+		factory.AssertProseMirrorPlainText(t, "Updated description", *result.UpdateTask.Task.Content)
 	})
 
-	t.Run("clear description with null", func(t *testing.T) {
+	t.Run("clear content with null", func(t *testing.T) {
 		query := `
 			mutation UpdateTask($input: UpdateTaskInput!) {
 				updateTask(input: $input) {
 					task {
 						id
-						description
+						content
 					}
 				}
 			}
@@ -639,24 +639,23 @@ func TestTask_OmittableDescription(t *testing.T) {
 		var result struct {
 			UpdateTask struct {
 				Task struct {
-					ID          string  `json:"id"`
-					Description *string `json:"description"`
+					ID      string `json:"id"`
+					Content string `json:"content"`
 				} `json:"task"`
 			} `json:"updateTask"`
 		}
 
 		err := owner.Execute(query, map[string]any{
 			"input": map[string]any{
-				"taskId":      taskID,
-				"description": nil,
+				"taskId":  taskID,
+				"content": nil,
 			},
 		}, &result)
 		require.NoError(t, err)
-		assert.Nil(t, result.UpdateTask.Task.Description)
+		factory.AssertProseMirrorPlainText(t, "", result.UpdateTask.Task.Content)
 	})
 
-	t.Run("update without description preserves value", func(t *testing.T) {
-		// First set a description
+	t.Run("update without content preserves value", func(t *testing.T) {
 		setQuery := `
 			mutation UpdateTask($input: UpdateTaskInput!) {
 				updateTask(input: $input) {
@@ -669,20 +668,19 @@ func TestTask_OmittableDescription(t *testing.T) {
 
 		err := owner.Execute(setQuery, map[string]any{
 			"input": map[string]any{
-				"taskId":      taskID,
-				"description": "Should persist",
+				"taskId":  taskID,
+				"content": factory.ProseMirrorPlainText("Should persist"),
 			},
 		}, nil)
 		require.NoError(t, err)
 
-		// Update only name
 		query := `
 			mutation UpdateTask($input: UpdateTaskInput!) {
 				updateTask(input: $input) {
 					task {
 						id
 						name
-						description
+						content
 					}
 				}
 			}
@@ -691,9 +689,9 @@ func TestTask_OmittableDescription(t *testing.T) {
 		var result struct {
 			UpdateTask struct {
 				Task struct {
-					ID          string  `json:"id"`
-					Name        string  `json:"name"`
-					Description *string `json:"description"`
+					ID      string  `json:"id"`
+					Name    string  `json:"name"`
+					Content *string `json:"content"`
 				} `json:"task"`
 			} `json:"updateTask"`
 		}
@@ -705,8 +703,8 @@ func TestTask_OmittableDescription(t *testing.T) {
 			},
 		}, &result)
 		require.NoError(t, err)
-		require.NotNil(t, result.UpdateTask.Task.Description)
-		assert.Equal(t, "Should persist", *result.UpdateTask.Task.Description)
+		require.NotNil(t, result.UpdateTask.Task.Content)
+		factory.AssertProseMirrorPlainText(t, "Should persist", *result.UpdateTask.Task.Content)
 	})
 }
 

--- a/e2e/internal/factory/factory.go
+++ b/e2e/internal/factory/factory.go
@@ -491,8 +491,8 @@ func CreateTask(c *testutil.Client, measureID *string, attrs ...Attrs) string {
 		input["measureId"] = *measureID
 	}
 
-	if desc := a.getStringPtr("description"); desc != nil {
-		input["description"] = *desc
+	if content := a.getStringPtr("content"); content != nil {
+		input["content"] = ProseMirrorPlainText(*content)
 	}
 
 	var result struct {
@@ -709,8 +709,8 @@ func (b *TaskBuilder) WithName(name string) *TaskBuilder {
 	return b
 }
 
-func (b *TaskBuilder) WithDescription(desc string) *TaskBuilder {
-	b.attrs["description"] = desc
+func (b *TaskBuilder) WithContent(content string) *TaskBuilder {
+	b.attrs["content"] = content
 	return b
 }
 
@@ -737,8 +737,8 @@ func CreateTaskComment(c *testutil.Client, taskID string, attrs ...Attrs) string
 	`
 
 	input := map[string]any{
-		"taskId":      taskID,
-		"description": a.getString("description", SafeName("Comment")),
+		"taskId":  taskID,
+		"content": ProseMirrorPlainText(a.getString("content", SafeName("Comment"))),
 	}
 
 	if ownerID, ok := a["ownerId"]; ok {
@@ -771,8 +771,8 @@ func NewTaskComment(c *testutil.Client, taskID string) *TaskCommentBuilder {
 	return &TaskCommentBuilder{client: c, taskID: taskID, attrs: Attrs{}}
 }
 
-func (b *TaskCommentBuilder) WithDescription(description string) *TaskCommentBuilder {
-	b.attrs["description"] = description
+func (b *TaskCommentBuilder) WithContent(content string) *TaskCommentBuilder {
+	b.attrs["content"] = content
 	return b
 }
 

--- a/e2e/internal/factory/rich_text.go
+++ b/e2e/internal/factory/rich_text.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package factory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.probo.inc/probo/pkg/prosemirror"
+)
+
+// ProseMirrorPlainText wraps plaintext as a ProseMirror document (one
+// paragraph per line), matching the task/comment SQL backfill.
+func ProseMirrorPlainText(text string) string {
+	return prosemirror.FromPlainText(text)
+}
+
+// AssertProseMirrorPlainText compares JSONB content to a plaintext document.
+// PostgreSQL JSONB reorders keys and adds whitespace on read, so this is a
+// semantic JSON comparison rather than a string match.
+func AssertProseMirrorPlainText(t testing.TB, expectedPlain, actualJSON string) {
+	t.Helper()
+	assert.JSONEq(t, ProseMirrorPlainText(expectedPlain), actualJSON)
+}

--- a/e2e/mcp/task_comment_test.go
+++ b/e2e/mcp/task_comment_test.go
@@ -34,13 +34,13 @@ func TestMCP_TaskComment_ListOldestFirst(t *testing.T) {
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 	mc := testutil.NewMCPClient(t, owner)
 	taskID := factory.NewTaskWithoutMeasure(owner).Create()
-	firstID := factory.NewTaskComment(owner, taskID).WithDescription("Oldest MCP comment").Create()
-	secondID := factory.NewTaskComment(owner, taskID).WithDescription("Newest MCP comment").Create()
+	firstID := factory.NewTaskComment(owner, taskID).WithContent("Oldest MCP comment").Create()
+	secondID := factory.NewTaskComment(owner, taskID).WithContent("Newest MCP comment").Create()
 
 	var listResult struct {
 		TaskComments []struct {
-			ID          string `json:"id"`
-			Description string `json:"description"`
+			ID      string `json:"id"`
+			Content string `json:"content"`
 		} `json:"task_comments"`
 	}
 	mc.CallToolInto("listTaskComments", map[string]any{
@@ -48,9 +48,9 @@ func TestMCP_TaskComment_ListOldestFirst(t *testing.T) {
 	}, &listResult)
 	require.GreaterOrEqual(t, len(listResult.TaskComments), 2)
 	assert.Equal(t, firstID, listResult.TaskComments[0].ID)
-	assert.Equal(t, "Oldest MCP comment", listResult.TaskComments[0].Description)
+	assert.Equal(t, "Oldest MCP comment\n", listResult.TaskComments[0].Content)
 	assert.Equal(t, secondID, listResult.TaskComments[1].ID)
-	assert.Equal(t, "Newest MCP comment", listResult.TaskComments[1].Description)
+	assert.Equal(t, "Newest MCP comment\n", listResult.TaskComments[1].Content)
 }
 
 func TestMCP_TaskComment_CRUD(t *testing.T) {
@@ -61,17 +61,17 @@ func TestMCP_TaskComment_CRUD(t *testing.T) {
 
 	var addResult struct {
 		TaskComment struct {
-			ID          string `json:"id"`
-			Description string `json:"description"`
-			OwnerID     string `json:"owner_id"`
+			ID      string `json:"id"`
+			Content string `json:"content"`
+			OwnerID string `json:"owner_id"`
 		} `json:"task_comment"`
 	}
 	mc.CallToolInto("addTaskComment", map[string]any{
-		"task_id":     taskID,
-		"description": "MCP comment",
+		"task_id": taskID,
+		"content": "MCP **comment**",
 	}, &addResult)
 	require.NotEmpty(t, addResult.TaskComment.ID)
-	assert.Equal(t, "MCP comment", addResult.TaskComment.Description)
+	assert.Equal(t, "MCP **comment**\n", addResult.TaskComment.Content)
 	assert.Equal(t, owner.GetProfileID().String(), addResult.TaskComment.OwnerID)
 
 	var getResult struct {
@@ -86,15 +86,26 @@ func TestMCP_TaskComment_CRUD(t *testing.T) {
 
 	var updateResult struct {
 		TaskComment struct {
-			ID          string `json:"id"`
-			Description string `json:"description"`
+			ID      string `json:"id"`
+			Content string `json:"content"`
 		} `json:"task_comment"`
 	}
 	mc.CallToolInto("updateTaskComment", map[string]any{
-		"id":          addResult.TaskComment.ID,
-		"description": "Updated MCP comment",
+		"id":      addResult.TaskComment.ID,
+		"content": "Updated MCP comment",
 	}, &updateResult)
-	assert.Equal(t, "Updated MCP comment", updateResult.TaskComment.Description)
+	assert.Equal(t, "Updated MCP comment\n", updateResult.TaskComment.Content)
+
+	mc.CallToolInto("updateTaskComment", map[string]any{
+		"id": addResult.TaskComment.ID,
+	}, &updateResult)
+	assert.Equal(t, "Updated MCP comment\n", updateResult.TaskComment.Content)
+
+	mc.CallToolInto("updateTaskComment", map[string]any{
+		"id":      addResult.TaskComment.ID,
+		"content": nil,
+	}, &updateResult)
+	assert.Equal(t, "", updateResult.TaskComment.Content)
 
 	var listResult struct {
 		TaskComments []struct {

--- a/e2e/mcp/task_test.go
+++ b/e2e/mcp/task_test.go
@@ -64,15 +64,19 @@ func TestMCP_Task_CRUD(t *testing.T) {
 	// Update
 	var updateResult struct {
 		Task struct {
-			ID   string `json:"id"`
-			Name string `json:"name"`
+			ID      string  `json:"id"`
+			Name    string  `json:"name"`
+			Content *string `json:"content"`
 		} `json:"task"`
 	}
 	mc.CallToolInto("updateTask", map[string]any{
-		"id":   addResult.Task.ID,
-		"name": "Updated Task",
+		"id":      addResult.Task.ID,
+		"name":    "Updated Task",
+		"content": "Task **description**",
 	}, &updateResult)
 	assert.Equal(t, "Updated Task", updateResult.Task.Name)
+	require.NotNil(t, updateResult.Task.Content)
+	assert.Equal(t, "Task **description**\n", *updateResult.Task.Content)
 
 	// List
 	var listResult struct {

--- a/packages/n8n-node/CHANGELOG.md
+++ b/packages/n8n-node/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `@probo/n8n-nodes-probo` package will be documented i
 
 ## Unreleased
 
+### Changed
+
+- Task and Task Comment operations return `content` as plaintext instead of ProseMirror JSON
+
 ## [0.226.0] - 2026-09-02
 
 ### Added

--- a/packages/n8n-node/nodes/Probo/GenericFunctions.ts
+++ b/packages/n8n-node/nodes/Probo/GenericFunctions.ts
@@ -265,6 +265,84 @@ export async function proboApiMultipartRequest(
 	}
 }
 
+export function plainTextToProseMirrorJSON(text: string): string {
+	return JSON.stringify({
+		type: 'doc',
+		content: text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n').map((line) => ({
+			type: 'paragraph',
+			...(line ? { content: [{ type: 'text', text: line }] } : {}),
+		})),
+	});
+}
+
+type ProseMirrorNode = {
+	type?: string;
+	text?: string;
+	content?: ProseMirrorNode[];
+};
+
+function isProseMirrorNode(value: unknown): value is ProseMirrorNode {
+	return typeof value === 'object' && value !== null;
+}
+
+function collectPlainText(node: ProseMirrorNode): string {
+	if (node.type === 'text') {
+		return node.text ?? '';
+	}
+
+	if (node.type === 'hardBreak' || node.type === 'horizontalRule') {
+		return '\n';
+	}
+
+	const inner = (node.content ?? []).map(collectPlainText).join('');
+
+	switch (node.type) {
+		case 'paragraph':
+		case 'heading':
+		case 'codeBlock':
+			return `${inner}\n`;
+		default:
+			return inner;
+	}
+}
+
+// GraphQL stores task/comment bodies as ProseMirror JSON. n8n create/update
+// accept plaintext, so reads convert that JSON back to text (one paragraph
+// per line), matching MCP's human-readable content field.
+export function proseMirrorJSONToPlainText(json: unknown): string {
+	if (typeof json !== 'string') {
+		return '';
+	}
+
+	if (json.trim() === '') {
+		return '';
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(json);
+	} catch {
+		return json;
+	}
+
+	if (!isProseMirrorNode(parsed) || parsed.type !== 'doc') {
+		return json;
+	}
+
+	return collectPlainText(parsed).replace(/\n+$/, '');
+}
+
+export function withPlainTextContent(value: IDataObject): IDataObject {
+	if (typeof value.content !== 'string') {
+		return value;
+	}
+
+	return {
+		...value,
+		content: proseMirrorJSONToPlainText(value.content),
+	};
+}
+
 export function toPeriod(
 	start?: string | null,
 	end?: string | null,

--- a/packages/n8n-node/nodes/Probo/actions/task/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/task/create.operation.ts
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
-import { proboApiRequest } from '../../GenericFunctions';
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { plainTextToProseMirrorJSON, proboApiRequest, withPlainTextContent } from '../../GenericFunctions';
 
 export const description: INodeProperties[] = [
 	{
@@ -64,8 +64,8 @@ export const description: INodeProperties[] = [
 		required: true,
 	},
 	{
-		displayName: 'Description',
-		name: 'description',
+		displayName: 'Content',
+		name: 'content',
 		type: 'string',
 		displayOptions: {
 			show: {
@@ -74,7 +74,7 @@ export const description: INodeProperties[] = [
 			},
 		},
 		default: '',
-		description: 'The description of the task',
+		description: 'The content of the task',
 	},
 	{
 		displayName: 'State',
@@ -194,7 +194,7 @@ export async function execute(
 	const organizationId = this.getNodeParameter('organizationId', itemIndex) as string;
 	const measureId = this.getNodeParameter('measureId', itemIndex, '') as string;
 	const name = this.getNodeParameter('name', itemIndex) as string;
-	const description = this.getNodeParameter('description', itemIndex, '') as string;
+	const content = this.getNodeParameter('content', itemIndex, '') as string;
 	const state = this.getNodeParameter('state', itemIndex, '') as string;
 	const priority = this.getNodeParameter('priority', itemIndex, '') as string;
 	const timeEstimate = this.getNodeParameter('timeEstimate', itemIndex, '') as string;
@@ -208,7 +208,7 @@ export async function execute(
 					node {
 						id
 						name
-						description
+						content
 						state
 						priority
 						timeEstimate
@@ -226,7 +226,7 @@ export async function execute(
 			organizationId,
 			name,
 			...(measureId && { measureId }),
-			...(description && { description }),
+			...(content && { content: plainTextToProseMirrorJSON(content) }),
 			...(state && { state }),
 			...(priority && { priority }),
 			...(timeEstimate && { timeEstimate }),
@@ -236,6 +236,13 @@ export async function execute(
 	};
 
 	const responseData = await proboApiRequest.call(this, query, variables);
+	const data = responseData.data as IDataObject | undefined;
+	const payload = data?.createTask as IDataObject | undefined;
+	const edge = payload?.taskEdge as IDataObject | undefined;
+	const node = edge?.node as IDataObject | undefined;
+	if (edge && node) {
+		edge.node = withPlainTextContent(node);
+	}
 
 	return {
 		json: responseData,

--- a/packages/n8n-node/nodes/Probo/actions/task/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/task/get.operation.ts
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
-import { proboApiRequest } from '../../GenericFunctions';
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { proboApiRequest, withPlainTextContent } from '../../GenericFunctions';
 
 export const description: INodeProperties[] = [
 	{
@@ -50,7 +50,7 @@ export async function execute(
 				... on Task {
 					id
 					name
-					description
+					content
 					state
 					priority
 					timeEstimate
@@ -67,6 +67,11 @@ export async function execute(
 	};
 
 	const responseData = await proboApiRequest.call(this, query, variables);
+	const data = responseData.data as IDataObject | undefined;
+	const node = data?.node as IDataObject | undefined;
+	if (data && node) {
+		data.node = withPlainTextContent(node);
+	}
 
 	return {
 		json: responseData,

--- a/packages/n8n-node/nodes/Probo/actions/task/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/task/getAll.operation.ts
@@ -19,7 +19,7 @@
 // SOFTWARE.
 
 import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
-import { proboApiRequestAllItems } from '../../GenericFunctions';
+import { proboApiRequestAllItems, withPlainTextContent } from '../../GenericFunctions';
 
 export const description: INodeProperties[] = [
 	{
@@ -85,7 +85,7 @@ export async function execute(
 							node {
 								id
 								name
-								description
+								content
 								state
 								priority
 								timeEstimate
@@ -118,7 +118,7 @@ export async function execute(
 	);
 
 	return {
-		json: { tasks },
+		json: { tasks: tasks.map(withPlainTextContent) },
 		pairedItem: { item: itemIndex },
 	};
 }

--- a/packages/n8n-node/nodes/Probo/actions/task/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/task/update.operation.ts
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
-import { proboApiRequest } from '../../GenericFunctions';
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { plainTextToProseMirrorJSON, proboApiRequest, withPlainTextContent } from '../../GenericFunctions';
 
 export const description: INodeProperties[] = [
 	{
@@ -50,8 +50,8 @@ export const description: INodeProperties[] = [
 		description: 'The name of the task',
 	},
 	{
-		displayName: 'Description',
-		name: 'description',
+		displayName: 'Content',
+		name: 'content',
 		type: 'string',
 		displayOptions: {
 			show: {
@@ -60,7 +60,7 @@ export const description: INodeProperties[] = [
 			},
 		},
 		default: '',
-		description: 'The description of the task',
+		description: 'The content of the task',
 	},
 	{
 		displayName: 'State',
@@ -213,7 +213,7 @@ export async function execute(
 ): Promise<INodeExecutionData> {
 	const taskId = this.getNodeParameter('taskId', itemIndex) as string;
 	const name = this.getNodeParameter('name', itemIndex, '') as string;
-	const description = this.getNodeParameter('description', itemIndex, '') as string;
+	const content = this.getNodeParameter('content', itemIndex, '') as string;
 	const state = this.getNodeParameter('state', itemIndex, '') as string;
 	const priority = this.getNodeParameter('priority', itemIndex, '') as string;
 	const rank = this.getNodeParameter('rank', itemIndex, '') as string;
@@ -228,7 +228,7 @@ export async function execute(
 				task {
 					id
 					name
-					description
+					content
 					state
 					priority
 					timeEstimate
@@ -242,7 +242,7 @@ export async function execute(
 
 	const input: Record<string, string> = { taskId };
 	if (name) input.name = name;
-	if (description) input.description = description;
+	if (content) input.content = plainTextToProseMirrorJSON(content);
 	if (state) input.state = state;
 	if (priority) input.priority = priority;
 	if (rank) input.rank = rank;
@@ -252,6 +252,12 @@ export async function execute(
 	if (measureId) input.measureId = measureId;
 
 	const responseData = await proboApiRequest.call(this, query, { input });
+	const data = responseData.data as IDataObject | undefined;
+	const payload = data?.updateTask as IDataObject | undefined;
+	const task = payload?.task as IDataObject | undefined;
+	if (payload && task) {
+		payload.task = withPlainTextContent(task);
+	}
 
 	return {
 		json: responseData,

--- a/packages/n8n-node/nodes/Probo/actions/taskComment/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/taskComment/create.operation.ts
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
-import { proboApiRequest } from '../../GenericFunctions';
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { plainTextToProseMirrorJSON, proboApiRequest, withPlainTextContent } from '../../GenericFunctions';
 
 export const description: INodeProperties[] = [
 	{
@@ -37,8 +37,8 @@ export const description: INodeProperties[] = [
 		required: true,
 	},
 	{
-		displayName: 'Description',
-		name: 'description',
+		displayName: 'Content',
+		name: 'content',
 		type: 'string',
 		typeOptions: {
 			rows: 4,
@@ -50,7 +50,7 @@ export const description: INodeProperties[] = [
 			},
 		},
 		default: '',
-		description: 'The comment description',
+		description: 'The comment content',
 		required: true,
 	},
 	{
@@ -73,7 +73,7 @@ export async function execute(
 	itemIndex: number,
 ): Promise<INodeExecutionData> {
 	const taskId = this.getNodeParameter('taskId', itemIndex) as string;
-	const description = this.getNodeParameter('description', itemIndex) as string;
+	const content = this.getNodeParameter('content', itemIndex) as string;
 	const ownerId = this.getNodeParameter('ownerId', itemIndex, '') as string;
 
 	const query = `
@@ -82,7 +82,7 @@ export async function execute(
 				taskCommentEdge {
 					node {
 						id
-						description
+						content
 						createdAt
 						updatedAt
 						owner {
@@ -95,12 +95,19 @@ export async function execute(
 		}
 	`;
 
-	const input: Record<string, string> = { taskId, description };
+	const input: Record<string, string> = { taskId, content: plainTextToProseMirrorJSON(content) };
 	if (ownerId) {
 		input.ownerId = ownerId;
 	}
 
 	const responseData = await proboApiRequest.call(this, query, { input });
+	const data = responseData.data as IDataObject | undefined;
+	const payload = data?.createTaskComment as IDataObject | undefined;
+	const edge = payload?.taskCommentEdge as IDataObject | undefined;
+	const node = edge?.node as IDataObject | undefined;
+	if (edge && node) {
+		edge.node = withPlainTextContent(node);
+	}
 
 	return {
 		json: responseData,

--- a/packages/n8n-node/nodes/Probo/actions/taskComment/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/taskComment/get.operation.ts
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
-import { proboApiRequest } from '../../GenericFunctions';
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { proboApiRequest, withPlainTextContent } from '../../GenericFunctions';
 
 export const description: INodeProperties[] = [
 	{
@@ -49,7 +49,7 @@ export async function execute(
 			node(id: $commentId) {
 				... on TaskComment {
 					id
-					description
+					content
 					createdAt
 					updatedAt
 					owner {
@@ -62,6 +62,11 @@ export async function execute(
 	`;
 
 	const responseData = await proboApiRequest.call(this, query, { commentId });
+	const data = responseData.data as IDataObject | undefined;
+	const node = data?.node as IDataObject | undefined;
+	if (data && node) {
+		data.node = withPlainTextContent(node);
+	}
 
 	return {
 		json: responseData,

--- a/packages/n8n-node/nodes/Probo/actions/taskComment/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/taskComment/getAll.operation.ts
@@ -20,7 +20,7 @@
 
 import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { proboApiRequestAllItems } from '../../GenericFunctions';
+import { proboApiRequestAllItems, withPlainTextContent } from '../../GenericFunctions';
 
 export const description: INodeProperties[] = [
 	{
@@ -86,7 +86,7 @@ export async function execute(
 						edges {
 							node {
 								id
-								description
+								content
 								createdAt
 								updatedAt
 								owner {
@@ -131,7 +131,7 @@ export async function execute(
 	);
 
 	return {
-		json: { comments },
+		json: { comments: comments.map(withPlainTextContent) },
 		pairedItem: { item: itemIndex },
 	};
 }

--- a/packages/n8n-node/nodes/Probo/actions/taskComment/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/taskComment/update.operation.ts
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
-import { proboApiRequest } from '../../GenericFunctions';
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { plainTextToProseMirrorJSON, proboApiRequest, withPlainTextContent } from '../../GenericFunctions';
 
 export const description: INodeProperties[] = [
 	{
@@ -50,14 +50,14 @@ export const description: INodeProperties[] = [
 		},
 		options: [
 			{
-				displayName: 'Description',
-				name: 'description',
+				displayName: 'Content',
+				name: 'content',
 				type: 'string',
 				typeOptions: {
 					rows: 4,
 				},
 				default: '',
-				description: 'The comment description',
+				description: 'The comment content',
 			},
 			{
 				displayName: 'Owner ID',
@@ -76,7 +76,7 @@ export async function execute(
 ): Promise<INodeExecutionData> {
 	const commentId = this.getNodeParameter('commentId', itemIndex) as string;
 	const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as {
-		description?: string;
+		content?: string;
 		ownerId?: string;
 	};
 
@@ -85,7 +85,7 @@ export async function execute(
 			updateTaskComment(input: $input) {
 				taskComment {
 					id
-					description
+					content
 					createdAt
 					updatedAt
 					owner {
@@ -97,15 +97,23 @@ export async function execute(
 		}
 	`;
 
-	const input: Record<string, string> = { taskCommentId: commentId };
-	if (additionalFields.description !== undefined) {
-		input.description = additionalFields.description;
+	const input: Record<string, string | null> = { taskCommentId: commentId };
+	if (additionalFields.content !== undefined) {
+		input.content = additionalFields.content === ''
+			? null
+			: plainTextToProseMirrorJSON(additionalFields.content);
 	}
 	if (additionalFields.ownerId) {
 		input.ownerId = additionalFields.ownerId;
 	}
 
 	const responseData = await proboApiRequest.call(this, query, { input });
+	const data = responseData.data as IDataObject | undefined;
+	const payload = data?.updateTaskComment as IDataObject | undefined;
+	const taskComment = payload?.taskComment as IDataObject | undefined;
+	if (payload && taskComment) {
+		payload.taskComment = withPlainTextContent(taskComment);
+	}
 
 	return {
 		json: responseData,

--- a/packages/ui/src/RichEditor/BlockMenu/BlockMenuContent.tsx
+++ b/packages/ui/src/RichEditor/BlockMenu/BlockMenuContent.tsx
@@ -27,6 +27,7 @@ import {
 import { type Editor } from "@tiptap/react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
+import { EditorFloatingPortal } from "../_lib/EditorFloatingPortal";
 import { getSlashStorage } from "../_lib/getSlashStorage";
 import { MenuButton } from "../MenuButton";
 import { deactivateSlashCommand } from "../SlashCommandExtension";
@@ -177,31 +178,34 @@ export function BlockMenuContent({ editor, slashState }: BlockMenuContentProps) 
   }, [editor, slashState.active, slashState.query, filteredItems, slashActiveIndex, handleSlashAction]);
 
   return (
-    <div
-      ref={(node) => {
-        slashDropdownRef.current = node;
-        slashMenuRefs.setFloating(node);
-      }}
-      style={slashMenuStyles}
-      onMouseDown={e => e.preventDefault()}
-      className={menu()}
-    >
-      {filteredItems.length > 0
-        ? filteredItems.map((item, index) => (
-            <MenuButton
-              key={item.label}
-              active={index === slashActiveIndex}
-              onClick={() => handleSlashAction(item)}
-            >
-              <item.icon size={16} weight="bold" />
-              {item.label}
-            </MenuButton>
-          ))
-        : (
-            <div className="px-2 py-1.5 text-sm text-txt-tertiary">
-              No results
-            </div>
-          )}
-    </div>
+    <EditorFloatingPortal>
+      <div
+        ref={(node) => {
+          slashDropdownRef.current = node;
+          slashMenuRefs.setFloating(node);
+        }}
+        style={slashMenuStyles}
+        onMouseDown={e => e.preventDefault()}
+        className={menu()}
+        data-rich-editor-floating=""
+      >
+        {filteredItems.length > 0
+          ? filteredItems.map((item, index) => (
+              <MenuButton
+                key={item.label}
+                active={index === slashActiveIndex}
+                onClick={() => handleSlashAction(item)}
+              >
+                <item.icon size={16} weight="bold" />
+                {item.label}
+              </MenuButton>
+            ))
+          : (
+              <div className="px-2 py-1.5 text-sm text-txt-tertiary">
+                No results
+              </div>
+            )}
+      </div>
+    </EditorFloatingPortal>
   );
 }

--- a/packages/ui/src/RichEditor/BlockMenu/BlockMenuTrigger.tsx
+++ b/packages/ui/src/RichEditor/BlockMenu/BlockMenuTrigger.tsx
@@ -75,6 +75,7 @@ export function BlockMenuTrigger({ editor, hoveredBlock }: BlockMenuTriggerProps
       onClick={handleTriggerClick}
       onMouseDown={e => e.preventDefault()}
       type="button"
+      data-rich-editor-floating=""
       style={{
         ...triggerStyles,
         visibility: isPositioned ? "visible" : "hidden",

--- a/packages/ui/src/RichEditor/BlockMenu/variants.ts
+++ b/packages/ui/src/RichEditor/BlockMenu/variants.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 
-import { tv } from "tailwind-variants";
+import { tv } from "tailwind-variants/lite";
 
 export const blockMenuVariants = tv({
   slots: {

--- a/packages/ui/src/RichEditor/BubbleMenu.tsx
+++ b/packages/ui/src/RichEditor/BubbleMenu.tsx
@@ -5,8 +5,10 @@
 import { CodeIcon, LinkIcon, TextBIcon, TextItalicIcon, TextStrikethroughIcon, TextUnderlineIcon, TrashIcon } from "@phosphor-icons/react";
 import { Editor, useEditorState } from "@tiptap/react";
 import { BubbleMenu as BaseBubbleMenu } from "@tiptap/react/menus";
-import { type KeyboardEvent, useEffect, useRef, useState } from "react";
-import { tv } from "tailwind-variants";
+import { type KeyboardEvent, useContext, useEffect, useRef, useState } from "react";
+import { tv } from "tailwind-variants/lite";
+
+import { OverlayPortalRootContext } from "../lib/overlayPortalRoot";
 
 import { MenuButton } from "./MenuButton";
 
@@ -26,21 +28,36 @@ type BubbleMenuProps = {
 
 export function BubbleMenu(props: BubbleMenuProps) {
   const { editor } = props;
+  const portalRoot = useContext(OverlayPortalRootContext);
   const [showLinkInput, setShowLinkInput] = useState(false);
   const [linkUrl, setLinkUrl] = useState("");
   const linkInputRef = useRef<HTMLInputElement>(null);
 
   const state = useEditorState({
     editor,
-    selector: ({ editor }) => ({
-      isBold: editor.isActive("bold"),
-      isItalic: editor.isActive("italic"),
-      isUnderline: editor.isActive("underline"),
-      isStrike: editor.isActive("strike"),
-      isCode: editor.isActive("code"),
-      isLink: editor.isActive("link"),
-      linkHref: editor.getAttributes("link").href as string | undefined,
-    }),
+    selector: ({ editor: current }) => {
+      if (current.isDestroyed) {
+        return {
+          isBold: false,
+          isItalic: false,
+          isUnderline: false,
+          isStrike: false,
+          isCode: false,
+          isLink: false,
+          linkHref: undefined,
+        };
+      }
+
+      return {
+        isBold: current.isActive("bold"),
+        isItalic: current.isActive("italic"),
+        isUnderline: current.isActive("underline"),
+        isStrike: current.isActive("strike"),
+        isCode: current.isActive("code"),
+        isLink: current.isActive("link"),
+        linkHref: current.getAttributes("link").href as string | undefined,
+      };
+    },
   });
 
   useEffect(() => {
@@ -82,14 +99,25 @@ export function BubbleMenu(props: BubbleMenuProps) {
       e.preventDefault();
       setShowLinkInput(false);
       setLinkUrl("");
-      editor.commands.focus();
+      if (!editor.isDestroyed) {
+        editor.commands.focus();
+      }
     }
   }
 
   return (
     <BaseBubbleMenu
       editor={editor}
+      {...(portalRoot ? { appendTo: () => portalRoot } : {})}
       className={root()}
+      data-rich-editor-floating=""
+      onMouseDown={(e) => {
+        if (e.target instanceof HTMLInputElement) {
+          return;
+        }
+
+        e.preventDefault();
+      }}
     >
       <div className={toolbar()}>
         <MenuButton

--- a/packages/ui/src/RichEditor/MenuButton.tsx
+++ b/packages/ui/src/RichEditor/MenuButton.tsx
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file.
 
 import type { PropsWithChildren } from "react";
-import { tv } from "tailwind-variants";
+import { tv } from "tailwind-variants/lite";
 
 const menuButtonVariants = tv({
   base: [
@@ -26,6 +26,7 @@ export function MenuButton({ children, active, onClick }: PropsWithChildren<Menu
   return (
     <button
       type="button"
+      onMouseDown={e => e.preventDefault()}
       onClick={onClick}
       className={menuButtonVariants({ active })}
     >

--- a/packages/ui/src/RichEditor/OptionsMenu/OptionsMenuContent.tsx
+++ b/packages/ui/src/RichEditor/OptionsMenu/OptionsMenuContent.tsx
@@ -7,6 +7,7 @@ import { Fragment, type Node as PmNode } from "@tiptap/pm/model";
 import { TextSelection } from "@tiptap/pm/state";
 import { type Editor } from "@tiptap/react";
 
+import { EditorFloatingPortal } from "../_lib/EditorFloatingPortal";
 import { getBlockNode, isBlockNodeType } from "../_lib/getBlockNode";
 import { MenuButton } from "../MenuButton";
 
@@ -188,80 +189,83 @@ export function OptionsMenuContent({
   };
 
   return (
-    <div
-      ref={(node) => {
-        setDropdownEl(node);
-        menuRefs.setFloating(node);
-      }}
-      style={menuStyles}
-      {...getFloatingProps()}
-      onMouseDown={e => e.preventDefault()}
-      className={menu()}
-    >
-      <div className="p-1 font-semibold text-sm">Turn into</div>
-      <MenuButton
-        active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "paragraph")}
-        onClick={() => handleAction(chain => chain.setParagraph(), "textblock")}
+    <EditorFloatingPortal>
+      <div
+        ref={(node) => {
+          setDropdownEl(node);
+          menuRefs.setFloating(node);
+        }}
+        style={menuStyles}
+        {...getFloatingProps()}
+        onMouseDown={e => e.preventDefault()}
+        className={menu()}
+        data-rich-editor-floating=""
       >
-        <TextTIcon size={16} weight="bold" />
-        Text
-      </MenuButton>
-      <MenuButton
-        active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "heading", { level: 1 })}
-        onClick={() => handleAction(chain => chain.toggleHeading({ level: 1 }), "textblock")}
-      >
-        <TextHOneIcon size={16} weight="bold" />
-        Heading 1
-      </MenuButton>
-      <MenuButton
-        active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "heading", { level: 2 })}
-        onClick={() => handleAction(chain => chain.toggleHeading({ level: 2 }), "textblock")}
-      >
-        <TextHTwoIcon size={16} weight="bold" />
-        Heading 2
-      </MenuButton>
-      <MenuButton
-        active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "heading", { level: 3 })}
-        onClick={() => handleAction(chain => chain.toggleHeading({ level: 3 }), "textblock")}
-      >
-        <TextHThreeIcon size={16} weight="bold" />
-        Heading 3
-      </MenuButton>
-      <MenuButton
-        active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "heading", { level: 4 })}
-        onClick={() => handleAction(chain => chain.toggleHeading({ level: 4 }), "textblock")}
-      >
-        <TextHFourIcon size={16} weight="bold" />
-        Heading 4
-      </MenuButton>
-      <MenuButton
-        active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "bulletList")}
-        onClick={() => handleAction(chain => chain.toggleBulletList(), "wrapper")}
-      >
-        <ListBulletsIcon size={16} weight="bold" />
-        Bullet List
-      </MenuButton>
-      <MenuButton
-        active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "orderedList")}
-        onClick={() => handleAction(chain => chain.toggleOrderedList(), "wrapper")}
-      >
-        <ListNumbersIcon size={16} weight="bold" />
-        Ordered List
-      </MenuButton>
-      <MenuButton
-        active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "codeBlock")}
-        onClick={() => handleAction(chain => chain.toggleCodeBlock(), "textblock")}
-      >
-        <CodeBlockIcon size={16} weight="bold" />
-        Code Block
-      </MenuButton>
-      <MenuButton
-        active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "blockquote")}
-        onClick={() => handleAction(chain => chain.toggleBlockquote(), "wrapper")}
-      >
-        <QuotesIcon size={16} weight="bold" />
-        Blockquote
-      </MenuButton>
-    </div>
+        <div className="p-1 font-semibold text-sm">Turn into</div>
+        <MenuButton
+          active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "paragraph")}
+          onClick={() => handleAction(chain => chain.setParagraph(), "textblock")}
+        >
+          <TextTIcon size={16} weight="bold" />
+          Text
+        </MenuButton>
+        <MenuButton
+          active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "heading", { level: 1 })}
+          onClick={() => handleAction(chain => chain.toggleHeading({ level: 1 }), "textblock")}
+        >
+          <TextHOneIcon size={16} weight="bold" />
+          Heading 1
+        </MenuButton>
+        <MenuButton
+          active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "heading", { level: 2 })}
+          onClick={() => handleAction(chain => chain.toggleHeading({ level: 2 }), "textblock")}
+        >
+          <TextHTwoIcon size={16} weight="bold" />
+          Heading 2
+        </MenuButton>
+        <MenuButton
+          active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "heading", { level: 3 })}
+          onClick={() => handleAction(chain => chain.toggleHeading({ level: 3 }), "textblock")}
+        >
+          <TextHThreeIcon size={16} weight="bold" />
+          Heading 3
+        </MenuButton>
+        <MenuButton
+          active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "heading", { level: 4 })}
+          onClick={() => handleAction(chain => chain.toggleHeading({ level: 4 }), "textblock")}
+        >
+          <TextHFourIcon size={16} weight="bold" />
+          Heading 4
+        </MenuButton>
+        <MenuButton
+          active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "bulletList")}
+          onClick={() => handleAction(chain => chain.toggleBulletList(), "wrapper")}
+        >
+          <ListBulletsIcon size={16} weight="bold" />
+          Bullet List
+        </MenuButton>
+        <MenuButton
+          active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "orderedList")}
+          onClick={() => handleAction(chain => chain.toggleOrderedList(), "wrapper")}
+        >
+          <ListNumbersIcon size={16} weight="bold" />
+          Ordered List
+        </MenuButton>
+        <MenuButton
+          active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "codeBlock")}
+          onClick={() => handleAction(chain => chain.toggleCodeBlock(), "textblock")}
+        >
+          <CodeBlockIcon size={16} weight="bold" />
+          Code Block
+        </MenuButton>
+        <MenuButton
+          active={hoveredBlock != null && isBlockNodeType(editor, hoveredBlock, "blockquote")}
+          onClick={() => handleAction(chain => chain.toggleBlockquote(), "wrapper")}
+        >
+          <QuotesIcon size={16} weight="bold" />
+          Blockquote
+        </MenuButton>
+      </div>
+    </EditorFloatingPortal>
   );
 }

--- a/packages/ui/src/RichEditor/OptionsMenu/OptionsMenuTrigger.tsx
+++ b/packages/ui/src/RichEditor/OptionsMenu/OptionsMenuTrigger.tsx
@@ -90,6 +90,7 @@ export function OptionsMenuTrigger({
       onDragStart={onDragStart}
       onDragEnd={() => setHoveredBlock(null)}
       type="button"
+      data-rich-editor-floating=""
       style={{
         ...triggerStyles,
         visibility: isPositioned ? "visible" : "hidden",

--- a/packages/ui/src/RichEditor/OptionsMenu/variants.ts
+++ b/packages/ui/src/RichEditor/OptionsMenu/variants.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 
-import { tv } from "tailwind-variants";
+import { tv } from "tailwind-variants/lite";
 
 export const optionsMenuVariants = tv({
   slots: {

--- a/packages/ui/src/RichEditor/PlaceholderExtension.ts
+++ b/packages/ui/src/RichEditor/PlaceholderExtension.ts
@@ -1,6 +1,22 @@
 // Copyright (c) 2026 Probo Inc <hello@probo.com>.
-// Use of this source code is governed by the MIT license
-// that can be found in the LICENSE file.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import { Extension } from "@tiptap/core";
 import { type EditorState, Plugin, PluginKey } from "@tiptap/pm/state";
@@ -12,7 +28,9 @@ function computeDecorations(
   state: EditorState,
   editable: boolean,
 ): DecorationSet {
-  if (!editable) return DecorationSet.empty;
+  if (!editable) {
+    return DecorationSet.empty;
+  }
 
   const { selection } = state;
   if (!selection.empty) return DecorationSet.empty;

--- a/packages/ui/src/RichEditor/RichEditor.tsx
+++ b/packages/ui/src/RichEditor/RichEditor.tsx
@@ -1,6 +1,22 @@
 // Copyright (c) 2026 Probo Inc <hello@probo.com>.
-// Use of this source code is governed by the MIT license
-// that can be found in the LICENSE file.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import { Blockquote } from "@tiptap/extension-blockquote";
 import { Bold } from "@tiptap/extension-bold";
@@ -79,15 +95,37 @@ const richEditorVariants = tv({
 type RichEditorProps = ComponentProps<"div"> & {
   content: string;
   disabled?: boolean;
-  onChangeContent: (content: string) => void;
+  onChangeContent?: (content: string) => void;
 };
 
+function parseContent(content: string): Content {
+  if (!content) {
+    return "";
+  }
+
+  try {
+    return JSON.parse(content) as Content;
+  } catch {
+    return "";
+  }
+}
+
 export function RichEditor(props: RichEditorProps) {
-  const { className, content, disabled = false, onChangeContent, ...divProps } = props;
+  const {
+    className,
+    content,
+    disabled = false,
+    onChangeContent,
+    ...divProps
+  } = props;
 
   const handleUpdate = useCallback(
     ({ editor }: { editor: Editor }) => {
-      onChangeContent(JSON.stringify(editor.getJSON()));
+      if (editor.isDestroyed) {
+        return;
+      }
+
+      onChangeContent?.(JSON.stringify(editor.getJSON()));
     },
     [onChangeContent],
   );
@@ -100,12 +138,15 @@ export function RichEditor(props: RichEditorProps) {
     },
     editable: !disabled,
     extensions,
-    content: (content ? JSON.parse(content) : "") as Content,
+    content: parseContent(content),
     onUpdate: handleUpdate,
   });
 
   useEffect(() => {
-    if (!editor) return;
+    if (!editor) {
+      return;
+    }
+
     editor.setEditable(!disabled, false);
   }, [editor, disabled]);
 

--- a/packages/ui/src/RichEditor/TableCellMenu/TableCellMenuContent.tsx
+++ b/packages/ui/src/RichEditor/TableCellMenu/TableCellMenuContent.tsx
@@ -7,6 +7,7 @@ import { TextSelection } from "@tiptap/pm/state";
 import { cellAround, CellSelection } from "@tiptap/pm/tables";
 import { type Editor } from "@tiptap/react";
 
+import { EditorFloatingPortal } from "../_lib/EditorFloatingPortal";
 import type { DropdownMenu } from "../_lib/useTableDropdownMenu";
 import { MenuButton } from "../MenuButton";
 
@@ -67,32 +68,35 @@ export function TableCellMenuContent({
   };
 
   return (
-    <div
-      ref={(node) => {
-        setDropdownEl(node);
-        menuRefs.setFloating(node);
-      }}
-      style={menuStyles}
-      {...getFloatingProps()}
-      onMouseDown={e => e.preventDefault()}
-      className={menu()}
-    >
-      {editor.can().mergeCells() && (
-        <MenuButton onClick={handleMergeCells}>
-          <IntersectIcon size={16} weight="bold" />
-          Merge cells
+    <EditorFloatingPortal>
+      <div
+        ref={(node) => {
+          setDropdownEl(node);
+          menuRefs.setFloating(node);
+        }}
+        style={menuStyles}
+        {...getFloatingProps()}
+        onMouseDown={e => e.preventDefault()}
+        className={menu()}
+        data-rich-editor-floating=""
+      >
+        {editor.can().mergeCells() && (
+          <MenuButton onClick={handleMergeCells}>
+            <IntersectIcon size={16} weight="bold" />
+            Merge cells
+          </MenuButton>
+        )}
+        {editor.can().splitCell() && (
+          <MenuButton onClick={handleSplitCell}>
+            <SplitHorizontalIcon size={16} weight="bold" />
+            Split cells
+          </MenuButton>
+        )}
+        <MenuButton onClick={handleClearContents}>
+          <BroomIcon size={16} weight="bold" />
+          Clear contents
         </MenuButton>
-      )}
-      {editor.can().splitCell() && (
-        <MenuButton onClick={handleSplitCell}>
-          <SplitHorizontalIcon size={16} weight="bold" />
-          Split cells
-        </MenuButton>
-      )}
-      <MenuButton onClick={handleClearContents}>
-        <BroomIcon size={16} weight="bold" />
-        Clear contents
-      </MenuButton>
-    </div>
+      </div>
+    </EditorFloatingPortal>
   );
 }

--- a/packages/ui/src/RichEditor/TableCellMenu/TableCellMenuTrigger.tsx
+++ b/packages/ui/src/RichEditor/TableCellMenu/TableCellMenuTrigger.tsx
@@ -10,6 +10,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { cellDomElement } from "../_lib/cellDomElement";
 import { DRAG_THRESHOLD } from "../_lib/constants";
+import { EditorFloatingPortal } from "../_lib/EditorFloatingPortal";
 import type { DropdownMenu } from "../_lib/useTableDropdownMenu";
 
 import { tableCellMenuVariants } from "./variants";
@@ -223,29 +224,32 @@ export function TableCellMenuTrigger({
   };
 
   return (
-    <button
-      ref={(node) => {
-        handleRefs.setFloating(node);
-        setTriggerEl(node);
-        menuRefs.setReference(node);
-      }}
-      onMouseDown={onHandleMouseDown}
-      onMouseEnter={() => setHandleHovered(true)}
-      onMouseLeave={() => setHandleHovered(false)}
-      type="button"
-      style={{
-        ...handleStyles,
-        visibility: isPositioned ? "visible" : "hidden",
-      }}
-      className={trigger()}
-    >
-      {handleHovered || menuOpen
-        ? (
-            <div className="rounded-full bg-level-0 w-4.5 h-3.5 my-0.5 flex items-center">
-              <DotsThreeCircleVerticalIcon size={18} weight="fill" />
-            </div>
-          )
-        : <CircleIcon size={10} weight="fill" />}
-    </button>
+    <EditorFloatingPortal>
+      <button
+        ref={(node) => {
+          handleRefs.setFloating(node);
+          setTriggerEl(node);
+          menuRefs.setReference(node);
+        }}
+        onMouseDown={onHandleMouseDown}
+        onMouseEnter={() => setHandleHovered(true)}
+        onMouseLeave={() => setHandleHovered(false)}
+        type="button"
+        data-rich-editor-floating=""
+        style={{
+          ...handleStyles,
+          visibility: isPositioned ? "visible" : "hidden",
+        }}
+        className={trigger()}
+      >
+        {handleHovered || menuOpen
+          ? (
+              <div className="rounded-full bg-level-0 w-4.5 h-3.5 my-0.5 flex items-center">
+                <DotsThreeCircleVerticalIcon size={18} weight="fill" />
+              </div>
+            )
+          : <CircleIcon size={10} weight="fill" />}
+      </button>
+    </EditorFloatingPortal>
   );
 }

--- a/packages/ui/src/RichEditor/TableCellMenu/variants.ts
+++ b/packages/ui/src/RichEditor/TableCellMenu/variants.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 
-import { tv } from "tailwind-variants";
+import { tv } from "tailwind-variants/lite";
 
 export const tableCellMenuVariants = tv({
   slots: {

--- a/packages/ui/src/RichEditor/TableColumnMenu/TableColumnMenuContent.tsx
+++ b/packages/ui/src/RichEditor/TableColumnMenu/TableColumnMenuContent.tsx
@@ -13,6 +13,7 @@ import { TextSelection } from "@tiptap/pm/state";
 import { CellSelection, TableMap } from "@tiptap/pm/tables";
 import { type Editor } from "@tiptap/react";
 
+import { EditorFloatingPortal } from "../_lib/EditorFloatingPortal";
 import type { DropdownMenu } from "../_lib/useTableDropdownMenu";
 import { MenuButton } from "../MenuButton";
 
@@ -234,43 +235,46 @@ export function TableColumnMenuContent({
   };
 
   return (
-    <div
-      ref={(node) => {
-        setDropdownEl(node);
-        menuRefs.setFloating(node);
-      }}
-      data-column-menu
-      style={menuStyles}
-      {...getFloatingProps()}
-      onMouseDown={e => e.preventDefault()}
-      className={menu()}
-    >
-      {isFirstColumn && (
-        <MenuButton active={isHeaderColumn()} onClick={handleToggleHeaderColumn}>
-          <CrownSimpleIcon size={16} weight="bold" />
-          Header column
+    <EditorFloatingPortal>
+      <div
+        ref={(node) => {
+          setDropdownEl(node);
+          menuRefs.setFloating(node);
+        }}
+        data-column-menu
+        data-rich-editor-floating=""
+        style={menuStyles}
+        {...getFloatingProps()}
+        onMouseDown={e => e.preventDefault()}
+        className={menu()}
+      >
+        {isFirstColumn && (
+          <MenuButton active={isHeaderColumn()} onClick={handleToggleHeaderColumn}>
+            <CrownSimpleIcon size={16} weight="bold" />
+            Header column
+          </MenuButton>
+        )}
+        <MenuButton onClick={handleInsertLeft}>
+          <PlusIcon size={16} weight="bold" />
+          Insert column left
         </MenuButton>
-      )}
-      <MenuButton onClick={handleInsertLeft}>
-        <PlusIcon size={16} weight="bold" />
-        Insert column left
-      </MenuButton>
-      <MenuButton onClick={handleInsertRight}>
-        <PlusIcon size={16} weight="bold" />
-        Insert column right
-      </MenuButton>
-      <MenuButton onClick={handleDuplicateColumn}>
-        <CopyIcon size={16} weight="bold" />
-        Duplicate column
-      </MenuButton>
-      <MenuButton onClick={handleClearContents}>
-        <BroomIcon size={16} weight="bold" />
-        Clear contents
-      </MenuButton>
-      <MenuButton onClick={handleDeleteColumn}>
-        <TrashIcon size={16} weight="bold" />
-        Delete column
-      </MenuButton>
-    </div>
+        <MenuButton onClick={handleInsertRight}>
+          <PlusIcon size={16} weight="bold" />
+          Insert column right
+        </MenuButton>
+        <MenuButton onClick={handleDuplicateColumn}>
+          <CopyIcon size={16} weight="bold" />
+          Duplicate column
+        </MenuButton>
+        <MenuButton onClick={handleClearContents}>
+          <BroomIcon size={16} weight="bold" />
+          Clear contents
+        </MenuButton>
+        <MenuButton onClick={handleDeleteColumn}>
+          <TrashIcon size={16} weight="bold" />
+          Delete column
+        </MenuButton>
+      </div>
+    </EditorFloatingPortal>
   );
 }

--- a/packages/ui/src/RichEditor/TableColumnMenu/TableColumnMenuTrigger.tsx
+++ b/packages/ui/src/RichEditor/TableColumnMenu/TableColumnMenuTrigger.tsx
@@ -9,6 +9,7 @@ import { type Editor } from "@tiptap/react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { DRAG_THRESHOLD } from "../_lib/constants";
+import { EditorFloatingPortal } from "../_lib/EditorFloatingPortal";
 import type { DropdownMenu } from "../_lib/useTableDropdownMenu";
 
 import { getColumnRect, type HoveredColumn, moveColumn } from "./TableColumnMenu";
@@ -342,39 +343,42 @@ export function TableColumnMenuTrigger({
   };
 
   return (
-    <>
-      <button
-        ref={(node) => {
-          handleRefs.setFloating(node);
-          setTriggerEl(node);
-          menuRefs.setReference(node);
-        }}
-        data-column-handle
-        onMouseDown={onHandleMouseDown}
-        type="button"
-        style={{
-          ...handleStyles,
-          visibility:
-            isPositioned && (hoveredCol || menuOpen) ? "visible" : "hidden",
-        }}
-        className={trigger()}
-      >
-        <DotsThreeIcon size={16} weight="bold" />
-      </button>
-      {dragIndicator && (
-        <div
-          style={{
-            position: "fixed",
-            left: dragIndicator.left - 1,
-            top: dragIndicator.top,
-            width: 2,
-            height: dragIndicator.height,
-            backgroundColor: "var(--color-border-info)",
-            zIndex: 40,
-            pointerEvents: "none",
+    <EditorFloatingPortal>
+      <>
+        <button
+          ref={(node) => {
+            handleRefs.setFloating(node);
+            setTriggerEl(node);
+            menuRefs.setReference(node);
           }}
-        />
-      )}
-    </>
+          data-column-handle
+          data-rich-editor-floating=""
+          onMouseDown={onHandleMouseDown}
+          type="button"
+          style={{
+            ...handleStyles,
+            visibility:
+              isPositioned && (hoveredCol || menuOpen) ? "visible" : "hidden",
+          }}
+          className={trigger()}
+        >
+          <DotsThreeIcon size={16} weight="bold" />
+        </button>
+        {dragIndicator && (
+          <div
+            style={{
+              position: "fixed",
+              left: dragIndicator.left - 1,
+              top: dragIndicator.top,
+              width: 2,
+              height: dragIndicator.height,
+              backgroundColor: "var(--color-border-info)",
+              zIndex: 40,
+              pointerEvents: "none",
+            }}
+          />
+        )}
+      </>
+    </EditorFloatingPortal>
   );
 }

--- a/packages/ui/src/RichEditor/TableColumnMenu/variants.ts
+++ b/packages/ui/src/RichEditor/TableColumnMenu/variants.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 
-import { tv } from "tailwind-variants";
+import { tv } from "tailwind-variants/lite";
 
 export const tableColumnMenuVariants = tv({
   slots: {

--- a/packages/ui/src/RichEditor/TableRowMenu/TableRowMenuContent.tsx
+++ b/packages/ui/src/RichEditor/TableRowMenu/TableRowMenuContent.tsx
@@ -13,6 +13,7 @@ import { TextSelection } from "@tiptap/pm/state";
 import { CellSelection, TableMap } from "@tiptap/pm/tables";
 import { type Editor } from "@tiptap/react";
 
+import { EditorFloatingPortal } from "../_lib/EditorFloatingPortal";
 import type { DropdownMenu } from "../_lib/useTableDropdownMenu";
 import { MenuButton } from "../MenuButton";
 
@@ -228,43 +229,46 @@ export function TableRowMenuContent({
   };
 
   return (
-    <div
-      ref={(node) => {
-        setDropdownEl(node);
-        menuRefs.setFloating(node);
-      }}
-      data-row-menu
-      style={menuStyles}
-      {...getFloatingProps()}
-      onMouseDown={e => e.preventDefault()}
-      className={menu()}
-    >
-      {isFirstRow && (
-        <MenuButton active={isHeaderRow()} onClick={handleToggleHeaderRow}>
-          <CrownSimpleIcon size={16} weight="bold" />
-          Header row
+    <EditorFloatingPortal>
+      <div
+        ref={(node) => {
+          setDropdownEl(node);
+          menuRefs.setFloating(node);
+        }}
+        data-row-menu
+        data-rich-editor-floating=""
+        style={menuStyles}
+        {...getFloatingProps()}
+        onMouseDown={e => e.preventDefault()}
+        className={menu()}
+      >
+        {isFirstRow && (
+          <MenuButton active={isHeaderRow()} onClick={handleToggleHeaderRow}>
+            <CrownSimpleIcon size={16} weight="bold" />
+            Header row
+          </MenuButton>
+        )}
+        <MenuButton onClick={handleInsertAbove}>
+          <PlusIcon size={16} weight="bold" />
+          Insert row above
         </MenuButton>
-      )}
-      <MenuButton onClick={handleInsertAbove}>
-        <PlusIcon size={16} weight="bold" />
-        Insert row above
-      </MenuButton>
-      <MenuButton onClick={handleInsertBelow}>
-        <PlusIcon size={16} weight="bold" />
-        Insert row below
-      </MenuButton>
-      <MenuButton onClick={handleDuplicateRow}>
-        <CopyIcon size={16} weight="bold" />
-        Duplicate row
-      </MenuButton>
-      <MenuButton onClick={handleClearContents}>
-        <BroomIcon size={16} weight="bold" />
-        Clear contents
-      </MenuButton>
-      <MenuButton onClick={handleDeleteRow}>
-        <TrashIcon size={16} weight="bold" />
-        Delete row
-      </MenuButton>
-    </div>
+        <MenuButton onClick={handleInsertBelow}>
+          <PlusIcon size={16} weight="bold" />
+          Insert row below
+        </MenuButton>
+        <MenuButton onClick={handleDuplicateRow}>
+          <CopyIcon size={16} weight="bold" />
+          Duplicate row
+        </MenuButton>
+        <MenuButton onClick={handleClearContents}>
+          <BroomIcon size={16} weight="bold" />
+          Clear contents
+        </MenuButton>
+        <MenuButton onClick={handleDeleteRow}>
+          <TrashIcon size={16} weight="bold" />
+          Delete row
+        </MenuButton>
+      </div>
+    </EditorFloatingPortal>
   );
 }

--- a/packages/ui/src/RichEditor/TableRowMenu/TableRowMenuTrigger.tsx
+++ b/packages/ui/src/RichEditor/TableRowMenu/TableRowMenuTrigger.tsx
@@ -9,6 +9,7 @@ import { type Editor } from "@tiptap/react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { DRAG_THRESHOLD } from "../_lib/constants";
+import { EditorFloatingPortal } from "../_lib/EditorFloatingPortal";
 import type { DropdownMenu } from "../_lib/useTableDropdownMenu";
 
 import { getRowRect, type HoveredRow, moveRow } from "./TableRowMenu";
@@ -342,39 +343,42 @@ export function TableRowMenuTrigger({
   };
 
   return (
-    <>
-      <button
-        ref={(node) => {
-          handleRefs.setFloating(node);
-          setTriggerEl(node);
-          menuRefs.setReference(node);
-        }}
-        data-row-handle
-        onMouseDown={onHandleMouseDown}
-        type="button"
-        style={{
-          ...handleStyles,
-          visibility:
-            isPositioned && (hoveredRow || menuOpen) ? "visible" : "hidden",
-        }}
-        className={trigger()}
-      >
-        <DotsThreeVerticalIcon size={16} weight="bold" />
-      </button>
-      {dragIndicator && (
-        <div
-          style={{
-            position: "fixed",
-            left: dragIndicator.left,
-            top: dragIndicator.top - 1,
-            width: dragIndicator.width,
-            height: 2,
-            backgroundColor: "var(--color-border-info)",
-            zIndex: 40,
-            pointerEvents: "none",
+    <EditorFloatingPortal>
+      <>
+        <button
+          ref={(node) => {
+            handleRefs.setFloating(node);
+            setTriggerEl(node);
+            menuRefs.setReference(node);
           }}
-        />
-      )}
-    </>
+          data-row-handle
+          data-rich-editor-floating=""
+          onMouseDown={onHandleMouseDown}
+          type="button"
+          style={{
+            ...handleStyles,
+            visibility:
+              isPositioned && (hoveredRow || menuOpen) ? "visible" : "hidden",
+          }}
+          className={trigger()}
+        >
+          <DotsThreeVerticalIcon size={16} weight="bold" />
+        </button>
+        {dragIndicator && (
+          <div
+            style={{
+              position: "fixed",
+              left: dragIndicator.left,
+              top: dragIndicator.top - 1,
+              width: dragIndicator.width,
+              height: 2,
+              backgroundColor: "var(--color-border-info)",
+              zIndex: 40,
+              pointerEvents: "none",
+            }}
+          />
+        )}
+      </>
+    </EditorFloatingPortal>
   );
 }

--- a/packages/ui/src/RichEditor/TableRowMenu/variants.ts
+++ b/packages/ui/src/RichEditor/TableRowMenu/variants.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license
 // that can be found in the LICENSE file.
 
-import { tv } from "tailwind-variants";
+import { tv } from "tailwind-variants/lite";
 
 export const tableRowMenuVariants = tv({
   slots: {

--- a/packages/ui/src/RichEditor/_lib/EditorFloatingPortal.tsx
+++ b/packages/ui/src/RichEditor/_lib/EditorFloatingPortal.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { FloatingPortal } from "@floating-ui/react";
+import { type ReactNode, useContext } from "react";
+
+import { OverlayPortalRootContext } from "../../lib/overlayPortalRoot";
+
+export function EditorFloatingPortal({ children }: { children: ReactNode }) {
+  const root = useContext(OverlayPortalRootContext);
+  if (!root) {
+    return children;
+  }
+
+  return <FloatingPortal root={root}>{children}</FloatingPortal>;
+}

--- a/packages/ui/src/RichEditor/_lib/useBlockTrigger.ts
+++ b/packages/ui/src/RichEditor/_lib/useBlockTrigger.ts
@@ -9,17 +9,20 @@ const TRIGGER_HEIGHT = 24;
 
 export function useBlockTrigger(hoveredBlock: HTMLElement | null, offsetValue: number) {
   const blockHeight = hoveredBlock?.getBoundingClientRect().height ?? 0;
-  const triggerPlacement = blockHeight > 2 * TRIGGER_HEIGHT ? "left-start" as const : "left" as const;
+  // Center on a single line. Only pin to the top for tall blocks (headings,
+  // lists) so the control does not sit above the first line of text.
+  const triggerPlacement = blockHeight > 4 * TRIGGER_HEIGHT ? "left-start" as const : "left" as const;
 
   const {
     refs: triggerRefs,
     floatingStyles: triggerStyles,
     isPositioned,
   } = useFloating({
-    strategy: "fixed",
+    strategy: "absolute",
     placement: triggerPlacement,
     middleware: [offset(offsetValue)],
-    whileElementsMounted: autoUpdate,
+    whileElementsMounted: (reference, floating, update) =>
+      autoUpdate(reference, floating, update, { animationFrame: true }),
   });
 
   useLayoutEffect(() => {

--- a/packages/ui/src/lib/overlayPortalRoot.ts
+++ b/packages/ui/src/lib/overlayPortalRoot.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { createContext } from "react";
+
+// Dialog popups provide a host here so floating menus can leave the
+// transformed, overflow-clipped popup without becoming inert outside the modal.
+export const OverlayPortalRootContext = createContext<HTMLElement | null>(null);

--- a/packages/ui/src/rich-editor.css
+++ b/packages/ui/src/rich-editor.css
@@ -1,3 +1,24 @@
+/* Copyright (c) 2026 Probo Inc <hello@probo.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 .ProseMirror-focused {
     outline-width: 0 !important;
     outline-color: transparent !important;

--- a/packages/ui/src/v2/Dialog/DialogPopup.tsx
+++ b/packages/ui/src/v2/Dialog/DialogPopup.tsx
@@ -20,6 +20,9 @@
 
 import { Dialog as BaseDialog } from "@base-ui/react/dialog";
 import type { ComponentProps } from "react";
+import { useState } from "react";
+
+import { OverlayPortalRootContext } from "../../lib/overlayPortalRoot";
 
 import { dialog } from "./variants";
 
@@ -27,20 +30,26 @@ export type DialogPopupProps
   = & Omit<ComponentProps<typeof BaseDialog.Popup>, "className">
     & {
       className?: string;
+      // When true, the popup itself does not scroll; inner regions manage overflow.
+      lockScroll?: boolean;
     };
 
 // Portal + dimmed backdrop + centered, styled popup frame. Children compose the
 // header / body / footer regions.
 export function DialogPopup(props: DialogPopupProps) {
-  const { className, children, ...popupProps } = props;
-  const { backdrop, popup } = dialog();
+  const { className, children, lockScroll = false, ...popupProps } = props;
+  const { backdrop, popup, overlayRoot: overlayRootSlot } = dialog({ lockScroll });
+  const [overlayRoot, setOverlayRoot] = useState<HTMLElement | null>(null);
 
   return (
     <BaseDialog.Portal>
-      <BaseDialog.Backdrop className={backdrop()} />
-      <BaseDialog.Popup className={popup({ className })} {...popupProps}>
-        {children}
-      </BaseDialog.Popup>
+      <OverlayPortalRootContext.Provider value={overlayRoot}>
+        <BaseDialog.Backdrop className={backdrop()} />
+        <BaseDialog.Popup className={popup({ className })} {...popupProps}>
+          {children}
+        </BaseDialog.Popup>
+        <div ref={setOverlayRoot} className={overlayRootSlot()} />
+      </OverlayPortalRootContext.Provider>
     </BaseDialog.Portal>
   );
 }

--- a/packages/ui/src/v2/Dialog/variants.ts
+++ b/packages/ui/src/v2/Dialog/variants.ts
@@ -33,7 +33,7 @@ export const dialog = tv({
     popup: [
       "fixed left-1/2 top-1/2 z-5 -translate-x-1/2 -translate-y-1/2",
       "flex w-[calc(100vw-2rem)] max-w-150 flex-col gap-4",
-      "max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-clip",
+      "max-h-[calc(100vh-2rem)] overflow-x-clip",
       "rounded-5 border border-sand-6 bg-sand-1 py-6 shadow-6 outline-none",
       "transition-all duration-150",
       "data-starting-style:scale-95 data-starting-style:opacity-0",
@@ -44,6 +44,16 @@ export const dialog = tv({
     description: "text-2 text-sand-11",
     body: "px-6",
     footer: "flex flex-wrap items-center justify-end gap-3 px-6 max-sm:flex-col-reverse max-sm:items-stretch",
+    overlayRoot: "relative z-5",
+  },
+  variants: {
+    lockScroll: {
+      true: { popup: "overflow-y-hidden" },
+      false: { popup: "overflow-y-auto" },
+    },
+  },
+  defaultVariants: {
+    lockScroll: false,
   },
 });
 

--- a/pkg/cmd/cmdutil/rich_text.go
+++ b/pkg/cmd/cmdutil/rich_text.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cmdutil
+
+import (
+	"fmt"
+	"strings"
+
+	"go.probo.inc/probo/pkg/prosemirror"
+)
+
+// FormatRichText renders stored ProseMirror JSON as markdown for human CLI
+// output. Empty or whitespace-only values return "".
+func FormatRichText(content string) (string, error) {
+	if strings.TrimSpace(content) == "" {
+		return "", nil
+	}
+
+	node, err := prosemirror.Parse(content)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse content: %w", err)
+	}
+
+	markdown, err := prosemirror.RenderMarkdown(node)
+	if err != nil {
+		return "", fmt.Errorf("cannot render content: %w", err)
+	}
+
+	return strings.TrimRight(markdown, "\n"), nil
+}

--- a/pkg/cmd/cmdutil/rich_text_test.go
+++ b/pkg/cmd/cmdutil/rich_text_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cmdutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/prosemirror"
+)
+
+func TestFormatRichText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := cmdutil.FormatRichText("")
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("prosemirror json", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := cmdutil.FormatRichText(prosemirror.FromPlainText("Review access controls"))
+		require.NoError(t, err)
+		assert.Equal(t, "Review access controls", got)
+	})
+
+	t.Run("empty document", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := cmdutil.FormatRichText(prosemirror.FromPlainText(""))
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := cmdutil.FormatRichText("not json")
+		require.Error(t, err)
+	})
+}

--- a/pkg/cmd/task/comment/create/create.go
+++ b/pkg/cmd/task/comment/create/create.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.probo.inc/probo/pkg/cli/api"
 	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/prosemirror"
 )
 
 const createMutation = `
@@ -36,7 +37,7 @@ mutation($input: CreateTaskCommentInput!) {
     taskCommentEdge {
       node {
         id
-        description
+        content
       }
     }
   }
@@ -47,8 +48,8 @@ type createResponse struct {
 	CreateTaskComment struct {
 		TaskCommentEdge struct {
 			Node struct {
-				ID          string `json:"id"`
-				Description string `json:"description"`
+				ID      string `json:"id"`
+				Content string `json:"content"`
 			} `json:"node"`
 		} `json:"taskCommentEdge"`
 	} `json:"createTaskComment"`
@@ -56,9 +57,9 @@ type createResponse struct {
 
 func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	var (
-		flagTask        string
-		flagOwner       string
-		flagDescription string
+		flagTask    string
+		flagOwner   string
+		flagContent string
 	)
 
 	cmd := &cobra.Command{
@@ -68,7 +69,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
   prb task comment create
 
   # Create a comment non-interactively
-  prb task comment create --task <task-id> --description "Looks good"`,
+  prb task comment create --task <task-id> --content "Looks good"`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := f.Config()
@@ -100,10 +101,10 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 					}
 				}
 
-				if flagDescription == "" {
+				if flagContent == "" {
 					err := huh.NewText().
 						Title("Comment").
-						Value(&flagDescription).
+						Value(&flagContent).
 						Run()
 					if err != nil {
 						return err
@@ -115,13 +116,13 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				return fmt.Errorf("task is required; pass --task or run interactively")
 			}
 
-			if flagDescription == "" {
-				return fmt.Errorf("description is required; pass --description or run interactively")
+			if flagContent == "" {
+				return fmt.Errorf("content is required; pass --content or run interactively")
 			}
 
 			input := map[string]any{
-				"taskId":      flagTask,
-				"description": flagDescription,
+				"taskId":  flagTask,
+				"content": prosemirror.FromPlainText(flagContent),
 			}
 
 			if flagOwner != "" {
@@ -153,7 +154,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVar(&flagTask, "task", "", "Task ID (required)")
 	cmd.Flags().StringVar(&flagOwner, "owner", "", "Owner profile ID (defaults to the authenticated user)")
-	cmd.Flags().StringVar(&flagDescription, "description", "", "Comment description (required)")
+	cmd.Flags().StringVar(&flagContent, "content", "", "Comment content (required)")
 
 	return cmd
 }

--- a/pkg/cmd/task/comment/list/list.go
+++ b/pkg/cmd/task/comment/list/list.go
@@ -39,7 +39,7 @@ query($id: ID!, $first: Int, $after: CursorKey, $orderBy: TaskCommentOrder) {
         edges {
           node {
             id
-            description
+            content
             createdAt
             owner {
               id
@@ -58,10 +58,10 @@ query($id: ID!, $first: Int, $after: CursorKey, $orderBy: TaskCommentOrder) {
 `
 
 type comment struct {
-	ID          string `json:"id"`
-	Description string `json:"description"`
-	CreatedAt   string `json:"createdAt"`
-	Owner       struct {
+	ID        string `json:"id"`
+	Content   string `json:"content"`
+	CreatedAt string `json:"createdAt"`
+	Owner     struct {
 		ID       string `json:"id"`
 		FullName string `json:"fullName"`
 	} `json:"owner"`
@@ -167,15 +167,20 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 
 			rows := make([][]string, 0, len(comments))
 			for _, c := range comments {
+				content, err := cmdutil.FormatRichText(c.Content)
+				if err != nil {
+					return fmt.Errorf("cannot format comment content: %w", err)
+				}
+
 				rows = append(rows, []string{
 					c.ID,
 					c.Owner.FullName,
-					c.Description,
+					content,
 					cmdutil.FormatTime(c.CreatedAt),
 				})
 			}
 
-			t := cmdutil.NewTable("ID", "OWNER", "DESCRIPTION", "CREATED").Rows(rows...)
+			t := cmdutil.NewTable("ID", "OWNER", "CONTENT", "CREATED").Rows(rows...)
 
 			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
 

--- a/pkg/cmd/task/comment/update/update.go
+++ b/pkg/cmd/task/comment/update/update.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.probo.inc/probo/pkg/cli/api"
 	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/prosemirror"
 )
 
 const updateMutation = `
@@ -34,7 +35,7 @@ mutation($input: UpdateTaskCommentInput!) {
   updateTaskComment(input: $input) {
     taskComment {
       id
-      description
+      content
     }
   }
 }
@@ -43,16 +44,16 @@ mutation($input: UpdateTaskCommentInput!) {
 type updateResponse struct {
 	UpdateTaskComment struct {
 		TaskComment struct {
-			ID          string `json:"id"`
-			Description string `json:"description"`
+			ID      string `json:"id"`
+			Content string `json:"content"`
 		} `json:"taskComment"`
 	} `json:"updateTaskComment"`
 }
 
 func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	var (
-		flagOwner       string
-		flagDescription string
+		flagOwner   string
+		flagContent string
 	)
 
 	cmd := &cobra.Command{
@@ -78,16 +79,20 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				cmdutil.TokenRefreshOption(cfg, host, hc),
 			)
 
-			if !cmd.Flags().Changed("description") && !cmd.Flags().Changed("owner") {
-				return fmt.Errorf("description or owner is required; pass --description or --owner")
+			if !cmd.Flags().Changed("content") && !cmd.Flags().Changed("owner") {
+				return fmt.Errorf("content or owner is required; pass --content or --owner")
 			}
 
 			input := map[string]any{
 				"taskCommentId": args[0],
 			}
 
-			if cmd.Flags().Changed("description") {
-				input["description"] = flagDescription
+			if cmd.Flags().Changed("content") {
+				if flagContent == "" {
+					input["content"] = nil
+				} else {
+					input["content"] = prosemirror.FromPlainText(flagContent)
+				}
 			}
 
 			if cmd.Flags().Changed("owner") {
@@ -118,7 +123,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flagOwner, "owner", "", "Owner profile ID")
-	cmd.Flags().StringVar(&flagDescription, "description", "", "Comment description")
+	cmd.Flags().StringVar(&flagContent, "content", "", "Comment content")
 
 	return cmd
 }

--- a/pkg/cmd/task/comment/view/view.go
+++ b/pkg/cmd/task/comment/view/view.go
@@ -36,7 +36,7 @@ query($id: ID!) {
     __typename
     ... on TaskComment {
       id
-      description
+      content
       createdAt
       updatedAt
       owner {
@@ -50,12 +50,12 @@ query($id: ID!) {
 
 type viewResponse struct {
 	Node *struct {
-		Typename    string `json:"__typename"`
-		ID          string `json:"id"`
-		Description string `json:"description"`
-		CreatedAt   string `json:"createdAt"`
-		UpdatedAt   string `json:"updatedAt"`
-		Owner       struct {
+		Typename  string `json:"__typename"`
+		ID        string `json:"id"`
+		Content   string `json:"content"`
+		CreatedAt string `json:"createdAt"`
+		UpdatedAt string `json:"updatedAt"`
+		Owner     struct {
 			ID       string `json:"id"`
 			FullName string `json:"fullName"`
 		} `json:"owner"`
@@ -122,9 +122,14 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 
 			label := lipgloss.NewStyle().Foreground(lipgloss.Color("242")).Width(22)
 
+			content, err := cmdutil.FormatRichText(c.Content)
+			if err != nil {
+				return fmt.Errorf("cannot format comment content: %w", err)
+			}
+
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("ID:"), c.ID)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Owner:"), c.Owner.FullName)
-			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Description:"), c.Description)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Content:"), content)
 			_, _ = fmt.Fprintln(out)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Created:"), cmdutil.FormatTime(c.CreatedAt))
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Updated:"), cmdutil.FormatTime(c.UpdatedAt))

--- a/pkg/cmd/task/create/create.go
+++ b/pkg/cmd/task/create/create.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.probo.inc/probo/pkg/cli/api"
 	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/prosemirror"
 )
 
 const createMutation = `
@@ -62,7 +63,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	var (
 		flagOrg          string
 		flagName         string
-		flagDescription  string
+		flagContent      string
 		flagState        string
 		flagPriority     string
 		flagMeasure      string
@@ -143,8 +144,8 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				"name":           flagName,
 			}
 
-			if flagDescription != "" {
-				input["description"] = flagDescription
+			if flagContent != "" {
+				input["content"] = prosemirror.FromPlainText(flagContent)
 			}
 
 			if flagState != "" {
@@ -202,7 +203,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
 	cmd.Flags().StringVar(&flagName, "name", "", "Task name (required)")
-	cmd.Flags().StringVar(&flagDescription, "description", "", "Task description")
+	cmd.Flags().StringVar(&flagContent, "content", "", "Task content")
 	cmd.Flags().StringVar(&flagState, "state", "", cmdutil.TaskStateFlagUsage())
 	cmd.Flags().StringVar(&flagPriority, "priority", "", "Task priority: URGENT, HIGH, MEDIUM, LOW")
 	cmd.Flags().StringVar(&flagMeasure, "measure", "", "Measure ID")

--- a/pkg/cmd/task/update/update.go
+++ b/pkg/cmd/task/update/update.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.probo.inc/probo/pkg/cli/api"
 	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/prosemirror"
 )
 
 const updateMutation = `
@@ -56,7 +57,7 @@ type updateResponse struct {
 func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	var (
 		flagName         string
-		flagDescription  string
+		flagContent      string
 		flagState        string
 		flagPriority     string
 		flagTimeEstimate string
@@ -96,8 +97,12 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 				input["name"] = flagName
 			}
 
-			if cmd.Flags().Changed("description") {
-				input["description"] = flagDescription
+			if cmd.Flags().Changed("content") {
+				if flagContent == "" {
+					input["content"] = nil
+				} else {
+					input["content"] = prosemirror.FromPlainText(flagContent)
+				}
 			}
 
 			if cmd.Flags().Changed("state") {
@@ -166,7 +171,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flagName, "name", "", "Task name")
-	cmd.Flags().StringVar(&flagDescription, "description", "", "Task description")
+	cmd.Flags().StringVar(&flagContent, "content", "", "Task content")
 	cmd.Flags().StringVar(&flagState, "state", "", cmdutil.TaskStateFlagUsage())
 	cmd.Flags().StringVar(&flagPriority, "priority", "", "Task priority: URGENT, HIGH, MEDIUM, LOW")
 	cmd.Flags().StringVar(&flagTimeEstimate, "time-estimate", "", "Time estimate")

--- a/pkg/cmd/task/view/view.go
+++ b/pkg/cmd/task/view/view.go
@@ -37,7 +37,7 @@ query($id: ID!) {
     ... on Task {
       id
       name
-      description
+      content
       state
       priority
       timeEstimate
@@ -54,7 +54,7 @@ type viewResponse struct {
 		Typename     string  `json:"__typename"`
 		ID           string  `json:"id"`
 		Name         string  `json:"name"`
-		Description  *string `json:"description"`
+		Content      string  `json:"content"`
 		State        string  `json:"state"`
 		Priority     string  `json:"priority"`
 		TimeEstimate *string `json:"timeEstimate"`
@@ -131,8 +131,13 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("State:"), t.State)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Priority:"), t.Priority)
 
-			if t.Description != nil && *t.Description != "" {
-				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Description:"), *t.Description)
+			content, err := cmdutil.FormatRichText(t.Content)
+			if err != nil {
+				return fmt.Errorf("cannot format task content: %w", err)
+			}
+
+			if content != "" {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Content:"), content)
 			}
 
 			if t.TimeEstimate != nil && *t.TimeEstimate != "" {

--- a/pkg/coredata/migrations/20260902T142309Z.sql
+++ b/pkg/coredata/migrations/20260902T142309Z.sql
@@ -1,0 +1,85 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+-- Add a ProseMirror JSONB content column for tasks and comments. Leave
+-- description in place (and nullable) so existing plaintext is not rewritten.
+
+ALTER TABLE tasks
+    ADD COLUMN content JSONB;
+
+ALTER TABLE task_comments
+    ADD COLUMN content JSONB;
+
+ALTER TABLE task_comments
+    ALTER COLUMN description DROP NOT NULL;
+
+CREATE FUNCTION pg_temp.plain_text_to_pm_doc(src text) RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+    line text;
+    blocks jsonb := '[]'::jsonb;
+    para jsonb;
+BEGIN
+    src := replace(replace(src, E'\r\n', E'\n'), E'\r', E'\n');
+
+    FOREACH line IN ARRAY string_to_array(src, E'\n')
+    LOOP
+        IF line = '' THEN
+            para := jsonb_build_object('type', 'paragraph');
+        ELSE
+            para := jsonb_build_object(
+                'type', 'paragraph',
+                'content', jsonb_build_array(
+                    jsonb_build_object('type', 'text', 'text', line)
+                )
+            );
+        END IF;
+
+        blocks := blocks || jsonb_build_array(para);
+    END LOOP;
+
+    -- string_to_array('', E'\n') is empty; FromPlainText("") still emits
+    -- one paragraph so Tiptap's block+ document schema can load it.
+    IF jsonb_array_length(blocks) = 0 THEN
+        blocks := jsonb_build_array(jsonb_build_object('type', 'paragraph'));
+    END IF;
+
+    RETURN jsonb_build_object('type', 'doc', 'content', blocks);
+END;
+$$;
+
+UPDATE tasks
+SET content = pg_temp.plain_text_to_pm_doc(COALESCE(description, ''))
+WHERE content IS NULL;
+
+UPDATE task_comments
+SET content = pg_temp.plain_text_to_pm_doc(COALESCE(description, ''))
+WHERE content IS NULL;
+
+ALTER TABLE tasks
+    ALTER COLUMN content SET NOT NULL;
+
+ALTER TABLE task_comments
+    ALTER COLUMN content SET NOT NULL;
+
+-- TODO: drop tasks.description later
+-- TODO: drop task_comments.description later

--- a/pkg/coredata/task.go
+++ b/pkg/coredata/task.go
@@ -41,7 +41,7 @@ type (
 		OrganizationID gid.GID        `db:"organization_id"`
 		MeasureID      *gid.GID       `db:"measure_id"`
 		Name           string         `db:"name"`
-		Description    *string        `db:"description"`
+		Content        string         `db:"content"`
 		State          TaskState      `db:"state"`
 		Priority       TaskPriority   `db:"priority"`
 		ReferenceID    string         `db:"reference_id"`
@@ -121,7 +121,7 @@ SELECT
 	organization_id,
     measure_id,
     name,
-    description,
+    content,
     state,
     priority,
     reference_id,
@@ -176,7 +176,7 @@ SELECT
     organization_id,
     measure_id,
     name,
-    description,
+    content,
     state,
     priority,
     reference_id,
@@ -236,7 +236,7 @@ INSERT INTO
 		organization_id,
         measure_id,
         name,
-        description,
+        content,
         reference_id,
         state,
         priority,
@@ -253,7 +253,7 @@ VALUES (
 	@organization_id,
     @measure_id,
     @name,
-    @description,
+    @content,
     @reference_id,
     @state,
     @priority,
@@ -273,7 +273,7 @@ RETURNING rank, priority_rank;
 		"organization_id":        t.OrganizationID,
 		"measure_id":             t.MeasureID,
 		"name":                   t.Name,
-		"description":            t.Description,
+		"content":                t.Content,
 		"reference_id":           t.ReferenceID,
 		"state":                  t.State,
 		"priority":               t.Priority,
@@ -316,7 +316,7 @@ INSERT INTO
 		organization_id,
         measure_id,
         name,
-        description,
+        content,
         reference_id,
         state,
         priority,
@@ -333,7 +333,7 @@ VALUES (
 	@organization_id,
     @measure_id,
     @name,
-    @description,
+    @content,
     @reference_id,
     @state,
     @priority,
@@ -346,7 +346,7 @@ VALUES (
 )
 ON CONFLICT (measure_id, reference_id) DO UPDATE SET
     name = @name,
-    description = @description,
+    content = @content,
     updated_at = @updated_at,
     deadline = @deadline
 RETURNING
@@ -354,7 +354,7 @@ RETURNING
     organization_id,
     measure_id,
     name,
-    description,
+    content,
     reference_id,
     state,
     priority,
@@ -373,7 +373,7 @@ RETURNING
 		"organization_id":        t.OrganizationID,
 		"measure_id":             t.MeasureID,
 		"name":                   t.Name,
-		"description":            t.Description,
+		"content":                t.Content,
 		"reference_id":           t.ReferenceID,
 		"state":                  t.State,
 		"priority":               t.Priority,
@@ -445,7 +445,7 @@ func (t *Tasks) LoadByOrganizationID(
 		measure_id,
 		organization_id,
 		name,
-		description,
+		content,
 		state,
 		priority,
 		reference_id,
@@ -530,7 +530,7 @@ SELECT
     measure_id,
 	organization_id,
     name,
-    description,
+    content,
     state,
     priority,
     reference_id,
@@ -578,7 +578,7 @@ func (t *Task) Update(
 UPDATE tasks
 SET
   name = @name,
-  description = @description,
+  content = @content,
   state = @state,
   priority = @priority,
   rank = @rank,
@@ -595,7 +595,7 @@ WHERE %s
 	args := pgx.NamedArgs{
 		"task_id":                t.ID,
 		"name":                   t.Name,
-		"description":            t.Description,
+		"content":                t.Content,
 		"state":                  t.State,
 		"priority":               t.Priority,
 		"rank":                   t.Rank,

--- a/pkg/coredata/task_comment.go
+++ b/pkg/coredata/task_comment.go
@@ -40,7 +40,7 @@ type (
 		OrganizationID gid.GID   `db:"organization_id"`
 		TaskID         gid.GID   `db:"task_id"`
 		OwnerID        gid.GID   `db:"owner_profile_id"`
-		Description    string    `db:"description"`
+		Content        string    `db:"content"`
 		CreatedAt      time.Time `db:"created_at"`
 		UpdatedAt      time.Time `db:"updated_at"`
 	}
@@ -62,30 +62,38 @@ func (tc *TaskComment) AuthorizationAttributes(
 	conn pg.Querier,
 	resourceIDs []gid.GID,
 ) (policy.AttributesByID, error) {
-	q := `SELECT id, organization_id FROM task_comments WHERE id = ANY(@resource_ids)`
+	q := `
+SELECT
+    tc.id,
+    tc.organization_id,
+    p.identity_id
+FROM
+    task_comments tc
+INNER JOIN
+    iam_membership_profiles p ON p.id = tc.owner_profile_id
+WHERE
+    tc.id = ANY(@resource_ids)
+`
 
-	args := pgx.StrictNamedArgs{
-		"resource_ids": resourceIDs,
-	}
-
-	rows, err := conn.Query(ctx, q, args)
+	rows, err := conn.Query(ctx, q, pgx.StrictNamedArgs{"resource_ids": resourceIDs})
 	if err != nil {
 		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
 	}
 
 	defer rows.Close()
 
-	attrsByID := make(policy.AttributesByID)
+	attrsByID := make(policy.AttributesByID, len(resourceIDs))
 
 	for rows.Next() {
-		var id, organizationID gid.GID
+		var id, organizationID, ownerIdentityID gid.GID
 
-		if err := rows.Scan(&id, &organizationID); err != nil {
+		if err := rows.Scan(&id, &organizationID, &ownerIdentityID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 
 		attrsByID[id] = policy.Attributes{
 			"organization_id": organizationID.String(),
+			"owner_id":        ownerIdentityID.String(),
 		}
 	}
 
@@ -108,7 +116,7 @@ SELECT
     organization_id,
     task_id,
     owner_profile_id,
-    description,
+    content,
     created_at,
     updated_at
 FROM
@@ -156,7 +164,7 @@ SELECT
     organization_id,
     task_id,
     owner_profile_id,
-    description,
+    content,
     created_at,
     updated_at
 FROM
@@ -236,7 +244,7 @@ INSERT INTO
         organization_id,
         task_id,
         owner_profile_id,
-        description,
+        content,
         created_at,
         updated_at
     )
@@ -246,7 +254,7 @@ VALUES (
     @organization_id,
     @task_id,
     @owner_profile_id,
-    @description,
+    @content,
     @created_at,
     @updated_at
 )
@@ -258,7 +266,7 @@ VALUES (
 		"organization_id":  tc.OrganizationID,
 		"task_id":          tc.TaskID,
 		"owner_profile_id": tc.OwnerID,
-		"description":      tc.Description,
+		"content":          tc.Content,
 		"created_at":       tc.CreatedAt,
 		"updated_at":       tc.UpdatedAt,
 	}
@@ -281,7 +289,7 @@ UPDATE
     task_comments
 SET
     owner_profile_id = @owner_profile_id,
-    description = @description,
+    content = @content,
     updated_at = @updated_at
 WHERE
     %s
@@ -293,7 +301,7 @@ WHERE
 	args := pgx.StrictNamedArgs{
 		"task_comment_id":  tc.ID,
 		"owner_profile_id": tc.OwnerID,
-		"description":      tc.Description,
+		"content":          tc.Content,
 		"updated_at":       tc.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())

--- a/pkg/probo/measure_service.go
+++ b/pkg/probo/measure_service.go
@@ -31,6 +31,7 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
+	"go.probo.inc/probo/pkg/prosemirror"
 	"go.probo.inc/probo/pkg/validator"
 )
 
@@ -493,7 +494,7 @@ func (s MeasureService) Import(
 						OrganizationID: organizationID,
 						MeasureID:      &measure.ID,
 						Name:           req.Measures[i].Tasks[j].Name,
-						Description:    &taskDescription,
+						Content:        prosemirror.FromPlainText(taskDescription),
 						ReferenceID:    req.Measures[i].Tasks[j].ReferenceID,
 						State:          coredata.TaskStateTodo,
 						Priority:       coredata.TaskPriorityMedium,

--- a/pkg/probo/policies.go
+++ b/pkg/probo/policies.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	organizationCondition = policy.Equals("principal.organization_id", "resource.organization_id")
+	ownerCondition        = policy.Equals("principal.id", "resource.owner_id")
 )
 
 // OwnerPolicy defines permissions for organization owners.
@@ -170,6 +171,21 @@ var AuditorPolicy = policy.NewPolicy(
 	).WithSID("employee-document-access").When(organizationCondition),
 ).WithDescription("Read-only probo access for auditors (excludes internal/employee content)")
 
+// TaskCommentOwnershipPolicy is attached to owner, admin, and viewer so
+// permission(action:) on a comment matches mutation authorization: only the
+// author can update; the author can delete; owner/admin still delete any
+// comment through core:* on their role policy.
+var TaskCommentOwnershipPolicy = policy.NewPolicy(
+	"probo:task-comment-ownership",
+	"Task Comment Ownership",
+	policy.Deny(ActionTaskCommentUpdate).
+		WithSID("deny-update-others-task-comments").
+		When(policy.NotEquals("principal.id", "resource.owner_id")),
+	policy.Allow(ActionTaskCommentUpdate, ActionTaskCommentDelete).
+		WithSID("manage-own-task-comment").
+		When(organizationCondition, ownerCondition),
+).WithDescription("Authors can update and delete their own task comments; nobody else can update them")
+
 // CommonThirdPartyCatalogPolicy grants every authenticated identity
 // read access to the global common third-party catalog. The catalog is
 // shared across all tenants and has no organization scoping, so the
@@ -263,9 +279,9 @@ var CompliancePortalAccessManagerPolicy = policy.NewPolicy(
 // ProboPolicySet returns the PolicySet for the probo service.
 func ProboPolicySet() *iam.PolicySet {
 	return iam.NewPolicySet().
-		AddRolePolicy("OWNER", OwnerPolicy).
-		AddRolePolicy("ADMIN", AdminPolicy).
-		AddRolePolicy("VIEWER", ViewerPolicy).
+		AddRolePolicy("OWNER", OwnerPolicy, TaskCommentOwnershipPolicy).
+		AddRolePolicy("ADMIN", AdminPolicy, TaskCommentOwnershipPolicy).
+		AddRolePolicy("VIEWER", ViewerPolicy, TaskCommentOwnershipPolicy).
 		AddRolePolicy("AUDITOR", AuditorPolicy).
 		AddRolePolicy("EMPLOYEE", EmployeePolicy).
 		AddRolePolicy("COMPLIANCE_PORTAL_MANAGER", CompliancePortalManagerPolicy).

--- a/pkg/probo/task_comment_service.go
+++ b/pkg/probo/task_comment_service.go
@@ -29,6 +29,7 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
+	"go.probo.inc/probo/pkg/prosemirror"
 	"go.probo.inc/probo/pkg/validator"
 )
 
@@ -38,16 +39,16 @@ type (
 	}
 
 	CreateTaskCommentRequest struct {
-		TaskID      gid.GID
-		OwnerID     *gid.GID
-		IdentityID  gid.GID
-		Description string
+		TaskID     gid.GID
+		OwnerID    *gid.GID
+		IdentityID gid.GID
+		Content    string
 	}
 
 	UpdateTaskCommentRequest struct {
-		ID          gid.GID
-		OwnerID     **gid.GID
-		Description **string
+		ID      gid.GID
+		OwnerID **gid.GID
+		Content **string
 	}
 )
 
@@ -57,7 +58,17 @@ func (req *CreateTaskCommentRequest) Validate() error {
 	v.Check(req.TaskID, "task_id", validator.Required(), validator.GID(coredata.TaskEntityType))
 	v.Check(req.OwnerID, "owner_id", validator.GID(coredata.MembershipProfileEntityType))
 	v.Check(req.IdentityID, "identity_id", validator.Required(), validator.GID(coredata.IdentityEntityType))
-	v.Check(req.Description, "description", validator.Required(), validator.SafeText(ContentMaxLength))
+	v.Check(req.Content, "content", validator.MaxLen(richTextMaxJSONBytes))
+
+	if len(req.Content) <= richTextMaxJSONBytes {
+		v.Check(
+			req.Content,
+			"content",
+			validator.HasVisibleRichText(),
+			validator.ProseMirrorDocumentContent(),
+			validator.ProseMirrorDocumentMaxTextLength(ContentMaxLength),
+		)
+	}
 
 	return v.Error()
 }
@@ -71,8 +82,14 @@ func (req *UpdateTaskCommentRequest) Validate() error {
 		v.Check(*req.OwnerID, "owner_id", validator.Required(), validator.GID(coredata.MembershipProfileEntityType))
 	}
 
-	if req.Description != nil {
-		v.Check(*req.Description, "description", validator.Required(), validator.SafeText(ContentMaxLength))
+	if req.Content != nil {
+		v.Check(
+			req.Content,
+			"content",
+			validator.MaxLen(richTextMaxJSONBytes),
+			validator.ProseMirrorDocumentContent(),
+			validator.ProseMirrorDocumentMaxTextLength(ContentMaxLength),
+		)
 	}
 
 	return v.Error()
@@ -159,16 +176,21 @@ func (s TaskCommentService) Create(
 		return nil, err
 	}
 
-	now := time.Now()
-	taskComment := &coredata.TaskComment{
-		ID:          gid.New(scope.GetTenantID(), coredata.TaskCommentEntityType),
-		TaskID:      req.TaskID,
-		Description: req.Description,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+	content, err := prosemirror.DefaultDocumentJSON(&req.Content)
+	if err != nil {
+		return nil, fmt.Errorf("cannot sanitize task comment content: %w", err)
 	}
 
-	err := s.svc.pg.WithTx(
+	now := time.Now()
+	taskComment := &coredata.TaskComment{
+		ID:        gid.New(scope.GetTenantID(), coredata.TaskCommentEntityType),
+		TaskID:    req.TaskID,
+		Content:   content,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	err = s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			task := &coredata.Task{}
@@ -245,8 +267,13 @@ func (s TaskCommentService) Update(
 				taskComment.OwnerID = **req.OwnerID
 			}
 
-			if req.Description != nil {
-				taskComment.Description = **req.Description
+			if req.Content != nil {
+				content, err := prosemirror.DefaultDocumentJSON(*req.Content)
+				if err != nil {
+					return fmt.Errorf("cannot sanitize task comment content: %w", err)
+				}
+
+				taskComment.Content = content
 			}
 
 			taskComment.UpdatedAt = time.Now()

--- a/pkg/probo/task_service.go
+++ b/pkg/probo/task_service.go
@@ -31,8 +31,11 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
+	"go.probo.inc/probo/pkg/prosemirror"
 	"go.probo.inc/probo/pkg/validator"
 )
+
+const richTextMaxJSONBytes = 64 << 10
 
 type (
 	TaskService struct {
@@ -43,7 +46,7 @@ type (
 		OrganizationID gid.GID
 		MeasureID      *gid.GID
 		Name           string
-		Description    *string
+		Content        *string
 		State          *coredata.TaskState
 		Priority       coredata.TaskPriority
 		TimeEstimate   *time.Duration
@@ -54,7 +57,7 @@ type (
 	UpdateTaskRequest struct {
 		TaskID       gid.GID
 		Name         *string
-		Description  **string
+		Content      **string
 		State        *coredata.TaskState
 		Priority     *coredata.TaskPriority
 		TimeEstimate **time.Duration
@@ -71,7 +74,13 @@ func (ctr *CreateTaskRequest) Validate() error {
 	v.Check(ctr.OrganizationID, "organization_id", validator.Required(), validator.GID(coredata.OrganizationEntityType))
 	v.Check(ctr.MeasureID, "measure_id", validator.GID(coredata.MeasureEntityType))
 	v.Check(ctr.Name, "name", validator.SafeTextNoNewLine(TitleMaxLength))
-	v.Check(ctr.Description, "description", validator.SafeText(ContentMaxLength))
+	v.Check(
+		ctr.Content,
+		"content",
+		validator.MaxLen(richTextMaxJSONBytes),
+		validator.ProseMirrorDocumentContent(),
+		validator.ProseMirrorDocumentMaxTextLength(ContentMaxLength),
+	)
 	v.Check(ctr.State, "state", validator.OneOfSlice(coredata.TaskStates()))
 	v.Check(ctr.Priority, "priority", validator.Required(), validator.OneOfSlice(coredata.TaskPriorities()))
 	v.Check(ctr.TimeEstimate, "time_estimate", validator.RangeDuration(0, 1000*time.Hour))
@@ -85,7 +94,13 @@ func (utr *UpdateTaskRequest) Validate() error {
 
 	v.Check(utr.TaskID, "task_id", validator.Required(), validator.GID(coredata.TaskEntityType))
 	v.Check(utr.Name, "name", validator.SafeTextNoNewLine(TitleMaxLength))
-	v.Check(utr.Description, "description", validator.SafeText(ContentMaxLength))
+	v.Check(
+		utr.Content,
+		"content",
+		validator.MaxLen(richTextMaxJSONBytes),
+		validator.ProseMirrorDocumentContent(),
+		validator.ProseMirrorDocumentMaxTextLength(ContentMaxLength),
+	)
 	v.Check(utr.Priority, "priority", validator.OneOfSlice(coredata.TaskPriorities()))
 	v.Check(utr.TimeEstimate, "time_estimate", validator.RangeDuration(0, 1000*time.Hour))
 	v.Check(utr.State, "state", validator.OneOfSlice(coredata.TaskStates()))
@@ -107,6 +122,11 @@ func (s TaskService) Create(
 	now := time.Now()
 	taskID := gid.New(scope.GetTenantID(), coredata.TaskEntityType)
 
+	content, err := prosemirror.DefaultDocumentJSON(req.Content)
+	if err != nil {
+		return nil, fmt.Errorf("cannot sanitize task content: %w", err)
+	}
+
 	referenceID, err := uuid.NewV4()
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate reference id: %w", err)
@@ -122,7 +142,7 @@ func (s TaskService) Create(
 		OrganizationID: req.OrganizationID,
 		MeasureID:      req.MeasureID,
 		Name:           req.Name,
-		Description:    req.Description,
+		Content:        content,
 		Priority:       req.Priority,
 		TimeEstimate:   req.TimeEstimate,
 		AssignedToID:   req.AssignedToID,
@@ -301,8 +321,13 @@ func (s TaskService) Update(
 				task.Name = *req.Name
 			}
 
-			if req.Description != nil {
-				task.Description = *req.Description
+			if req.Content != nil {
+				content, err := prosemirror.DefaultDocumentJSON(*req.Content)
+				if err != nil {
+					return fmt.Errorf("cannot sanitize task content: %w", err)
+				}
+
+				task.Content = content
 			}
 
 			if req.State != nil {

--- a/pkg/prosemirror/plain_text.go
+++ b/pkg/prosemirror/plain_text.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package prosemirror
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// FromPlainText wraps plaintext as a ProseMirror document (one paragraph per
+// line), matching the task/comment SQL backfill and console editor.
+func FromPlainText(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	lines := strings.Split(text, "\n")
+	content := make([]Node, 0, len(lines))
+
+	for _, line := range lines {
+		para := Node{Type: NodeParagraph}
+
+		if line != "" {
+			text := line
+			para.Content = []Node{{
+				Type: NodeText,
+				Text: &text,
+			}}
+		}
+
+		content = append(content, para)
+	}
+
+	encoded, err := json.Marshal(Node{
+		Type:    NodeDoc,
+		Content: content,
+	})
+	if err != nil {
+		panic(fmt.Errorf("cannot marshal plaintext document: %w", err))
+	}
+
+	return string(encoded)
+}

--- a/pkg/prosemirror/plain_text_test.go
+++ b/pkg/prosemirror/plain_text_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package prosemirror_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/prosemirror"
+)
+
+func TestFromPlainText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "single line",
+			in:   "First comment",
+			want: `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"First comment"}]}]}`,
+		},
+		{
+			name: "blank line becomes empty paragraph",
+			in:   "a\n\nb",
+			want: `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"a"}]},{"type":"paragraph"},{"type":"paragraph","content":[{"type":"text","text":"b"}]}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := prosemirror.FromPlainText(tt.in)
+			assert.Equal(t, tt.want, got)
+
+			require.NoError(t, prosemirror.ValidateDocumentContentJSON(got))
+		})
+	}
+}

--- a/pkg/prosemirror/sanitize.go
+++ b/pkg/prosemirror/sanitize.go
@@ -27,15 +27,24 @@ import (
 )
 
 // ValidateDocumentContentJSON returns nil if s is empty or whitespace-only.
-// Otherwise s must be valid ProseMirror JSON whose root node has type "doc".
+// Otherwise s must be valid ProseMirror JSON whose root node has type "doc"
+// and whose node tree matches the Tiptap schema, including parent-child
+// content rules.
 func ValidateDocumentContentJSON(s string) error {
 	if strings.TrimSpace(s) == "" {
 		return nil
 	}
 
-	_, err := parseDocRoot(s)
+	n, err := parseDocRoot(s)
+	if err != nil {
+		return err
+	}
 
-	return err
+	if err := validateDocument(n); err != nil {
+		return fmt.Errorf("cannot validate document content: %w", err)
+	}
+
+	return nil
 }
 
 func parseDocRoot(s string) (Node, error) {
@@ -51,6 +60,16 @@ func parseDocRoot(s string) (Node, error) {
 	return n, nil
 }
 
+// DefaultDocumentJSON sanitizes a ProseMirror document. A nil or
+// whitespace-only value becomes an empty document (one empty paragraph).
+func DefaultDocumentJSON(s *string) (string, error) {
+	if s == nil || strings.TrimSpace(*s) == "" {
+		return FromPlainText(""), nil
+	}
+
+	return SanitizeDocumentJSON(*s)
+}
+
 // SanitizeDocumentJSON parses a ProseMirror/Tiptap JSON document, replaces
 // unsafe link mark href values using the same rules as RenderHTML, and
 // re-serializes the document. Whitespace-only input is returned unchanged.
@@ -63,6 +82,10 @@ func SanitizeDocumentJSON(s string) (string, error) {
 	n, err := parseDocRoot(s)
 	if err != nil {
 		return "", err
+	}
+
+	if err := validateDocument(n); err != nil {
+		return "", fmt.Errorf("cannot sanitize document content: %w", err)
 	}
 
 	sanitizeNode(&n)

--- a/pkg/prosemirror/sanitize_test.go
+++ b/pkg/prosemirror/sanitize_test.go
@@ -28,6 +28,141 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateDocumentContentJSON_Schema(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{name: "empty", in: "", wantErr: false},
+		{name: "whitespace only", in: "   \n", wantErr: false},
+		{
+			name:    "valid paragraph",
+			in:      `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"hi"}]}]}`,
+			wantErr: false,
+		},
+		{name: "plain text", in: "not json", wantErr: true},
+		{name: "non-doc root", in: `{"type":"paragraph","content":[]}`, wantErr: true},
+		{name: "unknown node", in: `{"type":"doc","content":[{"type":"unknownWidget"}]}`, wantErr: true},
+		{
+			name:    "unknown mark",
+			in:      `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"glow"}],"text":"hi"}]}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid heading level",
+			in:      `{"type":"doc","content":[{"type":"heading","attrs":{"level":9},"content":[{"type":"text","text":"hi"}]}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "list item at root",
+			in:      `{"type":"doc","content":[{"type":"listItem","content":[{"type":"paragraph"}]}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty doc content",
+			in:      `{"type":"doc","content":[]}`,
+			wantErr: true,
+		},
+		{
+			name:    "heading inside paragraph",
+			in:      `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"heading","attrs":{"level":1},"content":[{"type":"text","text":"hi"}]}]}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "text at doc root",
+			in:      `{"type":"doc","content":[{"type":"text","text":"hi"}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "list item without paragraph",
+			in:      `{"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"heading","attrs":{"level":1},"content":[{"type":"text","text":"hi"}]}]}]}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "code block with paragraph child",
+			in:      `{"type":"doc","content":[{"type":"codeBlock","content":[{"type":"paragraph","content":[{"type":"text","text":"hi"}]}]}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "valid list",
+			in:      `{"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"hi"}]}]}]}]}`,
+			wantErr: false,
+		},
+		{
+			name:    "valid table",
+			in:      `{"type":"doc","content":[{"type":"table","content":[{"type":"tableRow","content":[{"type":"tableCell","content":[{"type":"paragraph"}]}]}]}]}`,
+			wantErr: false,
+		},
+		{
+			name:    "valid image block",
+			in:      `{"type":"doc","content":[{"type":"image","attrs":{"src":"https://example.com/img.png"}}]}`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateDocumentContentJSON(tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateDocumentContentJSON_TestdataDocument(t *testing.T) {
+	t.Parallel()
+
+	raw, err := json.Marshal(loadTestDocument(t))
+	require.NoError(t, err)
+	require.NoError(t, ValidateDocumentContentJSON(string(raw)))
+}
+
+func TestDefaultDocumentJSON_EmptyBecomesDoc(t *testing.T) {
+	t.Parallel()
+
+	empty := FromPlainText("")
+
+	got, err := DefaultDocumentJSON(nil)
+	require.NoError(t, err)
+	assert.Equal(t, empty, got)
+
+	blank := "   "
+	got, err = DefaultDocumentJSON(&blank)
+	require.NoError(t, err)
+	assert.Equal(t, empty, got)
+}
+
+func TestDefaultDocumentJSON_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	raw := "not json"
+	_, err := DefaultDocumentJSON(&raw)
+	require.Error(t, err)
+}
+
+func TestDefaultDocumentJSON_Sanitizes(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"link","attrs":{"href":"javascript:alert(1)"}}],"text":"click"}]}]}`
+	got, err := DefaultDocumentJSON(&raw)
+	require.NoError(t, err)
+
+	var doc Node
+	require.NoError(t, json.Unmarshal([]byte(got), &doc))
+	attrs, err := doc.Content[0].Content[0].Marks[0].LinkAttrs()
+	require.NoError(t, err)
+	assert.Equal(t, "#", attrs.Href)
+}
+
 func TestSanitizeDocumentJSON_EmptyUnchanged(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/prosemirror/schema.go
+++ b/pkg/prosemirror/schema.go
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package prosemirror
+
+import (
+	"fmt"
+)
+
+func validateDocument(n Node) error {
+	if n.Type != NodeDoc {
+		return fmt.Errorf("document content root must be type %q", NodeDoc)
+	}
+
+	return validateNode(n)
+}
+
+func validateNode(n Node) error {
+	switch n.Type {
+	case NodeDoc:
+		return validateChildren(n, "block", isBlock, 1)
+	case NodeParagraph:
+		if err := rejectNonTextPayload(n); err != nil {
+			return err
+		}
+
+		return validateChildren(n, "inline", isInline, 0)
+	case NodeHeading:
+		if err := rejectNonTextPayload(n); err != nil {
+			return err
+		}
+
+		attrs, err := n.HeadingAttrs()
+		if err != nil {
+			return fmt.Errorf("cannot validate heading node: %w", err)
+		}
+
+		if attrs.Level < 1 || attrs.Level > 6 {
+			return fmt.Errorf("cannot validate heading node: invalid level %d", attrs.Level)
+		}
+
+		return validateChildren(n, "inline", isInline, 0)
+	case NodeBlockquote:
+		if err := rejectNonTextPayload(n); err != nil {
+			return err
+		}
+
+		return validateChildren(n, "block", isBlock, 1)
+	case NodeCodeBlock:
+		return validateCodeBlock(n)
+	case NodeHorizontalRule, NodeImage, NodeHardBreak:
+		return validateLeaf(n)
+	case NodeText:
+		return validateText(n)
+	case NodeBulletList, NodeOrderedList:
+		if err := rejectNonTextPayload(n); err != nil {
+			return err
+		}
+
+		return validateChildren(n, "listItem", isListItem, 1)
+	case NodeListItem:
+		return validateListItem(n)
+	case NodeTable:
+		if err := rejectNonTextPayload(n); err != nil {
+			return err
+		}
+
+		return validateChildren(n, "tableRow", isTableRow, 1)
+	case NodeTableRow:
+		if err := rejectNonTextPayload(n); err != nil {
+			return err
+		}
+
+		return validateChildren(n, "tableCell", isTableCell, 1)
+	case NodeTableCell, NodeTableHeader:
+		if err := rejectNonTextPayload(n); err != nil {
+			return err
+		}
+
+		return validateChildren(n, "block", isBlock, 1)
+	default:
+		return fmt.Errorf("cannot validate node: unknown type %q", n.Type)
+	}
+}
+
+func validateChildren(n Node, expected string, allowed func(NodeType) bool, min int) error {
+	if len(n.Content) < min {
+		return fmt.Errorf("%s must contain at least %d %s", n.Type, min, expected)
+	}
+
+	for _, child := range n.Content {
+		if !allowed(child.Type) {
+			return fmt.Errorf("invalid child type %q in %s (expected %s)", child.Type, n.Type, expected)
+		}
+
+		if err := validateNode(child); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateListItem(n Node) error {
+	if err := rejectNonTextPayload(n); err != nil {
+		return err
+	}
+
+	if len(n.Content) == 0 || n.Content[0].Type != NodeParagraph {
+		return fmt.Errorf("listItem must start with a paragraph")
+	}
+
+	for i, child := range n.Content {
+		if i > 0 && !isBlock(child.Type) {
+			return fmt.Errorf("invalid child type %q in listItem (expected block)", child.Type)
+		}
+
+		if err := validateNode(child); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateCodeBlock(n Node) error {
+	if err := rejectNonTextPayload(n); err != nil {
+		return err
+	}
+
+	for _, child := range n.Content {
+		if child.Type != NodeText {
+			return fmt.Errorf("invalid child type %q in codeBlock (expected text)", child.Type)
+		}
+
+		if len(child.Marks) > 0 {
+			return fmt.Errorf("codeBlock text cannot have marks")
+		}
+
+		if err := validateText(child); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateLeaf(n Node) error {
+	if len(n.Content) > 0 {
+		return fmt.Errorf("%s cannot have children", n.Type)
+	}
+
+	return rejectNonTextPayload(n)
+}
+
+func validateText(n Node) error {
+	if n.Text == nil {
+		return fmt.Errorf("text node text is nil")
+	}
+
+	if len(n.Content) > 0 {
+		return fmt.Errorf("text node cannot have children")
+	}
+
+	for _, mark := range n.Marks {
+		switch mark.Type {
+		case MarkStrong, MarkEm, MarkUnderline, MarkStrike, MarkCode, MarkLink:
+		default:
+			return fmt.Errorf("cannot validate mark: unknown type %q", mark.Type)
+		}
+	}
+
+	return nil
+}
+
+func rejectNonTextPayload(n Node) error {
+	if n.Text != nil {
+		return fmt.Errorf("%s cannot have text", n.Type)
+	}
+
+	if len(n.Marks) > 0 {
+		return fmt.Errorf("%s cannot have marks", n.Type)
+	}
+
+	return nil
+}
+
+func isBlock(t NodeType) bool {
+	switch t {
+	case NodeParagraph, NodeHeading, NodeBlockquote, NodeCodeBlock,
+		NodeHorizontalRule, NodeBulletList, NodeOrderedList, NodeTable, NodeImage:
+		return true
+	default:
+		return false
+	}
+}
+
+func isInline(t NodeType) bool {
+	return t == NodeText || t == NodeHardBreak
+}
+
+func isListItem(t NodeType) bool {
+	return t == NodeListItem
+}
+
+func isTableRow(t NodeType) bool {
+	return t == NodeTableRow
+}
+
+func isTableCell(t NodeType) bool {
+	return t == NodeTableCell || t == NodeTableHeader
+}

--- a/pkg/server/api/console/v1/graphql/task.graphql
+++ b/pkg/server/api/console/v1/graphql/task.graphql
@@ -44,7 +44,7 @@ input TaskOrder
 type Task implements Node {
     id: ID!
     name: String!
-    description: String
+    content: String!
     state: TaskState!
     priority: TaskPriority!
     rank: Int!
@@ -101,7 +101,7 @@ input CreateTaskInput {
     organizationId: ID!
     measureId: ID
     name: String!
-    description: String
+    content: String
     state: TaskState
     priority: TaskPriority!
     timeEstimate: Duration
@@ -112,7 +112,7 @@ input CreateTaskInput {
 input UpdateTaskInput {
     taskId: ID!
     name: String
-    description: String @goField(omittable: true)
+    content: String @goField(omittable: true)
     state: TaskState
     priority: TaskPriority
     rank: Int

--- a/pkg/server/api/console/v1/graphql/task_comment.graphql
+++ b/pkg/server/api/console/v1/graphql/task_comment.graphql
@@ -36,7 +36,7 @@ input TaskCommentOrder
 
 type TaskComment implements Node {
     id: ID!
-    description: String!
+    content: String!
     owner: Profile! @goField(forceResolver: true)
     task: Task! @goField(forceResolver: true)
     createdAt: Datetime!
@@ -73,13 +73,13 @@ extend type Mutation {
 input CreateTaskCommentInput {
     taskId: ID!
     ownerId: ID
-    description: String!
+    content: String!
 }
 
 input UpdateTaskCommentInput {
     taskCommentId: ID!
     ownerId: ID @goField(omittable: true)
-    description: String @goField(omittable: true)
+    content: String @goField(omittable: true)
 }
 
 input DeleteTaskCommentInput {

--- a/pkg/server/api/console/v1/task_comment_resolvers.go
+++ b/pkg/server/api/console/v1/task_comment_resolvers.go
@@ -34,10 +34,10 @@ func (r *mutationResolver) CreateTaskComment(ctx context.Context, input types.Cr
 	taskComment, err := r.probo.TaskComments.Create(
 		ctx, scope,
 		probo.CreateTaskCommentRequest{
-			TaskID:      input.TaskID,
-			OwnerID:     input.OwnerID,
-			IdentityID:  identity.ID,
-			Description: input.Description,
+			TaskID:     input.TaskID,
+			OwnerID:    input.OwnerID,
+			IdentityID: identity.ID,
+			Content:    input.Content,
 		},
 	)
 	if err != nil {
@@ -69,9 +69,9 @@ func (r *mutationResolver) UpdateTaskComment(ctx context.Context, input types.Up
 	taskComment, err := r.probo.TaskComments.Update(
 		ctx, scope,
 		probo.UpdateTaskCommentRequest{
-			ID:          input.TaskCommentID,
-			OwnerID:     gqlutils.UnwrapOmittable(input.OwnerID),
-			Description: gqlutils.UnwrapOmittable(input.Description),
+			ID:      input.TaskCommentID,
+			OwnerID: gqlutils.UnwrapOmittable(input.OwnerID),
+			Content: gqlutils.UnwrapOmittable(input.Content),
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/console/v1/task_resolvers.go
+++ b/pkg/server/api/console/v1/task_resolvers.go
@@ -35,7 +35,7 @@ func (r *mutationResolver) CreateTask(ctx context.Context, input types.CreateTas
 			MeasureID:      input.MeasureID,
 			OrganizationID: input.OrganizationID,
 			Name:           input.Name,
-			Description:    input.Description,
+			Content:        input.Content,
 			State:          input.State,
 			Priority:       input.Priority,
 			TimeEstimate:   input.TimeEstimate,
@@ -78,7 +78,7 @@ func (r *mutationResolver) UpdateTask(ctx context.Context, input types.UpdateTas
 		probo.UpdateTaskRequest{
 			TaskID:       input.TaskID,
 			Name:         input.Name,
-			Description:  gqlutils.UnwrapOmittable(input.Description),
+			Content:      gqlutils.UnwrapOmittable(input.Content),
 			State:        input.State,
 			Priority:     input.Priority,
 			Rank:         input.Rank,

--- a/pkg/server/api/console/v1/types/task.go
+++ b/pkg/server/api/console/v1/types/task.go
@@ -74,7 +74,7 @@ func NewTask(t *coredata.Task) *Task {
 		},
 
 		Name:         t.Name,
-		Description:  t.Description,
+		Content:      t.Content,
 		State:        t.State,
 		Priority:     t.Priority,
 		Rank:         t.Rank,

--- a/pkg/server/api/console/v1/types/task_comment.go
+++ b/pkg/server/api/console/v1/types/task_comment.go
@@ -78,8 +78,8 @@ func NewTaskComment(c *coredata.TaskComment) *TaskComment {
 		Owner: &Profile{
 			ID: c.OwnerID,
 		},
-		Description: c.Description,
-		CreatedAt:   c.CreatedAt,
-		UpdatedAt:   c.UpdatedAt,
+		Content:   c.Content,
+		CreatedAt: c.CreatedAt,
+		UpdatedAt: c.UpdatedAt,
 	}
 }

--- a/pkg/server/api/mcp/v1/resolver.go
+++ b/pkg/server/api/mcp/v1/resolver.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/accessreview"
@@ -86,6 +87,38 @@ func markdownToProseMirrorJSON(markdown string) (string, error) {
 	}
 
 	return string(out), nil
+}
+
+func optionalMarkdownToProseMirrorJSON(markdown *string) (*string, error) {
+	if markdown == nil || strings.TrimSpace(*markdown) == "" {
+		return nil, nil
+	}
+
+	converted, err := markdownToProseMirrorJSON(*markdown)
+	if err != nil {
+		return nil, err
+	}
+
+	return &converted, nil
+}
+
+func omittableMarkdownToProseMirrorJSON(field **string) (**string, error) {
+	if field == nil || *field == nil {
+		return field, nil
+	}
+
+	if strings.TrimSpace(**field) == "" {
+		cleared := (*string)(nil)
+
+		return &cleared, nil
+	}
+
+	converted, err := markdownToProseMirrorJSON(**field)
+	if err != nil {
+		return nil, err
+	}
+
+	return optionalPtr(&converted), nil
 }
 
 func (r *Resolver) Authorize(ctx context.Context, entityID gid.GID, action iam.Action, opts ...authz.AuthorizeFuncOption) (*coredata.Scope, error) {

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2130,13 +2130,18 @@ func (r *Resolver) AddTaskTool(ctx context.Context, req *mcp.CallToolRequest, in
 		priority = *input.Priority
 	}
 
+	content, err := optionalMarkdownToProseMirrorJSON(input.Content)
+	if err != nil {
+		panic(fmt.Errorf("cannot convert markdown to prosemirror: %w", err))
+	}
+
 	task, err := svc.Tasks.Create(
 		ctx, scope,
 		probo.CreateTaskRequest{
 			OrganizationID: input.OrganizationID,
 			MeasureID:      input.MeasureID,
 			Name:           input.Name,
-			Description:    input.Description,
+			Content:        content,
 			State:          input.State,
 			Priority:       priority,
 			TimeEstimate:   input.TimeEstimate,
@@ -2161,12 +2166,17 @@ func (r *Resolver) UpdateTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 
 	svc := r.proboSvc
 
+	content, err := omittableMarkdownToProseMirrorJSON(UnwrapOmittable(input.Content))
+	if err != nil {
+		panic(fmt.Errorf("cannot convert markdown to prosemirror: %w", err))
+	}
+
 	task, err := svc.Tasks.Update(
 		ctx, scope,
 		probo.UpdateTaskRequest{
 			TaskID:       input.ID,
 			Name:         input.Name,
-			Description:  UnwrapOmittable(input.Description),
+			Content:      content,
 			State:        input.State,
 			Priority:     input.Priority,
 			Rank:         input.Rank,
@@ -9424,7 +9434,12 @@ func (r *Resolver) ListTaskCommentsTool(ctx context.Context, req *mcp.CallToolRe
 		return nil, types.ListTaskCommentsOutput{}, fmt.Errorf("internal server error")
 	}
 
-	return nil, types.NewListTaskCommentsOutput(commentPage), nil
+	output, err := types.NewListTaskCommentsOutput(commentPage)
+	if err != nil {
+		return nil, types.ListTaskCommentsOutput{}, err
+	}
+
+	return nil, output, nil
 }
 
 func (r *Resolver) GetTaskCommentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTaskCommentInput) (*mcp.CallToolResult, types.GetTaskCommentOutput, error) {
@@ -9444,8 +9459,13 @@ func (r *Resolver) GetTaskCommentTool(ctx context.Context, req *mcp.CallToolRequ
 		return nil, types.GetTaskCommentOutput{}, fmt.Errorf("internal server error")
 	}
 
+	converted, err := types.NewTaskComment(taskComment)
+	if err != nil {
+		return nil, types.GetTaskCommentOutput{}, err
+	}
+
 	return nil, types.GetTaskCommentOutput{
-		TaskComment: types.NewTaskComment(taskComment),
+		TaskComment: converted,
 	}, nil
 }
 
@@ -9457,13 +9477,18 @@ func (r *Resolver) AddTaskCommentTool(ctx context.Context, req *mcp.CallToolRequ
 
 	identity := authn.IdentityFromContext(ctx)
 
+	content, err := markdownToProseMirrorJSON(input.Content)
+	if err != nil {
+		panic(fmt.Errorf("cannot convert markdown to prosemirror: %w", err))
+	}
+
 	taskComment, err := r.proboSvc.TaskComments.Create(
 		ctx, scope,
 		probo.CreateTaskCommentRequest{
-			TaskID:      input.TaskID,
-			OwnerID:     input.OwnerID,
-			IdentityID:  identity.ID,
-			Description: input.Description,
+			TaskID:     input.TaskID,
+			OwnerID:    input.OwnerID,
+			IdentityID: identity.ID,
+			Content:    content,
 		},
 	)
 	if err != nil {
@@ -9480,8 +9505,13 @@ func (r *Resolver) AddTaskCommentTool(ctx context.Context, req *mcp.CallToolRequ
 		return nil, types.AddTaskCommentOutput{}, fmt.Errorf("internal server error")
 	}
 
+	converted, err := types.NewTaskComment(taskComment)
+	if err != nil {
+		return nil, types.AddTaskCommentOutput{}, err
+	}
+
 	return nil, types.AddTaskCommentOutput{
-		TaskComment: types.NewTaskComment(taskComment),
+		TaskComment: converted,
 	}, nil
 }
 
@@ -9491,12 +9521,17 @@ func (r *Resolver) UpdateTaskCommentTool(ctx context.Context, req *mcp.CallToolR
 		return nil, types.UpdateTaskCommentOutput{}, err
 	}
 
+	content, err := omittableMarkdownToProseMirrorJSON(UnwrapOmittable(input.Content))
+	if err != nil {
+		panic(fmt.Errorf("cannot convert markdown to prosemirror: %w", err))
+	}
+
 	taskComment, err := r.proboSvc.TaskComments.Update(
 		ctx, scope,
 		probo.UpdateTaskCommentRequest{
-			ID:          input.ID,
-			OwnerID:     optionalPtr(input.OwnerID),
-			Description: optionalPtr(input.Description),
+			ID:      input.ID,
+			OwnerID: optionalPtr(input.OwnerID),
+			Content: content,
 		},
 	)
 	if err != nil {
@@ -9513,8 +9548,13 @@ func (r *Resolver) UpdateTaskCommentTool(ctx context.Context, req *mcp.CallToolR
 		return nil, types.UpdateTaskCommentOutput{}, fmt.Errorf("internal server error")
 	}
 
+	converted, err := types.NewTaskComment(taskComment)
+	if err != nil {
+		return nil, types.UpdateTaskCommentOutput{}, err
+	}
+
 	return nil, types.UpdateTaskCommentOutput{
-		TaskComment: types.NewTaskComment(taskComment),
+		TaskComment: converted,
 	}, nil
 }
 

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -6928,6 +6928,7 @@ components:
         - id
         - organization_id
         - name
+        - content
         - state
         - priority
         - rank
@@ -6950,13 +6951,9 @@ components:
         name:
           type: string
           description: Task name
-        description:
-          anyOf:
-            - type: string
-              description: Task description
-            - type: "null"
-              description: No description
-          description: Task description
+        content:
+          type: string
+          description: Task content in markdown (converted from stored ProseMirror JSON)
         state:
           $ref: "#/components/schemas/TaskState"
           description: Task state
@@ -7069,9 +7066,9 @@ components:
         name:
           type: string
           description: Task name
-        description:
+        content:
           type: string
-          description: Task description
+          description: Task content in markdown format
         time_estimate:
           $ref: "#/components/schemas/Duration"
           description: Time estimate
@@ -7114,9 +7111,9 @@ components:
         name:
           type: string
           description: Task name
-        description:
+        content:
           type: ["string", "null"]
-          description: Task description
+          description: Task content in markdown format
           go.probo.inc/mcpgen/omittable: true
         state:
           anyOf:
@@ -7258,7 +7255,7 @@ components:
         - organization_id
         - task_id
         - owner_id
-        - description
+        - content
         - created_at
         - updated_at
       properties:
@@ -7274,9 +7271,9 @@ components:
         owner_id:
           $ref: "#/components/schemas/GID"
           description: Owner membership profile ID
-        description:
+        content:
           type: string
-          description: Task comment description
+          description: Task comment body in markdown (converted from stored ProseMirror JSON)
         created_at:
           type: string
           format: date-time
@@ -7341,7 +7338,7 @@ components:
       type: object
       required:
         - task_id
-        - description
+        - content
       properties:
         task_id:
           $ref: "#/components/schemas/GID"
@@ -7349,9 +7346,9 @@ components:
         owner_id:
           $ref: "#/components/schemas/GID"
           description: Owner membership profile ID. Defaults to the caller's profile in the task organization when omitted.
-        description:
+        content:
           type: string
-          description: Task comment description
+          description: Task comment content in markdown format
 
     AddTaskCommentOutput:
       type: object
@@ -7372,9 +7369,10 @@ components:
         owner_id:
           $ref: "#/components/schemas/GID"
           description: Owner membership profile ID
-        description:
-          type: string
-          description: Task comment description
+        content:
+          type: ["string", "null"]
+          description: Task comment content in markdown format
+          go.probo.inc/mcpgen/omittable: true
 
     UpdateTaskCommentOutput:
       type: object

--- a/pkg/server/api/mcp/v1/types/document.go
+++ b/pkg/server/api/mcp/v1/types/document.go
@@ -47,6 +47,24 @@ func proseMirrorJSONToMarkdown(pmJSON string) (string, error) {
 	return md, nil
 }
 
+// richTextToMarkdown converts stored ProseMirror JSON to markdown.
+func richTextToMarkdown(s string) (string, error) {
+	return proseMirrorJSONToMarkdown(s)
+}
+
+func optionalRichTextToMarkdown(s *string) (*string, error) {
+	if s == nil {
+		return nil, nil
+	}
+
+	md, err := richTextToMarkdown(*s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &md, nil
+}
+
 func NewDocument(d *coredata.Document) *Document {
 	return &Document{
 		ID:                    d.ID,

--- a/pkg/server/api/mcp/v1/types/rich_text_test.go
+++ b/pkg/server/api/mcp/v1/types/rich_text_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/prosemirror"
+)
+
+func TestRichTextToMarkdown(t *testing.T) {
+	t.Parallel()
+
+	doc, err := prosemirror.ParseMarkdown("MCP **comment**")
+	require.NoError(t, err)
+
+	encoded, err := json.Marshal(doc)
+	require.NoError(t, err)
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := richTextToMarkdown("")
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("prosemirror json", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := richTextToMarkdown(string(encoded))
+		require.NoError(t, err)
+		assert.Equal(t, "MCP **comment**\n", got)
+	})
+
+	t.Run("legacy plain text", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := richTextToMarkdown("Oldest MCP comment")
+		require.Error(t, err)
+	})
+
+	t.Run("render error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := richTextToMarkdown(`{"type":"doc","content":[{"type":"unknownWidget"}]}`)
+		require.Error(t, err)
+	})
+}

--- a/pkg/server/api/mcp/v1/types/task.go
+++ b/pkg/server/api/mcp/v1/types/task.go
@@ -21,17 +21,24 @@
 package types
 
 import (
+	"fmt"
+
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/page"
 )
 
 func NewTask(t *coredata.Task) *Task {
+	content, err := richTextToMarkdown(t.Content)
+	if err != nil {
+		panic(fmt.Errorf("cannot convert task content to markdown: %w", err))
+	}
+
 	return &Task{
 		ID:             t.ID,
 		OrganizationID: t.OrganizationID,
 		MeasureID:      t.MeasureID,
 		Name:           t.Name,
-		Description:    t.Description,
+		Content:        content,
 		State:          t.State,
 		Priority:       t.Priority,
 		Rank:           t.Rank,

--- a/pkg/server/api/mcp/v1/types/task_comment.go
+++ b/pkg/server/api/mcp/v1/types/task_comment.go
@@ -21,28 +21,40 @@
 package types
 
 import (
+	"fmt"
+
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/page"
 )
 
-func NewTaskComment(c *coredata.TaskComment) *TaskComment {
+func NewTaskComment(c *coredata.TaskComment) (*TaskComment, error) {
+	content, err := richTextToMarkdown(c.Content)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert task comment content to markdown: %w", err)
+	}
+
 	return &TaskComment{
 		ID:             c.ID,
 		OrganizationID: c.OrganizationID,
 		TaskID:         c.TaskID,
 		OwnerID:        c.OwnerID,
-		Description:    c.Description,
+		Content:        content,
 		CreatedAt:      c.CreatedAt,
 		UpdatedAt:      c.UpdatedAt,
-	}
+	}, nil
 }
 
 func NewListTaskCommentsOutput(
 	commentPage *page.Page[*coredata.TaskComment, coredata.TaskCommentOrderField],
-) ListTaskCommentsOutput {
+) (ListTaskCommentsOutput, error) {
 	comments := make([]*TaskComment, 0, len(commentPage.Data))
 	for _, v := range commentPage.Data {
-		comments = append(comments, NewTaskComment(v))
+		comment, err := NewTaskComment(v)
+		if err != nil {
+			return ListTaskCommentsOutput{}, err
+		}
+
+		comments = append(comments, comment)
 	}
 
 	var nextCursor *page.CursorKey
@@ -55,5 +67,5 @@ func NewListTaskCommentsOutput(
 	return ListTaskCommentsOutput{
 		NextCursor:   nextCursor,
 		TaskComments: comments,
-	}
+	}, nil
 }

--- a/pkg/validator/validator_prosemirror.go
+++ b/pkg/validator/validator_prosemirror.go
@@ -22,14 +22,16 @@ package validator
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"go.probo.inc/probo/pkg/prosemirror"
 )
 
 // ProseMirrorDocumentContent requires non-empty string values to be valid
-// ProseMirror/Tiptap JSON with root type "doc". Empty and whitespace-only
-// strings are allowed.
+// ProseMirror/Tiptap JSON with root type "doc" and a node tree that matches
+// the Tiptap schema, including parent-child content rules.
+// Empty and whitespace-only strings are allowed.
 func ProseMirrorDocumentContent() ValidatorFunc {
 	return func(value any) *ValidationError {
 		actualValue, isNil := dereferenceValue(value)
@@ -85,6 +87,60 @@ func ProseMirrorDocumentMaxTextLength(maxLength int) ValidatorFunc {
 				ErrorCodeTooLong,
 				fmt.Sprintf("text content must be at most %d characters", maxLength),
 			)
+		}
+
+		return nil
+	}
+}
+
+func parseProseMirrorDocument(s string) (prosemirror.Node, bool) {
+	n, err := prosemirror.Parse(s)
+	if err != nil || n.Type != prosemirror.NodeDoc {
+		return prosemirror.Node{}, false
+	}
+
+	return n, true
+}
+
+func nodeHasVisibleText(n prosemirror.Node) bool {
+	if n.Type == prosemirror.NodeHorizontalRule || n.Type == prosemirror.NodeImage {
+		return true
+	}
+
+	if n.Type == prosemirror.NodeText && n.Text != nil && strings.TrimSpace(*n.Text) != "" {
+		return true
+	}
+
+	return slices.ContainsFunc(n.Content, nodeHasVisibleText)
+}
+
+// HasVisibleRichText requires a ProseMirror document with user-visible
+// content. Empty documents (blank paragraphs, lists, or tables) fail the
+// same way as empty or whitespace-only values. Horizontal rules and images
+// count as visible even without text.
+func HasVisibleRichText() ValidatorFunc {
+	return func(value any) *ValidationError {
+		actualValue, isNil := dereferenceValue(value)
+		if isNil {
+			return newValidationError(ErrorCodeRequired, "field is required")
+		}
+
+		s, ok := actualValue.(string)
+		if !ok {
+			return newValidationError(ErrorCodeInvalidFormat, "value must be a string")
+		}
+
+		if strings.TrimSpace(s) == "" {
+			return newValidationError(ErrorCodeRequired, "field is required")
+		}
+
+		n, ok := parseProseMirrorDocument(s)
+		if !ok {
+			return newValidationError(ErrorCodeInvalidFormat, "must be a ProseMirror document")
+		}
+
+		if !nodeHasVisibleText(n) {
+			return newValidationError(ErrorCodeRequired, "field is required")
 		}
 
 		return nil

--- a/pkg/validator/validator_prosemirror_test.go
+++ b/pkg/validator/validator_prosemirror_test.go
@@ -40,6 +40,9 @@ func TestProseMirrorDocumentContent(t *testing.T) {
 		{"valid doc", validDoc, false},
 		{"plain text", "not json", true},
 		{"non-doc root", `{"type":"paragraph","content":[]}`, true},
+		{"unknown node", `{"type":"doc","content":[{"type":"unknownWidget"}]}`, true},
+		{"unknown mark", `{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"glow"}],"text":"hi"}]}]}`, true},
+		{"invalid heading level", `{"type":"doc","content":[{"type":"heading","attrs":{"level":9},"content":[{"type":"text","text":"hi"}]}]}`, true},
 		{"nil value", nil, false},
 		{"nil *string", (*string)(nil), false},
 		{"non-string", 1, true},
@@ -98,6 +101,52 @@ func TestProseMirrorDocumentMaxTextLength(t *testing.T) {
 			err := fn(tt.value)
 			if (err != nil) != tt.wantError {
 				t.Errorf("ProseMirrorDocumentMaxTextLength() error = %v, wantError %v", err, tt.wantError)
+			}
+
+			if err != nil && tt.wantCode != "" && err.Code != tt.wantCode {
+				t.Errorf("expected code %s, got %s", tt.wantCode, err.Code)
+			}
+		})
+	}
+}
+
+func TestHasVisibleRichText(t *testing.T) {
+	t.Parallel()
+
+	emptyHR := `{"type":"doc","content":[{"type":"horizontalRule"}]}`
+	imageOnly := `{"type":"doc","content":[{"type":"image","attrs":{"src":"https://example.com/img.png"}}]}`
+	emptyList := `{"type":"doc","content":[{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph"}]}]}]}`
+	emptyTable := `{"type":"doc","content":[{"type":"table","content":[{"type":"tableRow","content":[{"type":"tableCell","content":[{"type":"paragraph"}]}]}]}]}`
+
+	tests := []struct {
+		name      string
+		value     any
+		wantError bool
+		wantCode  ErrorCode
+	}{
+		{"nil value", nil, true, ErrorCodeRequired},
+		{"empty string", "", true, ErrorCodeRequired},
+		{"whitespace only", "   \n", true, ErrorCodeRequired},
+		{"doc with text", proseMirrorDoc("hello"), false, ""},
+		{"empty paragraph doc", `{"type":"doc","content":[{"type":"paragraph"}]}`, true, ErrorCodeRequired},
+		{"text on non-text node", `{"type":"doc","content":[{"type":"paragraph","text":"hello"}]}`, true, ErrorCodeRequired},
+		{"horizontal rule only", emptyHR, false, ""},
+		{"image only", imageOnly, false, ""},
+		{"empty list", emptyList, true, ErrorCodeRequired},
+		{"empty table", emptyTable, true, ErrorCodeRequired},
+		{"plain text", "hello", true, ErrorCodeInvalidFormat},
+		{"non-string", 1, true, ErrorCodeInvalidFormat},
+	}
+
+	fn := HasVisibleRichText()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := fn(tt.value)
+			if (err != nil) != tt.wantError {
+				t.Errorf("HasVisibleRichText() error = %v, wantError %v", err, tt.wantError)
 			}
 
 			if err != nil && tt.wantCode != "" && err.Code != tt.wantCode {


### PR DESCRIPTION
Tasks still used plain text while documents already share one Tiptap editor. Store the editor body in a new JSONB
content column and leave description as nullable leftover plaintext so existing rows are not rewritten.

Reuse that editor so descriptions and comments get the same formatting, and speak markdown on MCP the same way document content already does.

The kit editor changes only where a dialog or leftover data would break document behavior. Safe parse so old plaintext does not crash, optional onChange for read-only comments, and portaled menus so slash, block, and table UI is not clipped by New task and does not dismiss it.

Comment update is author-only; delete is author/admin/owner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces plain-text task descriptions and comments with shared Tiptap content stored as ProseMirror JSON. The console now supports rich text, while MCP continues to accept and return markdown; legacy plaintext remains readable and accepted on writes.

### Tests **`+1012`** **`-112`**

- Covers rich-text conversion, markdown round-trips, schema limits, legacy fallbacks, CRUD flows, and comment permissions.

### Coredata **`+125`** **`-32`**

- Adds content columns and persistence queries without backfilling legacy description values.

### GraphQL API **`+19`** **`-19`**

- Replaces task and comment `description` fields with `content` in the console schema and resolvers.

### MCP **`+148`** **`-40`**

- Converts markdown to editor content on writes, renders stored content as markdown on reads, and supports clearing optional content.

### prb (CLI) **`+126`** **`-51`**

- Replaces description flags with `--content`, converts text to editor documents, and formats content for list and view output.

### Service **`+470`** **`-34`**

- Validates rich-text documents against the Tiptap schema, accepts legacy plaintext writes, converts imported measure text, and limits comment updates to authors while preserving owner and admin deletion access.

### App: console **`+677`** **`-182`**

- Adds rich task and comment editing, inline comment updates, empty-content validation, loading skeletons, and quiet description autosave.

### Package: `n8n-node` **`+166`** **`-46`**

- Updates task and comment operations to accept `content` and return it as plaintext.

### Package: `ui` **`+549`** **`-326`**

- Adds portaled slash, block, and table menus that no longer get clipped inside dialogs, safe parsing of legacy plaintext, optional onChange for read-only comments, and placeholder styling.

<sup>Written for commit 3859c0399874ff5f6091c7eace57b861431d41c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



