### PR TITLE
Classify Identity Center auth from sign-in

### DIFF
--- a/pkg/accessreview/drivers/aws_identity_center.go
+++ b/pkg/accessreview/drivers/aws_identity_center.go
@@ -64,10 +64,12 @@ type (
 		Status      istypes.UserStatus
 		CreatedAt   *time.Time
 
-		// MFAEnabled and LastLogin are filled after listing, from registered
-		// MFA devices and CloudTrail UserAuthentication. Nil is no signal.
-		MFAEnabled *bool
-		LastLogin  *time.Time
+		// MFAEnabled, LastLogin, and CredentialType are filled after listing,
+		// from registered MFA devices and CloudTrail UserAuthentication.
+		// Nil / empty is no signal.
+		MFAEnabled     *bool
+		LastLogin      *time.Time
+		CredentialType string
 	}
 
 	identityCenterInstance struct {
@@ -810,10 +812,31 @@ func identityCenterActive(status istypes.UserStatus) *bool {
 	}
 }
 
+// identityCenterAuthMethod maps CloudTrail CredentialType to the portal
+// first factor. No type is UNKNOWN: a 90-day gap is unobserved, not SSO.
+func identityCenterAuthMethod(credentialType string) coredata.AccessReviewEntryAuthMethod {
+	local := false
+
+	for part := range strings.SplitSeq(credentialType, ",") {
+		switch strings.ToUpper(strings.TrimSpace(part)) {
+		case "EXTERNAL_IDP":
+			return coredata.AccessReviewEntryAuthMethodSSO
+		case "PASSWORD", "EMAIL_OTP", "WEBAUTHN", "TOTP", "RESYNC_TOTP":
+			local = true
+		}
+	}
+
+	if local {
+		return coredata.AccessReviewEntryAuthMethodPassword
+	}
+
+	return coredata.AccessReviewEntryAuthMethodUnknown
+}
+
 // identityCenterUserRecord maps one Identity Center user. MFA and last
 // login come from registered devices and CloudTrail UserAuthentication
-// when those calls succeed. Active follows UserStatus when the store
-// reports it.
+// when those calls succeed. Auth follows the observed CredentialType.
+// Active follows UserStatus when the store reports it.
 func identityCenterUserRecord(user identityCenterUser) AccountRecord {
 	return AccountRecord{
 		Email:       user.Email,
@@ -823,7 +846,7 @@ func identityCenterUserRecord(user identityCenterUser) AccountRecord {
 		IsAdmin:     identityCenterIsAdmin(user),
 		Active:      identityCenterActive(user.Status),
 		MFAStatus:   awsMFAStatus(user.MFAEnabled),
-		AuthMethod:  coredata.AccessReviewEntryAuthMethodSSO,
+		AuthMethod:  identityCenterAuthMethod(user.CredentialType),
 		AccountType: coredata.AccessReviewEntryAccountTypeUser,
 		LastLogin:   user.LastLogin,
 		CreatedAt:   user.CreatedAt,

--- a/pkg/accessreview/drivers/aws_identity_center_activity.go
+++ b/pkg/accessreview/drivers/aws_identity_center_activity.go
@@ -50,8 +50,8 @@ const (
 
 type (
 	identityCenterLogin struct {
-		at      time.Time
-		usedMFA bool
+		at             time.Time
+		credentialType string
 	}
 
 	identityCenterCloudTrailEvent struct {
@@ -189,7 +189,7 @@ func lookupIdentityCenterLogins(
 		}
 
 		for _, event := range page.Events {
-			userID, usedMFA, ok := parseIdentityCenterLoginEvent(aws.ToString(event.CloudTrailEvent))
+			userID, credentialType, ok := parseIdentityCenterLoginEvent(aws.ToString(event.CloudTrailEvent))
 			if !ok {
 				continue
 			}
@@ -206,7 +206,10 @@ func lookupIdentityCenterLogins(
 				continue
 			}
 
-			found[userID] = identityCenterLogin{at: event.EventTime.UTC(), usedMFA: usedMFA}
+			found[userID] = identityCenterLogin{
+				at:             event.EventTime.UTC(),
+				credentialType: credentialType,
+			}
 			if len(found) == len(wanted) {
 				return found, nil
 			}
@@ -219,19 +222,19 @@ func lookupIdentityCenterLogins(
 	)
 }
 
-func parseIdentityCenterLoginEvent(raw string) (string, bool, bool) {
+func parseIdentityCenterLoginEvent(raw string) (string, string, bool) {
 	if raw == "" {
-		return "", false, false
+		return "", "", false
 	}
 
 	var event identityCenterCloudTrailEvent
 	if err := json.Unmarshal([]byte(raw), &event); err != nil {
-		return "", false, false
+		return "", "", false
 	}
 
 	userID := event.UserIdentity.OnBehalfOf.UserID
 	if userID == "" {
-		return "", false, false
+		return "", "", false
 	}
 
 	credentialType := event.AdditionalEventData.CredentialType
@@ -239,7 +242,7 @@ func parseIdentityCenterLoginEvent(raw string) (string, bool, bool) {
 		credentialType = event.UserIdentity.AdditionalEventData.CredentialType
 	}
 
-	return userID, identityCenterCredentialUsedMFA(credentialType), true
+	return userID, credentialType, true
 }
 
 func identityCenterCredentialUsedMFA(credentialType string) bool {
@@ -287,7 +290,9 @@ func applyIdentityCenterActivity(
 	for i := range users {
 		if login, ok := logins[users[i].ID]; ok {
 			users[i].LastLogin = new(login.at)
-			if login.usedMFA {
+
+			users[i].CredentialType = login.credentialType
+			if identityCenterCredentialUsedMFA(login.credentialType) {
 				users[i].MFAEnabled = new(true)
 			}
 		}

--- a/pkg/accessreview/drivers/aws_identity_center_activity_test.go
+++ b/pkg/accessreview/drivers/aws_identity_center_activity_test.go
@@ -37,12 +37,12 @@ func TestParseIdentityCenterLoginEvent(t *testing.T) {
 		func(t *testing.T) {
 			t.Parallel()
 
-			userID, usedMFA, ok := parseIdentityCenterLoginEvent(
+			userID, credentialType, ok := parseIdentityCenterLoginEvent(
 				`{"userIdentity":{"onBehalfOf":{"userId":"11111111-1111-1111-1111-111111111111"}},"additionalEventData":{"CredentialType":"PASSWORD,TOTP"}}`,
 			)
 			require.True(t, ok)
 			assert.Equal(t, "11111111-1111-1111-1111-111111111111", userID)
-			assert.True(t, usedMFA)
+			assert.Equal(t, "PASSWORD,TOTP", credentialType)
 		},
 	)
 
@@ -51,12 +51,12 @@ func TestParseIdentityCenterLoginEvent(t *testing.T) {
 		func(t *testing.T) {
 			t.Parallel()
 
-			userID, usedMFA, ok := parseIdentityCenterLoginEvent(
+			userID, credentialType, ok := parseIdentityCenterLoginEvent(
 				`{"userIdentity":{"onBehalfOf":{"userId":"carol"}},"additionalEventData":{"CredentialType":"PASSWORD"}}`,
 			)
 			require.True(t, ok)
 			assert.Equal(t, "carol", userID)
-			assert.False(t, usedMFA)
+			assert.Equal(t, "PASSWORD", credentialType)
 		},
 	)
 
@@ -65,12 +65,12 @@ func TestParseIdentityCenterLoginEvent(t *testing.T) {
 		func(t *testing.T) {
 			t.Parallel()
 
-			userID, usedMFA, ok := parseIdentityCenterLoginEvent(
+			userID, credentialType, ok := parseIdentityCenterLoginEvent(
 				`{"userIdentity":{"onBehalfOf":{"userId":"bob"},"additionalEventData":{"CredentialType":"WEBAUTHN"}}}`,
 			)
 			require.True(t, ok)
 			assert.Equal(t, "bob", userID)
-			assert.True(t, usedMFA)
+			assert.Equal(t, "WEBAUTHN", credentialType)
 		},
 	)
 
@@ -119,8 +119,8 @@ func TestApplyIdentityCenterActivity(t *testing.T) {
 	applyIdentityCenterActivity(
 		users,
 		map[string]identityCenterLogin{
-			"bob":   {at: lastLogin, usedMFA: true},
-			"carol": {at: lastLogin, usedMFA: false},
+			"bob":   {at: lastLogin, credentialType: "PASSWORD,TOTP"},
+			"carol": {at: lastLogin, credentialType: "PASSWORD"},
 		},
 		map[string]bool{"dave": true},
 	)
@@ -129,14 +129,17 @@ func TestApplyIdentityCenterActivity(t *testing.T) {
 	assert.True(t, users[0].LastLogin.Equal(lastLogin))
 	require.NotNil(t, users[0].MFAEnabled)
 	assert.True(t, *users[0].MFAEnabled)
+	assert.Equal(t, "PASSWORD,TOTP", users[0].CredentialType)
 
 	require.NotNil(t, users[1].LastLogin)
 	assert.True(t, users[1].LastLogin.Equal(lastLogin))
 	assert.Nil(t, users[1].MFAEnabled)
+	assert.Equal(t, "PASSWORD", users[1].CredentialType)
 
 	assert.Nil(t, users[2].LastLogin)
 	require.NotNil(t, users[2].MFAEnabled)
 	assert.True(t, *users[2].MFAEnabled)
+	assert.Empty(t, users[2].CredentialType)
 }
 
 func TestApplyIdentityCenterActivity_DeviceOverridesPasswordLogin(t *testing.T) {
@@ -147,7 +150,7 @@ func TestApplyIdentityCenterActivity_DeviceOverridesPasswordLogin(t *testing.T) 
 
 	applyIdentityCenterActivity(
 		users,
-		map[string]identityCenterLogin{"bob": {at: lastLogin, usedMFA: false}},
+		map[string]identityCenterLogin{"bob": {at: lastLogin, credentialType: "PASSWORD"}},
 		map[string]bool{"bob": true},
 	)
 

--- a/pkg/accessreview/drivers/aws_identity_center_test.go
+++ b/pkg/accessreview/drivers/aws_identity_center_test.go
@@ -113,10 +113,12 @@ func TestListIdentityCenterUsers_FindsInstanceOutsideSessionRegion(t *testing.T)
 	carol := byID["arn:aws:identitystore::123456789012:user/22222222-2222-2222-2222-222222222222"]
 	assert.Equal(t, "Carol Engineer", carol.FullName)
 	assert.ElementsMatch(t, []string{"Engineers", "ReadOnlyAccess"}, carol.Roles)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodPassword, carol.AuthMethod)
 	assert.Equal(t, coredata.MFAStatusUnknown, carol.MFAStatus)
 	require.NotNil(t, carol.LastLogin)
 	assert.True(t, carol.LastLogin.Equal(time.Unix(1782864000, 0).UTC()))
 
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodPassword, bob.AuthMethod)
 	assert.Equal(t, coredata.MFAStatusEnabled, bob.MFAStatus)
 	require.NotNil(t, bob.LastLogin)
 	assert.True(t, bob.LastLogin.Equal(time.Unix(1786752000, 0).UTC()))
@@ -124,6 +126,7 @@ func TestListIdentityCenterUsers_FindsInstanceOutsideSessionRegion(t *testing.T)
 	dave := byID["arn:aws:identitystore::123456789012:user/33333333-3333-3333-3333-333333333333"]
 	assert.Equal(t, "Dave Unused", dave.FullName)
 	assert.Empty(t, dave.Roles)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodUnknown, dave.AuthMethod)
 	assert.Nil(t, dave.IsAdmin)
 }
 
@@ -152,7 +155,7 @@ func TestListIdentityCenterUsers_ListsDirectAndGroupAssignments(t *testing.T) {
 	assert.Equal(t, "bob@example.com", bob.Email)
 	assert.Equal(t, "Security Lead", bob.JobTitle)
 	assert.Equal(t, []string{"AdministratorAccess"}, bob.Roles)
-	assert.Equal(t, coredata.AccessReviewEntryAuthMethodSSO, bob.AuthMethod)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodPassword, bob.AuthMethod)
 	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, bob.AccountType)
 	assert.Equal(t, coredata.MFAStatusEnabled, bob.MFAStatus)
 	require.NotNil(t, bob.IsAdmin)
@@ -168,7 +171,7 @@ func TestListIdentityCenterUsers_ListsDirectAndGroupAssignments(t *testing.T) {
 	assert.Equal(t, "Carol Engineer", carol.FullName)
 	assert.Equal(t, "carol@example.com", carol.Email)
 	assert.ElementsMatch(t, []string{"Engineers", "ReadOnlyAccess"}, carol.Roles)
-	assert.Equal(t, coredata.AccessReviewEntryAuthMethodSSO, carol.AuthMethod)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodPassword, carol.AuthMethod)
 	assert.Equal(t, coredata.MFAStatusUnknown, carol.MFAStatus)
 	assert.Nil(t, carol.IsAdmin)
 	require.NotNil(t, carol.Active)
@@ -180,7 +183,7 @@ func TestListIdentityCenterUsers_ListsDirectAndGroupAssignments(t *testing.T) {
 	assert.Equal(t, "Dave Unused", dave.FullName)
 	assert.Equal(t, "dave@example.com", dave.Email)
 	assert.Empty(t, dave.Roles)
-	assert.Equal(t, coredata.AccessReviewEntryAuthMethodSSO, dave.AuthMethod)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodUnknown, dave.AuthMethod)
 	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, dave.AccountType)
 	assert.Equal(t, coredata.MFAStatusUnknown, dave.MFAStatus)
 	assert.Nil(t, dave.IsAdmin)
@@ -204,6 +207,7 @@ func TestListIdentityCenterUsers_DegradesWhenActivityDenied(t *testing.T) {
 	}
 
 	for _, record := range records {
+		assert.Equal(t, coredata.AccessReviewEntryAuthMethodUnknown, record.AuthMethod)
 		assert.Equal(t, coredata.MFAStatusUnknown, record.MFAStatus)
 		assert.Nil(t, record.LastLogin)
 	}
@@ -247,6 +251,39 @@ func TestListIdentityCenterUsers_FailsOnCancel(t *testing.T) {
 	assert.Empty(t, users)
 }
 
+func TestIdentityCenterAuthMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		credentialType string
+		want           coredata.AccessReviewEntryAuthMethod
+	}{
+		{name: "empty is unknown", credentialType: "", want: coredata.AccessReviewEntryAuthMethodUnknown},
+		{name: "unrecognized is unknown", credentialType: "SOMETHING_ELSE", want: coredata.AccessReviewEntryAuthMethodUnknown},
+		{name: "external idp is sso", credentialType: "EXTERNAL_IDP", want: coredata.AccessReviewEntryAuthMethodSSO},
+		{name: "password is password", credentialType: "PASSWORD", want: coredata.AccessReviewEntryAuthMethodPassword},
+		{name: "password and totp is password", credentialType: "PASSWORD,TOTP", want: coredata.AccessReviewEntryAuthMethodPassword},
+		{name: "email otp is password", credentialType: "EMAIL_OTP", want: coredata.AccessReviewEntryAuthMethodPassword},
+		{name: "webauthn is password", credentialType: "WEBAUTHN", want: coredata.AccessReviewEntryAuthMethodPassword},
+		{name: "totp is password", credentialType: "TOTP", want: coredata.AccessReviewEntryAuthMethodPassword},
+		{name: "resync totp is password", credentialType: "RESYNC_TOTP", want: coredata.AccessReviewEntryAuthMethodPassword},
+		{name: "external idp wins over local", credentialType: "PASSWORD,EXTERNAL_IDP", want: coredata.AccessReviewEntryAuthMethodSSO},
+		{name: "mixed case external idp", credentialType: "external_idp", want: coredata.AccessReviewEntryAuthMethodSSO},
+	}
+
+	for _, tc := range tests {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				assert.Equal(t, tc.want, identityCenterAuthMethod(tc.credentialType))
+			},
+		)
+	}
+}
+
 func TestIdentityCenterUserRecord_MapsPrimaryEmailAndAdminName(t *testing.T) {
 	t.Parallel()
 
@@ -270,7 +307,7 @@ func TestIdentityCenterUserRecord_MapsPrimaryEmailAndAdminName(t *testing.T) {
 	assert.Equal(t, "Bob Admin", record.FullName)
 	assert.Equal(t, "Security Lead", record.JobTitle)
 	assert.Equal(t, []string{"AdministratorAccess"}, record.Roles)
-	assert.Equal(t, coredata.AccessReviewEntryAuthMethodSSO, record.AuthMethod)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodUnknown, record.AuthMethod)
 	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, record.AccountType)
 	assert.Equal(t, coredata.MFAStatusUnknown, record.MFAStatus)
 	require.NotNil(t, record.IsAdmin)
@@ -289,15 +326,29 @@ func TestIdentityCenterUserRecord_MapsActivitySignals(t *testing.T) {
 
 	record := identityCenterUserRecord(
 		identityCenterUser{
-			ARN:        "arn:aws:identitystore::123456789012:user/bob",
-			UserName:   "bob",
-			MFAEnabled: new(true),
-			LastLogin:  &lastLogin,
+			ARN:            "arn:aws:identitystore::123456789012:user/bob",
+			UserName:       "bob",
+			MFAEnabled:     new(true),
+			LastLogin:      &lastLogin,
+			CredentialType: "PASSWORD,TOTP",
 		},
 	)
 
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodPassword, record.AuthMethod)
 	assert.Equal(t, coredata.MFAStatusEnabled, record.MFAStatus)
 	assert.Equal(t, &lastLogin, record.LastLogin)
+
+	federated := identityCenterUserRecord(
+		identityCenterUser{
+			ARN:            "arn:aws:identitystore::123456789012:user/carol",
+			UserName:       "carol",
+			LastLogin:      &lastLogin,
+			CredentialType: "EXTERNAL_IDP",
+		},
+	)
+
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodSSO, federated.AuthMethod)
+	assert.Equal(t, coredata.MFAStatusUnknown, federated.MFAStatus)
 }
 
 func TestIdentityCenterUserRecord_FallsBackToUserNameEmailAndDisplayName(t *testing.T) {
@@ -333,6 +384,7 @@ func TestIdentityCenterUserRecord_LeavesUnknownSignalsNil(t *testing.T) {
 
 	assert.Empty(t, record.Email)
 	assert.Equal(t, "mystery", record.FullName)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodUnknown, record.AuthMethod)
 	assert.Equal(t, coredata.MFAStatusUnknown, record.MFAStatus)
 	assert.Nil(t, record.Active)
 	assert.Nil(t, record.IsAdmin)


### PR DESCRIPTION
Every Identity Center user was labeled SSO, including directory passwords and users with no CloudTrail event. Reviewers use Auth to judge the login path and whether MFA applies.

Map EXTERNAL_IDP to SSO, local factors (password, email OTP, passkey, TOTP) to PASSWORD, and no observed CredentialType to UNKNOWN. CloudTrail only retains 90 days, so absence is unobserved, not a guessed method. Do not infer auth from Manual provisioning or empty ExternalIds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies Identity Center auth from CloudTrail sign-in events instead of labeling every user SSO. EXTERNAL_IDP maps to SSO, local factors (password, email OTP, passkey, TOTP) to PASSWORD, and no observed CredentialType to UNKNOWN since CloudTrail only retains 90 days.

### Service **`+45`** **`-17`**

- Propagates the CloudTrail CredentialType into Identity Center user records.
- Replaces the unconditional SSO label; MFA detection still reads the same CredentialType.

### Tests **`+72`** **`-17`**

- Updates existing fixtures to assert the new auth classification.
- Adds table-driven coverage for `identityCenterAuthMethod` including combined and mixed-case credential types.

<sup>Written for commit 40bb81e0eafd5ad338ebdbf50705f3b5afa8129f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

