### PR TITLE
Add GCP project IAM access-review driver

### DIFF
--- a/pkg/accessreview/drivers/cassette_safety_test.go
+++ b/pkg/accessreview/drivers/cassette_safety_test.go
@@ -55,6 +55,8 @@ func TestCassettesUseSyntheticEmails(t *testing.T) {
 		".localhost",
 		// Google Workspace test domain family (RFC-style synthetic).
 		".test-google-a.com",
+		// Synthetic GCP project used in hand-authored cassettes.
+		".my-project.iam.gserviceaccount.com",
 	}
 
 	// allowedExactDomains lists individual domains that pre-date this

--- a/pkg/accessreview/drivers/gcp.go
+++ b/pkg/accessreview/drivers/gcp.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+const (
+	// gcpRoleOwner is the only IAM role this driver treats as an explicit
+	// admin signal. A custom role can grant the same permissions under any
+	// name, so anything else reports no signal rather than false.
+	gcpRoleOwner = "roles/owner"
+)
+
+type (
+	// GCPDriver lists the identities of the one GCP project the connector
+	// names: IAM users, groups, and service accounts from the project policy,
+	// plus every service account that lives in the project. One connector
+	// produces one source.
+	GCPDriver struct {
+		session *cloudgcp.Session
+	}
+)
+
+var _ Driver = (*GCPDriver)(nil)
+
+// NewGCPDriver builds the driver over a session already impersonated on the
+// connected project.
+func NewGCPDriver(session *cloudgcp.Session) *GCPDriver {
+	return &GCPDriver{session: session}
+}
+
+func (d *GCPDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
+	principals, err := listProjectIAMPrincipals(ctx, d.session)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list iam identities of the gcp project: %w", err)
+	}
+
+	accounts, err := listProjectServiceAccounts(ctx, d.session)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list service accounts of the gcp project: %w", err)
+	}
+
+	identities := unionGCPIdentities(principals, accounts)
+
+	if err := attachUserManagedKeys(ctx, d.session, identities); err != nil {
+		return nil, err
+	}
+
+	records := make([]AccountRecord, 0, len(identities))
+	for _, identity := range identities {
+		records = append(records, gcpIdentityRecord(identity))
+	}
+
+	return records, nil
+}
+
+func gcpIdentityRecord(identity gcpIdentity) AccountRecord {
+	return AccountRecord{
+		Email:       identity.Email,
+		FullName:    identity.DisplayName,
+		Roles:       slices.Clone(identity.Roles),
+		IsAdmin:     gcpIsAdmin(identity.Roles),
+		Active:      gcpActive(identity),
+		MFAStatus:   coredata.MFAStatusUnknown,
+		AuthMethod:  gcpAuthMethod(identity),
+		AccountType: gcpAccountType(identity.Kind),
+		ExternalID:  gcpExternalID(identity),
+	}
+}
+
+// gcpIsAdmin reports admin only when a binding names roles/owner. It returns
+// nil rather than false otherwise, because a custom role can grant the same
+// privileges under any name.
+func gcpIsAdmin(roles []string) *bool {
+	if slices.Contains(roles, gcpRoleOwner) {
+		return new(true)
+	}
+
+	return nil
+}
+
+// gcpActive reports the service-account disabled flag when the identity was
+// listed. Users and groups have no enabled flag on the project policy, so
+// they stay unknown.
+func gcpActive(identity gcpIdentity) *bool {
+	if identity.Kind != gcpPrincipalServiceAccount || identity.Disabled == nil {
+		return nil
+	}
+
+	return new(!*identity.Disabled)
+}
+
+func gcpAuthMethod(identity gcpIdentity) coredata.AccessReviewEntryAuthMethod {
+	switch identity.Kind {
+	case gcpPrincipalUser:
+		return coredata.AccessReviewEntryAuthMethodSSO
+	case gcpPrincipalServiceAccount:
+		if identity.HasUserManagedKey {
+			return coredata.AccessReviewEntryAuthMethodAPIKey
+		}
+
+		return coredata.AccessReviewEntryAuthMethodUnknown
+	default:
+		return coredata.AccessReviewEntryAuthMethodUnknown
+	}
+}
+
+func gcpAccountType(kind gcpPrincipalKind) coredata.AccessReviewEntryAccountType {
+	if kind == gcpPrincipalServiceAccount {
+		return coredata.AccessReviewEntryAccountTypeServiceAccount
+	}
+
+	return coredata.AccessReviewEntryAccountTypeUser
+}
+
+func gcpExternalID(identity gcpIdentity) string {
+	if identity.UniqueID != "" {
+		return identity.UniqueID
+	}
+
+	return identity.Principal
+}

--- a/pkg/accessreview/drivers/gcp_iam.go
+++ b/pkg/accessreview/drivers/gcp_iam.go
@@ -1,0 +1,353 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
+	iam "google.golang.org/api/iam/v1"
+	"google.golang.org/api/option"
+)
+
+const (
+	gcpPrincipalUserPrefix           = "user:"
+	gcpPrincipalGroupPrefix          = "group:"
+	gcpPrincipalServiceAccountPrefix = "serviceAccount:"
+	gcpUserManagedKeyType            = "USER_MANAGED"
+	gcpServiceAccountsPageSize       = 100
+)
+
+type (
+	gcpPrincipalKind string
+
+	// gcpIdentity is one IAM principal of a single GCP project, joined from
+	// the project policy and, when listing is allowed, the project's service
+	// accounts and their keys.
+	gcpIdentity struct {
+		Principal         string
+		Email             string
+		Kind              gcpPrincipalKind
+		Roles             []string
+		UniqueID          string
+		DisplayName       string
+		Disabled          *bool
+		HasUserManagedKey bool
+	}
+
+	gcpServiceAccount struct {
+		Email       string
+		UniqueID    string
+		DisplayName string
+		Disabled    bool
+	}
+)
+
+const (
+	gcpPrincipalUser           gcpPrincipalKind = "user"
+	gcpPrincipalGroup          gcpPrincipalKind = "group"
+	gcpPrincipalServiceAccount gcpPrincipalKind = "serviceAccount"
+)
+
+func listProjectIAMPrincipals(ctx context.Context, session *cloudgcp.Session) ([]gcpIdentity, error) {
+	svc, err := cloudresourcemanager.NewService(
+		ctx,
+		option.WithHTTPClient(session.HTTPClient()),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gcp resource manager client: %w", err)
+	}
+
+	policy, err := svc.Projects.GetIamPolicy(
+		session.AccountID(),
+		&cloudresourcemanager.GetIamPolicyRequest{},
+	).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get gcp project iam policy: %w", err)
+	}
+
+	return principalsFromPolicy(policy), nil
+}
+
+func principalsFromPolicy(policy *cloudresourcemanager.Policy) []gcpIdentity {
+	if policy == nil {
+		return nil
+	}
+
+	byPrincipal := make(map[string]gcpIdentity)
+
+	for _, binding := range policy.Bindings {
+		if binding == nil || binding.Role == "" {
+			continue
+		}
+
+		for _, member := range binding.Members {
+			identity, ok := parseGCPPrincipal(member)
+			if !ok {
+				continue
+			}
+
+			existing, ok := byPrincipal[identity.Principal]
+			if !ok {
+				existing = identity
+			}
+
+			if !slices.Contains(existing.Roles, binding.Role) {
+				existing.Roles = append(existing.Roles, binding.Role)
+			}
+
+			byPrincipal[identity.Principal] = existing
+		}
+	}
+
+	principals := make([]gcpIdentity, 0, len(byPrincipal))
+	for _, identity := range byPrincipal {
+		principals = append(principals, identity)
+	}
+
+	return principals
+}
+
+func parseGCPPrincipal(member string) (gcpIdentity, bool) {
+	member = strings.TrimSpace(member)
+	if skipGCPPrincipal(member) {
+		return gcpIdentity{}, false
+	}
+
+	switch {
+	case strings.HasPrefix(member, gcpPrincipalUserPrefix):
+		email := strings.TrimPrefix(member, gcpPrincipalUserPrefix)
+		if email == "" {
+			return gcpIdentity{}, false
+		}
+
+		return gcpIdentity{
+			Principal: member,
+			Email:     email,
+			Kind:      gcpPrincipalUser,
+		}, true
+	case strings.HasPrefix(member, gcpPrincipalGroupPrefix):
+		email := strings.TrimPrefix(member, gcpPrincipalGroupPrefix)
+		if email == "" {
+			return gcpIdentity{}, false
+		}
+
+		return gcpIdentity{
+			Principal: member,
+			Email:     email,
+			Kind:      gcpPrincipalGroup,
+		}, true
+	case strings.HasPrefix(member, gcpPrincipalServiceAccountPrefix):
+		email := strings.TrimPrefix(member, gcpPrincipalServiceAccountPrefix)
+		if email == "" {
+			return gcpIdentity{}, false
+		}
+
+		return gcpIdentity{
+			Principal: member,
+			Email:     email,
+			Kind:      gcpPrincipalServiceAccount,
+		}, true
+	default:
+		return gcpIdentity{}, false
+	}
+}
+
+func skipGCPPrincipal(member string) bool {
+	switch member {
+	case "allUsers", "allAuthenticatedUsers":
+		return true
+	}
+
+	for _, prefix := range []string{
+		"domain:",
+		"deleted:",
+		"principal:",
+		"principalSet:",
+	} {
+		if strings.HasPrefix(member, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func listProjectServiceAccounts(ctx context.Context, session *cloudgcp.Session) ([]gcpServiceAccount, error) {
+	svc, err := iam.NewService(
+		ctx,
+		option.WithHTTPClient(session.HTTPClient()),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gcp iam client: %w", err)
+	}
+
+	parent, err := url.JoinPath("projects", url.PathEscape(session.AccountID()))
+	if err != nil {
+		return nil, fmt.Errorf("cannot build gcp service account parent: %w", err)
+	}
+
+	var (
+		accounts  []gcpServiceAccount
+		pageToken string
+	)
+
+	for range maxPaginationPages {
+		call := svc.Projects.ServiceAccounts.List(parent).
+			PageSize(gcpServiceAccountsPageSize).
+			Context(ctx)
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+
+		resp, err := call.Do()
+		if err != nil {
+			return nil, fmt.Errorf("cannot list gcp service accounts: %w", err)
+		}
+
+		for _, account := range resp.Accounts {
+			if account == nil || account.Email == "" {
+				continue
+			}
+
+			accounts = append(
+				accounts,
+				gcpServiceAccount{
+					Email:       account.Email,
+					UniqueID:    account.UniqueId,
+					DisplayName: account.DisplayName,
+					Disabled:    account.Disabled,
+				},
+			)
+		}
+
+		pageToken = resp.NextPageToken
+		if pageToken == "" {
+			return accounts, nil
+		}
+	}
+
+	return nil, fmt.Errorf("cannot list gcp service accounts: %w", ErrPaginationLimitReached)
+}
+
+func unionGCPIdentities(principals []gcpIdentity, accounts []gcpServiceAccount) []gcpIdentity {
+	byEmail := make(map[string]int, len(principals))
+	identities := make([]gcpIdentity, 0, len(principals)+len(accounts))
+
+	for _, principal := range principals {
+		if principal.Kind == gcpPrincipalServiceAccount {
+			byEmail[principal.Email] = len(identities)
+		}
+
+		identities = append(identities, principal)
+	}
+
+	for _, account := range accounts {
+		if i, ok := byEmail[account.Email]; ok {
+			identities[i].UniqueID = account.UniqueID
+			identities[i].DisplayName = account.DisplayName
+			identities[i].Disabled = new(account.Disabled)
+
+			continue
+		}
+
+		identities = append(
+			identities,
+			gcpIdentity{
+				Principal:   gcpPrincipalServiceAccountPrefix + account.Email,
+				Email:       account.Email,
+				Kind:        gcpPrincipalServiceAccount,
+				UniqueID:    account.UniqueID,
+				DisplayName: account.DisplayName,
+				Disabled:    new(account.Disabled),
+			},
+		)
+	}
+
+	slices.SortFunc(
+		identities,
+		func(a, b gcpIdentity) int {
+			return strings.Compare(a.Principal, b.Principal)
+		},
+	)
+
+	return identities
+}
+
+func attachUserManagedKeys(
+	ctx context.Context,
+	session *cloudgcp.Session,
+	identities []gcpIdentity,
+) error {
+	svc, err := iam.NewService(
+		ctx,
+		option.WithHTTPClient(session.HTTPClient()),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		return fmt.Errorf("cannot create gcp iam client: %w", err)
+	}
+
+	for i := range identities {
+		if identities[i].Kind != gcpPrincipalServiceAccount || identities[i].UniqueID == "" {
+			continue
+		}
+
+		hasKey, err := serviceAccountHasUserManagedKey(ctx, svc, identities[i].Email)
+		if err != nil {
+			return fmt.Errorf("cannot list gcp service account keys: %w", err)
+		}
+
+		identities[i].HasUserManagedKey = hasKey
+	}
+
+	return nil
+}
+
+func serviceAccountHasUserManagedKey(ctx context.Context, svc *iam.Service, email string) (bool, error) {
+	name, err := url.JoinPath("projects/-/serviceAccounts", url.PathEscape(email))
+	if err != nil {
+		return false, fmt.Errorf("cannot build gcp service account resource name: %w", err)
+	}
+
+	resp, err := svc.Projects.ServiceAccounts.Keys.List(name).
+		KeyTypes(gcpUserManagedKeyType).
+		Context(ctx).
+		Do()
+	if err != nil {
+		return false, fmt.Errorf("cannot list keys of a gcp service account: %w", err)
+	}
+
+	for _, key := range resp.Keys {
+		if key != nil && key.KeyType == gcpUserManagedKeyType {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/accessreview/drivers/gcp_iam_test.go
+++ b/pkg/accessreview/drivers/gcp_iam_test.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
+)
+
+func TestParseGCPPrincipal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		member    string
+		wantOK    bool
+		wantKind  gcpPrincipalKind
+		wantEmail string
+	}{
+		{
+			name:      "user",
+			member:    "user:alice@example.com",
+			wantOK:    true,
+			wantKind:  gcpPrincipalUser,
+			wantEmail: "alice@example.com",
+		},
+		{
+			name:      "group",
+			member:    "group:eng@example.com",
+			wantOK:    true,
+			wantKind:  gcpPrincipalGroup,
+			wantEmail: "eng@example.com",
+		},
+		{
+			name:      "service account",
+			member:    "serviceAccount:ci@my-project.iam.gserviceaccount.com",
+			wantOK:    true,
+			wantKind:  gcpPrincipalServiceAccount,
+			wantEmail: "ci@my-project.iam.gserviceaccount.com",
+		},
+		{name: "allUsers", member: "allUsers"},
+		{name: "allAuthenticatedUsers", member: "allAuthenticatedUsers"},
+		{name: "domain", member: "domain:example.com"},
+		{name: "deleted user", member: "deleted:user:alice@example.com?uid=123"},
+		{name: "principal", member: "principal://iam.googleapis.com/locations/global/workforcePools/p/subject/s"},
+		{name: "principalSet", member: "principalSet://iam.googleapis.com/locations/global/workforcePools/p/*"},
+		{name: "empty user", member: "user:"},
+		{name: "unknown kind", member: "folder:123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				got, ok := parseGCPPrincipal(tt.member)
+				assert.Equal(t, tt.wantOK, ok)
+
+				if !tt.wantOK {
+					return
+				}
+
+				assert.Equal(t, tt.member, got.Principal)
+				assert.Equal(t, tt.wantKind, got.Kind)
+				assert.Equal(t, tt.wantEmail, got.Email)
+			},
+		)
+	}
+}
+
+func TestGCPIsAdmin(t *testing.T) {
+	t.Parallel()
+
+	require.NotNil(t, gcpIsAdmin([]string{"roles/viewer", gcpRoleOwner}))
+	assert.True(t, *gcpIsAdmin([]string{gcpRoleOwner}))
+	assert.Nil(t, gcpIsAdmin([]string{"roles/editor"}))
+	assert.Nil(t, gcpIsAdmin([]string{"projects/my-project/roles/customAdmin"}))
+	assert.Nil(t, gcpIsAdmin(nil))
+}
+
+func TestGCPIdentityRecord_MapsOwnerUser(t *testing.T) {
+	t.Parallel()
+
+	record := gcpIdentityRecord(
+		gcpIdentity{
+			Principal: "user:alice@example.com",
+			Email:     "alice@example.com",
+			Kind:      gcpPrincipalUser,
+			Roles:     []string{gcpRoleOwner},
+		},
+	)
+
+	assert.Equal(t, "alice@example.com", record.Email)
+	assert.Equal(t, []string{gcpRoleOwner}, record.Roles)
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, record.AccountType)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodSSO, record.AuthMethod)
+	assert.Equal(t, coredata.MFAStatusUnknown, record.MFAStatus)
+	assert.Equal(t, "user:alice@example.com", record.ExternalID)
+	require.NotNil(t, record.IsAdmin)
+	assert.True(t, *record.IsAdmin)
+	assert.Nil(t, record.Active)
+	assert.Nil(t, record.LastLogin)
+}
+
+func TestGCPIdentityRecord_MapsDisabledServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	record := gcpIdentityRecord(
+		gcpIdentity{
+			Principal:         "serviceAccount:bot@my-project.iam.gserviceaccount.com",
+			Email:             "bot@my-project.iam.gserviceaccount.com",
+			Kind:              gcpPrincipalServiceAccount,
+			Roles:             []string{"roles/editor"},
+			UniqueID:          "333",
+			Disabled:          new(true),
+			HasUserManagedKey: true,
+		},
+	)
+
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeServiceAccount, record.AccountType)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodAPIKey, record.AuthMethod)
+	assert.Equal(t, "333", record.ExternalID)
+	assert.Nil(t, record.IsAdmin)
+	require.NotNil(t, record.Active)
+	assert.False(t, *record.Active)
+}
+
+func TestPrincipalsFromPolicy_SkipsAndUnionsRoles(t *testing.T) {
+	t.Parallel()
+
+	principals := principalsFromPolicy(
+		&cloudresourcemanager.Policy{
+			Bindings: []*cloudresourcemanager.Binding{
+				{
+					Role: gcpRoleOwner,
+					Members: []string{
+						"user:alice@example.com",
+						"allUsers",
+						"domain:example.com",
+					},
+				},
+				{
+					Role: "roles/viewer",
+					Members: []string{
+						"user:alice@example.com",
+						"group:eng@example.com",
+					},
+				},
+			},
+		},
+	)
+
+	byPrincipal := make(map[string]gcpIdentity, len(principals))
+	for _, principal := range principals {
+		byPrincipal[principal.Principal] = principal
+	}
+
+	require.Len(t, principals, 2)
+	assert.ElementsMatch(
+		t,
+		[]string{gcpRoleOwner, "roles/viewer"},
+		byPrincipal["user:alice@example.com"].Roles,
+	)
+	assert.Equal(t, []string{"roles/viewer"}, byPrincipal["group:eng@example.com"].Roles)
+}
+
+func TestUnionGCPIdentities_IncludesUnboundServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	identities := unionGCPIdentities(
+		[]gcpIdentity{
+			{
+				Principal: "user:alice@example.com",
+				Email:     "alice@example.com",
+				Kind:      gcpPrincipalUser,
+				Roles:     []string{gcpRoleOwner},
+			},
+			{
+				Principal: "serviceAccount:ci@my-project.iam.gserviceaccount.com",
+				Email:     "ci@my-project.iam.gserviceaccount.com",
+				Kind:      gcpPrincipalServiceAccount,
+				Roles:     []string{"roles/editor"},
+			},
+		},
+		[]gcpServiceAccount{
+			{
+				Email:       "ci@my-project.iam.gserviceaccount.com",
+				UniqueID:    "111",
+				DisplayName: "CI",
+			},
+			{
+				Email:    "unbound@my-project.iam.gserviceaccount.com",
+				UniqueID: "222",
+				Disabled: true,
+			},
+		},
+	)
+
+	require.Len(t, identities, 3)
+
+	var ci, unbound gcpIdentity
+
+	for _, identity := range identities {
+		switch identity.Email {
+		case "ci@my-project.iam.gserviceaccount.com":
+			ci = identity
+		case "unbound@my-project.iam.gserviceaccount.com":
+			unbound = identity
+		}
+	}
+
+	assert.Equal(t, "111", ci.UniqueID)
+	assert.Equal(t, "CI", ci.DisplayName)
+	assert.Equal(t, []string{"roles/editor"}, ci.Roles)
+	require.NotNil(t, ci.Disabled)
+	assert.False(t, *ci.Disabled)
+
+	assert.Equal(t, "222", unbound.UniqueID)
+	assert.Empty(t, unbound.Roles)
+	require.NotNil(t, unbound.Disabled)
+	assert.True(t, *unbound.Disabled)
+}
+
+func TestProjectIDFromServiceAccountEmail(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(
+		t,
+		"my-project",
+		projectIDFromServiceAccountEmail("probo-audit@my-project.iam.gserviceaccount.com"),
+	)
+	assert.Empty(t, projectIDFromServiceAccountEmail("alice@example.com"))
+	assert.Empty(t, projectIDFromServiceAccountEmail(""))
+}

--- a/pkg/accessreview/drivers/gcp_name.go
+++ b/pkg/accessreview/drivers/gcp_name.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.gearno.de/kit/log"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/option"
+)
+
+const gcpServiceAccountEmailSuffix = ".iam.gserviceaccount.com"
+
+// gcpNameResolver names the connected project for the source-name worker.
+// The official display name is preferred, then the connected project's
+// project ID, then the project ID from the impersonated service-account
+// email, then the project number so two sources in one organization still
+// differ.
+type gcpNameResolver struct {
+	session             *cloudgcp.Session
+	serviceAccountEmail string
+	logger              *log.Logger
+}
+
+func NewGCPNameResolver(
+	session *cloudgcp.Session,
+	serviceAccountEmail string,
+	logger *log.Logger,
+) NameResolver {
+	return &gcpNameResolver{
+		session:             session,
+		serviceAccountEmail: serviceAccountEmail,
+		logger:              logger,
+	}
+}
+
+func (r *gcpNameResolver) ResolveInstanceName(ctx context.Context) (string, error) {
+	project, err := r.getProject(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", err
+		}
+
+		r.logger.WarnCtx(
+			ctx,
+			"cannot read gcp project name, trying project id",
+			cloudgcp.SafeLogFields(err)...,
+		)
+	}
+
+	if project != nil {
+		if name := strings.TrimSpace(project.Name); name != "" {
+			return name, nil
+		}
+
+		if id := strings.TrimSpace(project.ProjectId); id != "" {
+			return id, nil
+		}
+	}
+
+	if id := projectIDFromServiceAccountEmail(r.serviceAccountEmail); id != "" {
+		return id, nil
+	}
+
+	return r.session.AccountID(), nil
+}
+
+func (r *gcpNameResolver) getProject(ctx context.Context) (*cloudresourcemanager.Project, error) {
+	svc, err := cloudresourcemanager.NewService(
+		ctx,
+		option.WithHTTPClient(r.session.HTTPClient()),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gcp resource manager client: %w", err)
+	}
+
+	project, err := svc.Projects.Get(r.session.AccountID()).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get gcp project: %w", err)
+	}
+
+	return project, nil
+}
+
+func projectIDFromServiceAccountEmail(email string) string {
+	_, host, ok := strings.Cut(strings.TrimSpace(email), "@")
+	if !ok {
+		return ""
+	}
+
+	if !strings.HasSuffix(host, gcpServiceAccountEmailSuffix) {
+		return ""
+	}
+
+	return strings.TrimSuffix(host, gcpServiceAccountEmailSuffix)
+}

--- a/pkg/accessreview/drivers/gcp_test.go
+++ b/pkg/accessreview/drivers/gcp_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/log"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	"go.probo.inc/probo/pkg/coredata"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
+)
+
+const (
+	vcrGCPProjectNumber = "123456789012"
+	vcrGCPAccessToken   = "vcr-gcp-access-token"
+	vcrGCPServiceEmail  = "probo-audit@my-project.iam.gserviceaccount.com"
+)
+
+func newGCPTestSession(t *testing.T, rec *recorder.Recorder) *cloudgcp.Session {
+	t.Helper()
+
+	return cloudgcp.NewSessionFromToken(
+		vcrGCPProjectNumber,
+		vcrGCPAccessToken,
+		cloudgcp.WithHTTPClient(newVCRClient(rec, "")),
+	)
+}
+
+func TestGCPDriver(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp")
+	session := newGCPTestSession(t, rec)
+
+	records, err := NewGCPDriver(session).
+		ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 5)
+
+	byID := make(map[string]AccountRecord, len(records))
+	for _, record := range records {
+		byID[record.ExternalID] = record
+	}
+
+	alice := byID["user:alice@example.com"]
+	assert.Equal(t, "alice@example.com", alice.Email)
+	assert.Equal(t, []string{gcpRoleOwner}, alice.Roles)
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, alice.AccountType)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodSSO, alice.AuthMethod)
+	assert.Equal(t, coredata.MFAStatusUnknown, alice.MFAStatus)
+	require.NotNil(t, alice.IsAdmin)
+	assert.True(t, *alice.IsAdmin)
+	assert.Nil(t, alice.Active)
+	assert.Nil(t, alice.LastLogin)
+
+	eng := byID["group:eng@example.com"]
+	assert.Equal(t, "eng@example.com", eng.Email)
+	assert.Equal(t, []string{"roles/viewer"}, eng.Roles)
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeUser, eng.AccountType)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodUnknown, eng.AuthMethod)
+	assert.Nil(t, eng.IsAdmin)
+	assert.Nil(t, eng.Active)
+
+	ci := byID["111111111111111111111"]
+	assert.Equal(t, "ci@my-project.iam.gserviceaccount.com", ci.Email)
+	assert.Equal(t, "CI Deploy", ci.FullName)
+	assert.Equal(t, []string{"roles/editor"}, ci.Roles)
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeServiceAccount, ci.AccountType)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodAPIKey, ci.AuthMethod)
+	assert.Nil(t, ci.IsAdmin)
+	require.NotNil(t, ci.Active)
+	assert.True(t, *ci.Active)
+
+	unbound := byID["222222222222222222222"]
+	assert.Equal(t, "unbound@my-project.iam.gserviceaccount.com", unbound.Email)
+	assert.Empty(t, unbound.Roles)
+	assert.Equal(t, coredata.AccessReviewEntryAccountTypeServiceAccount, unbound.AccountType)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodUnknown, unbound.AuthMethod)
+	require.NotNil(t, unbound.Active)
+	assert.True(t, *unbound.Active)
+
+	disabled := byID["333333333333333333333"]
+	assert.Equal(t, "disabled-bot@my-project.iam.gserviceaccount.com", disabled.Email)
+	assert.Equal(t, []string{"projects/my-project/roles/customAdmin"}, disabled.Roles)
+	assert.Nil(t, disabled.IsAdmin)
+	require.NotNil(t, disabled.Active)
+	assert.False(t, *disabled.Active)
+}
+
+func TestGCPDriver_FailsWhenServiceAccountsDenied(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_service_accounts_denied")
+	session := newGCPTestSession(t, rec)
+
+	_, err := NewGCPDriver(session).
+		ListAccounts(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot list service accounts of the gcp project")
+}
+
+func TestGCPDriver_FailsWhenIAMPolicyDenied(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_iam_denied")
+	session := newGCPTestSession(t, rec)
+
+	_, err := NewGCPDriver(session).
+		ListAccounts(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot get gcp project iam policy")
+}
+
+func TestGCPNameResolver_UsesDisplayName(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_project_name")
+	session := newGCPTestSession(t, rec)
+
+	name, err := NewGCPNameResolver(
+		session,
+		vcrGCPServiceEmail,
+		log.NewLogger(log.WithName("test")),
+	).ResolveInstanceName(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Acme Prod", name)
+}
+
+func TestGCPNameResolver_UsesProjectIDWhenDisplayNameEmpty(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_project_id_no_display_name")
+	session := newGCPTestSession(t, rec)
+
+	name, err := NewGCPNameResolver(
+		session,
+		vcrGCPServiceEmail,
+		log.NewLogger(log.WithName("test")),
+	).ResolveInstanceName(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "connected-project", name)
+}
+
+func TestGCPNameResolver_FallsBackToServiceAccountProjectID(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_project_id")
+	session := newGCPTestSession(t, rec)
+
+	name, err := NewGCPNameResolver(
+		session,
+		vcrGCPServiceEmail,
+		log.NewLogger(log.WithName("test")),
+	).ResolveInstanceName(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "my-project", name)
+}
+
+func TestGCPNameResolver_FallsBackToProjectNumber(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_project_number")
+	session := newGCPTestSession(t, rec)
+
+	name, err := NewGCPNameResolver(
+		session,
+		"",
+		log.NewLogger(log.WithName("test")),
+	).ResolveInstanceName(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, vcrGCPProjectNumber, name)
+}

--- a/pkg/accessreview/drivers/testdata/gcp.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp.yaml
@@ -1,0 +1,113 @@
+---
+# Hand-authored GCP cassette. Never recorded against a live project.
+# getIamPolicy plus serviceAccounts.list and keys.list for the listed SAs.
+# Synthetic principals: alice (owner user), eng (viewer group), ci (SA with
+# a user-managed key), unbound (listed SA with no binding), disabled-bot
+# (custom role, disabled). allUsers and domain: are present and skipped.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: cloudresourcemanager.googleapis.com
+        url: https://cloudresourcemanager.googleapis.com/v1/projects/123456789012:getIamPolicy
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"bindings":[{"role":"roles/owner","members":["user:alice@example.com"]},{"role":"roles/viewer","members":["group:eng@example.com","allUsers","domain:example.com"]},{"role":"roles/editor","members":["serviceAccount:ci@my-project.iam.gserviceaccount.com"]},{"role":"projects/my-project/roles/customAdmin","members":["serviceAccount:disabled-bot@my-project.iam.gserviceaccount.com"]}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: iam.googleapis.com
+        url: https://iam.googleapis.com/v1/projects/123456789012/serviceAccounts
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"accounts":[{"email":"ci@my-project.iam.gserviceaccount.com","uniqueId":"111111111111111111111","displayName":"CI Deploy","disabled":false},{"email":"unbound@my-project.iam.gserviceaccount.com","uniqueId":"222222222222222222222","displayName":"Unbound Runner","disabled":false},{"email":"disabled-bot@my-project.iam.gserviceaccount.com","uniqueId":"333333333333333333333","displayName":"Disabled Bot","disabled":true}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: iam.googleapis.com
+        url: https://iam.googleapis.com/v1/projects/-/serviceAccounts/ci@my-project.iam.gserviceaccount.com/keys
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"keys":[{"name":"projects/my-project/serviceAccounts/ci@my-project.iam.gserviceaccount.com/keys/key1","keyType":"USER_MANAGED"}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: iam.googleapis.com
+        url: https://iam.googleapis.com/v1/projects/-/serviceAccounts/disabled-bot@my-project.iam.gserviceaccount.com/keys
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"keys":[]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: iam.googleapis.com
+        url: https://iam.googleapis.com/v1/projects/-/serviceAccounts/unbound@my-project.iam.gserviceaccount.com/keys
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"keys":[]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms

--- a/pkg/accessreview/drivers/testdata/gcp_iam_denied.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp_iam_denied.yaml
@@ -1,0 +1,25 @@
+---
+# Hand-authored. getIamPolicy 403 must fail the fetch.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: cloudresourcemanager.googleapis.com
+        url: https://cloudresourcemanager.googleapis.com/v1/projects/123456789012:getIamPolicy
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"error":{"code":403,"message":"Permission denied","status":"PERMISSION_DENIED"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 403 Forbidden
+        code: 403
+        duration: 1ms

--- a/pkg/accessreview/drivers/testdata/gcp_project_id.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp_project_id.yaml
@@ -1,0 +1,26 @@
+---
+# Hand-authored. projects.get is 403; resolver falls back to the project
+# ID in the impersonated service-account email.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: cloudresourcemanager.googleapis.com
+        url: https://cloudresourcemanager.googleapis.com/v1/projects/123456789012
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"error":{"code":403,"message":"Permission denied","status":"PERMISSION_DENIED"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 403 Forbidden
+        code: 403
+        duration: 1ms

--- a/pkg/accessreview/drivers/testdata/gcp_project_id_no_display_name.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp_project_id_no_display_name.yaml
@@ -1,0 +1,26 @@
+---
+# Hand-authored. projects.get succeeds with no display name; resolver
+# uses the connected project's projectId, not the service-account email.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: cloudresourcemanager.googleapis.com
+        url: https://cloudresourcemanager.googleapis.com/v1/projects/123456789012
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"projectNumber":"123456789012","projectId":"connected-project","name":"","lifecycleState":"ACTIVE"}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms

--- a/pkg/accessreview/drivers/testdata/gcp_project_name.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp_project_name.yaml
@@ -1,0 +1,25 @@
+---
+# Hand-authored. projects.get returns a display name.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: cloudresourcemanager.googleapis.com
+        url: https://cloudresourcemanager.googleapis.com/v1/projects/123456789012
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"projectNumber":"123456789012","projectId":"my-project","name":"Acme Prod","lifecycleState":"ACTIVE"}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms

--- a/pkg/accessreview/drivers/testdata/gcp_project_number.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp_project_number.yaml
@@ -1,0 +1,26 @@
+---
+# Hand-authored. projects.get is 403 and no service-account email is
+# supplied; resolver falls back to the project number.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: cloudresourcemanager.googleapis.com
+        url: https://cloudresourcemanager.googleapis.com/v1/projects/123456789012
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"error":{"code":403,"message":"Permission denied","status":"PERMISSION_DENIED"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 403 Forbidden
+        code: 403
+        duration: 1ms

--- a/pkg/accessreview/drivers/testdata/gcp_service_accounts_denied.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp_service_accounts_denied.yaml
@@ -1,0 +1,47 @@
+---
+# Hand-authored. getIamPolicy succeeds; serviceAccounts.list is 403.
+# The fetch must fail.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: cloudresourcemanager.googleapis.com
+        url: https://cloudresourcemanager.googleapis.com/v1/projects/123456789012:getIamPolicy
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"bindings":[{"role":"roles/owner","members":["user:alice@example.com"]},{"role":"roles/viewer","members":["group:eng@example.com","allUsers","domain:example.com"]},{"role":"roles/editor","members":["serviceAccount:ci@my-project.iam.gserviceaccount.com"]},{"role":"projects/my-project/roles/customAdmin","members":["serviceAccount:disabled-bot@my-project.iam.gserviceaccount.com"]}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: iam.googleapis.com
+        url: https://iam.googleapis.com/v1/projects/123456789012/serviceAccounts
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"error":{"code":403,"message":"Permission denied","status":"PERMISSION_DENIED"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 403 Forbidden
+        code: 403
+        duration: 1ms

--- a/pkg/accessreview/drivers/vcr_test.go
+++ b/pkg/accessreview/drivers/vcr_test.go
@@ -29,6 +29,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )
@@ -150,6 +152,45 @@ func sanitizeAWSSigningHeaders(i *cassette.Interaction) error {
 	}
 
 	return nil
+}
+
+// newGCPRecorder replays a hand-authored GCP cassette. It never records:
+// recording would require live GCP credentials, which these tests refuse to
+// read from the environment.
+func newGCPRecorder(t *testing.T, cassettePath string) *recorder.Recorder {
+	t.Helper()
+
+	return newRecorderWithMatcher(
+		t,
+		cassettePath,
+		"",
+		gcpAPIMatcher,
+	)
+}
+
+// gcpAPIMatcher matches Google API REST calls by method, host, path, and
+// pageToken. Client-default query parameters (alt, prettyPrint, pageSize,
+// keyTypes) are ignored so cassettes stay stable across library versions.
+func gcpAPIMatcher(r *http.Request, i cassette.Request) bool {
+	if r.Method != i.Method {
+		return false
+	}
+
+	host := r.URL.Host
+	if host == "" {
+		host = r.Host
+	}
+
+	cassetteURL, err := url.Parse(i.URL)
+	if err != nil {
+		return false
+	}
+
+	if host != cassetteURL.Host || r.URL.Path != cassetteURL.Path {
+		return false
+	}
+
+	return r.URL.Query().Get("pageToken") == cassetteURL.Query().Get("pageToken")
 }
 
 // newAWSRecorder replays a hand-authored AWS cassette. It never records:
@@ -332,4 +373,104 @@ type roundTripFunc func(req *http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func TestGCPAPIMatcher(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceAccounts = "https://iam.googleapis.com/v1/projects/123456789012/serviceAccounts"
+		serviceKeys     = "https://iam.googleapis.com/v1/projects/-/serviceAccounts/ci@my-project.iam.gserviceaccount.com/keys"
+		resourceManager = "https://cloudresourcemanager.googleapis.com/v1/projects/123456789012:getIamPolicy"
+	)
+
+	tests := []struct {
+		name        string
+		method      string
+		requestURL  string
+		cassetteURL string
+		want        bool
+	}{
+		{
+			name:        "same path without page token",
+			method:      http.MethodGet,
+			requestURL:  serviceAccounts,
+			cassetteURL: serviceAccounts,
+			want:        true,
+		},
+		{
+			name:        "same path and page token",
+			method:      http.MethodGet,
+			requestURL:  serviceAccounts + "?pageToken=abc",
+			cassetteURL: serviceAccounts + "?pageToken=abc",
+			want:        true,
+		},
+		{
+			name:        "same path with different page tokens",
+			method:      http.MethodGet,
+			requestURL:  serviceAccounts + "?pageToken=abc",
+			cassetteURL: serviceAccounts + "?pageToken=def",
+			want:        false,
+		},
+		{
+			name:        "page token only on the request",
+			method:      http.MethodGet,
+			requestURL:  serviceAccounts + "?pageToken=abc",
+			cassetteURL: serviceAccounts,
+			want:        false,
+		},
+		{
+			name:        "page token only on the cassette",
+			method:      http.MethodGet,
+			requestURL:  serviceAccounts,
+			cassetteURL: serviceAccounts + "?pageToken=abc",
+			want:        false,
+		},
+		{
+			name:        "ignores client-default query parameters",
+			method:      http.MethodGet,
+			requestURL:  serviceAccounts + "?alt=json&prettyPrint=false&pageSize=100&keyTypes=USER_MANAGED",
+			cassetteURL: serviceAccounts,
+			want:        true,
+		},
+		{
+			name:        "matches page token while ignoring client defaults",
+			method:      http.MethodGet,
+			requestURL:  serviceAccounts + "?alt=json&pageSize=100&pageToken=abc",
+			cassetteURL: serviceAccounts + "?pageToken=abc",
+			want:        true,
+		},
+		{
+			name:        "different path",
+			method:      http.MethodGet,
+			requestURL:  serviceAccounts,
+			cassetteURL: serviceKeys,
+			want:        false,
+		},
+		{
+			name:        "different host",
+			method:      http.MethodPost,
+			requestURL:  resourceManager,
+			cassetteURL: serviceAccounts,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				req, err := http.NewRequest(tt.method, tt.requestURL, nil)
+				require.NoError(t, err)
+
+				got := gcpAPIMatcher(
+					req,
+					cassette.Request{Method: tt.method, URL: tt.cassetteURL},
+				)
+				assert.Equal(t, tt.want, got)
+			},
+		)
+	}
 }

--- a/pkg/cloud/gcp/error.go
+++ b/pkg/cloud/gcp/error.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package gcp
+
+import (
+	"errors"
+
+	"go.gearno.de/kit/log"
+	"google.golang.org/api/googleapi"
+)
+
+// SafeLogFields returns status and reason from a Google API error. It
+// never includes Message, Body, or Errors[].Message: those strings
+// often name the resource, which for IAM is a service-account email.
+func SafeLogFields(err error) []log.Attr {
+	apiErr, ok := errors.AsType[*googleapi.Error](err)
+	if !ok {
+		return nil
+	}
+
+	fields := []log.Attr{log.Int("status", apiErr.Code)}
+	if len(apiErr.Errors) > 0 && apiErr.Errors[0].Reason != "" {
+		fields = append(fields, log.String("reason", apiErr.Errors[0].Reason))
+	}
+
+	return fields
+}

--- a/pkg/cloud/gcp/error_test.go
+++ b/pkg/cloud/gcp/error_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package gcp_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.gearno.de/kit/log"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	"google.golang.org/api/googleapi"
+)
+
+func TestSafeLogFields_OmitsServiceAccountEmail(t *testing.T) {
+	t.Parallel()
+
+	const email = "ci@my-project.iam.gserviceaccount.com"
+
+	message := "Permission 'iam.serviceAccountKeys.list' denied on resource " +
+		"'projects/-/serviceAccounts/" + email + "' (or it may not exist)."
+
+	tests := []struct {
+		name string
+		err  error
+		want []log.Attr
+	}{
+		{
+			name: "permission denied with reason",
+			err: &googleapi.Error{
+				Code:    http.StatusForbidden,
+				Message: message,
+				Errors: []googleapi.ErrorItem{
+					{Reason: "forbidden", Message: message},
+				},
+			},
+			want: []log.Attr{
+				log.Int("status", http.StatusForbidden),
+				log.String("reason", "forbidden"),
+			},
+		},
+		{
+			name: "permission denied without reason",
+			err: &googleapi.Error{
+				Code:    http.StatusForbidden,
+				Message: message,
+			},
+			want: []log.Attr{log.Int("status", http.StatusForbidden)},
+		},
+		{
+			name: "wrapped google api error",
+			err: fmt.Errorf(
+				"cannot list keys of a gcp service account: %w",
+				&googleapi.Error{
+					Code:    http.StatusForbidden,
+					Message: message,
+					Errors: []googleapi.ErrorItem{
+						{Reason: "forbidden", Message: message},
+					},
+				},
+			),
+			want: []log.Attr{
+				log.Int("status", http.StatusForbidden),
+				log.String("reason", "forbidden"),
+			},
+		},
+		{
+			name: "non google api error",
+			err:  fmt.Errorf("cannot list keys of a gcp service account"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				got := cloudgcp.SafeLogFields(tt.err)
+				assert.Equal(t, tt.want, got)
+
+				for _, field := range got {
+					assert.NotContains(t, field.Key, email)
+					assert.NotContains(t, field.Value.String(), email)
+				}
+			},
+		)
+	}
+}

--- a/pkg/cloud/gcp/session.go
+++ b/pkg/cloud/gcp/session.go
@@ -76,6 +76,9 @@ type (
 		session *Session
 		base    http.RoundTripper
 	}
+
+	// SessionOption configures a session built by NewSessionFromToken.
+	SessionOption func(*Session)
 )
 
 var (
@@ -125,16 +128,27 @@ func NewSession(
 	return session, nil
 }
 
+// WithHTTPClient sets the transport the authorized client wraps. Tests pass a
+// VCR client. Omit it to use the default SSRF-protected pool.
+func WithHTTPClient(httpClient *http.Client) SessionOption {
+	return func(s *Session) {
+		s.httpClient = httpClient
+	}
+}
+
 // NewSessionFromToken builds a session from an already-issued access token.
 // Production uses NewSession, which obtains credentials through WIF.
-func NewSessionFromToken(projectNumber, accessToken string) *Session {
-	httpClient := httpclient.DefaultPooledClient(httpclient.WithSSRFProtection())
+func NewSessionFromToken(projectNumber, accessToken string, opts ...SessionOption) *Session {
 	session := &Session{
-		httpClient: httpClient,
+		httpClient: httpclient.DefaultPooledClient(httpclient.WithSSRFProtection()),
 		token:      &oauth2.Token{AccessToken: accessToken},
 		accountID:  projectNumber,
 	}
-	session.authorizedClient = authorizeSession(httpClient, session)
+	for _, opt := range opts {
+		opt(session)
+	}
+
+	session.authorizedClient = authorizeSession(session.httpClient, session)
 
 	return session
 }

--- a/pkg/connector/provider/gcp.go
+++ b/pkg/connector/provider/gcp.go
@@ -50,9 +50,10 @@ func gcpRegistration() *Registration {
 		// Endpoints for an override to move.
 		EndpointOverrideUnsupported: "the GCP APIs resolve their own hosts, not values in Endpoints",
 		WorkloadIdentity: &WorkloadIdentityConfig{
-			NewSession: newGCPSession,
-			NewDriver:  newGCPDriver,
-			Probe:      probeGCP,
+			NewSession:      newGCPSession,
+			NewDriver:       newGCPDriver,
+			Probe:           probeGCP,
+			NewNameResolver: newGCPNameResolver,
 			ExtraSettings: []ExtraSetting{
 				{Key: "workloadIdentityProvider", Label: "Workload identity provider", Required: true},
 				{Key: "serviceAccountEmail", Label: "Service account email", Required: true},
@@ -91,20 +92,41 @@ func newGCPSession(
 	return session, nil
 }
 
-// newGCPDriver is a placeholder until the access-review driver lands. Register
-// requires a factory; returning a clear error keeps a silent no-op driver out
-// of the catalog.
+func newGCPNameResolver(
+	ctx context.Context,
+	session cloud.Session,
+	conn *coredata.Connector,
+	logger *log.Logger,
+) drivers.NameResolver {
+	gcpSession, ok := session.(*cloudgcp.Session)
+	if !ok {
+		logger.ErrorCtx(ctx, "cannot create gcp name resolver", log.String("cloud", session.Cloud()))
+		return nil
+	}
+
+	settings, err := coredata.ConnectorSettings[coredata.GCPConnectorSettings](conn)
+	if err != nil {
+		logger.ErrorCtx(ctx, "cannot read gcp connector settings", log.Error(err))
+		return nil
+	}
+
+	return drivers.NewGCPNameResolver(gcpSession, settings.ServiceAccountEmail, logger)
+}
+
+// newGCPDriver builds the access review driver over the session already
+// impersonated on the connected project.
 func newGCPDriver(
 	_ context.Context,
 	session cloud.Session,
 	_ *coredata.Connector,
 	_ *log.Logger,
 ) (drivers.Driver, error) {
-	if _, ok := session.(*cloudgcp.Session); !ok {
+	gcpSession, ok := session.(*cloudgcp.Session)
+	if !ok {
 		return nil, fmt.Errorf("cannot create gcp driver: session is for %s", session.Cloud())
 	}
 
-	return nil, fmt.Errorf("cannot create gcp driver: not implemented")
+	return drivers.NewGCPDriver(gcpSession), nil
 }
 
 // probeGCP checks the connection by completing the STS exchange and

--- a/pkg/connector/provider/gcp_test.go
+++ b/pkg/connector/provider/gcp_test.go
@@ -86,7 +86,7 @@ func TestGCPRegistration(t *testing.T) {
 	assert.Equal(t, "serviceAccountEmail", reg.WorkloadIdentityExtraSettings()[1].Key)
 	assert.True(t, reg.WorkloadIdentityExtraSettings()[1].Required)
 	assert.Nil(t, reg.NewNameResolver)
-	assert.Nil(t, reg.WorkloadIdentity.NewNameResolver)
+	require.NotNil(t, reg.WorkloadIdentity.NewNameResolver)
 }
 
 func TestGCPNewSession(t *testing.T) {
@@ -142,7 +142,7 @@ func TestGCPNewDriver(t *testing.T) {
 		assert.Contains(t, err.Error(), "session is for AWS")
 	})
 
-	t.Run("returns not implemented for a gcp session", func(t *testing.T) {
+	t.Run("returns a driver for a gcp session", func(t *testing.T) {
 		t.Parallel()
 
 		conn := gcpTestConnector(
@@ -156,15 +156,68 @@ func TestGCPNewDriver(t *testing.T) {
 		session, err := reg.WorkloadIdentity.NewSession(context.Background(), awsTestIssuer(t), conn)
 		require.NoError(t, err)
 
-		_, err = reg.WorkloadIdentity.NewDriver(
+		driver, err := reg.WorkloadIdentity.NewDriver(
 			context.Background(),
 			session,
 			conn,
 			log.NewLogger(log.WithOutput(io.Discard)),
 		)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not implemented")
+		require.NoError(t, err)
+		require.NotNil(t, driver)
 	})
+}
+
+func TestGCPNewNameResolver(t *testing.T) {
+	t.Parallel()
+
+	r := provider.NewBuiltinRegistry()
+	reg, ok := r.Get(coredata.ConnectorProviderGCP)
+	require.True(t, ok)
+	require.NotNil(t, reg.WorkloadIdentity.NewNameResolver)
+
+	conn := gcpTestConnector(
+		t,
+		coredata.GCPConnectorSettings{
+			WorkloadIdentityProvider: gcpTestProviderResource,
+			ServiceAccountEmail:      gcpTestServiceAccount,
+		},
+	)
+	logger := log.NewLogger(log.WithOutput(io.Discard))
+
+	t.Run(
+		"refuses a session on another cloud",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.Nil(
+				t,
+				reg.WorkloadIdentity.NewNameResolver(
+					context.Background(),
+					awsForeignSession{},
+					conn,
+					logger,
+				),
+			)
+		},
+	)
+
+	t.Run(
+		"returns a resolver for a gcp session",
+		func(t *testing.T) {
+			t.Parallel()
+
+			session, err := reg.WorkloadIdentity.NewSession(context.Background(), awsTestIssuer(t), conn)
+			require.NoError(t, err)
+
+			resolver := reg.WorkloadIdentity.NewNameResolver(
+				context.Background(),
+				session,
+				conn,
+				logger,
+			)
+			require.NotNil(t, resolver)
+		},
+	)
 }
 
 func TestGCPProbe(t *testing.T) {


### PR DESCRIPTION
The AWS path already reviews one cloud account. GCP had a session and provider, but ListAccounts was a stub, so a connected project could not produce a source. List project IAM principals and service accounts, degrade when listing SAs is denied, and name the project from display name, then ID, then number.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the GCP IAM access-review driver so connected GCP projects now produce a source instead of failing on the old `ListAccounts` stub. It collects project IAM principals and service accounts, fails the fetch when either listing is denied, and names the project from display name, then ID, then project number.

### Service **`+1000`** **`-12`**

- Maps owner bindings to admin, users to SSO, and service accounts with user-managed keys to API-key authentication.
- Reports service-account status and metadata; custom roles get no admin signal rather than a false one.
- Registers the driver and a project name resolver that falls back from display name to project ID to project number.
- Adds HTTP client injection for `NewSessionFromToken` and logs Google API errors with status and reason only, keeping service-account emails out of logs.

### Tests **`+760`** **`-5`**

- Covers principal parsing, identity mapping, permission-denied failures, and project-name fallbacks with hand-authored GCP cassettes.
- Keeps cassette requests synthetic and prevents tests from using live GCP credentials.

<sup>Written for commit 405f2518cf128372a3a1ba5e7edae44db6d975f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

