### PR TITLE
Leave download signatures unchecked

### DIFF
--- a/apps/console/src/components/documents/PdfDownloadDialog.tsx
+++ b/apps/console/src/components/documents/PdfDownloadDialog.tsx
@@ -60,7 +60,7 @@ export const PdfDownloadDialog = forwardRef<PdfDownloadDialogRef, Props>(
         defaultValues: {
           withWatermark: false,
           watermarkText: defaultEmail,
-          withSignatures: true,
+          withSignatures: false,
         },
       });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- default the single-document PDF download dialog to exclude signatures
- keep signature inclusion available as an explicit opt-in

## Testing
- `cd apps/console && npm run check`
- manually opened Download PDF from a document detail page on a fresh page load
- verified Include signatures starts unchecked and can be checked explicitly

## Walkthrough
[document_download_signature_fresh_default.mp4](https://cursor.com/agents/bc-ba35e293-817e-4566-b111-84542f87246c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocument_download_signature_fresh_default.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-822](https://linear.app/probo/issue/ENG-822/uncheck-signature-by-default-when-downloading-documents)

<div><a href="https://cursor.com/agents/bc-ba35e293-817e-4566-b111-84542f87246c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba35e293-817e-4566-b111-84542f87246c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Starts the single-document PDF download dialog with signatures unchecked so signature pages are excluded by default. Users can still opt in to include signatures when needed.

### App: console **`+1`** **`-1`**

Changes the default value of the signatures toggle in the PDF download dialog from true to false.

<sup>Written for commit 945bcc046fe04372100fe831408a533cfdc69eed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

