### PR TITLE
Claude/google deployment options dle757

### DIFF
--- a/.github/workflows/deploy-gcp.yaml
+++ b/.github/workflows/deploy-gcp.yaml
@@ -1,0 +1,239 @@
+name: "Deploy to GCP (GKE)"
+
+# probod is a single stateful Go binary (API + GraphQL + MCP + background
+# workers + static frontends) backed by PostgreSQL, an S3-compatible store,
+# and headless Chrome. That shape does not fit Cloud Run (no split
+# worker process, no local disk), so this pushes the image built here to
+# Google Artifact Registry and deploys it with the chart already checked in
+# at contrib/helm/charts/probo via `helm upgrade`, onto GKE.
+#
+# Auth mirrors the existing team pattern: google-github-actions/auth with a
+# service-account key in GCP_SA_KEY (rather than Workload Identity
+# Federation).
+#
+# Required repository/environment secrets:
+#   GCP_SA_KEY              service account JSON key (Artifact Registry
+#                           writer, Cloud Build editor, GKE developer)
+#   GCP_PROJECT_ID          GCP project id
+#   GKE_CLUSTER             GKE cluster name
+#   GKE_CLUSTER_LOCATION    GKE cluster region (regional cluster) or zone
+#   GAR_LOCATION            Artifact Registry location, e.g. us-central1
+#   PROBO_DOMAIN            public hostname, e.g. probo.example.com
+#   PROBO_ENCRYPTION_KEY    openssl rand -base64 32
+#   PROBO_COOKIE_SECRET     openssl rand -base64 32
+#   PROBO_PASSWORD_PEPPER   openssl rand -base64 32
+#   PROBO_TRUST_TOKEN_SECRET  openssl rand -base64 32
+#   PROBO_OAUTH2_SIGNING_KEY  PEM RSA private key (openssl genpkey ...)
+#   POSTGRES_HOST / POSTGRES_DATABASE / POSTGRES_USERNAME / POSTGRES_PASSWORD
+#   S3_BUCKET / S3_REGION / S3_ENDPOINT / S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY
+#     (GCS via its S3-compatible XML API: endpoint
+#     https://storage.googleapis.com, HMAC keys from `gcloud storage hmac
+#     keys create`)
+#   SMTP_ADDR / SMTP_USER / SMTP_PASSWORD
+#
+# Optional (added only when set):
+#   OPENAI_API_KEY, ANTHROPIC_API_KEY
+#
+# Prerequisites this workflow does not create: the GKE cluster, the
+# Artifact Registry Docker repo named "probo" in GAR_LOCATION, the Cloud
+# SQL/PostgreSQL instance, and the GCS bucket + HMAC key.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cmd/**"
+      - "pkg/**"
+      - "apps/**"
+      - "packages/**"
+      - "Dockerfile"
+      - "entrypoint.sh"
+      - "contrib/helm/charts/probo/**"
+      - ".github/workflows/deploy-gcp.yaml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: "deploy-gcp"
+  cancel-in-progress: false
+
+permissions:
+  contents: "read"
+
+jobs:
+  deploy:
+    name: "build-and-deploy"
+    runs-on: "ubuntu-latest"
+    environment: production
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          submodules: recursive
+
+      - uses: "./.github/actions/setup"
+
+      - name: "Build frontend apps"
+        run: |
+          npm --workspace @probo/emails run build
+          make relay
+          npm --workspace @probo/console run build
+          npm --workspace @probo/compliance-portal run build
+          npm --workspace @probo/employee-portal run build
+        env:
+          NODE_ENV: production
+
+      - name: "Generate Go code"
+        run: |
+          go generate ./pkg/server/api/connect/v1
+          go generate ./pkg/server/api/mcp/v1
+          go generate ./pkg/server/api/console/v1
+          go generate ./pkg/server/api/complianceportal/v1
+
+      - name: "Build probod binaries (linux/amd64)"
+        env:
+          CGO_ENABLED: "0"
+          GOOS: "linux"
+          GOARCH: "amd64"
+        run: |
+          VERSION="$(git rev-parse --short HEAD)"
+          BOOTSTRAP_VERSION="$(cat cmd/probod-bootstrap/VERSION)"
+          mkdir -p linux/amd64
+          go build -ldflags "-s -w -X 'main.version=${VERSION}' -X 'main.env=prod'" \
+            -gcflags="-e" -o linux/amd64/probod ./cmd/probod/main.go
+          go build -ldflags "-s -w -X 'main.version=${BOOTSTRAP_VERSION}'" \
+            -gcflags="-e" -o linux/amd64/probod-bootstrap ./cmd/probod-bootstrap/main.go
+
+      - name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v2"
+        with:
+          credentials_json: "${{ secrets.GCP_SA_KEY }}"
+
+      - name: "Set up gcloud"
+        uses: "google-github-actions/setup-gcloud@v2"
+
+      - name: "Install gke-gcloud-auth-plugin"
+        run: "gcloud components install gke-gcloud-auth-plugin --quiet"
+
+      - name: "Compute image tag"
+        id: tag
+        run: echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: "Build and push Docker image via Cloud Build"
+        env:
+          IMAGE: "${{ secrets.GAR_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/probo/probod"
+          TAG: "${{ steps.tag.outputs.value }}"
+        run: |
+          # Submit async to avoid the log-streaming permission requirement.
+          BUILD=$(gcloud builds submit \
+            --tag "${IMAGE}:${TAG}" \
+            --project "${{ secrets.GCP_PROJECT_ID }}" \
+            --async \
+            --format="value(name)")
+          BUILD_ID="${BUILD##*/}"
+          echo "Build submitted: $BUILD_ID"
+
+          for i in $(seq 1 90); do
+            STATUS=$(gcloud builds describe "$BUILD_ID" \
+              --project "${{ secrets.GCP_PROJECT_ID }}" \
+              --format="value(status)" 2>/dev/null || echo "UNKNOWN")
+            echo "[$i/90] Status: $STATUS"
+            case "$STATUS" in
+              SUCCESS) echo "Build succeeded"; exit 0 ;;
+              FAILURE|CANCELLED|TIMEOUT|INTERNAL_ERROR) echo "Build failed with status: $STATUS"; exit 1 ;;
+            esac
+            sleep 10
+          done
+          echo "Timed out waiting for build to complete"
+          exit 1
+
+      - name: "Get GKE credentials"
+        run: |
+          gcloud container clusters get-credentials "${{ secrets.GKE_CLUSTER }}" \
+            --region "${{ secrets.GKE_CLUSTER_LOCATION }}" \
+            --project "${{ secrets.GCP_PROJECT_ID }}"
+
+      - name: "Install Helm"
+        uses: "azure/setup-helm@v4"
+
+      - name: "Deploy with Helm"
+        env:
+          IMAGE: "${{ secrets.GAR_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/probo/probod"
+          TAG: "${{ steps.tag.outputs.value }}"
+          PROBO_DOMAIN: "${{ secrets.PROBO_DOMAIN }}"
+          PROBO_ENCRYPTION_KEY: "${{ secrets.PROBO_ENCRYPTION_KEY }}"
+          PROBO_COOKIE_SECRET: "${{ secrets.PROBO_COOKIE_SECRET }}"
+          PROBO_PASSWORD_PEPPER: "${{ secrets.PROBO_PASSWORD_PEPPER }}"
+          PROBO_TRUST_TOKEN_SECRET: "${{ secrets.PROBO_TRUST_TOKEN_SECRET }}"
+          PROBO_OAUTH2_SIGNING_KEY: "${{ secrets.PROBO_OAUTH2_SIGNING_KEY }}"
+          POSTGRES_HOST: "${{ secrets.POSTGRES_HOST }}"
+          POSTGRES_DATABASE: "${{ secrets.POSTGRES_DATABASE }}"
+          POSTGRES_USERNAME: "${{ secrets.POSTGRES_USERNAME }}"
+          POSTGRES_PASSWORD: "${{ secrets.POSTGRES_PASSWORD }}"
+          S3_BUCKET: "${{ secrets.S3_BUCKET }}"
+          S3_REGION: "${{ secrets.S3_REGION }}"
+          S3_ENDPOINT: "${{ secrets.S3_ENDPOINT }}"
+          S3_ACCESS_KEY_ID: "${{ secrets.S3_ACCESS_KEY_ID }}"
+          S3_SECRET_ACCESS_KEY: "${{ secrets.S3_SECRET_ACCESS_KEY }}"
+          SMTP_ADDR: "${{ secrets.SMTP_ADDR }}"
+          SMTP_USER: "${{ secrets.SMTP_USER }}"
+          SMTP_PASSWORD: "${{ secrets.SMTP_PASSWORD }}"
+          OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
+          ANTHROPIC_API_KEY: "${{ secrets.ANTHROPIC_API_KEY }}"
+        run: |
+          # A PEM private key can't safely go through --set-string (newlines,
+          # comma-splitting), so it's the one value written to a temp file
+          # and passed via --set-file. Everything else uses --set-string as
+          # discrete args, which sidesteps gcloud-style delimiter escaping
+          # entirely since each flag is its own argv entry.
+          SIGNING_KEY_FILE="$(mktemp)"
+          printf '%s' "$PROBO_OAUTH2_SIGNING_KEY" > "$SIGNING_KEY_FILE"
+
+          HELM_ARGS=(
+            --install
+            --namespace probo --create-namespace
+            --set "image.repository=${IMAGE}"
+            --set "image.tag=${TAG}"
+
+            # Use managed Postgres/GCS, not the chart's bundled dev services.
+            --set "postgresql.enabled=false"
+            --set "seaweedfs.enabled=false"
+
+            --set "probo.baseUrl=${PROBO_DOMAIN}"
+            --set "probo.auth.cookieDomain=${PROBO_DOMAIN}"
+            --set "probo.trustAuth.cookieDomain=${PROBO_DOMAIN}"
+            --set "probo.cors.allowedOrigins[0]=https://${PROBO_DOMAIN}"
+            --set "ingress.hosts[0].host=${PROBO_DOMAIN}"
+            --set "ingress.tls[0].secretName=probo-tls"
+            --set "ingress.tls[0].hosts[0]=${PROBO_DOMAIN}"
+            --set-string "probo.encryptionKey=${PROBO_ENCRYPTION_KEY}"
+            --set-string "probo.auth.cookieSecret=${PROBO_COOKIE_SECRET}"
+            --set-string "probo.auth.passwordPepper=${PROBO_PASSWORD_PEPPER}"
+            --set-string "probo.trustAuth.tokenSecret=${PROBO_TRUST_TOKEN_SECRET}"
+            --set-file "probo.oauth2.signingKey=${SIGNING_KEY_FILE}"
+
+            --set-string "postgresql.host=${POSTGRES_HOST}"
+            --set-string "postgresql.database=${POSTGRES_DATABASE}"
+            --set-string "postgresql.username=${POSTGRES_USERNAME}"
+            --set-string "postgresql.password=${POSTGRES_PASSWORD}"
+
+            --set-string "s3.bucket=${S3_BUCKET}"
+            --set-string "s3.region=${S3_REGION}"
+            --set-string "s3.endpoint=${S3_ENDPOINT}"
+            --set-string "s3.accessKeyId=${S3_ACCESS_KEY_ID}"
+            --set-string "s3.secretAccessKey=${S3_SECRET_ACCESS_KEY}"
+
+            --set-string "probo.mailer.smtp.addr=${SMTP_ADDR}"
+            --set-string "probo.mailer.smtp.user=${SMTP_USER}"
+            --set-string "probo.mailer.smtp.password=${SMTP_PASSWORD}"
+          )
+
+          if [ -n "$OPENAI_API_KEY" ]; then
+            HELM_ARGS+=(--set-string "probo.openai.apiKey=${OPENAI_API_KEY}")
+          fi
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            HELM_ARGS+=(--set-string "probo.anthropic.apiKey=${ANTHROPIC_API_KEY}")
+          fi
+
+          helm upgrade probo contrib/helm/charts/probo "${HELM_ARGS[@]}" \
+            --wait --timeout 10m
+
+          rm -f "$SIGNING_KEY_FILE"

--- a/.github/workflows/deploy-gcp.yaml
+++ b/.github/workflows/deploy-gcp.yaml
@@ -13,8 +13,13 @@ name: "Deploy to GCP (GKE)"
 #
 # Required repository/environment secrets:
 #   GCP_SA_KEY              service account JSON key (Artifact Registry
-#                           writer, Cloud Build editor, GKE developer)
+#                           writer, Cloud Build editor, GKE developer, and
+#                           the Secret Manager + Cloud SQL/Storage viewer
+#                           roles provision-gcp-infra.yaml grants it)
 #   GCP_PROJECT_ID          GCP project id
+#   GCP_REGION              region the Postgres instance and GCS bucket live
+#                           in (set by provision-gcp-infra.yaml)
+#   GCS_BUCKET_NAME         the bucket name given to provision-gcp-infra.yaml
 #   GKE_CLUSTER             GKE cluster name
 #   GKE_CLUSTER_LOCATION    GKE cluster region (regional cluster) or zone
 #   GAR_LOCATION            Artifact Registry location, e.g. us-central1
@@ -24,19 +29,22 @@ name: "Deploy to GCP (GKE)"
 #   PROBO_PASSWORD_PEPPER   openssl rand -base64 32
 #   PROBO_TRUST_TOKEN_SECRET  openssl rand -base64 32
 #   PROBO_OAUTH2_SIGNING_KEY  PEM RSA private key (openssl genpkey ...)
-#   POSTGRES_HOST / POSTGRES_DATABASE / POSTGRES_USERNAME / POSTGRES_PASSWORD
-#   S3_BUCKET / S3_REGION / S3_ENDPOINT / S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY
-#     (GCS via its S3-compatible XML API: endpoint
-#     https://storage.googleapis.com, HMAC keys from `gcloud storage hmac
-#     keys create`)
 #   SMTP_ADDR / SMTP_USER / SMTP_PASSWORD
 #
 # Optional (added only when set):
 #   OPENAI_API_KEY, ANTHROPIC_API_KEY
 #
-# Prerequisites this workflow does not create: the GKE cluster, the
-# Artifact Registry Docker repo named "probo" in GAR_LOCATION, the Cloud
-# SQL/PostgreSQL instance, and the GCS bucket + HMAC key.
+# Not required anymore: POSTGRES_HOST/PASSWORD and S3_ACCESS_KEY_ID/
+# S3_SECRET_ACCESS_KEY used to be manually-copied secrets. They're now
+# resolved at deploy time straight from the infrastructure that
+# provision-gcp-infra.yaml (contrib/terraform/gcp-probo-infra) creates —
+# the DB host and HMAC access key are looked up with gcloud, the DB
+# password and HMAC secret key are read from Secret Manager. Run that
+# workflow first; see contrib/terraform/gcp-probo-infra/README.md.
+#
+# Prerequisites this workflow does not create: the GKE cluster and the
+# Artifact Registry Docker repo named "probo" in GAR_LOCATION. The Postgres
+# instance and GCS bucket come from provision-gcp-infra.yaml, not this one.
 
 on:
   push:
@@ -154,6 +162,33 @@ jobs:
       - name: "Install Helm"
         uses: "azure/setup-helm@v4"
 
+      - name: "Resolve Postgres/GCS connection details"
+        id: infra
+        env:
+          PROJECT: "${{ secrets.GCP_PROJECT_ID }}"
+        run: |
+          # These come from contrib/terraform/gcp-probo-infra, applied by
+          # provision-gcp-infra.yaml — nothing here creates them. Resource
+          # names (instance, service account, secret ids) must match that
+          # module's defaults.
+          DB_HOST=$(gcloud sql instances describe probo-db \
+            --project "$PROJECT" --format="value(ipAddresses[0].ipAddress)")
+          DB_PASSWORD=$(gcloud secrets versions access latest \
+            --secret=probo-db-password --project "$PROJECT")
+          S3_ACCESS_KEY_ID=$(gcloud storage hmac keys list \
+            --service-account="probo-storage@${PROJECT}.iam.gserviceaccount.com" \
+            --project "$PROJECT" --format="value(accessId)" --limit=1)
+          S3_SECRET_ACCESS_KEY=$(gcloud secrets versions access latest \
+            --secret=probo-s3-hmac-secret --project "$PROJECT")
+
+          echo "::add-mask::${DB_PASSWORD}"
+          echo "::add-mask::${S3_SECRET_ACCESS_KEY}"
+
+          echo "db_host=${DB_HOST}" >> "$GITHUB_OUTPUT"
+          echo "db_password=${DB_PASSWORD}" >> "$GITHUB_OUTPUT"
+          echo "s3_access_key_id=${S3_ACCESS_KEY_ID}" >> "$GITHUB_OUTPUT"
+          echo "s3_secret_access_key=${S3_SECRET_ACCESS_KEY}" >> "$GITHUB_OUTPUT"
+
       - name: "Deploy with Helm"
         env:
           IMAGE: "${{ secrets.GAR_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/probo/probod"
@@ -164,15 +199,18 @@ jobs:
           PROBO_PASSWORD_PEPPER: "${{ secrets.PROBO_PASSWORD_PEPPER }}"
           PROBO_TRUST_TOKEN_SECRET: "${{ secrets.PROBO_TRUST_TOKEN_SECRET }}"
           PROBO_OAUTH2_SIGNING_KEY: "${{ secrets.PROBO_OAUTH2_SIGNING_KEY }}"
-          POSTGRES_HOST: "${{ secrets.POSTGRES_HOST }}"
-          POSTGRES_DATABASE: "${{ secrets.POSTGRES_DATABASE }}"
-          POSTGRES_USERNAME: "${{ secrets.POSTGRES_USERNAME }}"
-          POSTGRES_PASSWORD: "${{ secrets.POSTGRES_PASSWORD }}"
-          S3_BUCKET: "${{ secrets.S3_BUCKET }}"
-          S3_REGION: "${{ secrets.S3_REGION }}"
-          S3_ENDPOINT: "${{ secrets.S3_ENDPOINT }}"
-          S3_ACCESS_KEY_ID: "${{ secrets.S3_ACCESS_KEY_ID }}"
-          S3_SECRET_ACCESS_KEY: "${{ secrets.S3_SECRET_ACCESS_KEY }}"
+          # Fixed values matching contrib/terraform/gcp-probo-infra's
+          # defaults (database_name/database_user variables) — change both
+          # sides together if you override them there.
+          POSTGRES_DATABASE: "probod"
+          POSTGRES_USERNAME: "probod"
+          POSTGRES_HOST: "${{ steps.infra.outputs.db_host }}"
+          POSTGRES_PASSWORD: "${{ steps.infra.outputs.db_password }}"
+          S3_BUCKET: "${{ secrets.GCS_BUCKET_NAME }}"
+          S3_REGION: "${{ secrets.GCP_REGION }}"
+          S3_ENDPOINT: "https://storage.googleapis.com"
+          S3_ACCESS_KEY_ID: "${{ steps.infra.outputs.s3_access_key_id }}"
+          S3_SECRET_ACCESS_KEY: "${{ steps.infra.outputs.s3_secret_access_key }}"
           SMTP_ADDR: "${{ secrets.SMTP_ADDR }}"
           SMTP_USER: "${{ secrets.SMTP_USER }}"
           SMTP_PASSWORD: "${{ secrets.SMTP_PASSWORD }}"

--- a/.github/workflows/provision-gcp-infra.yaml
+++ b/.github/workflows/provision-gcp-infra.yaml
@@ -1,0 +1,70 @@
+name: "Provision GCP Infra (Postgres + GCS)"
+
+# Applies contrib/terraform/gcp-probo-infra: the Cloud SQL Postgres
+# instance, GCS bucket, HMAC key, and the two Secret Manager secrets that
+# deploy-gcp.yaml reads at deploy time. Manual trigger only, on purpose —
+# this touches a stateful database, so it must never run implicitly on a
+# push the way the app deploy does.
+#
+# See contrib/terraform/gcp-probo-infra/README.md for the one-time bootstrap
+# (enabling APIs, creating the Terraform state bucket) that has to happen
+# before the first run.
+#
+# Required secrets (beyond GCP_SA_KEY / GCP_PROJECT_ID, shared with
+# deploy-gcp.yaml): TF_STATE_BUCKET, GCP_REGION, GCS_BUCKET_NAME
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Terraform action"
+        type: choice
+        options: [plan, apply]
+        default: plan
+
+permissions:
+  contents: "read"
+
+jobs:
+  terraform:
+    name: "terraform-${{ inputs.action }}"
+    runs-on: "ubuntu-latest"
+    environment: production
+    defaults:
+      run:
+        working-directory: "contrib/terraform/gcp-probo-infra"
+    steps:
+      - uses: "actions/checkout@v4"
+
+      - name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v2"
+        with:
+          credentials_json: "${{ secrets.GCP_SA_KEY }}"
+
+      - uses: "hashicorp/setup-terraform@v3"
+
+      - name: "Resolve deploy service account email"
+        id: sa
+        run: |
+          EMAIL=$(echo '${{ secrets.GCP_SA_KEY }}' | jq -r .client_email)
+          echo "::add-mask::${EMAIL}"
+          echo "email=${EMAIL}" >> "$GITHUB_OUTPUT"
+
+      - name: "Terraform init"
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
+            -backend-config="prefix=probo-infra"
+
+      - name: "Terraform ${{ inputs.action }}"
+        env:
+          TF_VAR_project_id: "${{ secrets.GCP_PROJECT_ID }}"
+          TF_VAR_region: "${{ secrets.GCP_REGION }}"
+          TF_VAR_bucket_name: "${{ secrets.GCS_BUCKET_NAME }}"
+          TF_VAR_deploy_service_account_email: "${{ steps.sa.outputs.email }}"
+        run: |
+          if [ "${{ inputs.action }}" = "apply" ]; then
+            terraform apply -auto-approve
+          else
+            terraform plan
+          fi

--- a/contrib/terraform/gcp-probo-infra/README.md
+++ b/contrib/terraform/gcp-probo-infra/README.md
@@ -1,0 +1,58 @@
+# gcp-probo-infra
+
+Provisions the stateful GCP infrastructure `probod` needs beyond the GKE
+cluster itself: a Cloud SQL Postgres instance (private IP, peered onto the
+cluster's VPC), a GCS bucket for file storage, a service account + HMAC key
+pair so `probod` can talk to that bucket over its S3-compatible API, and two
+Secret Manager secrets (the generated DB password and the HMAC secret key)
+that [`deploy-gcp.yaml`](../../../.github/workflows/deploy-gcp.yaml) reads at
+deploy time.
+
+Applied via [`provision-gcp-infra.yaml`](../../../.github/workflows/provision-gcp-infra.yaml),
+a manual (`workflow_dispatch`) workflow — deliberately not tied to every push,
+since this touches a stateful database.
+
+## One-time bootstrap (before the first run)
+
+Terraform can't create its own state bucket, and the APIs this module
+enables can't be enabled by a plan that needs them already enabled. Run once,
+by hand, against the target project:
+
+```bash
+gcloud config set project YOUR_PROJECT_ID
+
+gcloud services enable \
+  sqladmin.googleapis.com \
+  storage.googleapis.com \
+  secretmanager.googleapis.com \
+  servicenetworking.googleapis.com \
+  compute.googleapis.com
+
+# Terraform state bucket — name it, and set TF_STATE_BUCKET to it.
+gcloud storage buckets create gs://YOUR_TF_STATE_BUCKET --location=YOUR_REGION
+```
+
+Then add these repository secrets (in addition to the ones `deploy-gcp.yaml`
+already needs — `GCP_SA_KEY`, `GCP_PROJECT_ID`):
+
+| Secret | Example |
+|---|---|
+| `TF_STATE_BUCKET` | `probo-tfstate` |
+| `GCP_REGION` | `us-central1` |
+| `GCS_BUCKET_NAME` | `probo-production-files` (must be globally unique) |
+
+Run `provision-gcp-infra.yaml` with `action: plan` first to review, then
+again with `action: apply`.
+
+## What it doesn't do
+
+- Doesn't create the GKE cluster or the VPC — `var.network` (default
+  `"default"`) must name a VPC that already exists and that the cluster's
+  nodes are on.
+- Doesn't rotate the DB password or HMAC key. Re-running `apply` after a
+  manual rotation in the console will fight the state; rotate through
+  Terraform (`terraform taint random_password.db`, or the HMAC key
+  resource) instead.
+- `deletion_protection = true` on the Cloud SQL instance is a guard against
+  `terraform destroy`, not a backup strategy — point-in-time recovery is
+  enabled, but test a real restore before you need one.

--- a/contrib/terraform/gcp-probo-infra/main.tf
+++ b/contrib/terraform/gcp-probo-infra/main.tf
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026 Probo Inc <hello@probo.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+locals {
+  apis = [
+    "sqladmin.googleapis.com",
+    "storage.googleapis.com",
+    "secretmanager.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "compute.googleapis.com",
+  ]
+}
+
+resource "google_project_service" "this" {
+  for_each = toset(local.apis)
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+data "google_compute_network" "vpc" {
+  name = var.network
+}
+
+# Cloud SQL's private-IP path requires a reserved peering range and a
+# service-networking connection onto the same VPC the GKE cluster uses.
+resource "google_compute_global_address" "private_ip_range" {
+  name          = "probo-db-private-ip"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = data.google_compute_network.vpc.id
+
+  depends_on = [google_project_service.this]
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  network                 = data.google_compute_network.vpc.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_range.name]
+}
+
+resource "random_password" "db" {
+  length  = 32
+  special = false
+}
+
+resource "google_sql_database_instance" "probo" {
+  name             = var.sql_instance_name
+  project          = var.project_id
+  region           = var.region
+  database_version = "POSTGRES_16"
+
+  depends_on = [google_service_networking_connection.private_vpc_connection]
+
+  settings {
+    tier = var.sql_tier
+
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = data.google_compute_network.vpc.id
+    }
+
+    backup_configuration {
+      enabled                        = true
+      point_in_time_recovery_enabled = true
+    }
+  }
+
+  # A safety net, not a substitute for a backup/restore drill: this only
+  # stops `terraform destroy` from taking the instance out from under you.
+  deletion_protection = true
+}
+
+resource "google_sql_database" "probod" {
+  name     = var.database_name
+  project  = var.project_id
+  instance = google_sql_database_instance.probo.name
+}
+
+resource "google_sql_user" "probod" {
+  name     = var.database_user
+  project  = var.project_id
+  instance = google_sql_database_instance.probo.name
+  password = random_password.db.result
+}
+
+resource "google_storage_bucket" "files" {
+  name                        = var.bucket_name
+  project                     = var.project_id
+  location                    = var.region
+  uniform_bucket_level_access = true
+  force_destroy               = false
+
+  versioning {
+    enabled = true
+  }
+}
+
+# HMAC keys are only issued for service accounts, which is why probod talks
+# to GCS through a dedicated one rather than the workload's own identity.
+resource "google_service_account" "storage" {
+  account_id   = var.storage_service_account_id
+  project      = var.project_id
+  display_name = "probod S3-compatible access to ${var.bucket_name}"
+}
+
+resource "google_storage_bucket_iam_member" "storage_access" {
+  bucket = google_storage_bucket.files.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.storage.email}"
+}
+
+resource "google_storage_hmac_key" "probo" {
+  service_account_email = google_service_account.storage.email
+  project                = var.project_id
+}
+
+resource "google_secret_manager_secret" "db_password" {
+  secret_id = "probo-db-password"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.this]
+}
+
+resource "google_secret_manager_secret_version" "db_password" {
+  secret      = google_secret_manager_secret.db_password.id
+  secret_data = random_password.db.result
+}
+
+resource "google_secret_manager_secret" "s3_hmac_secret" {
+  secret_id = "probo-s3-hmac-secret"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.this]
+}
+
+resource "google_secret_manager_secret_version" "s3_hmac_secret" {
+  secret      = google_secret_manager_secret.s3_hmac_secret.id
+  secret_data = google_storage_hmac_key.probo.secret
+}
+
+# Lets deploy-gcp.yaml read both secrets with the same service account it
+# already authenticates as, instead of a manual copy-paste into GitHub Secrets.
+resource "google_secret_manager_secret_iam_member" "deploy_reads_db_password" {
+  secret_id = google_secret_manager_secret.db_password.id
+  project   = var.project_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.deploy_service_account_email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "deploy_reads_s3_hmac_secret" {
+  secret_id = google_secret_manager_secret.s3_hmac_secret.id
+  project   = var.project_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.deploy_service_account_email}"
+}

--- a/contrib/terraform/gcp-probo-infra/outputs.tf
+++ b/contrib/terraform/gcp-probo-infra/outputs.tf
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Probo Inc <hello@probo.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+output "sql_instance_name" {
+  value = google_sql_database_instance.probo.name
+}
+
+output "sql_private_ip_address" {
+  value = google_sql_database_instance.probo.private_ip_address
+}
+
+output "database_name" {
+  value = google_sql_database.probod.name
+}
+
+output "database_user" {
+  value = google_sql_user.probod.name
+}
+
+output "bucket_name" {
+  value = google_storage_bucket.files.name
+}
+
+output "storage_service_account_email" {
+  value = google_service_account.storage.email
+}
+
+output "s3_access_key_id" {
+  value = google_storage_hmac_key.probo.access_id
+}
+
+output "db_password_secret_id" {
+  value = google_secret_manager_secret.db_password.secret_id
+}
+
+output "s3_hmac_secret_secret_id" {
+  value = google_secret_manager_secret.s3_hmac_secret.secret_id
+}

--- a/contrib/terraform/gcp-probo-infra/variables.tf
+++ b/contrib/terraform/gcp-probo-infra/variables.tf
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Probo Inc <hello@probo.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "GCP project id that owns the Cloud SQL instance, bucket, and secrets."
+}
+
+variable "region" {
+  type        = string
+  description = "Region for the Cloud SQL instance and the GCS bucket, e.g. us-central1."
+}
+
+variable "network" {
+  type        = string
+  default     = "default"
+  description = "VPC (by name) that the GKE cluster runs in. Cloud SQL is peered onto this network so probod reaches it over a private IP."
+}
+
+variable "sql_instance_name" {
+  type        = string
+  default     = "probo-db"
+  description = "Cloud SQL instance name. Keep in sync with deploy-gcp.yaml, which looks the instance up by this name."
+}
+
+variable "sql_tier" {
+  type        = string
+  default     = "db-custom-2-8192"
+  description = "Cloud SQL machine tier (2 vCPU / 8 GiB by default)."
+}
+
+variable "database_name" {
+  type        = string
+  default     = "probod"
+  description = "Database name. Keep in sync with deploy-gcp.yaml's POSTGRES_DATABASE."
+}
+
+variable "database_user" {
+  type        = string
+  default     = "probod"
+  description = "Database user. Keep in sync with deploy-gcp.yaml's POSTGRES_USERNAME."
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "Globally unique GCS bucket name for probod's file storage."
+}
+
+variable "storage_service_account_id" {
+  type        = string
+  default     = "probo-storage"
+  description = "Service account id (not email) that holds the HMAC key probod uses to talk to the bucket over the S3-compatible API."
+}
+
+variable "deploy_service_account_email" {
+  type        = string
+  description = "Email of the service account behind deploy-gcp.yaml's GCP_SA_KEY. Granted read access to the two secrets this module creates so the deploy workflow can fetch them without a manual copy-paste step."
+}

--- a/contrib/terraform/gcp-probo-infra/versions.tf
+++ b/contrib/terraform/gcp-probo-infra/versions.tf
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Probo Inc <hello@probo.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  # Configured at `terraform init` time with -backend-config flags (see
+  # ../../../.github/workflows/provision-gcp-infra.yaml), since the state
+  # bucket name isn't known to this module and must exist before init runs.
+  backend "gcs" {}
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds GCP deployment options for probod: a GKE deploy workflow that builds the image and deploys it via the existing Helm chart, plus Terraform that provisions the Cloud SQL Postgres, GCS bucket, and secrets it needs. Previously the deploy assumed a Postgres instance and GCS bucket already existed and took their host and credentials as manually-copied GitHub secrets; now the deploy workflow resolves them from gcloud and Secret Manager at deploy time.

### Other **`+770`** **`-0`**

- `deploy-gcp.yaml` builds the frontends and probod binaries, pushes the image to Artifact Registry via Cloud Build (async + poll), then runs `helm upgrade` onto GKE.
- `provision-gcp-infra.yaml` is a manual `workflow_dispatch` Terraform apply that creates a private-IP Cloud SQL instance, GCS bucket, storage service account + HMAC key, and two Secret Manager secrets.
- The Terraform module grants the deploy service account read access to both secrets.
- POSTGRES_HOST/PASSWORD and S3_ACCESS_KEY_ID/S3_SECRET_ACCESS_KEY are no longer hand-configured GitHub secrets.
- Run `provision-gcp-infra.yaml` (`action: apply`) before the first deploy; the GKE cluster and Artifact Registry "probo" repo must already exist.
- The README documents the one-time bootstrap (enabling APIs, creating the Terraform state bucket) and what the module intentionally doesn't create.

<sup>Written for commit 877567cc5272bd78d84c238b5fda8ed1b3e546f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

