### PR TITLE
Fill GCP last login and MFA

### DIFF
--- a/cmd/probod/CHANGELOG.md
+++ b/cmd/probod/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `probod` (the server, including the bundled `@probo/conso
 
 ## Unreleased
 
+### Changed
+
+- GCP access-review MFA now uses the same WIF-impersonated service-account
+  token with `admin.directory.user.readonly` in addition to
+  `cloud-platform`. A Workspace Users-read admin role on that service
+  account is still required; a Directory 403 keeps identities and last
+  login and leaves MFA unknown.
+
 ## [0.279.0] - 2026-09-04
 
 ### Added

--- a/contrib/terraform/gcp-audit-role/CHANGELOG.md
+++ b/contrib/terraform/gcp-audit-role/CHANGELOG.md
@@ -5,6 +5,12 @@ be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Document the optional Google Admin console Users-read role on
+  `probo-audit` so the same WIF token can read 2-Step Verification
+  enrollment. Cloud IAM cannot grant that; skip it and MFA stays unknown.
+
 ## [0.1.0] - 2026-09-03
 
 ### Added

--- a/contrib/terraform/gcp-audit-role/README.md
+++ b/contrib/terraform/gcp-audit-role/README.md
@@ -66,6 +66,20 @@ output "probo_service_account_email" {
 Give Probo the `workload_identity_provider` and `service_account_email`
 outputs when you create the connector.
 
+## Optional: MFA for human users
+
+Human identities on the project are Google Workspace or Cloud Identity
+users. Cloud IAM cannot grant Directory reads, so this module does not
+cover MFA. After you apply, a Super Admin can assign a Users-read admin
+role to the `probo-audit` service account in the Google Admin console
+(Account > Admin roles > Assign service accounts). See [Assign a Google
+Workspace administrator role to a service
+account](https://developers.google.com/workspace/guides/create-credentials#assign_a_google_workspace_administrator_role_to_a_service_account).
+
+Probo then reads 2-Step Verification enrollment with the same WIF token.
+Skip this step if you do not need MFA on the GCP source; those accounts
+stay MFA unknown.
+
 ## Verifying an install
 
 Probo probes the install by exchanging a token and impersonating the service

--- a/pkg/accessreview/drivers/gcp.go
+++ b/pkg/accessreview/drivers/gcp.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"slices"
 
+	"go.gearno.de/kit/log"
 	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/coredata"
 )
@@ -43,6 +44,7 @@ type (
 	// produces one source.
 	GCPDriver struct {
 		session *cloudgcp.Session
+		logger  *log.Logger
 	}
 )
 
@@ -50,8 +52,8 @@ var _ Driver = (*GCPDriver)(nil)
 
 // NewGCPDriver builds the driver over a session already impersonated on the
 // connected project.
-func NewGCPDriver(session *cloudgcp.Session) *GCPDriver {
-	return &GCPDriver{session: session}
+func NewGCPDriver(session *cloudgcp.Session, logger *log.Logger) *GCPDriver {
+	return &GCPDriver{session: session, logger: logger}
 }
 
 func (d *GCPDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
@@ -74,6 +76,18 @@ func (d *GCPDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
 	records := make([]AccountRecord, 0, len(identities))
 	for _, identity := range identities {
 		records = append(records, gcpIdentityRecord(identity))
+	}
+
+	if err := enrichGCPIdentities(ctx, d.session, records); err != nil {
+		if ctx.Err() != nil {
+			return nil, err
+		}
+
+		d.logger.WarnCtx(
+			ctx,
+			"cannot enrich gcp activity, reporting last login and mfa unknown",
+			cloudgcp.SafeLogFields(err)...,
+		)
 	}
 
 	return records, nil

--- a/pkg/accessreview/drivers/gcp_activity.go
+++ b/pkg/accessreview/drivers/gcp_activity.go
@@ -1,0 +1,615 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	"go.probo.inc/probo/pkg/coredata"
+	cloudlogging "google.golang.org/api/logging/v2"
+	"google.golang.org/api/option"
+	policyanalyzer "google.golang.org/api/policyanalyzer/v1"
+)
+
+const (
+	// gcpActivityLookback is Cloud Audit Logs Admin Activity retention
+	// that this driver will walk. Older project actions are invisible,
+	// not absent.
+	gcpActivityLookback = 90 * 24 * time.Hour
+
+	// gcpActivityTimeout caps enrichment so a long Logging walk cannot
+	// spend the campaign fetch budget and then drop the identity list.
+	gcpActivityTimeout = 20 * time.Second
+
+	gcpActivityLogID               = "cloudaudit.googleapis.com%2Factivity"
+	gcpActivityTypeSALastAuth      = "serviceAccountLastAuthentication"
+	gcpActivityTypeSAKeyLastAuth   = "serviceAccountKeyLastAuthentication"
+	gcpLoggingPageSize             = 1000
+	gcpPolicyAnalyzerPageSize      = 1000
+	gcpLoggingFilterMaxLen         = 18000
+	gcpLoggingOrderByNewest        = "timestamp desc"
+	gcpServiceAccountsResourceMark = "/serviceAccounts/"
+)
+
+type gcpPolicyActivityPayload struct {
+	LastAuthenticatedTime string `json:"lastAuthenticatedTime"`
+}
+
+type gcpAuditLogPayload struct {
+	AuthenticationInfo struct {
+		PrincipalEmail string `json:"principalEmail"`
+	} `json:"authenticationInfo"`
+}
+
+func enrichGCPIdentities(
+	ctx context.Context,
+	session *cloudgcp.Session,
+	records []AccountRecord,
+) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	enrichCtx, cancel := context.WithTimeout(ctx, gcpActivityTimeout)
+	defer cancel()
+
+	logins, usedKey, activityErr := fetchGCPActivity(enrichCtx, session, records)
+	if errors.Is(activityErr, context.Canceled) && ctx.Err() != nil {
+		return activityErr
+	}
+
+	mfa, mfaErr := fetchGCPMFA(enrichCtx, session, records)
+	if errors.Is(mfaErr, context.Canceled) && ctx.Err() != nil {
+		return mfaErr
+	}
+
+	applyGCPActivity(records, logins, usedKey, mfa)
+
+	if activityErr != nil {
+		return activityErr
+	}
+
+	return mfaErr
+}
+
+func fetchGCPActivity(
+	ctx context.Context,
+	session *cloudgcp.Session,
+	records []AccountRecord,
+) (map[string]time.Time, map[string]bool, error) {
+	saLogins, usedKey, paErr := queryGCPPolicyAnalyzer(ctx, session)
+	if paErr != nil && ctx.Err() != nil {
+		return nil, nil, paErr
+	}
+
+	calEmails := gcpActivityEmails(records, gcpPrincipalUser)
+	if paErr != nil {
+		calEmails = append(calEmails, gcpActivityEmails(records, gcpPrincipalServiceAccount)...)
+	}
+
+	calLogins, calErr := queryGCPAdminActivity(ctx, session, calEmails)
+	if calErr != nil && ctx.Err() != nil {
+		return saLogins, usedKey, calErr
+	}
+
+	logins := make(map[string]time.Time, len(saLogins)+len(calLogins))
+	mapsCopyTimes(logins, saLogins)
+	mapsCopyTimes(logins, calLogins)
+
+	if paErr != nil {
+		if calErr != nil {
+			return logins, usedKey, paErr
+		}
+
+		return logins, usedKey, nil
+	}
+
+	return logins, usedKey, calErr
+}
+
+func queryGCPPolicyAnalyzer(
+	ctx context.Context,
+	session *cloudgcp.Session,
+) (map[string]time.Time, map[string]bool, error) {
+	svc, err := policyanalyzer.NewService(
+		ctx,
+		option.WithHTTPClient(session.HTTPClient()),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot create gcp policy analyzer client: %w", err)
+	}
+
+	lastAuthParent, err := gcpActivityTypeParent(session.AccountID(), gcpActivityTypeSALastAuth)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	logins, err := queryGCPPolicyActivities(ctx, svc, lastAuthParent)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot query gcp service account last authentication: %w", err)
+	}
+
+	keyParent, err := gcpActivityTypeParent(session.AccountID(), gcpActivityTypeSAKeyLastAuth)
+	if err != nil {
+		return logins, nil, err
+	}
+
+	keyLogins, keyErr := queryGCPPolicyActivities(ctx, svc, keyParent)
+	if keyErr != nil {
+		if ctx.Err() != nil {
+			return logins, nil, keyErr
+		}
+
+		if !cloudgcp.As[cloudgcp.ErrPermissionDenied](keyErr) {
+			return logins, nil, fmt.Errorf("cannot query gcp service account key last authentication: %w", keyErr)
+		}
+
+		return logins, nil, nil
+	}
+
+	usedKey := make(map[string]bool, len(keyLogins))
+	for id := range keyLogins {
+		usedKey[id] = true
+		usedKey[strings.ToLower(id)] = true
+	}
+
+	return logins, usedKey, nil
+}
+
+func queryGCPPolicyActivities(
+	ctx context.Context,
+	svc *policyanalyzer.Service,
+	parent string,
+) (map[string]time.Time, error) {
+	found := make(map[string]time.Time)
+	pageToken := ""
+
+	for range maxPaginationPages {
+		call := svc.Projects.Locations.ActivityTypes.Activities.Query(parent).
+			PageSize(gcpPolicyAnalyzerPageSize).
+			Context(ctx)
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+
+		resp, err := call.Do()
+		if err != nil {
+			return found, err
+		}
+
+		for _, activity := range resp.Activities {
+			id, at, ok := parseGCPPolicyActivity(activity)
+			if !ok {
+				continue
+			}
+
+			foldGCPActivityTimestamp(found, id, at)
+		}
+
+		pageToken = resp.NextPageToken
+		if pageToken == "" {
+			return found, nil
+		}
+	}
+
+	return found, fmt.Errorf("cannot query gcp policy analyzer activities: %w", ErrPaginationLimitReached)
+}
+
+func parseGCPPolicyActivity(activity *policyanalyzer.GoogleCloudPolicyanalyzerV1Activity) (string, time.Time, bool) {
+	if activity == nil {
+		return "", time.Time{}, false
+	}
+
+	id, ok := gcpServiceAccountIDFromResource(activity.FullResourceName)
+	if !ok {
+		return "", time.Time{}, false
+	}
+
+	var payload gcpPolicyActivityPayload
+
+	if len(activity.Activity) == 0 {
+		return "", time.Time{}, false
+	}
+
+	if err := json.Unmarshal(activity.Activity, &payload); err != nil {
+		return "", time.Time{}, false
+	}
+
+	at, ok := parseGCPTimestamp(payload.LastAuthenticatedTime)
+	if !ok {
+		return "", time.Time{}, false
+	}
+
+	return id, at, true
+}
+
+func gcpServiceAccountIDFromResource(name string) (string, bool) {
+	_, rest, ok := strings.Cut(name, gcpServiceAccountsResourceMark)
+	if !ok {
+		return "", false
+	}
+
+	id, _, _ := strings.Cut(rest, "/")
+
+	return id, id != ""
+}
+
+func queryGCPAdminActivity(
+	ctx context.Context,
+	session *cloudgcp.Session,
+	emails []string,
+) (map[string]time.Time, error) {
+	if len(emails) == 0 {
+		return nil, nil
+	}
+
+	svc, err := cloudlogging.NewService(
+		ctx,
+		option.WithHTTPClient(session.HTTPClient()),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gcp logging client: %w", err)
+	}
+
+	resource, err := url.JoinPath("projects", url.PathEscape(session.AccountID()))
+	if err != nil {
+		return nil, fmt.Errorf("cannot build gcp logging resource name: %w", err)
+	}
+
+	since := time.Now().UTC().Add(-gcpActivityLookback)
+
+	wanted := make(map[string]struct{}, len(emails))
+	for _, email := range emails {
+		wanted[strings.ToLower(email)] = struct{}{}
+	}
+
+	found := make(map[string]time.Time, len(emails))
+
+	for _, filter := range gcpEmailFilterBatches(session.AccountID(), since, emails, gcpLoggingFilterMaxLen) {
+		if err := listGCPAdminActivity(
+			ctx,
+			svc,
+			resource,
+			filter,
+			wanted,
+			found,
+		); err != nil {
+			return found, err
+		}
+
+		if len(found) == len(wanted) {
+			return found, nil
+		}
+	}
+
+	return found, nil
+}
+
+func listGCPAdminActivity(
+	ctx context.Context,
+	svc *cloudlogging.Service,
+	resource string,
+	filter string,
+	wanted map[string]struct{},
+	found map[string]time.Time,
+) error {
+	pageToken := ""
+
+	for range maxPaginationPages {
+		req := &cloudlogging.ListLogEntriesRequest{
+			ResourceNames: []string{resource},
+			Filter:        filter,
+			OrderBy:       gcpLoggingOrderByNewest,
+			PageSize:      gcpLoggingPageSize,
+			PageToken:     pageToken,
+		}
+
+		resp, err := svc.Entries.List(req).Context(ctx).Do()
+		if err != nil {
+			return fmt.Errorf("cannot list gcp admin activity: %w", err)
+		}
+
+		for _, entry := range resp.Entries {
+			email, at, ok := parseGCPAdminActivityEntry(entry)
+			if !ok {
+				continue
+			}
+
+			if _, want := wanted[email]; !want {
+				continue
+			}
+
+			foldGCPActivityTimestamp(found, email, at)
+
+			if len(found) == len(wanted) {
+				return nil
+			}
+		}
+
+		pageToken = resp.NextPageToken
+		if pageToken == "" {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("cannot list all gcp admin activity: %w", ErrPaginationLimitReached)
+}
+
+func parseGCPAdminActivityEntry(entry *cloudlogging.LogEntry) (string, time.Time, bool) {
+	if entry == nil {
+		return "", time.Time{}, false
+	}
+
+	at, ok := parseGCPTimestamp(entry.Timestamp)
+	if !ok {
+		return "", time.Time{}, false
+	}
+
+	var payload gcpAuditLogPayload
+
+	if len(entry.ProtoPayload) == 0 {
+		return "", time.Time{}, false
+	}
+
+	if err := json.Unmarshal(entry.ProtoPayload, &payload); err != nil {
+		return "", time.Time{}, false
+	}
+
+	email := strings.ToLower(strings.TrimSpace(payload.AuthenticationInfo.PrincipalEmail))
+	if email == "" {
+		return "", time.Time{}, false
+	}
+
+	return email, at, true
+}
+
+func applyGCPActivity(
+	records []AccountRecord,
+	logins map[string]time.Time,
+	usedKey map[string]bool,
+	mfa map[string]coredata.MFAStatus,
+) {
+	for i := range records {
+		kind := gcpRecordKind(records[i])
+		if kind == gcpPrincipalGroup {
+			continue
+		}
+
+		if at, ok := gcpActivityLookupTime(logins, records[i]); ok {
+			records[i].LastLogin = new(at)
+		}
+
+		if kind == gcpPrincipalServiceAccount &&
+			records[i].AuthMethod == coredata.AccessReviewEntryAuthMethodUnknown &&
+			gcpActivityLookupBool(usedKey, records[i]) {
+			records[i].AuthMethod = coredata.AccessReviewEntryAuthMethodAPIKey
+		}
+
+		if kind != gcpPrincipalUser {
+			continue
+		}
+
+		if status, ok := mfa[strings.ToLower(records[i].Email)]; ok {
+			records[i].MFAStatus = status
+		}
+	}
+}
+
+func gcpRecordKind(rec AccountRecord) gcpPrincipalKind {
+	if rec.AccountType == coredata.AccessReviewEntryAccountTypeServiceAccount {
+		return gcpPrincipalServiceAccount
+	}
+
+	if strings.HasPrefix(rec.ExternalID, gcpPrincipalGroupPrefix) {
+		return gcpPrincipalGroup
+	}
+
+	return gcpPrincipalUser
+}
+
+func gcpActivityEmails(records []AccountRecord, kind gcpPrincipalKind) []string {
+	emails := make([]string, 0, len(records))
+	seen := make(map[string]struct{}, len(records))
+
+	for _, rec := range records {
+		if gcpRecordKind(rec) != kind || rec.Email == "" {
+			continue
+		}
+
+		key := strings.ToLower(rec.Email)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+
+		seen[key] = struct{}{}
+
+		emails = append(emails, rec.Email)
+	}
+
+	return emails
+}
+
+func gcpActivityLookupTime(logins map[string]time.Time, rec AccountRecord) (time.Time, bool) {
+	if at, ok := logins[strings.ToLower(rec.Email)]; ok {
+		return at, true
+	}
+
+	if rec.ExternalID != "" {
+		if at, ok := logins[rec.ExternalID]; ok {
+			return at, true
+		}
+
+		if at, ok := logins[strings.ToLower(rec.ExternalID)]; ok {
+			return at, true
+		}
+	}
+
+	return time.Time{}, false
+}
+
+func gcpActivityLookupBool(flags map[string]bool, rec AccountRecord) bool {
+	if flags[strings.ToLower(rec.Email)] {
+		return true
+	}
+
+	if rec.ExternalID != "" && (flags[rec.ExternalID] || flags[strings.ToLower(rec.ExternalID)]) {
+		return true
+	}
+
+	return false
+}
+
+func foldGCPActivityTimestamp(found map[string]time.Time, id string, at time.Time) {
+	key := strings.ToLower(id)
+	if prev, ok := found[key]; ok && !at.After(prev) {
+		return
+	}
+
+	found[key] = at
+}
+
+func gcpEmailFilterBatches(project string, since time.Time, emails []string, maxLen int) []string {
+	if len(emails) == 0 {
+		return nil
+	}
+
+	var (
+		batches []string
+		batch   []string
+	)
+
+	for _, email := range emails {
+		trial := append(append([]string{}, batch...), email)
+
+		filter := gcpAdminActivityFilter(project, since, trial)
+		if len(batch) > 0 && len(filter) > maxLen {
+			batches = append(batches, gcpAdminActivityFilter(project, since, batch))
+			batch = []string{email}
+
+			continue
+		}
+
+		batch = trial
+	}
+
+	if len(batch) > 0 {
+		batches = append(batches, gcpAdminActivityFilter(project, since, batch))
+	}
+
+	return batches
+}
+
+func gcpAdminActivityFilter(project string, since time.Time, emails []string) string {
+	var b strings.Builder
+
+	b.WriteString("logName=")
+	b.WriteString(gcpLoggingQuote(gcpActivityLogName(project)))
+	b.WriteString(" AND timestamp>=")
+	b.WriteString(gcpLoggingQuote(since.UTC().Format(time.RFC3339)))
+
+	if len(emails) == 0 {
+		return b.String()
+	}
+
+	b.WriteString(" AND (")
+
+	for i, email := range emails {
+		if i > 0 {
+			b.WriteString(" OR ")
+		}
+
+		b.WriteString("protoPayload.authenticationInfo.principalEmail=")
+		b.WriteString(gcpLoggingQuote(email))
+	}
+
+	b.WriteByte(')')
+
+	return b.String()
+}
+
+func gcpActivityLogName(project string) string {
+	return "projects/" + url.PathEscape(project) + "/logs/" + gcpActivityLogID
+}
+
+func gcpActivityTypeParent(project string, activityType string) (string, error) {
+	parent, err := url.JoinPath(
+		"projects",
+		url.PathEscape(project),
+		"locations",
+		"global",
+		"activityTypes",
+		activityType,
+	)
+	if err != nil {
+		return "", fmt.Errorf("cannot build gcp policy analyzer parent: %w", err)
+	}
+
+	return parent, nil
+}
+
+func gcpLoggingQuote(value string) string {
+	var b strings.Builder
+
+	b.WriteByte('"')
+
+	for _, r := range value {
+		if r == '\\' || r == '"' {
+			b.WriteByte('\\')
+		}
+
+		b.WriteRune(r)
+	}
+
+	b.WriteByte('"')
+
+	return b.String()
+}
+
+func parseGCPTimestamp(raw string) (time.Time, bool) {
+	if raw == "" {
+		return time.Time{}, false
+	}
+
+	if at, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return at.UTC(), true
+	}
+
+	if at, err := time.Parse(time.RFC3339, raw); err == nil {
+		return at.UTC(), true
+	}
+
+	return time.Time{}, false
+}
+
+func mapsCopyTimes(dst map[string]time.Time, src map[string]time.Time) {
+	for key, at := range src {
+		foldGCPActivityTimestamp(dst, key, at)
+	}
+}

--- a/pkg/accessreview/drivers/gcp_activity_test.go
+++ b/pkg/accessreview/drivers/gcp_activity_test.go
@@ -1,0 +1,413 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	"go.probo.inc/probo/pkg/coredata"
+	cloudlogging "google.golang.org/api/logging/v2"
+	policyanalyzer "google.golang.org/api/policyanalyzer/v1"
+)
+
+func gcpTestRecords() []AccountRecord {
+	return []AccountRecord{
+		{
+			Email:       "alice@example.com",
+			ExternalID:  "user:alice@example.com",
+			AccountType: coredata.AccessReviewEntryAccountTypeUser,
+			AuthMethod:  coredata.AccessReviewEntryAuthMethodSSO,
+			MFAStatus:   coredata.MFAStatusUnknown,
+		},
+		{
+			Email:       "eng@example.com",
+			ExternalID:  "group:eng@example.com",
+			AccountType: coredata.AccessReviewEntryAccountTypeUser,
+			AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
+			MFAStatus:   coredata.MFAStatusUnknown,
+		},
+		{
+			Email:       "sa@my-project.iam.gserviceaccount.com",
+			ExternalID:  "111111111111",
+			AccountType: coredata.AccessReviewEntryAccountTypeServiceAccount,
+			AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
+			MFAStatus:   coredata.MFAStatusUnknown,
+		},
+	}
+}
+
+func TestFoldGCPActivityTimestamp(t *testing.T) {
+	t.Parallel()
+
+	older := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	found := map[string]time.Time{}
+
+	foldGCPActivityTimestamp(found, "Alice@example.com", older)
+	foldGCPActivityTimestamp(found, "alice@example.com", newer)
+	foldGCPActivityTimestamp(found, "alice@example.com", older)
+
+	require.Contains(t, found, "alice@example.com")
+	assert.True(t, found["alice@example.com"].Equal(newer))
+}
+
+func TestParseGCPAdminActivityEntry(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"reads principal email and timestamp",
+		func(t *testing.T) {
+			t.Parallel()
+
+			email, at, ok := parseGCPAdminActivityEntry(
+				&cloudlogging.LogEntry{
+					Timestamp:    "2026-08-15T12:00:00Z",
+					ProtoPayload: []byte(`{"authenticationInfo":{"principalEmail":"Alice@example.com"}}`),
+				},
+			)
+			require.True(t, ok)
+			assert.Equal(t, "alice@example.com", email)
+			assert.True(t, at.Equal(time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)))
+		},
+	)
+
+	t.Run(
+		"rejects missing email",
+		func(t *testing.T) {
+			t.Parallel()
+
+			_, _, ok := parseGCPAdminActivityEntry(
+				&cloudlogging.LogEntry{
+					Timestamp:    "2026-08-15T12:00:00Z",
+					ProtoPayload: []byte(`{"authenticationInfo":{}}`),
+				},
+			)
+			assert.False(t, ok)
+		},
+	)
+
+	t.Run(
+		"rejects invalid json",
+		func(t *testing.T) {
+			t.Parallel()
+
+			_, _, ok := parseGCPAdminActivityEntry(
+				&cloudlogging.LogEntry{
+					Timestamp:    "2026-08-15T12:00:00Z",
+					ProtoPayload: []byte(`{`),
+				},
+			)
+			assert.False(t, ok)
+		},
+	)
+}
+
+func TestParseGCPPolicyActivity(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"reads last authenticated time and email",
+		func(t *testing.T) {
+			t.Parallel()
+
+			id, at, ok := parseGCPPolicyActivity(
+				&policyanalyzer.GoogleCloudPolicyanalyzerV1Activity{
+					FullResourceName: "//iam.googleapis.com/projects/123456789012/serviceAccounts/sa@my-project.iam.gserviceaccount.com",
+					Activity:         []byte(`{"lastAuthenticatedTime":"2026-08-10T07:00:00Z"}`),
+				},
+			)
+			require.True(t, ok)
+			assert.Equal(t, "sa@my-project.iam.gserviceaccount.com", id)
+			assert.True(t, at.Equal(time.Date(2026, 8, 10, 7, 0, 0, 0, time.UTC)))
+		},
+	)
+
+	t.Run(
+		"reads unique id from resource name",
+		func(t *testing.T) {
+			t.Parallel()
+
+			id, _, ok := parseGCPPolicyActivity(
+				&policyanalyzer.GoogleCloudPolicyanalyzerV1Activity{
+					FullResourceName: "//iam.googleapis.com/projects/123456789012/serviceAccounts/111111111111",
+					Activity:         []byte(`{"lastAuthenticatedTime":"2026-08-10T07:00:00Z"}`),
+				},
+			)
+			require.True(t, ok)
+			assert.Equal(t, "111111111111", id)
+		},
+	)
+
+	t.Run(
+		"rejects missing last authenticated time",
+		func(t *testing.T) {
+			t.Parallel()
+
+			_, _, ok := parseGCPPolicyActivity(
+				&policyanalyzer.GoogleCloudPolicyanalyzerV1Activity{
+					FullResourceName: "//iam.googleapis.com/projects/123456789012/serviceAccounts/sa@my-project.iam.gserviceaccount.com",
+					Activity:         []byte(`{}`),
+				},
+			)
+			assert.False(t, ok)
+		},
+	)
+}
+
+func TestGcpServiceAccountIDFromResource(t *testing.T) {
+	t.Parallel()
+
+	id, ok := gcpServiceAccountIDFromResource(
+		"//iam.googleapis.com/projects/123456789012/serviceAccounts/sa@my-project.iam.gserviceaccount.com/keys/KEY1",
+	)
+	require.True(t, ok)
+	assert.Equal(t, "sa@my-project.iam.gserviceaccount.com", id)
+
+	_, ok = gcpServiceAccountIDFromResource("//compute.googleapis.com/projects/123/instances/one")
+	assert.False(t, ok)
+}
+
+func TestGcpRecordKind(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(
+		t,
+		gcpPrincipalUser,
+		gcpRecordKind(AccountRecord{
+			ExternalID:  "user:alice@example.com",
+			AccountType: coredata.AccessReviewEntryAccountTypeUser,
+		}),
+	)
+	assert.Equal(
+		t,
+		gcpPrincipalGroup,
+		gcpRecordKind(AccountRecord{
+			ExternalID:  "group:eng@example.com",
+			AccountType: coredata.AccessReviewEntryAccountTypeUser,
+		}),
+	)
+	assert.Equal(
+		t,
+		gcpPrincipalServiceAccount,
+		gcpRecordKind(AccountRecord{
+			ExternalID:  "111111111111",
+			AccountType: coredata.AccessReviewEntryAccountTypeServiceAccount,
+		}),
+	)
+}
+
+func TestApplyGCPActivity(t *testing.T) {
+	t.Parallel()
+
+	aliceLogin := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	saLogin := time.Date(2026, 8, 10, 7, 0, 0, 0, time.UTC)
+	records := gcpTestRecords()
+
+	applyGCPActivity(
+		records,
+		map[string]time.Time{
+			"alice@example.com": aliceLogin,
+			"111111111111":      saLogin,
+			"eng@example.com":   aliceLogin,
+		},
+		map[string]bool{"sa@my-project.iam.gserviceaccount.com": true},
+		map[string]coredata.MFAStatus{"alice@example.com": coredata.MFAStatusEnabled},
+	)
+
+	require.NotNil(t, records[0].LastLogin)
+	assert.True(t, records[0].LastLogin.Equal(aliceLogin))
+	assert.Equal(t, coredata.MFAStatusEnabled, records[0].MFAStatus)
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodSSO, records[0].AuthMethod)
+
+	assert.Nil(t, records[1].LastLogin)
+	assert.Equal(t, coredata.MFAStatusUnknown, records[1].MFAStatus)
+
+	require.NotNil(t, records[2].LastLogin)
+	assert.True(t, records[2].LastLogin.Equal(saLogin))
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodAPIKey, records[2].AuthMethod)
+	assert.Equal(t, coredata.MFAStatusUnknown, records[2].MFAStatus)
+}
+
+func TestApplyGCPActivity_DoesNotOverwriteKnownAuthMethod(t *testing.T) {
+	t.Parallel()
+
+	records := []AccountRecord{
+		{
+			Email:       "sa@my-project.iam.gserviceaccount.com",
+			ExternalID:  "111111111111",
+			AccountType: coredata.AccessReviewEntryAccountTypeServiceAccount,
+			AuthMethod:  coredata.AccessReviewEntryAuthMethodAPIKey,
+			MFAStatus:   coredata.MFAStatusUnknown,
+		},
+	}
+
+	applyGCPActivity(
+		records,
+		nil,
+		map[string]bool{"sa@my-project.iam.gserviceaccount.com": true},
+		nil,
+	)
+
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodAPIKey, records[0].AuthMethod)
+	assert.Nil(t, records[0].LastLogin)
+}
+
+func TestGcpEmailFilterBatches(t *testing.T) {
+	t.Parallel()
+
+	since := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	emails := []string{"alice@example.com", "bob@example.com"}
+
+	t.Run(
+		"keeps a short list in one filter",
+		func(t *testing.T) {
+			t.Parallel()
+
+			batches := gcpEmailFilterBatches("123456789012", since, emails, gcpLoggingFilterMaxLen)
+			require.Len(t, batches, 1)
+			assert.Contains(t, batches[0], "cloudaudit.googleapis.com%2Factivity")
+			assert.NotContains(t, batches[0], "data_access")
+			assert.Contains(t, batches[0], "alice@example.com")
+			assert.Contains(t, batches[0], "bob@example.com")
+		},
+	)
+
+	t.Run(
+		"splits when the filter would exceed the budget",
+		func(t *testing.T) {
+			t.Parallel()
+
+			first := gcpAdminActivityFilter("123456789012", since, emails[:1])
+			batches := gcpEmailFilterBatches("123456789012", since, emails, len(first)+1)
+			require.Len(t, batches, 2)
+			assert.Contains(t, batches[0], "alice@example.com")
+			assert.NotContains(t, batches[0], "bob@example.com")
+			assert.Contains(t, batches[1], "bob@example.com")
+		},
+	)
+}
+
+func TestEnrichGCPIdentities_FillsLastLoginAndMFA(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_activity")
+	session := newGCPTestSession(t, rec)
+	records := gcpTestRecords()
+
+	err := enrichGCPIdentities(context.Background(), session, records)
+	require.NoError(t, err)
+
+	require.NotNil(t, records[0].LastLogin)
+	assert.True(t, records[0].LastLogin.Equal(time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)))
+	assert.Equal(t, coredata.MFAStatusEnabled, records[0].MFAStatus)
+
+	assert.Nil(t, records[1].LastLogin)
+	assert.Equal(t, coredata.MFAStatusUnknown, records[1].MFAStatus)
+
+	require.NotNil(t, records[2].LastLogin)
+	assert.True(t, records[2].LastLogin.Equal(time.Date(2026, 8, 10, 7, 0, 0, 0, time.UTC)))
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodAPIKey, records[2].AuthMethod)
+	assert.Equal(t, coredata.MFAStatusUnknown, records[2].MFAStatus)
+}
+
+func TestEnrichGCPIdentities_FallsBackToAdminActivityWhenPolicyAnalyzerDenied(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_activity_pa_denied")
+	session := newGCPTestSession(t, rec)
+	records := gcpTestRecords()
+
+	err := enrichGCPIdentities(context.Background(), session, records)
+	require.NoError(t, err)
+
+	require.NotNil(t, records[0].LastLogin)
+	assert.True(t, records[0].LastLogin.Equal(time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)))
+
+	assert.Nil(t, records[1].LastLogin)
+
+	require.NotNil(t, records[2].LastLogin)
+	assert.True(t, records[2].LastLogin.Equal(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)))
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodUnknown, records[2].AuthMethod)
+}
+
+func TestEnrichGCPIdentities_KeepsPolicyAnalyzerLoginWhenKeyActivityFails(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_activity_key_failed")
+	session := newGCPTestSession(t, rec)
+	records := gcpTestRecords()
+
+	err := enrichGCPIdentities(context.Background(), session, records)
+	require.NoError(t, err)
+
+	require.NotNil(t, records[0].LastLogin)
+	assert.True(t, records[0].LastLogin.Equal(time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)))
+	assert.Equal(t, coredata.MFAStatusEnabled, records[0].MFAStatus)
+
+	assert.Nil(t, records[1].LastLogin)
+	assert.Equal(t, coredata.MFAStatusUnknown, records[1].MFAStatus)
+
+	require.NotNil(t, records[2].LastLogin)
+	assert.True(t, records[2].LastLogin.Equal(time.Date(2026, 8, 10, 7, 0, 0, 0, time.UTC)))
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodUnknown, records[2].AuthMethod)
+	assert.Equal(t, coredata.MFAStatusUnknown, records[2].MFAStatus)
+}
+
+func TestEnrichGCPIdentities_DegradesWhenActivityDenied(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_activity_denied")
+	session := newGCPTestSession(t, rec)
+	records := gcpTestRecords()
+
+	err := enrichGCPIdentities(context.Background(), session, records)
+	require.Error(t, err)
+	assert.True(t, cloudgcp.As[cloudgcp.ErrPermissionDenied](err))
+
+	for _, record := range records {
+		assert.Nil(t, record.LastLogin)
+		assert.Equal(t, coredata.MFAStatusUnknown, record.MFAStatus)
+	}
+
+	assert.Equal(t, coredata.AccessReviewEntryAuthMethodUnknown, records[2].AuthMethod)
+}
+
+func TestEnrichGCPIdentities_FailsOnCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_activity")
+	session := newGCPTestSession(t, rec)
+	records := gcpTestRecords()
+
+	err := enrichGCPIdentities(ctx, session, records)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, records[0].LastLogin)
+	assert.Equal(t, coredata.MFAStatusUnknown, records[0].MFAStatus)
+}

--- a/pkg/accessreview/drivers/gcp_mfa.go
+++ b/pkg/accessreview/drivers/gcp_mfa.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	"go.probo.inc/probo/pkg/coredata"
+	admin "google.golang.org/api/admin/directory/v1"
+	"google.golang.org/api/option"
+)
+
+func fetchGCPMFA(
+	ctx context.Context,
+	session *cloudgcp.Session,
+	records []AccountRecord,
+) (map[string]coredata.MFAStatus, error) {
+	emails := gcpActivityEmails(records, gcpPrincipalUser)
+	if len(emails) == 0 {
+		return nil, nil
+	}
+
+	svc, err := admin.NewService(
+		ctx,
+		option.WithHTTPClient(session.HTTPClient()),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gcp admin directory client: %w", err)
+	}
+
+	found := make(map[string]coredata.MFAStatus, len(emails))
+
+	for _, email := range emails {
+		user, err := svc.Users.Get(email).Projection("full").Context(ctx).Do()
+		if err != nil {
+			if ctx.Err() != nil {
+				return found, err
+			}
+
+			if cloudgcp.As[cloudgcp.ErrPermissionDenied](err) {
+				return found, fmt.Errorf("cannot read gcp directory mfa enrollment: %w", err)
+			}
+
+			if cloudgcp.As[cloudgcp.ErrNotFound](err) {
+				continue
+			}
+
+			return found, fmt.Errorf("cannot get gcp directory user: %w", err)
+		}
+
+		status := coredata.MFAStatusDisabled
+		if user != nil && user.IsEnrolledIn2Sv {
+			status = coredata.MFAStatusEnabled
+		}
+
+		found[strings.ToLower(email)] = status
+	}
+
+	return found, nil
+}

--- a/pkg/accessreview/drivers/gcp_mfa_test.go
+++ b/pkg/accessreview/drivers/gcp_mfa_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestFetchGCPMFA_ReadsEnrollment(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_mfa")
+	session := newGCPTestSession(t, rec)
+	records := gcpTestRecords()
+
+	mfa, err := fetchGCPMFA(context.Background(), session, records)
+	require.NoError(t, err)
+	require.Equal(t, coredata.MFAStatusEnabled, mfa["alice@example.com"])
+	assert.NotContains(t, mfa, "eng@example.com")
+	assert.NotContains(t, mfa, "sa@my-project.iam.gserviceaccount.com")
+}
+
+func TestFetchGCPMFA_DegradesWhenDenied(t *testing.T) {
+	t.Parallel()
+
+	rec := newGCPRecorder(t, "testdata/gcp_mfa_denied")
+	session := newGCPTestSession(t, rec)
+	records := gcpTestRecords()
+
+	mfa, err := fetchGCPMFA(context.Background(), session, records)
+	require.Error(t, err)
+	assert.True(t, cloudgcp.As[cloudgcp.ErrPermissionDenied](err))
+	assert.Empty(t, mfa)
+}
+
+func TestFetchGCPMFA_SkipsGroupsAndServiceAccounts(t *testing.T) {
+	t.Parallel()
+
+	mfa, err := fetchGCPMFA(
+		context.Background(),
+		cloudgcp.NewSessionFromToken(
+			vcrGCPProjectNumber,
+			vcrGCPAccessToken,
+			cloudgcp.WithHTTPClient(
+				&http.Client{
+					Transport: roundTripFunc(
+						func(*http.Request) (*http.Response, error) {
+							t.Fatal("fetchGCPMFA must not call the network for groups or service accounts")
+							return nil, nil
+						},
+					),
+				},
+			),
+		),
+		[]AccountRecord{
+			{
+				Email:       "eng@example.com",
+				ExternalID:  "group:eng@example.com",
+				AccountType: coredata.AccessReviewEntryAccountTypeUser,
+				MFAStatus:   coredata.MFAStatusUnknown,
+			},
+			{
+				Email:       "sa@my-project.iam.gserviceaccount.com",
+				ExternalID:  "111111111111",
+				AccountType: coredata.AccessReviewEntryAccountTypeServiceAccount,
+				MFAStatus:   coredata.MFAStatusUnknown,
+			},
+		},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, mfa)
+}

--- a/pkg/accessreview/drivers/gcp_test.go
+++ b/pkg/accessreview/drivers/gcp_test.go
@@ -54,7 +54,7 @@ func TestGCPDriver(t *testing.T) {
 	rec := newGCPRecorder(t, "testdata/gcp")
 	session := newGCPTestSession(t, rec)
 
-	records, err := NewGCPDriver(session).
+	records, err := NewGCPDriver(session, log.NewLogger(log.WithName("test"))).
 		ListAccounts(context.Background())
 	require.NoError(t, err)
 	require.Len(t, records, 5)
@@ -115,7 +115,7 @@ func TestGCPDriver_FailsWhenServiceAccountsDenied(t *testing.T) {
 	rec := newGCPRecorder(t, "testdata/gcp_service_accounts_denied")
 	session := newGCPTestSession(t, rec)
 
-	_, err := NewGCPDriver(session).
+	_, err := NewGCPDriver(session, log.NewLogger(log.WithName("test"))).
 		ListAccounts(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot list service accounts of the gcp project")
@@ -127,7 +127,7 @@ func TestGCPDriver_FailsWhenIAMPolicyDenied(t *testing.T) {
 	rec := newGCPRecorder(t, "testdata/gcp_iam_denied")
 	session := newGCPTestSession(t, rec)
 
-	_, err := NewGCPDriver(session).
+	_, err := NewGCPDriver(session, log.NewLogger(log.WithName("test"))).
 		ListAccounts(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot get gcp project iam policy")

--- a/pkg/accessreview/drivers/testdata/gcp.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp.yaml
@@ -111,3 +111,66 @@ interactions:
         status: 200 OK
         code: 200
         duration: 1ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: policyanalyzer.googleapis.com
+        url: https://policyanalyzer.googleapis.com/v1/projects/123456789012/locations/global/activityTypes/serviceAccountLastAuthentication/activities:query
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"error":{"code":403,"message":"The caller does not have permission","status":"PERMISSION_DENIED"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 403 Forbidden
+        code: 403
+        duration: 1ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: logging.googleapis.com
+        url: https://logging.googleapis.com/v2/entries:list
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"error":{"code":403,"message":"The caller does not have permission","status":"PERMISSION_DENIED"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 403 Forbidden
+        code: 403
+        duration: 1ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: admin.googleapis.com
+        url: https://admin.googleapis.com/admin/directory/v1/users/alice@example.com
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"error":{"code":403,"message":"The caller does not have permission","status":"PERMISSION_DENIED"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 403 Forbidden
+        code: 403
+        duration: 1ms

--- a/pkg/accessreview/drivers/testdata/gcp_activity.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp_activity.yaml
@@ -1,0 +1,90 @@
+---
+# Policy Analyzer last-auth and key last-auth succeed, then Admin Activity
+# for users (alice), then Directory MFA for alice. The group is never
+# queried. Call order is the contract.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: policyanalyzer.googleapis.com
+        url: https://policyanalyzer.googleapis.com/v1/projects/123456789012/locations/global/activityTypes/serviceAccountLastAuthentication/activities:query
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"activities":[{"fullResourceName":"//iam.googleapis.com/projects/123456789012/serviceAccounts/sa@my-project.iam.gserviceaccount.com","activityType":"serviceAccountLastAuthentication","activity":{"lastAuthenticatedTime":"2026-08-10T07:00:00Z"}}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: policyanalyzer.googleapis.com
+        url: https://policyanalyzer.googleapis.com/v1/projects/123456789012/locations/global/activityTypes/serviceAccountKeyLastAuthentication/activities:query
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"activities":[{"fullResourceName":"//iam.googleapis.com/projects/123456789012/serviceAccounts/sa@my-project.iam.gserviceaccount.com/keys/KEY1","activityType":"serviceAccountKeyLastAuthentication","activity":{"lastAuthenticatedTime":"2026-08-09T07:00:00Z"}}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: logging.googleapis.com
+        url: https://logging.googleapis.com/v2/entries:list
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"entries":[{"timestamp":"2026-08-15T12:00:00Z","protoPayload":{"@type":"type.googleapis.com/google.cloud.audit.AuditLog","authenticationInfo":{"principalEmail":"alice@example.com"}}},{"timestamp":"2026-08-01T12:00:00Z","protoPayload":{"authenticationInfo":{"principalEmail":"alice@example.com"}}}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: admin.googleapis.com
+        url: https://admin.googleapis.com/admin/directory/v1/users/alice@example.com
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"primaryEmail":"alice@example.com","isEnrolledIn2Sv":true}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms

--- a/pkg/accessreview/drivers/testdata/gcp_activity_denied.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp_activity_denied.yaml
@@ -1,51 +1,10 @@
 ---
-# Hand-authored. getIamPolicy succeeds; serviceAccounts.list is 403.
-# The fetch must fail.
+# Policy Analyzer and Admin Activity are both denied, then Directory MFA
+# is denied. Identities must still be returned with last login nil and
+# MFA unknown. Call order is the contract.
 version: 2
 interactions:
     - id: 0
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        host: cloudresourcemanager.googleapis.com
-        url: https://cloudresourcemanager.googleapis.com/v1/projects/123456789012:getIamPolicy
-        method: POST
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: -1
-        uncompressed: true
-        body: '{"bindings":[{"role":"roles/owner","members":["user:alice@example.com"]},{"role":"roles/viewer","members":["group:eng@example.com","allUsers","domain:example.com"]},{"role":"roles/editor","members":["serviceAccount:ci@my-project.iam.gserviceaccount.com"]},{"role":"projects/my-project/roles/customAdmin","members":["serviceAccount:disabled-bot@my-project.iam.gserviceaccount.com"]}]}'
-        headers:
-            Content-Type:
-                - application/json
-        status: 200 OK
-        code: 200
-        duration: 1ms
-    - id: 1
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        host: iam.googleapis.com
-        url: https://iam.googleapis.com/v1/projects/123456789012/serviceAccounts
-        method: GET
-      response:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: -1
-        uncompressed: true
-        body: '{"error":{"code":403,"message":"Permission denied","status":"PERMISSION_DENIED"}}'
-        headers:
-            Content-Type:
-                - application/json
-        status: 403 Forbidden
-        code: 403
-        duration: 1ms
-    - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -66,7 +25,7 @@ interactions:
         status: 403 Forbidden
         code: 403
         duration: 1ms
-    - id: 3
+    - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -87,7 +46,7 @@ interactions:
         status: 403 Forbidden
         code: 403
         duration: 1ms
-    - id: 4
+    - id: 2
       request:
         proto: HTTP/1.1
         proto_major: 1

--- a/pkg/accessreview/drivers/testdata/gcp_activity_key_failed.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp_activity_key_failed.yaml
@@ -1,0 +1,90 @@
+---
+# Policy Analyzer last-auth succeeds, key last-auth fails, then Admin
+# Activity covers users only. The last-auth timestamp must be kept.
+# Directory MFA for alice still succeeds. Call order is the contract.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: policyanalyzer.googleapis.com
+        url: https://policyanalyzer.googleapis.com/v1/projects/123456789012/locations/global/activityTypes/serviceAccountLastAuthentication/activities:query
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"activities":[{"fullResourceName":"//iam.googleapis.com/projects/123456789012/serviceAccounts/sa@my-project.iam.gserviceaccount.com","activityType":"serviceAccountLastAuthentication","activity":{"lastAuthenticatedTime":"2026-08-10T07:00:00Z"}}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: policyanalyzer.googleapis.com
+        url: https://policyanalyzer.googleapis.com/v1/projects/123456789012/locations/global/activityTypes/serviceAccountKeyLastAuthentication/activities:query
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"error":{"code":500,"message":"Internal error encountered","status":"INTERNAL"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 500 Internal Server Error
+        code: 500
+        duration: 1ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: logging.googleapis.com
+        url: https://logging.googleapis.com/v2/entries:list
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"entries":[{"timestamp":"2026-08-15T12:00:00Z","protoPayload":{"authenticationInfo":{"principalEmail":"alice@example.com"}}}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: admin.googleapis.com
+        url: https://admin.googleapis.com/admin/directory/v1/users/alice@example.com
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"primaryEmail":"alice@example.com","isEnrolledIn2Sv":true}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms

--- a/pkg/accessreview/drivers/testdata/gcp_activity_pa_denied.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp_activity_pa_denied.yaml
@@ -1,0 +1,69 @@
+---
+# Policy Analyzer last-auth is denied, so Admin Activity covers users and
+# service accounts. Directory MFA for alice still succeeds. Call order is
+# the contract.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: policyanalyzer.googleapis.com
+        url: https://policyanalyzer.googleapis.com/v1/projects/123456789012/locations/global/activityTypes/serviceAccountLastAuthentication/activities:query
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"error":{"code":403,"message":"The caller does not have permission","status":"PERMISSION_DENIED"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 403 Forbidden
+        code: 403
+        duration: 1ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: logging.googleapis.com
+        url: https://logging.googleapis.com/v2/entries:list
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"entries":[{"timestamp":"2026-08-15T12:00:00Z","protoPayload":{"authenticationInfo":{"principalEmail":"alice@example.com"}}},{"timestamp":"2026-07-01T00:00:00Z","protoPayload":{"authenticationInfo":{"principalEmail":"sa@my-project.iam.gserviceaccount.com"}}}]}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: admin.googleapis.com
+        url: https://admin.googleapis.com/admin/directory/v1/users/alice@example.com
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"primaryEmail":"alice@example.com","isEnrolledIn2Sv":true}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms

--- a/pkg/accessreview/drivers/testdata/gcp_mfa.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp_mfa.yaml
@@ -1,0 +1,26 @@
+---
+# Directory Users.Get for the listed user only. Groups and service
+# accounts are not queried. Call order is the contract.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: admin.googleapis.com
+        url: https://admin.googleapis.com/admin/directory/v1/users/alice@example.com
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"primaryEmail":"alice@example.com","isEnrolledIn2Sv":true}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 200 OK
+        code: 200
+        duration: 1ms

--- a/pkg/accessreview/drivers/testdata/gcp_mfa_denied.yaml
+++ b/pkg/accessreview/drivers/testdata/gcp_mfa_denied.yaml
@@ -1,0 +1,26 @@
+---
+# Directory Users.Get is denied. MFA stays unknown. Call order is the
+# contract.
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        host: admin.googleapis.com
+        url: https://admin.googleapis.com/admin/directory/v1/users/alice@example.com
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: -1
+        uncompressed: true
+        body: '{"error":{"code":403,"message":"The caller does not have permission","status":"PERMISSION_DENIED"}}'
+        headers:
+            Content-Type:
+                - application/json
+        status: 403 Forbidden
+        code: 403
+        duration: 1ms

--- a/pkg/cloud/gcp/error.go
+++ b/pkg/cloud/gcp/error.go
@@ -22,6 +22,7 @@ package gcp
 
 import (
 	"errors"
+	"net/http"
 
 	"go.gearno.de/kit/log"
 	"google.golang.org/api/googleapi"
@@ -42,4 +43,33 @@ func SafeLogFields(err error) []log.Attr {
 	}
 
 	return fields
+}
+
+type (
+	// ErrPermissionDenied matches a Google API 403. Pass it to As.
+	ErrPermissionDenied struct{}
+
+	// ErrNotFound matches a Google API 404. Pass it to As.
+	ErrNotFound struct{}
+
+	statusError interface {
+		ErrPermissionDenied | ErrNotFound
+		code() int
+	}
+)
+
+func (ErrPermissionDenied) code() int { return http.StatusForbidden }
+
+func (ErrNotFound) code() int { return http.StatusNotFound }
+
+// As reports whether err is or wraps a Google API error whose status is T.
+func As[T statusError](err error) bool {
+	apiErr, ok := errors.AsType[*googleapi.Error](err)
+	if !ok {
+		return false
+	}
+
+	var status T
+
+	return apiErr.Code == status.code()
 }

--- a/pkg/cloud/gcp/error_test.go
+++ b/pkg/cloud/gcp/error_test.go
@@ -21,6 +21,7 @@
 package gcp_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -102,6 +103,86 @@ func TestSafeLogFields_OmitsServiceAccountEmail(t *testing.T) {
 					assert.NotContains(t, field.Key, email)
 					assert.NotContains(t, field.Value.String(), email)
 				}
+			},
+		)
+	}
+}
+
+func TestAs_PermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "forbidden",
+			err:  &googleapi.Error{Code: http.StatusForbidden, Message: "denied"},
+			want: true,
+		},
+		{
+			name: "wrapped forbidden",
+			err:  fmt.Errorf("cannot list: %w", &googleapi.Error{Code: http.StatusForbidden}),
+			want: true,
+		},
+		{
+			name: "not found",
+			err:  &googleapi.Error{Code: http.StatusNotFound},
+		},
+		{
+			name: "canceled",
+			err:  context.Canceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				assert.Equal(t, tt.want, cloudgcp.As[cloudgcp.ErrPermissionDenied](tt.err))
+			},
+		)
+	}
+}
+
+func TestAs_NotFound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "not found",
+			err:  &googleapi.Error{Code: http.StatusNotFound, Message: "missing"},
+			want: true,
+		},
+		{
+			name: "wrapped not found",
+			err:  fmt.Errorf("cannot get: %w", &googleapi.Error{Code: http.StatusNotFound}),
+			want: true,
+		},
+		{
+			name: "forbidden",
+			err:  &googleapi.Error{Code: http.StatusForbidden},
+		},
+		{
+			name: "canceled",
+			err:  context.Canceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				assert.Equal(t, tt.want, cloudgcp.As[cloudgcp.ErrNotFound](tt.err))
 			},
 		)
 	}

--- a/pkg/cloud/gcp/session.go
+++ b/pkg/cloud/gcp/session.go
@@ -51,7 +51,9 @@ const (
 	idTokenType            = "urn:ietf:params:oauth:token-type:id_token"
 	accessTokenType        = "urn:ietf:params:oauth:token-type:access_token"
 	cloudPlatformScope     = "https://www.googleapis.com/auth/cloud-platform"
-	serviceAccountLifetime = "3600s"
+	// Admin Directory is a Workspace API; cloud-platform does not cover it.
+	adminDirectoryUserReadonlyScope = "https://www.googleapis.com/auth/admin.directory.user.readonly"
+	serviceAccountLifetime          = "3600s"
 )
 
 type (
@@ -84,6 +86,11 @@ type (
 var (
 	_ cloud.Session     = (*Session)(nil)
 	_ http.RoundTripper = (*sessionTransport)(nil)
+
+	serviceAccountScopes = []string{
+		cloudPlatformScope,
+		adminDirectoryUserReadonlyScope,
+	}
 )
 
 // NewSession opens a session on the project named by providerResource, by
@@ -299,7 +306,7 @@ func (s *Session) impersonate(ctx context.Context, federated *oauth2.Token) (*oa
 	resp, err := svc.Projects.ServiceAccounts.GenerateAccessToken(
 		name,
 		&iamcredentials.GenerateAccessTokenRequest{
-			Scope:    []string{cloudPlatformScope},
+			Scope:    serviceAccountScopes,
 			Lifetime: serviceAccountLifetime,
 		},
 	).Context(ctx).Do()

--- a/pkg/cloud/gcp/session_exchange_test.go
+++ b/pkg/cloud/gcp/session_exchange_test.go
@@ -199,8 +199,10 @@ func newExchangeTestSession(t *testing.T) *exchangeProbe {
 					return
 				}
 
-				if !slices.Equal(req.Scope, []string{cloudPlatformScope}) ||
-					req.Lifetime != serviceAccountLifetime {
+				if !slices.Equal(
+					req.Scope,
+					[]string{cloudPlatformScope, adminDirectoryUserReadonlyScope},
+				) || req.Lifetime != serviceAccountLifetime {
 					http.Error(w, "unexpected iam request", http.StatusBadRequest)
 					return
 				}

--- a/pkg/connector/provider/gcp.go
+++ b/pkg/connector/provider/gcp.go
@@ -119,14 +119,14 @@ func newGCPDriver(
 	_ context.Context,
 	session cloud.Session,
 	_ *coredata.Connector,
-	_ *log.Logger,
+	logger *log.Logger,
 ) (drivers.Driver, error) {
 	gcpSession, ok := session.(*cloudgcp.Session)
 	if !ok {
 		return nil, fmt.Errorf("cannot create gcp driver: session is for %s", session.Cloud())
 	}
 
-	return drivers.NewGCPDriver(gcpSession), nil
+	return drivers.NewGCPDriver(gcpSession, logger), nil
 }
 
 // probeGCP checks the connection by completing the STS exchange and


### PR DESCRIPTION
The project IAM driver listed identities with no activity or enrollment signal. Reviewers need last action on this project and a best-effort MFA status, the same contract as Identity Center: a missing Logging, Policy Analyzer, or Directory grant must not drop the list. Cancel still fails the fetch.

Admin Activity covers users. Policy Analyzer covers service accounts, with a Cloud Audit Logs fallback. MFA is Directory isEnrolledIn2Sv for already-listed user emails only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fills GCP project identities' last login and best-effort MFA status in the project IAM driver, which previously listed identities with no activity or enrollment signal. A missing Logging, Policy Analyzer, or Directory grant no longer drops the list; enrichment degrades to unknown values, while a cancelled context still fails the fetch.

### Tests **`+598`** **`-5`**

- Recorded interactions cover success, denied, Policy Analyzer fallback, and key-failed paths for activity and MFA.

### Service **`+1250`** **`-6`**

- Last login comes from Policy Analyzer for service accounts and Admin Activity for users, with a Cloud Audit Logs fallback when Policy Analyzer is denied; activity is walked 90 days back within a 20-second cap.
- MFA reads Directory `isEnrolledIn2Sv` for already-listed user emails, using the same WIF token that now also requests the `admin.directory.user.readonly` scope.
- Service accounts authenticated only via keys are marked as API key auth.

### Other **`+28`** **`-0`**

- Changelogs document the new Directory scope, and the `gcp-audit-role` README explains the optional Workspace Users-read role that admins must assign in the Google Admin console for MFA to work.

<sup>Written for commit af96cc4fd620596b6207fd858172984bfc5a839d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

