### PR TITLE
Add the GCP workload-identity provider

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1865,7 +1865,8 @@
     "emptyConnected": "No access sources are connected yet.",
     "emptyConnectedSearch": "No connected sources match your search.",
     "searchLoadFailed": "Some sources could not be loaded, so the search is incomplete. Retry to search them all.",
-    "emptyAvailableSearch": "No available providers match your search."
+    "emptyAvailableSearch": "No available providers match your search.",
+    "comingSoon": "Coming soon"
   },
   "assetDetailsPage": {
     "validation": { "nameRequired": "Name is required", "amountRequired": "Amount is required", "dataTypesStoredRequired": "Data types stored is required", "ownerRequired": "Owner is required" },

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -3191,7 +3191,8 @@
     "emptyConnected": "Aucune source d’accès n’est encore connectée.",
     "emptyConnectedSearch": "Aucune source connectée ne correspond à votre recherche.",
     "searchLoadFailed": "Certaines sources n’ont pas pu être chargées, la recherche est donc incomplète. Réessayez pour toutes les rechercher.",
-    "emptyAvailableSearch": "Aucun fournisseur disponible ne correspond à votre recherche."
+    "emptyAvailableSearch": "Aucun fournisseur disponible ne correspond à votre recherche.",
+    "comingSoon": "Bientôt disponible"
   },
   "assetDetailsPage": {
     "validation": {

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -3195,7 +3195,8 @@
     "emptyConnected": "Er zijn nog geen toegangsbronnen verbonden.",
     "emptyConnectedSearch": "Geen verbonden bronnen komen overeen met uw zoekopdracht.",
     "searchLoadFailed": "Sommige bronnen konden niet worden geladen, dus de zoekopdracht is onvolledig. Probeer opnieuw om alle bronnen te doorzoeken.",
-    "emptyAvailableSearch": "Geen beschikbare providers komen overeen met uw zoekopdracht."
+    "emptyAvailableSearch": "Geen beschikbare providers komen overeen met uw zoekopdracht.",
+    "comingSoon": "Binnenkort beschikbaar"
   },
   "assetDetailsPage": {
     "validation": {

--- a/apps/console/src/pages/organizations/access-reviews/connections/_components/AccessReviewSourceProviderListItem.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/connections/_components/AccessReviewSourceProviderListItem.tsx
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { ThirdPartyLogo } from "@probo/ui";
+import { Badge, ThirdPartyLogo } from "@probo/ui";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
@@ -103,6 +103,7 @@ export function AccessReviewSourceProviderListItem({
     = supportsOAuth && provider.provider === "DATADOG";
   const supportsZendeskOAuth
     = supportsOAuth && provider.provider === "ZENDESK";
+  const isComingSoon = provider.provider === "GCP";
   const methods = connectMethods(provider);
 
   const connectWithOAuth = () => {
@@ -163,14 +164,22 @@ export function AccessReviewSourceProviderListItem({
         <ConnectorDocumentationLink url={provider.documentationUrl} />
       </div>
       <div className={trailing()}>
-        <ActionSplitButton
-          actions={actions}
-          chooseAnotherMethodLabel={t(
-            "addAccessReviewSourceDialog.actions.chooseAnotherMethod",
-          )}
-        />
+        {isComingSoon
+          ? (
+              <Badge variant="info">
+                {t("accessReviewConnectionsPage.comingSoon")}
+              </Badge>
+            )
+          : (
+              <ActionSplitButton
+                actions={actions}
+                chooseAnotherMethodLabel={t(
+                  "addAccessReviewSourceDialog.actions.chooseAnotherMethod",
+                )}
+              />
+            )}
       </div>
-      {supportsAPIKey && (
+      {!isComingSoon && supportsAPIKey && (
         <APIKeyConnectorDialog
           providerKey={activeDialog === "apiKey" ? provider : null}
           organizationId={organizationId}
@@ -179,7 +188,7 @@ export function AccessReviewSourceProviderListItem({
           onSuccess={() => setActiveDialog(null)}
         />
       )}
-      {provider.clientCredentialsSupported && (
+      {!isComingSoon && provider.clientCredentialsSupported && (
         <ClientCredentialsConnectorDialog
           providerKey={activeDialog === "clientCredentials" ? provider : null}
           organizationId={organizationId}
@@ -188,14 +197,14 @@ export function AccessReviewSourceProviderListItem({
           onSuccess={() => setActiveDialog(null)}
         />
       )}
-      {supportsDatadogOAuth && (
+      {!isComingSoon && supportsDatadogOAuth && (
         <DatadogConnectDialog
           providerKey={activeDialog === "datadog" ? provider : null}
           organizationId={organizationId}
           onClose={() => setActiveDialog(null)}
         />
       )}
-      {supportsZendeskOAuth && (
+      {!isComingSoon && supportsZendeskOAuth && (
         <ZendeskConnectDialog
           providerKey={activeDialog === "zendesk" ? provider : null}
           organizationId={organizationId}

--- a/e2e/console/connector_test.go
+++ b/e2e/console/connector_test.go
@@ -125,9 +125,16 @@ func TestAccessReviewDrivers(t *testing.T) {
 	assert.True(t, providerNames["BREX"], "expected BREX provider to be present")
 	assert.True(t, providerNames["HUBSPOT"], "expected HUBSPOT provider to be present")
 	assert.True(t, providerNames["AWS"], "expected AWS provider to be present when identity federation is enabled")
+	assert.True(t, providerNames["GCP"], "expected GCP provider to be present when identity federation is enabled")
 	assert.Equal(t, []string{"OAUTH2"}, protocolsByProvider["GITHUB"])
 	assert.True(t, workloadIdentitySupported["AWS"])
 	assert.Equal(t, []string{"roleArn"}, workloadIdentitySettingKeys["AWS"])
+	assert.True(t, workloadIdentitySupported["GCP"])
+	assert.Equal(
+		t,
+		[]string{"workloadIdentityProvider", "serviceAccountEmail"},
+		workloadIdentitySettingKeys["GCP"],
+	)
 	assert.False(t, workloadIdentitySupported["BREX"])
 	assert.Empty(t, workloadIdentitySettingKeys["BREX"])
 

--- a/packages/ui/src/Atoms/ThirdParties/GCP.tsx
+++ b/packages/ui/src/Atoms/ThirdParties/GCP.tsx
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import type { ComponentProps } from "react";
+
+export function GCP(props: ComponentProps<"svg">) {
+  return (
+    <svg
+      viewBox="0 -3 34 34"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M21.85,7.41l1,0,2.85-2.85.14-1.21A12.81,12.81,0,0,0,5,9.6a1.55,1.55,0,0,1,1-.06l5.7-.94s.29-.48.44-.45a7.11,7.11,0,0,1,9.73-.74Z"
+        fill="#EA4335"
+      />
+      <path
+        d="M29.76,9.6a12.84,12.84,0,0,0-3.87-6.24l-4,4A7.11,7.11,0,0,1,24.5,13v.71a3.56,3.56,0,1,1,0,7.12H17.38l-.71.72v4.27l.71.71H24.5A9.26,9.26,0,0,0,29.76,9.6Z"
+        fill="#4285F4"
+      />
+      <path
+        d="M10.25,26.49h7.12v-5.7H10.25a3.54,3.54,0,0,1-1.47-.32l-1,.31L4.91,23.63l-.25,1A9.21,9.21,0,0,0,10.25,26.49Z"
+        fill="#34A853"
+      />
+      <path
+        d="M10.25,8A9.26,9.26,0,0,0,4.66,24.6l4.13-4.13a3.56,3.56,0,1,1,4.71-4.71l4.13-4.13A9.25,9.25,0,0,0,10.25,8Z"
+        fill="#FBBC05"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/Atoms/ThirdParties/ThirdPartyLogo.tsx
+++ b/packages/ui/src/Atoms/ThirdParties/ThirdPartyLogo.tsx
@@ -42,6 +42,7 @@ import { Deepgram } from "./Deepgram";
 import { DocuSign } from "./DocuSign";
 import { Dotfile } from "./Dotfile";
 import { Figma } from "./Figma";
+import { GCP } from "./GCP";
 import { GitHub } from "./GitHub";
 import { GitLab } from "./GitLab";
 import { Google } from "./Google";
@@ -110,6 +111,7 @@ const thirdParties: Record<string, FC<ComponentProps<"svg">>> = {
   DOCUSIGN: DocuSign,
   DOTFILE: Dotfile,
   FIGMA: Figma,
+  GCP: GCP,
   GITHUB: GitHub,
   GITLAB: GitLab,
   GOOGLE: Google,

--- a/packages/ui/src/Atoms/ThirdParties/index.ts
+++ b/packages/ui/src/Atoms/ThirdParties/index.ts
@@ -20,6 +20,7 @@ export { Deepgram } from "./Deepgram";
 export { DocuSign } from "./DocuSign";
 export { Dotfile } from "./Dotfile";
 export { Figma } from "./Figma";
+export { GCP } from "./GCP";
 export { GitHub } from "./GitHub";
 export { GitLab } from "./GitLab";
 export { Google } from "./Google";

--- a/pkg/connector/provider/builtin.go
+++ b/pkg/connector/provider/builtin.go
@@ -78,6 +78,7 @@ func NewBuiltinRegistryWith(opts ...Option) (*Registry, error) {
 		docusignRegistration(),
 		dotfileRegistration(),
 		grafanaRegistration(),
+		gcpRegistration(),
 		githubRegistration(),
 		gitlabRegistration(),
 		googleAnalyticsRegistration(),

--- a/pkg/connector/provider/gcp.go
+++ b/pkg/connector/provider/gcp.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/accessreview/drivers"
+	"go.probo.inc/probo/pkg/cloud"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/identityfederation"
+)
+
+// gcpRegistration declares GCP as a workload identity provider: Probo holds no
+// GCP credential and mints an assertion the customer's Workload Identity
+// Federation pool exchanges, then impersonates the named service account. It
+// therefore declares no OAuth2, API-key or client-credentials path — there is
+// no credential for a customer to paste or an operator to configure.
+//
+// Isolation is the per-organization issuer; a successful impersonation is the
+// whole check, so there is no grant readback beside Probe.
+func gcpRegistration() *Registration {
+	return &Registration{
+		Provider:         coredata.ConnectorProviderGCP,
+		DisplayName:      "Google Cloud",
+		DocumentationURL: accessReviewDocsURL("gcp"),
+		// See Registration.EndpointOverrideUnsupported: Google API clients
+		// resolve every host they dial themselves, so there is no host in
+		// Endpoints for an override to move.
+		EndpointOverrideUnsupported: "the GCP APIs resolve their own hosts, not values in Endpoints",
+		WorkloadIdentity: &WorkloadIdentityConfig{
+			NewSession: newGCPSession,
+			NewDriver:  newGCPDriver,
+			Probe:      probeGCP,
+			ExtraSettings: []ExtraSetting{
+				{Key: "workloadIdentityProvider", Label: "Workload identity provider", Required: true},
+				{Key: "serviceAccountEmail", Label: "Service account email", Required: true},
+			},
+		},
+	}
+}
+
+// newGCPSession opens a session on the project the connector names, by
+// exchanging an assertion and impersonating the service account the customer
+// created for Probo there.
+//
+// The organization comes from the connector row, never from its settings: it
+// selects whose assertion is minted, and so whose cloud project the resulting
+// credentials can reach.
+func newGCPSession(
+	_ context.Context,
+	issuer *identityfederation.Issuer,
+	conn *coredata.Connector,
+) (cloud.Session, error) {
+	settings, err := coredata.ConnectorSettings[coredata.GCPConnectorSettings](conn)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read gcp connector settings: %w", err)
+	}
+
+	session, err := cloudgcp.NewSession(
+		issuer,
+		conn.OrganizationID,
+		settings.WorkloadIdentityProvider,
+		settings.ServiceAccountEmail,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return session, nil
+}
+
+// newGCPDriver is a placeholder until the access-review driver lands. Register
+// requires a factory; returning a clear error keeps a silent no-op driver out
+// of the catalog.
+func newGCPDriver(
+	_ context.Context,
+	session cloud.Session,
+	_ *coredata.Connector,
+	_ *log.Logger,
+) (drivers.Driver, error) {
+	if _, ok := session.(*cloudgcp.Session); !ok {
+		return nil, fmt.Errorf("cannot create gcp driver: session is for %s", session.Cloud())
+	}
+
+	return nil, fmt.Errorf("cannot create gcp driver: not implemented")
+}
+
+// probeGCP checks the connection by completing the STS exchange and
+// impersonation. It reaches for the concrete session because a cloud.Session
+// deliberately exposes only which cloud and which account it names.
+func probeGCP(ctx context.Context, session cloud.Session, _ *coredata.Connector) error {
+	gcpSession, ok := session.(*cloudgcp.Session)
+	if !ok {
+		return fmt.Errorf("cannot probe gcp connector: session is for %s", session.Cloud())
+	}
+
+	return gcpSession.CheckAccess(ctx)
+}

--- a/pkg/connector/provider/gcp_test.go
+++ b/pkg/connector/provider/gcp_test.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/cloud"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	"go.probo.inc/probo/pkg/connector/provider"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+const (
+	gcpTestProviderResource = "projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo"
+	gcpTestServiceAccount   = "probo-audit@my-project.iam.gserviceaccount.com"
+)
+
+func gcpTestConnector(t *testing.T, settings coredata.GCPConnectorSettings) *coredata.Connector {
+	t.Helper()
+
+	tenantID := gid.NewTenantID()
+	conn := &coredata.Connector{
+		ID:             gid.New(tenantID, coredata.ConnectorEntityType),
+		OrganizationID: gid.New(tenantID, coredata.OrganizationEntityType),
+		Provider:       coredata.ConnectorProviderGCP,
+		Protocol:       coredata.ConnectorProtocolWorkloadIdentity,
+	}
+	require.NoError(t, conn.SetSettings(&settings))
+
+	return conn
+}
+
+type awsForeignSession struct{}
+
+var _ cloud.Session = awsForeignSession{}
+
+func (awsForeignSession) Cloud() string     { return cloud.AWS }
+func (awsForeignSession) AccountID() string { return "123456789012" }
+
+func TestGCPRegistration(t *testing.T) {
+	t.Parallel()
+
+	r := provider.NewBuiltinRegistry()
+	reg, ok := r.Get(coredata.ConnectorProviderGCP)
+	require.True(t, ok)
+
+	assert.Equal(t, "Google Cloud", reg.DisplayName)
+	assert.Equal(t, "https://www.probo.com/docs/product/access-review/gcp", reg.DocumentationURL)
+	assert.True(t, reg.SupportsWorkloadIdentity())
+	assert.False(t, reg.SupportsAPIKey())
+	assert.False(t, reg.IsManagedAPIKey())
+	assert.False(t, reg.SupportsClientCredentials())
+	assert.Nil(t, reg.OAuth2)
+	assert.Nil(t, reg.NewDriver)
+	assert.NotEmpty(t, reg.EndpointOverrideUnsupported)
+	assert.Equal(t, provider.Endpoints{}, reg.Endpoints)
+
+	require.Len(t, reg.WorkloadIdentityExtraSettings(), 2)
+	assert.Equal(t, "workloadIdentityProvider", reg.WorkloadIdentityExtraSettings()[0].Key)
+	assert.True(t, reg.WorkloadIdentityExtraSettings()[0].Required)
+	assert.Equal(t, "serviceAccountEmail", reg.WorkloadIdentityExtraSettings()[1].Key)
+	assert.True(t, reg.WorkloadIdentityExtraSettings()[1].Required)
+	assert.Nil(t, reg.NewNameResolver)
+	assert.Nil(t, reg.WorkloadIdentity.NewNameResolver)
+}
+
+func TestGCPNewSession(t *testing.T) {
+	t.Parallel()
+
+	r := provider.NewBuiltinRegistry()
+	reg, ok := r.Get(coredata.ConnectorProviderGCP)
+	require.True(t, ok)
+
+	conn := gcpTestConnector(
+		t,
+		coredata.GCPConnectorSettings{
+			WorkloadIdentityProvider: gcpTestProviderResource,
+			ServiceAccountEmail:      gcpTestServiceAccount,
+		},
+	)
+
+	session, err := reg.WorkloadIdentity.NewSession(context.Background(), awsTestIssuer(t), conn)
+	require.NoError(t, err)
+
+	assert.Equal(t, cloud.GCP, session.Cloud())
+	assert.Equal(t, "123456789012", session.AccountID())
+
+	_, ok = session.(*cloudgcp.Session)
+	assert.True(t, ok)
+}
+
+func TestGCPNewDriver(t *testing.T) {
+	t.Parallel()
+
+	r := provider.NewBuiltinRegistry()
+	reg, ok := r.Get(coredata.ConnectorProviderGCP)
+	require.True(t, ok)
+
+	t.Run("refuses a session on another cloud", func(t *testing.T) {
+		t.Parallel()
+
+		conn := gcpTestConnector(
+			t,
+			coredata.GCPConnectorSettings{
+				WorkloadIdentityProvider: gcpTestProviderResource,
+				ServiceAccountEmail:      gcpTestServiceAccount,
+			},
+		)
+
+		_, err := reg.WorkloadIdentity.NewDriver(
+			context.Background(),
+			awsForeignSession{},
+			conn,
+			log.NewLogger(log.WithOutput(io.Discard)),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "session is for AWS")
+	})
+
+	t.Run("returns not implemented for a gcp session", func(t *testing.T) {
+		t.Parallel()
+
+		conn := gcpTestConnector(
+			t,
+			coredata.GCPConnectorSettings{
+				WorkloadIdentityProvider: gcpTestProviderResource,
+				ServiceAccountEmail:      gcpTestServiceAccount,
+			},
+		)
+
+		session, err := reg.WorkloadIdentity.NewSession(context.Background(), awsTestIssuer(t), conn)
+		require.NoError(t, err)
+
+		_, err = reg.WorkloadIdentity.NewDriver(
+			context.Background(),
+			session,
+			conn,
+			log.NewLogger(log.WithOutput(io.Discard)),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not implemented")
+	})
+}
+
+func TestGCPProbe(t *testing.T) {
+	t.Parallel()
+
+	r := provider.NewBuiltinRegistry()
+	reg, ok := r.Get(coredata.ConnectorProviderGCP)
+	require.True(t, ok)
+	require.NotNil(t, reg.WorkloadIdentity.Probe)
+
+	t.Run("refuses a session on another cloud", func(t *testing.T) {
+		t.Parallel()
+
+		conn := gcpTestConnector(
+			t,
+			coredata.GCPConnectorSettings{
+				WorkloadIdentityProvider: gcpTestProviderResource,
+				ServiceAccountEmail:      gcpTestServiceAccount,
+			},
+		)
+
+		err := reg.WorkloadIdentity.Probe(
+			context.Background(),
+			awsForeignSession{},
+			conn,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "session is for AWS")
+	})
+}

--- a/pkg/coredata/connector_provider.go
+++ b/pkg/coredata/connector_provider.go
@@ -96,6 +96,7 @@ const (
 	ConnectorProviderCalCom          ConnectorProvider = "CAL_COM"
 	ConnectorProviderCalendly        ConnectorProvider = "CALENDLY"
 	ConnectorProviderAWS             ConnectorProvider = "AWS"
+	ConnectorProviderGCP             ConnectorProvider = "GCP"
 )
 
 var (
@@ -170,6 +171,7 @@ func ConnectorProviders() []ConnectorProvider {
 		ConnectorProviderCalCom,
 		ConnectorProviderCalendly,
 		ConnectorProviderAWS,
+		ConnectorProviderGCP,
 	}
 }
 
@@ -240,7 +242,8 @@ func (v ConnectorProvider) IsValid() bool {
 		ConnectorProviderAuthentik,
 		ConnectorProviderCalCom,
 		ConnectorProviderCalendly,
-		ConnectorProviderAWS:
+		ConnectorProviderAWS,
+		ConnectorProviderGCP:
 		return true
 	}
 

--- a/pkg/coredata/connector_settings.go
+++ b/pkg/coredata/connector_settings.go
@@ -245,6 +245,16 @@ type (
 		// is the one that ARN names; it is not stored separately.
 		RoleARN string `json:"role_arn"`
 	}
+
+	// GCPConnectorSettings names the workload identity provider and the
+	// service account Probo impersonates. Every field is public knowledge —
+	// the project owns the trust, and the connection itself holds no
+	// credential — so unlike the connection blob these stay in plain
+	// settings JSONB.
+	GCPConnectorSettings struct {
+		WorkloadIdentityProvider string `json:"workload_identity_provider"`
+		ServiceAccountEmail      string `json:"service_account_email"`
+	}
 )
 
 // GrantType returns the OAuth2 grant type recorded on the connector's

--- a/pkg/coredata/connector_settings_test.go
+++ b/pkg/coredata/connector_settings_test.go
@@ -21,6 +21,7 @@
 package coredata_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,6 +84,32 @@ func TestConnectorSettings_RoundTrip(t *testing.T) {
 		require.NoError(t, c.SetSettings(&want))
 
 		got, err := coredata.ConnectorSettings[coredata.AWSConnectorSettings](c)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("GCPConnectorSettings", func(t *testing.T) {
+		t.Parallel()
+
+		want := coredata.GCPConnectorSettings{
+			WorkloadIdentityProvider: "projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo",
+			ServiceAccountEmail:      "probo-audit@my-project.iam.gserviceaccount.com",
+		}
+		c := &coredata.Connector{}
+		require.NoError(t, c.SetSettings(&want))
+
+		raw := map[string]string{}
+		require.NoError(t, json.Unmarshal(c.RawSettings, &raw))
+		assert.Equal(
+			t,
+			map[string]string{
+				"workload_identity_provider": want.WorkloadIdentityProvider,
+				"service_account_email":      want.ServiceAccountEmail,
+			},
+			raw,
+		)
+
+		got, err := coredata.ConnectorSettings[coredata.GCPConnectorSettings](c)
 		require.NoError(t, err)
 		assert.Equal(t, want, got)
 	})

--- a/pkg/coredata/migrations/20260902T164058Z.sql
+++ b/pkg/coredata/migrations/20260902T164058Z.sql
@@ -1,0 +1,21 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TYPE connector_provider ADD VALUE IF NOT EXISTS 'GCP';

--- a/pkg/server/api/console/v1/graphql/connector.graphql
+++ b/pkg/server/api/console/v1/graphql/connector.graphql
@@ -119,6 +119,7 @@ enum ConnectorProvider
     CALENDLY
         @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderCalendly")
     AWS @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderAWS")
+    GCP @goEnum(value: "go.probo.inc/probo/pkg/coredata.ConnectorProviderGCP")
 }
 
 enum ConnectorProtocol


### PR DESCRIPTION
The AWS WIF path is already multi-cloud. This registers GCP so a connector can name one project and open a session. The access-review driver is still a stub; create and the console page come next.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers GCP as a workload-identity connector provider, mirroring the AWS WIF path, so a connector can name a project and open a session. The access-review driver is still a stub; the console lists GCP with a "Coming soon" badge instead of connect actions.

### Coredata **`+35`** **`-1`**

Adds the `GCP` provider enum value plus a migration, and `GCPConnectorSettings` (workload identity provider and service account email) stored in plain settings since the connection holds no credential.

### Service **`+121`** **`-0`**

Registers the GCP provider with a session factory that exchanges an assertion and impersonates the named service account; the probe completes the STS exchange and impersonation. No OAuth2 or API-key path is declared because the connection holds no credential.

### GraphQL API **`+1`** **`-0`**

Exposes `GCP` in the `ConnectorProvider` enum.

### App: console **`+26`** **`-14`**

Shows GCP in the connector catalog with a "Coming soon" badge and hides all connect actions for it.

### Package: `ui` **`+51`** **`-0`**

Adds the GCP third-party logo.

### Tests **`+231`** **`-0`**

Covers registration, session creation, driver refusal of foreign sessions, probe, and settings round-trip, and asserts GCP appears in the console connector catalog.

<sup>Written for commit 5b37bc83b0a163e9c9e7f2d0d555bc0ee927c49f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

