### PR TITLE
Add GCP WIF cloud session package

### DIFF
--- a/pkg/cloud/gcp/session.go
+++ b/pkg/cloud/gcp/session.go
@@ -1,0 +1,395 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Package gcp vends a one-hour authenticated session on one customer GCP
+// project by exchanging a Probo-minted OIDC token and impersonating the
+// customer's audit service account.
+//
+// Probo holds no GCP credential for any customer. It mints a short-lived
+// assertion (pkg/identityfederation), exchanges it at sts.googleapis.com, and
+// impersonates the customer's service account. The customer revokes by
+// deleting the workload identity binding.
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"go.gearno.de/kit/httpclient"
+	"go.probo.inc/probo/pkg/cloud"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/identityfederation"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/iamcredentials/v1"
+	"google.golang.org/api/option"
+	"google.golang.org/api/sts/v1"
+)
+
+const (
+	tokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange"
+	idTokenType            = "urn:ietf:params:oauth:token-type:id_token"
+	accessTokenType        = "urn:ietf:params:oauth:token-type:access_token"
+	cloudPlatformScope     = "https://www.googleapis.com/auth/cloud-platform"
+	serviceAccountLifetime = "3600s"
+)
+
+type (
+	// Session is authenticated access to one GCP project, held as an HTTP
+	// client whose token refreshes itself through WIF and impersonation.
+	// Build service clients with HTTPClient; do not copy the token out.
+	Session struct {
+		httpClient             *http.Client
+		authorizedClient       *http.Client
+		mu                     sync.Mutex
+		token                  *oauth2.Token
+		issuer                 *identityfederation.Issuer
+		organizationID         gid.GID
+		provider               providerResource
+		serviceAccountEmail    string
+		accountID              string
+		stsEndpoint            string
+		iamCredentialsEndpoint string
+	}
+
+	sessionTransport struct {
+		session *Session
+		base    http.RoundTripper
+	}
+)
+
+var (
+	_ cloud.Session     = (*Session)(nil)
+	_ http.RoundTripper = (*sessionTransport)(nil)
+)
+
+// NewSession opens a session on the project named by providerResource, by
+// exchanging an assertion minted for organizationID and impersonating
+// serviceAccountEmail.
+//
+// organizationID must come from the connector row being serviced, never from
+// user input: it selects whose cloud accounts the resulting credentials reach.
+//
+// No credential is fetched here, which is why there is no context to pass. The
+// first API call performs the exchange and impersonation and owns caching and
+// refresh from then on, so a session is cheap to build and no token is ever
+// written to disk.
+func NewSession(
+	issuer *identityfederation.Issuer,
+	organizationID gid.GID,
+	providerResource string,
+	serviceAccountEmail string,
+) (*Session, error) {
+	parsed, err := parseProviderResource(providerResource)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open gcp session: %w", err)
+	}
+
+	email, err := parseServiceAccountEmail(serviceAccountEmail)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open gcp session: %w", err)
+	}
+
+	httpClient := httpclient.DefaultPooledClient(httpclient.WithSSRFProtection())
+
+	session := &Session{
+		httpClient:          httpClient,
+		issuer:              issuer,
+		organizationID:      organizationID,
+		provider:            parsed,
+		serviceAccountEmail: email,
+		accountID:           parsed.projectNumber,
+	}
+	session.authorizedClient = authorizeSession(httpClient, session)
+
+	return session, nil
+}
+
+// NewSessionFromToken builds a session from an already-issued access token.
+// Production uses NewSession, which obtains credentials through WIF.
+func NewSessionFromToken(projectNumber, accessToken string) *Session {
+	httpClient := httpclient.DefaultPooledClient(httpclient.WithSSRFProtection())
+	session := &Session{
+		httpClient: httpClient,
+		token:      &oauth2.Token{AccessToken: accessToken},
+		accountID:  projectNumber,
+	}
+	session.authorizedClient = authorizeSession(httpClient, session)
+
+	return session
+}
+
+// Cloud implements cloud.Session.
+func (s *Session) Cloud() string {
+	return cloud.GCP
+}
+
+// AccountID is the GCP project number the workload identity provider lives in.
+func (s *Session) AccountID() string {
+	return s.accountID
+}
+
+// HTTPClient is the SSRF-protected client with the impersonated token already
+// attached. Pass it to option.WithHTTPClient. Token refresh uses the request
+// context.
+func (s *Session) HTTPClient() *http.Client {
+	return s.authorizedClient
+}
+
+// CheckAccess reports whether this session can actually reach its project.
+//
+// It completes the STS exchange and service-account impersonation. Every
+// federated principal granted workloadIdentityUser on the service account can
+// do that, so a failure means the exchange itself was refused — a missing
+// pool, an attribute condition that does not name this organization, an
+// unpublished signing key — and never a missing IAM role on the service
+// account. That is what makes it a connection check rather than a capability
+// check.
+//
+// It is also the first call to force the exchange: NewSession fetches no
+// credential, so until something talks to GCP there is nothing to be wrong.
+func (s *Session) CheckAccess(ctx context.Context) error {
+	_, err := s.accessToken(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot reach gcp project: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Session) accessToken(ctx context.Context) (*oauth2.Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.token.Valid() {
+		return s.token, nil
+	}
+
+	token, err := s.fetchServiceAccountToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s.token = token
+
+	return token, nil
+}
+
+func (s *Session) fetchServiceAccountToken(ctx context.Context) (*oauth2.Token, error) {
+	assertion, err := s.mintAssertion(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	federated, err := s.exchangeAssertion(ctx, assertion)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.impersonate(ctx, federated)
+}
+
+func (s *Session) mintAssertion(ctx context.Context) (string, error) {
+	audience, err := jwtAudience(s.provider)
+	if err != nil {
+		return "", fmt.Errorf("cannot build gcp identity federation audience: %w", err)
+	}
+
+	token, err := s.issuer.Token(ctx, s.organizationID, audience)
+	if err != nil {
+		return "", fmt.Errorf("cannot mint gcp identity federation token: %w", err)
+	}
+
+	return token, nil
+}
+
+func (s *Session) exchangeAssertion(ctx context.Context, assertion string) (*oauth2.Token, error) {
+	opts := []option.ClientOption{
+		option.WithHTTPClient(s.httpClient),
+		option.WithoutAuthentication(),
+	}
+	if s.stsEndpoint != "" {
+		opts = append(opts, option.WithEndpoint(s.stsEndpoint))
+	}
+
+	svc, err := sts.NewService(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gcp sts client: %w", err)
+	}
+
+	audience, err := stsAudience(s.provider)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build gcp sts audience: %w", err)
+	}
+
+	resp, err := svc.V1.Token(
+		&sts.GoogleIdentityStsV1ExchangeTokenRequest{
+			Audience:           audience,
+			GrantType:          tokenExchangeGrantType,
+			RequestedTokenType: accessTokenType,
+			Scope:              cloudPlatformScope,
+			SubjectToken:       assertion,
+			SubjectTokenType:   idTokenType,
+		},
+	).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("cannot exchange gcp identity federation token: %w", err)
+	}
+
+	return &oauth2.Token{
+		AccessToken: resp.AccessToken,
+		TokenType:   resp.TokenType,
+		Expiry:      time.Now().Add(time.Duration(resp.ExpiresIn) * time.Second),
+	}, nil
+}
+
+func (s *Session) impersonate(ctx context.Context, federated *oauth2.Token) (*oauth2.Token, error) {
+	name, err := serviceAccountResourceName(s.serviceAccountEmail)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := []option.ClientOption{
+		option.WithHTTPClient(authorizeClient(s.httpClient, oauth2.StaticTokenSource(federated))),
+		option.WithoutAuthentication(),
+	}
+	if s.iamCredentialsEndpoint != "" {
+		opts = append(opts, option.WithEndpoint(s.iamCredentialsEndpoint))
+	}
+
+	svc, err := iamcredentials.NewService(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gcp iam credentials client: %w", err)
+	}
+
+	resp, err := svc.Projects.ServiceAccounts.GenerateAccessToken(
+		name,
+		&iamcredentials.GenerateAccessTokenRequest{
+			Scope:    []string{cloudPlatformScope},
+			Lifetime: serviceAccountLifetime,
+		},
+	).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("cannot impersonate gcp service account: %w", err)
+	}
+
+	expiry, err := time.Parse(time.RFC3339, resp.ExpireTime)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse gcp service account token expiry: %w", err)
+	}
+
+	return &oauth2.Token{
+		AccessToken: resp.AccessToken,
+		TokenType:   "Bearer",
+		Expiry:      expiry,
+	}, nil
+}
+
+func jwtAudience(p providerResource) (string, error) {
+	path, err := iamResourcePath(p)
+	if err != nil {
+		return "", err
+	}
+
+	return new(url.URL{
+		Scheme: "https",
+		Host:   iamHost,
+		Path:   path,
+	}).String(), nil
+}
+
+func stsAudience(p providerResource) (string, error) {
+	path, err := iamResourcePath(p)
+	if err != nil {
+		return "", err
+	}
+
+	return new(url.URL{
+		Host: iamHost,
+		Path: path,
+	}).String(), nil
+}
+
+func iamResourcePath(p providerResource) (string, error) {
+	path, err := url.JoinPath(
+		"/",
+		"projects",
+		url.PathEscape(p.projectNumber),
+		"locations",
+		"global",
+		"workloadIdentityPools",
+		url.PathEscape(p.poolID),
+		"providers",
+		url.PathEscape(p.providerID),
+	)
+	if err != nil {
+		return "", fmt.Errorf("cannot build gcp iam resource path: %w", err)
+	}
+
+	return path, nil
+}
+
+func serviceAccountResourceName(email string) (string, error) {
+	name, err := url.JoinPath("projects/-/serviceAccounts", url.PathEscape(email))
+	if err != nil {
+		return "", fmt.Errorf("cannot build service account resource name: %w", err)
+	}
+
+	return name, nil
+}
+
+func authorizeSession(base *http.Client, session *Session) *http.Client {
+	client := *base
+	client.Transport = &sessionTransport{
+		session: session,
+		base:    base.Transport,
+	}
+
+	return &client
+}
+
+func (t *sessionTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := t.session.accessToken(req.Context())
+	if err != nil {
+		if req.Body != nil {
+			_ = req.Body.Close()
+		}
+
+		return nil, err
+	}
+
+	authorized := req.Clone(req.Context())
+	token.SetAuthHeader(authorized)
+
+	return t.base.RoundTrip(authorized)
+}
+
+func authorizeClient(base *http.Client, src oauth2.TokenSource) *http.Client {
+	client := *base
+	client.Transport = &oauth2.Transport{
+		Source: src,
+		Base:   base.Transport,
+	}
+
+	return &client
+}

--- a/pkg/cloud/gcp/session_exchange_test.go
+++ b/pkg/cloud/gcp/session_exchange_test.go
@@ -1,0 +1,286 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package gcp
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/httpclient"
+	"go.probo.inc/probo/pkg/baseurl"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/crypto/jose"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/identityfederation"
+)
+
+const (
+	exchangeProviderResource = "projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo"
+	exchangeServiceAccount   = "probo-audit@my-project.iam.gserviceaccount.com"
+	exchangeIAMPath          = "/v1/projects/-/serviceAccounts/" + exchangeServiceAccount + ":generateAccessToken"
+	exchangeFederatedToken   = "federated-access-token"
+	exchangeSAToken          = "sa-access-token"
+)
+
+func TestAudienceForms(t *testing.T) {
+	t.Parallel()
+
+	p := providerResource{
+		projectNumber: "123456789012",
+		poolID:        "probo",
+		providerID:    "probo",
+	}
+
+	jwt, err := jwtAudience(p)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"https://iam.googleapis.com/projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo",
+		jwt,
+	)
+
+	sts, err := stsAudience(p)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"//iam.googleapis.com/projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo",
+		sts,
+	)
+}
+
+func TestCheckAccess_ExchangesAndImpersonates(t *testing.T) {
+	t.Parallel()
+
+	probe := newExchangeTestSession(t)
+
+	err := probe.session.CheckAccess(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"https://iam.googleapis.com/projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo",
+		probe.jwtAudience,
+	)
+	assert.Equal(
+		t,
+		"//iam.googleapis.com/projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo",
+		probe.stsAudience,
+	)
+	assert.Equal(t, "Bearer "+exchangeFederatedToken, probe.iamAuth)
+}
+
+func TestCheckAccess_CachesTokenForFirstAPICall(t *testing.T) {
+	t.Parallel()
+
+	probe := newExchangeTestSession(t)
+
+	err := probe.session.CheckAccess(context.Background())
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		probe.serverURL+"/probe",
+		nil,
+	)
+	require.NoError(t, err)
+
+	resp, err := probe.session.HTTPClient().Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "Bearer "+exchangeSAToken, probe.apiAuth)
+	assert.Equal(t, 1, probe.stsHits)
+	assert.Equal(t, 1, probe.iamHits)
+}
+
+func TestHTTPClient_HonorsRequestContext(t *testing.T) {
+	t.Parallel()
+
+	probe := newExchangeTestSession(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probe.serverURL+"/probe", nil)
+	require.NoError(t, err)
+
+	_, err = probe.session.HTTPClient().Do(req)
+	require.Error(t, err)
+}
+
+type exchangeProbe struct {
+	session     *Session
+	serverURL   string
+	stsHits     int
+	iamHits     int
+	stsAudience string
+	jwtAudience string
+	iamAuth     string
+	apiAuth     string
+}
+
+func newExchangeTestSession(t *testing.T) *exchangeProbe {
+	t.Helper()
+
+	probe := &exchangeProbe{}
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/v1/token":
+				probe.stsHits++
+
+				var req struct {
+					Audience     string `json:"audience"`
+					SubjectToken string `json:"subjectToken"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					http.Error(w, "cannot decode sts request", http.StatusBadRequest)
+					return
+				}
+
+				probe.stsAudience = req.Audience
+
+				audience, err := jwtAudienceFromToken(req.SubjectToken)
+				if err != nil {
+					http.Error(w, "cannot decode subject token", http.StatusBadRequest)
+					return
+				}
+
+				probe.jwtAudience = audience
+
+				_ = json.NewEncoder(w).Encode(
+					map[string]any{
+						"access_token":      exchangeFederatedToken,
+						"expires_in":        3600,
+						"token_type":        "Bearer",
+						"issued_token_type": accessTokenType,
+					},
+				)
+			case exchangeIAMPath:
+				var req struct {
+					Scope    []string `json:"scope"`
+					Lifetime string   `json:"lifetime"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					http.Error(w, "cannot decode iam request", http.StatusBadRequest)
+					return
+				}
+
+				if !slices.Equal(req.Scope, []string{cloudPlatformScope}) ||
+					req.Lifetime != serviceAccountLifetime {
+					http.Error(w, "unexpected iam request", http.StatusBadRequest)
+					return
+				}
+
+				probe.iamHits++
+				probe.iamAuth = r.Header.Get("Authorization")
+
+				_ = json.NewEncoder(w).Encode(
+					map[string]any{
+						"accessToken": exchangeSAToken,
+						"expireTime":  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+					},
+				)
+			case "/probe":
+				probe.apiAuth = r.Header.Get("Authorization")
+
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				http.NotFound(w, r)
+			}
+		}),
+	)
+	t.Cleanup(server.Close)
+
+	session, err := NewSession(
+		exchangeTestIssuer(t),
+		gid.New(gid.NewTenantID(), coredata.OrganizationEntityType),
+		exchangeProviderResource,
+		exchangeServiceAccount,
+	)
+	require.NoError(t, err)
+
+	session.httpClient = httpclient.DefaultPooledClient(
+		httpclient.WithSSRFProtection(),
+		httpclient.WithSSRFAllowLoopback(),
+	)
+	session.stsEndpoint = server.URL + "/"
+	session.iamCredentialsEndpoint = server.URL + "/"
+	session.authorizedClient = authorizeSession(session.httpClient, session)
+	probe.session = session
+	probe.serverURL = server.URL
+
+	return probe
+}
+
+func jwtAudienceFromToken(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return "", errors.New("subject token is not a jwt")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", err
+	}
+
+	var claims identityfederation.Claims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", err
+	}
+
+	return claims.Audience, nil
+}
+
+func exchangeTestIssuer(t *testing.T) *identityfederation.Issuer {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	keyRing, err := jose.NewKeyRing(
+		[]jose.SigningKey{{PrivateKey: key, KID: "test", Active: true}},
+	)
+	require.NoError(t, err)
+
+	base, err := baseurl.Parse("https://proboidentity.com")
+	require.NoError(t, err)
+
+	issuer, err := identityfederation.NewIssuer(base, keyRing, identityfederation.DefaultTokenTTL)
+	require.NoError(t, err)
+
+	return issuer
+}

--- a/pkg/cloud/gcp/session_test.go
+++ b/pkg/cloud/gcp/session_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package gcp_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/baseurl"
+	"go.probo.inc/probo/pkg/cloud"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/crypto/jose"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/identityfederation"
+)
+
+const testIssuerBase = "https://proboidentity.com"
+
+func testIssuer(t *testing.T) *identityfederation.Issuer {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	keyRing, err := jose.NewKeyRing(
+		[]jose.SigningKey{{PrivateKey: key, KID: "test", Active: true}},
+	)
+	require.NoError(t, err)
+
+	base, err := baseurl.Parse(testIssuerBase)
+	require.NoError(t, err)
+
+	issuer, err := identityfederation.NewIssuer(base, keyRing, identityfederation.DefaultTokenTTL)
+	require.NoError(t, err)
+
+	return issuer
+}
+
+func testOrganizationID() gid.GID {
+	return gid.New(gid.NewTenantID(), coredata.OrganizationEntityType)
+}
+
+func TestNewSession(t *testing.T) {
+	t.Parallel()
+
+	session, err := cloudgcp.NewSession(
+		testIssuer(t),
+		testOrganizationID(),
+		testProviderResource,
+		testServiceAccount,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, cloud.GCP, session.Cloud())
+	assert.Equal(t, "123456789012", session.AccountID(), "account comes from the provider resource")
+	assert.NotNil(t, session.HTTPClient())
+}
+
+func TestNewSessionFromToken(t *testing.T) {
+	t.Parallel()
+
+	session := cloudgcp.NewSessionFromToken("123456789012", "sa-access-token")
+
+	assert.Equal(t, cloud.GCP, session.Cloud())
+	assert.Equal(t, "123456789012", session.AccountID())
+	assert.NotNil(t, session.HTTPClient())
+
+	err := session.CheckAccess(context.Background())
+	require.NoError(t, err)
+}
+
+func TestNewSession_Validation(t *testing.T) {
+	t.Parallel()
+
+	issuer := testIssuer(t)
+	organizationID := testOrganizationID()
+
+	tests := []struct {
+		name                string
+		providerResource    string
+		serviceAccountEmail string
+		wantMessage         string
+		forbidden           string
+	}{
+		{
+			name:                "malformed provider resource",
+			providerResource:    "not-a-provider",
+			serviceAccountEmail: testServiceAccount,
+			wantMessage:         "workloadIdentityProvider is not a workload identity provider resource",
+			forbidden:           "not-a-provider",
+		},
+		{
+			name:                "malformed service account email",
+			providerResource:    testProviderResource,
+			serviceAccountEmail: "alice@example.com",
+			wantMessage:         "serviceAccountEmail is not a service account email",
+			forbidden:           "alice@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := cloudgcp.NewSession(issuer, organizationID, tt.providerResource, tt.serviceAccountEmail)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantMessage)
+			assert.NotContains(t, err.Error(), tt.forbidden)
+		})
+	}
+}
+
+func TestNewSession_DoesNotReadADC(t *testing.T) {
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/definitely/not-a-credentials-file.json")
+
+	session, err := cloudgcp.NewSession(
+		testIssuer(t),
+		testOrganizationID(),
+		testProviderResource,
+		testServiceAccount,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, cloud.GCP, session.Cloud())
+}

--- a/pkg/cloud/gcp/settings.go
+++ b/pkg/cloud/gcp/settings.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package gcp
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	iamHost = "iam.googleapis.com"
+)
+
+var (
+	errInvalidProviderResource    = errors.New("workloadIdentityProvider is not a workload identity provider resource")
+	errInvalidServiceAccountEmail = errors.New("serviceAccountEmail is not a service account email")
+
+	providerResourcePattern = regexp.MustCompile(
+		`^(?:https://iam\.googleapis\.com/|//iam\.googleapis\.com/)?` +
+			`/?projects/([1-9][0-9]*)` +
+			`/locations/global` +
+			`/workloadIdentityPools/([a-z0-9][a-z0-9-]{2,30}[a-z0-9])` +
+			`/providers/([a-z0-9][a-z0-9-]{2,30}[a-z0-9])/?$`,
+	)
+	serviceAccountEmailPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z][a-z0-9-]{4,28}[a-z0-9]\.iam\.gserviceaccount\.com$`)
+)
+
+type (
+	// ConnectorSettings is the customer-supplied WIF provider resource and the
+	// service account Probo impersonates. Both values are public knowledge.
+	ConnectorSettings struct {
+		WorkloadIdentityProvider string
+		ServiceAccountEmail      string
+	}
+
+	providerResource struct {
+		projectNumber string
+		poolID        string
+		providerID    string
+	}
+)
+
+// NewConnectorSettings validates the customer-supplied provider resource and
+// service account email. Values are stored trimmed in canonical form. Returned
+// errors are safe to show a client: they never echo the resource or email.
+func NewConnectorSettings(providerResource, serviceAccountEmail string) (ConnectorSettings, error) {
+	parsed, err := parseProviderResource(providerResource)
+	if err != nil {
+		return ConnectorSettings{}, fmt.Errorf("cannot create gcp connector: %w", err)
+	}
+
+	email, err := parseServiceAccountEmail(serviceAccountEmail)
+	if err != nil {
+		return ConnectorSettings{}, fmt.Errorf("cannot create gcp connector: %w", err)
+	}
+
+	return ConnectorSettings{
+		WorkloadIdentityProvider: canonicalProviderResource(parsed),
+		ServiceAccountEmail:      email,
+	}, nil
+}
+
+func parseProviderResource(raw string) (providerResource, error) {
+	matches := providerResourcePattern.FindStringSubmatch(strings.TrimSpace(raw))
+	if matches == nil {
+		return providerResource{}, errInvalidProviderResource
+	}
+
+	return providerResource{
+		projectNumber: matches[1],
+		poolID:        matches[2],
+		providerID:    matches[3],
+	}, nil
+}
+
+func parseServiceAccountEmail(raw string) (string, error) {
+	email := strings.TrimSpace(raw)
+	if !serviceAccountEmailPattern.MatchString(email) {
+		return "", errInvalidServiceAccountEmail
+	}
+
+	return email, nil
+}
+
+func canonicalProviderResource(p providerResource) string {
+	return strings.Join(
+		[]string{
+			"projects",
+			p.projectNumber,
+			"locations",
+			"global",
+			"workloadIdentityPools",
+			p.poolID,
+			"providers",
+			p.providerID,
+		},
+		"/",
+	)
+}

--- a/pkg/cloud/gcp/settings_test.go
+++ b/pkg/cloud/gcp/settings_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package gcp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+)
+
+const (
+	testProviderResource = "projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo"
+	testServiceAccount   = "probo-audit@my-project.iam.gserviceaccount.com"
+)
+
+func TestNewConnectorSettings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stores a canonical provider resource and email", func(t *testing.T) {
+		t.Parallel()
+
+		settings, err := cloudgcp.NewConnectorSettings(testProviderResource, testServiceAccount)
+		require.NoError(t, err)
+		assert.Equal(t, testProviderResource, settings.WorkloadIdentityProvider)
+		assert.Equal(t, testServiceAccount, settings.ServiceAccountEmail)
+	})
+
+	t.Run("accepts pool and provider ids that start with a digit", func(t *testing.T) {
+		t.Parallel()
+
+		resource := "projects/123456789012/locations/global/workloadIdentityPools/1abc/providers/2024p"
+		settings, err := cloudgcp.NewConnectorSettings(resource, testServiceAccount)
+		require.NoError(t, err)
+		assert.Equal(t, resource, settings.WorkloadIdentityProvider)
+	})
+
+	t.Run("trims space and strips audience prefixes", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			resource string
+		}{
+			{name: "https prefix", resource: "https://iam.googleapis.com/" + testProviderResource},
+			{name: "scheme-relative prefix", resource: "//iam.googleapis.com/" + testProviderResource},
+			{name: "surrounding space", resource: "  " + testProviderResource + "  "},
+			{name: "trailing slash", resource: testProviderResource + "/"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				settings, err := cloudgcp.NewConnectorSettings(tt.resource, "  "+testServiceAccount+"  ")
+				require.NoError(t, err)
+				assert.Equal(t, testProviderResource, settings.WorkloadIdentityProvider)
+				assert.Equal(t, testServiceAccount, settings.ServiceAccountEmail)
+			})
+		}
+	})
+
+	t.Run("refuses a malformed provider resource without echoing it", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			resource string
+		}{
+			{name: "empty", resource: ""},
+			{name: "project id instead of number", resource: "projects/my-project/locations/global/workloadIdentityPools/probo/providers/probo"},
+			{name: "regional location", resource: "projects/123456789012/locations/us-central1/workloadIdentityPools/probo/providers/probo"},
+			{name: "missing provider", resource: "projects/123456789012/locations/global/workloadIdentityPools/probo"},
+			{name: "uppercase pool", resource: "projects/123456789012/locations/global/workloadIdentityPools/Probo/providers/probo"},
+			{name: "short pool id", resource: "projects/123456789012/locations/global/workloadIdentityPools/ab/providers/probo"},
+			{name: "pool id ending with hyphen", resource: "projects/123456789012/locations/global/workloadIdentityPools/pool-/providers/probo"},
+			{name: "provider id ending with hyphen", resource: "projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo-"},
+			{name: "pool id starting with hyphen", resource: "projects/123456789012/locations/global/workloadIdentityPools/-pool/providers/probo"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				_, err := cloudgcp.NewConnectorSettings(tt.resource, testServiceAccount)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "workloadIdentityProvider is not a workload identity provider resource")
+
+				if tt.resource != "" {
+					assert.NotContains(t, err.Error(), tt.resource)
+				}
+			})
+		}
+	})
+
+	t.Run("refuses a malformed service account email without echoing it", func(t *testing.T) {
+		t.Parallel()
+
+		raw := "alice@example.com"
+
+		_, err := cloudgcp.NewConnectorSettings(testProviderResource, raw)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "serviceAccountEmail is not a service account email")
+		assert.NotContains(t, err.Error(), raw)
+		assert.NotContains(t, err.Error(), "alice")
+	})
+}

--- a/pkg/cloud/gcp/setup.go
+++ b/pkg/cloud/gcp/setup.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package gcp
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/identityfederation"
+)
+
+const (
+	// DefaultTerraformModuleSource is the public registry address of the GCP
+	// audit-role module. Phase 3 owns the module; this package only formats
+	// the snippet.
+	DefaultTerraformModuleSource = "getprobo/audit-role/gcp"
+
+	// DefaultServiceAccountName is the service account the customer setup
+	// template creates.
+	DefaultServiceAccountName = "probo-audit"
+
+	// AudienceTemplate is the JWT audience the customer will configure after
+	// they create the pool. The exact audience is unknown at setup time.
+	AudienceTemplate = "https://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID"
+)
+
+type (
+	// ConnectorSetup is the server-derived values the connect dialog shows so
+	// the customer never retypes an issuer, subject or audience.
+	ConnectorSetup struct {
+		Issuer                      string
+		Audience                    string
+		Subject                     string
+		SuggestedServiceAccountName string
+		TerraformSnippet            string
+	}
+
+	// ConnectorInstallConfig is the deployment-supplied install artifact used
+	// to fill the Terraform snippet. An empty source omits the snippet.
+	ConnectorInstallConfig struct {
+		TerraformModuleSource string
+	}
+
+	// ConnectorSetupInput is what BuildConnectorSetup needs. Every Probo-derived
+	// string is supplied already resolved so this function never talks to config
+	// or an issuer.
+	ConnectorSetupInput struct {
+		IssuerURL             string
+		Subject               string
+		TerraformModuleSource string
+	}
+)
+
+// BuildConnectorSetup fills issuer, subject and snippets from already-resolved
+// values. It does not mint a token and does not read global config.
+func BuildConnectorSetup(in ConnectorSetupInput) (ConnectorSetup, error) {
+	if in.IssuerURL == "" {
+		return ConnectorSetup{}, fmt.Errorf("cannot build gcp connector setup: issuer is required")
+	}
+
+	if in.Subject == "" {
+		return ConnectorSetup{}, fmt.Errorf("cannot build gcp connector setup: subject is required")
+	}
+
+	return ConnectorSetup{
+		Issuer:                      in.IssuerURL,
+		Audience:                    AudienceTemplate,
+		Subject:                     in.Subject,
+		SuggestedServiceAccountName: DefaultServiceAccountName,
+		TerraformSnippet:            terraformSnippet(in.TerraformModuleSource, in.IssuerURL, in.Subject),
+	}, nil
+}
+
+// ConnectorSetupFor resolves issuer and subject from the live issuer, then
+// fills snippets. It is what GraphQL and MCP call so those surfaces cannot
+// drift from token minting.
+func ConnectorSetupFor(
+	issuer *identityfederation.Issuer,
+	organizationID gid.GID,
+	install ConnectorInstallConfig,
+) (ConnectorSetup, error) {
+	if issuer == nil {
+		return ConnectorSetup{}, fmt.Errorf("cannot build gcp connector setup: identity federation is not configured")
+	}
+
+	issuerURL, err := issuer.IssuerURL(organizationID)
+	if err != nil {
+		return ConnectorSetup{}, fmt.Errorf("cannot build gcp connector setup: %w", err)
+	}
+
+	return BuildConnectorSetup(
+		ConnectorSetupInput{
+			IssuerURL:             issuerURL,
+			Subject:               organizationID.String(),
+			TerraformModuleSource: install.TerraformModuleSource,
+		},
+	)
+}
+
+func terraformSnippet(moduleSource, issuerURL, subject string) string {
+	if moduleSource == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("module \"probo_audit\" {\n")
+	b.WriteString("  source = ")
+	b.WriteString(strconv.Quote(moduleSource))
+	b.WriteString("\n\n")
+	b.WriteString("  probo_issuer_url     = ")
+	b.WriteString(strconv.Quote(issuerURL))
+	b.WriteString("\n")
+	b.WriteString("  probo_subject        = ")
+	b.WriteString(strconv.Quote(subject))
+	b.WriteString("\n")
+	b.WriteString("  service_account_name = ")
+	b.WriteString(strconv.Quote(DefaultServiceAccountName))
+	b.WriteString("\n")
+	b.WriteString("}\n")
+
+	return b.String()
+}

--- a/pkg/cloud/gcp/setup_test.go
+++ b/pkg/cloud/gcp/setup_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package gcp_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+)
+
+const setupOrganizationID = "e5IaD7ibAAEAAAAAAZZ9aR_Oq_Npymhg"
+
+func TestBuildConnectorSetup(t *testing.T) {
+	t.Parallel()
+
+	issuer := "https://proboidentity.com/" + setupOrganizationID
+	subject := setupOrganizationID
+
+	t.Run("fills every Probo-derived value and preserves issuer casing", func(t *testing.T) {
+		t.Parallel()
+
+		setup, err := cloudgcp.BuildConnectorSetup(
+			cloudgcp.ConnectorSetupInput{
+				IssuerURL:             issuer,
+				Subject:               subject,
+				TerraformModuleSource: cloudgcp.DefaultTerraformModuleSource,
+			},
+		)
+		require.NoError(t, err)
+
+		assert.Equal(t, issuer, setup.Issuer)
+		assert.Equal(t, cloudgcp.AudienceTemplate, setup.Audience)
+		assert.Equal(t, subject, setup.Subject)
+		assert.Equal(t, cloudgcp.DefaultServiceAccountName, setup.SuggestedServiceAccountName)
+		assert.Contains(t, setup.TerraformSnippet, strconv.Quote(issuer))
+		assert.Contains(t, setup.TerraformSnippet, strconv.Quote(subject))
+		assert.Contains(t, setup.TerraformSnippet, "probo_issuer_url")
+		assert.Contains(t, setup.TerraformSnippet, "probo_subject")
+		assert.Contains(t, setup.TerraformSnippet, "service_account_name")
+		assert.Contains(t, setup.TerraformSnippet, strconv.Quote(cloudgcp.DefaultServiceAccountName))
+		assert.Contains(t, setup.TerraformSnippet, cloudgcp.DefaultTerraformModuleSource)
+	})
+
+	t.Run("omits the snippet when the module source is empty", func(t *testing.T) {
+		t.Parallel()
+
+		setup, err := cloudgcp.BuildConnectorSetup(
+			cloudgcp.ConnectorSetupInput{
+				IssuerURL: issuer,
+				Subject:   subject,
+			},
+		)
+		require.NoError(t, err)
+
+		assert.Empty(t, setup.TerraformSnippet)
+	})
+
+	t.Run("refuses a missing issuer", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := cloudgcp.BuildConnectorSetup(cloudgcp.ConnectorSetupInput{Subject: subject})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issuer is required")
+	})
+
+	t.Run("refuses a missing subject", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := cloudgcp.BuildConnectorSetup(cloudgcp.ConnectorSetupInput{IssuerURL: issuer})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "subject is required")
+	})
+}
+
+func TestConnectorSetupFor(t *testing.T) {
+	t.Parallel()
+
+	organizationID := testOrganizationID()
+
+	setup, err := cloudgcp.ConnectorSetupFor(
+		testIssuer(t),
+		organizationID,
+		cloudgcp.ConnectorInstallConfig{TerraformModuleSource: cloudgcp.DefaultTerraformModuleSource},
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, setup.Issuer, organizationID.String())
+	assert.Equal(t, organizationID.String(), setup.Subject)
+	assert.Equal(t, cloudgcp.AudienceTemplate, setup.Audience)
+	assert.Contains(t, setup.TerraformSnippet, strconv.Quote(organizationID.String()))
+}
+
+func TestConnectorSetupFor_RequiresIssuer(t *testing.T) {
+	t.Parallel()
+
+	_, err := cloudgcp.ConnectorSetupFor(nil, testOrganizationID(), cloudgcp.ConnectorInstallConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity federation is not configured")
+}


### PR DESCRIPTION
The access-review engine already federates through a shared issuer, but AWS is the only cloud on that path. This package mints a per-customer OIDC assertion,
exchanges it at STS, and impersonates the customer's audit service account without Application Default
Credentials.

JWT aud uses the https form; the STS audience uses the scheme-relative form. Mixing them fails the
exchange.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the GCP cloud session package so the access-review engine can federate to GCP the same way it already does to AWS. It mints a per-customer OIDC assertion, exchanges it at STS, and impersonates the customer's audit service account without Application Default Credentials. The JWT audience uses the https form while the STS audience uses the scheme-relative form; mixing them fails the exchange.

### Service **`+656`** **`-0`**

- Opens a one-hour session per customer project via WIF exchange and service-account impersonation, with token refresh handled by the returned HTTP client.
- Validates connector provider resources and service account emails; errors never echo the customer-supplied value.
- Builds the connector setup values (issuer, subject, audience, Terraform snippet) from the live issuer so GraphQL and MCP cannot drift from token minting.

### Tests **`+679`** **`-0`**

- Verifies both audience forms reach STS and that impersonation uses the federated token.
- Confirms validation rejects malformed resources without echoing them and that no credential file is read.

<sup>Written for commit 4669dd1a3b77b44c485e500c1b321c6dd29c45c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

