### PR TITLE
Expose GCP workload-identity connect surfaces

### DIFF
--- a/apps/console/src/pages/organizations/access-reviews/_components/ActionSplitButton.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/_components/ActionSplitButton.tsx
@@ -24,11 +24,13 @@ import {
   DropdownItem,
   IconChevronDown,
 } from "@probo/ui";
+import { Link } from "react-router";
 
 export interface ActionSplitButtonAction {
   id: string;
   label: string;
   href?: string;
+  to?: string;
   onSelect?: () => void;
 }
 
@@ -48,33 +50,9 @@ export function ActionSplitButton({
 
   const splitClassName
     = alternativeActions.length > 0 ? "rounded-r-none" : undefined;
-  const preferredButton = preferredAction.href
-    ? (
-        <Button
-          type="button"
-          variant="primary"
-          className={splitClassName}
-          asChild
-        >
-          <a
-            href={preferredAction.href}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {preferredAction.label}
-          </a>
-        </Button>
-      )
-    : (
-        <Button
-          type="button"
-          variant="primary"
-          className={splitClassName}
-          onClick={preferredAction.onSelect}
-        >
-          {preferredAction.label}
-        </Button>
-      );
+  const preferredButton = (
+    <ActionButton action={preferredAction} className={splitClassName} />
+  );
 
   if (alternativeActions.length === 0) {
     return preferredButton;
@@ -96,25 +74,76 @@ export function ActionSplitButton({
         )}
       >
         {alternativeActions.map(action => (
-          action.href
-            ? (
-                <DropdownItem key={action.id} asChild>
-                  <a
-                    href={action.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {action.label}
-                  </a>
-                </DropdownItem>
-              )
-            : (
-                <DropdownItem key={action.id} onSelect={action.onSelect}>
-                  {action.label}
-                </DropdownItem>
-              )
+          <ActionMenuItem key={action.id} action={action} />
         ))}
       </Dropdown>
     </div>
+  );
+}
+
+function ActionButton({
+  action,
+  className,
+}: {
+  action: ActionSplitButtonAction;
+  className?: string;
+}) {
+  if (action.to) {
+    return (
+      <Button variant="primary" className={className} asChild>
+        <Link to={action.to}>{action.label}</Link>
+      </Button>
+    );
+  }
+  if (action.href) {
+    return (
+      <Button variant="primary" className={className} asChild>
+        <a
+          href={action.href}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {action.label}
+        </a>
+      </Button>
+    );
+  }
+  return (
+    <Button
+      type="button"
+      variant="primary"
+      className={className}
+      onClick={action.onSelect}
+    >
+      {action.label}
+    </Button>
+  );
+}
+
+function ActionMenuItem({ action }: { action: ActionSplitButtonAction }) {
+  if (action.to) {
+    return (
+      <DropdownItem asChild>
+        <Link to={action.to}>{action.label}</Link>
+      </DropdownItem>
+    );
+  }
+  if (action.href) {
+    return (
+      <DropdownItem asChild>
+        <a
+          href={action.href}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {action.label}
+        </a>
+      </DropdownItem>
+    );
+  }
+  return (
+    <DropdownItem onSelect={action.onSelect}>
+      {action.label}
+    </DropdownItem>
   );
 }

--- a/apps/console/src/pages/organizations/access-reviews/_locales/en-US.json
+++ b/apps/console/src/pages/organizations/access-reviews/_locales/en-US.json
@@ -1,0 +1,44 @@
+{
+  "createGcpAccessReviewSourcePage": {
+    "pageTitle": "Connect GCP",
+    "title": "Connect GCP",
+    "description": "Deploy the audit service account. Then enter the provider resource and the service account email.",
+    "permissionDenied": "You do not have permission to create access sources.",
+    "fields": {
+      "workloadIdentityProvider": "Workload identity provider",
+      "serviceAccountEmail": "Service account email",
+      "issuer": "Issuer",
+      "audience": "Audience",
+      "subject": "Subject",
+      "workloadIdentityProviderPlaceholder": "projects/123456789012/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID",
+      "serviceAccountEmailPlaceholder": "probo-audit@PROJECT_ID.iam.gserviceaccount.com"
+    },
+    "messages": {
+      "copyFailed": "Copy failed",
+      "copied": "Copied to clipboard",
+      "copiedIssuer": "Issuer copied.",
+      "copiedAudience": "Audience copied.",
+      "copiedSubject": "Subject copied.",
+      "copiedTerraform": "Terraform snippet copied.",
+      "error": "Error",
+      "success": "Success",
+      "created": "Access source created successfully."
+    },
+    "errors": {
+      "workloadIdentityProvider": "Enter a valid workload identity provider resource.",
+      "serviceAccountEmail": "Enter a valid service account email.",
+      "create": "Could not create the connector. Check the provider resource and the service account email, then try again.",
+      "disconnected": "Probo could not impersonate the audit service account. Confirm that the module is applied in this project and that the issuer and subject match the values shown during setup.",
+      "delete": "Could not delete the connector. Try again.",
+      "source": "Failed to create access source",
+      "copy": "Copy the value manually."
+    },
+    "actions": {
+      "copy": "Copy",
+      "connect": "Connect",
+      "back": "Back",
+      "installViaTerraform": "Install via Terraform",
+      "chooseAnotherInstallMethod": "Choose another install method"
+    }
+  }
+}

--- a/apps/console/src/pages/organizations/access-reviews/_locales/fr-FR.json
+++ b/apps/console/src/pages/organizations/access-reviews/_locales/fr-FR.json
@@ -1,0 +1,44 @@
+{
+  "createGcpAccessReviewSourcePage": {
+    "pageTitle": "Connecter GCP",
+    "title": "Connecter GCP",
+    "description": "Déployez le compte de service d’audit. Saisissez ensuite la ressource du fournisseur et l’e-mail du compte de service.",
+    "permissionDenied": "Vous n’avez pas la permission de créer des sources d’accès.",
+    "fields": {
+      "workloadIdentityProvider": "Fournisseur d’identité de charge de travail",
+      "serviceAccountEmail": "E-mail du compte de service",
+      "issuer": "Émetteur",
+      "audience": "Audience",
+      "subject": "Sujet",
+      "workloadIdentityProviderPlaceholder": "projects/123456789012/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID",
+      "serviceAccountEmailPlaceholder": "probo-audit@PROJECT_ID.iam.gserviceaccount.com"
+    },
+    "messages": {
+      "copyFailed": "Échec de la copie",
+      "copied": "Copié dans le presse-papiers",
+      "copiedIssuer": "Émetteur copié.",
+      "copiedAudience": "Audience copiée.",
+      "copiedSubject": "Sujet copié.",
+      "copiedTerraform": "Extrait Terraform copié.",
+      "error": "Erreur",
+      "success": "Succès",
+      "created": "Source d’accès créée avec succès."
+    },
+    "errors": {
+      "workloadIdentityProvider": "Saisissez une ressource de fournisseur d’identité de charge de travail valide.",
+      "serviceAccountEmail": "Saisissez un e-mail de compte de service valide.",
+      "create": "Échec de la création du connecteur. Vérifiez la ressource du fournisseur et l’e-mail du compte de service, puis réessayez.",
+      "disconnected": "Probo n’a pas pu usurper le compte de service d’audit. Vérifiez que le module est appliqué dans ce projet et que l’émetteur et le sujet correspondent aux valeurs affichées lors de la configuration.",
+      "delete": "Impossible de supprimer le connecteur. Réessayez.",
+      "source": "Échec de la création de la source d’accès",
+      "copy": "Copiez la valeur manuellement."
+    },
+    "actions": {
+      "copy": "Copier",
+      "connect": "Connecter",
+      "back": "Retour",
+      "installViaTerraform": "Installer via Terraform",
+      "chooseAnotherInstallMethod": "Choisir une autre méthode d’installation"
+    }
+  }
+}

--- a/apps/console/src/pages/organizations/access-reviews/_locales/nl-NL.json
+++ b/apps/console/src/pages/organizations/access-reviews/_locales/nl-NL.json
@@ -1,0 +1,44 @@
+{
+  "createGcpAccessReviewSourcePage": {
+    "pageTitle": "GCP verbinden",
+    "title": "GCP verbinden",
+    "description": "Implementeer het audit-serviceaccount. Voer daarna de providerresource en het e-mailadres van het serviceaccount in.",
+    "permissionDenied": "U heeft geen rechten om toegangsbronnen aan te maken.",
+    "fields": {
+      "workloadIdentityProvider": "Workload Identity-provider",
+      "serviceAccountEmail": "E-mailadres van serviceaccount",
+      "issuer": "Uitgever",
+      "audience": "Audience",
+      "subject": "Subject",
+      "workloadIdentityProviderPlaceholder": "projects/123456789012/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID",
+      "serviceAccountEmailPlaceholder": "probo-audit@PROJECT_ID.iam.gserviceaccount.com"
+    },
+    "messages": {
+      "copyFailed": "Kopiëren mislukt",
+      "copied": "Gekopieerd naar klembord",
+      "copiedIssuer": "Uitgever gekopieerd.",
+      "copiedAudience": "Audience gekopieerd.",
+      "copiedSubject": "Subject gekopieerd.",
+      "copiedTerraform": "Terraform-fragment gekopieerd.",
+      "error": "Fout",
+      "success": "Succes",
+      "created": "Toegangsbron succesvol aangemaakt."
+    },
+    "errors": {
+      "workloadIdentityProvider": "Voer een geldige Workload Identity-providerresource in.",
+      "serviceAccountEmail": "Voer een geldig e-mailadres van een serviceaccount in.",
+      "create": "Aanmaken van de connector mislukt. Controleer de providerresource en het e-mailadres van het serviceaccount en probeer het opnieuw.",
+      "disconnected": "Probo kon het audit-serviceaccount niet impersoneren. Controleer of de module in dit project is toegepast en of de issuer en het subject overeenkomen met de waarden die tijdens de installatie zijn getoond.",
+      "delete": "Kan de connector niet verwijderen. Probeer het opnieuw.",
+      "source": "Aanmaken van toegangsbron mislukt",
+      "copy": "Kopieer de waarde handmatig."
+    },
+    "actions": {
+      "copy": "Kopiëren",
+      "connect": "Verbinden",
+      "back": "Terug",
+      "installViaTerraform": "Installeren via Terraform",
+      "chooseAnotherInstallMethod": "Kies een andere installatiemethode"
+    }
+  }
+}

--- a/apps/console/src/pages/organizations/access-reviews/connections/CreateGcpAccessReviewSourcePage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/connections/CreateGcpAccessReviewSourcePage.tsx
@@ -1,0 +1,418 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { usePageTitle } from "@probo/hooks";
+import {
+  Button,
+  Card,
+  Field,
+  IconSquareBehindSquare2,
+  Input,
+  PageHeader,
+  useToast,
+} from "@probo/ui";
+import { type ChangeEvent, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { type PreloadedQuery, usePreloadedQuery } from "react-relay";
+import { Link, useNavigate } from "react-router";
+import { ConnectionHandler, graphql } from "relay-runtime";
+
+import type { accessReviewSourceMutationsCreateMutation } from "#/__generated__/core/accessReviewSourceMutationsCreateMutation.graphql";
+import type { CreateGcpAccessReviewSourcePageCreateMutation } from "#/__generated__/core/CreateGcpAccessReviewSourcePageCreateMutation.graphql";
+import type { CreateGcpAccessReviewSourcePageDeleteMutation } from "#/__generated__/core/CreateGcpAccessReviewSourcePageDeleteMutation.graphql";
+import type { CreateGcpAccessReviewSourcePageQuery } from "#/__generated__/core/CreateGcpAccessReviewSourcePageQuery.graphql";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { useMutation } from "#/lib/relay/useMutation";
+
+import {
+  ActionSplitButton,
+  type ActionSplitButtonAction,
+} from "../_components/ActionSplitButton";
+import { ConnectorDocumentationLink } from "../dialogs/_components/ConnectorDocumentationLink";
+import {
+  gcpAccessReviewSourceName,
+  isGCPServiceAccountEmail,
+  isGCPWorkloadIdentityProvider,
+} from "../dialogs/_lib/connectorSettings";
+import { createAccessReviewSourceMutation, prependCreatedSourceEdge } from "../dialogs/accessReviewSourceMutations";
+
+export const createGcpAccessReviewSourcePageQuery = graphql`
+  query CreateGcpAccessReviewSourcePageQuery($organizationId: ID!) {
+    gcpConnectorSetup(organizationId: $organizationId) {
+      issuer
+      audience
+      subject
+      terraformSnippet
+    }
+    accessReviewDrivers {
+      provider
+      displayName
+      documentationUrl
+    }
+    organization: node(id: $organizationId) {
+      __typename
+      ... on Organization {
+        id
+        canCreateSource: permission(action: "access-review:source:create")
+      }
+    }
+  }
+`;
+
+const createWorkloadIdentityConnectorMutation = graphql`
+  mutation CreateGcpAccessReviewSourcePageCreateMutation(
+    $input: CreateWorkloadIdentityConnectorInput!
+  ) {
+    createWorkloadIdentityConnector(input: $input) {
+      connector {
+        id
+        provider
+        connectionStatus
+      }
+    }
+  }
+`;
+
+const deleteConnectorMutation = graphql`
+  mutation CreateGcpAccessReviewSourcePageDeleteMutation(
+    $input: DeleteConnectorInput!
+  ) {
+    deleteConnector(input: $input) {
+      deletedConnectorId
+    }
+  }
+`;
+
+interface CreateGcpAccessReviewSourcePageProps {
+  queryRef: PreloadedQuery<CreateGcpAccessReviewSourcePageQuery>;
+}
+
+export function CreateGcpAccessReviewSourcePage({
+  queryRef,
+}: CreateGcpAccessReviewSourcePageProps) {
+  const { t } = useTranslation("organizations/access-reviews");
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const organizationId = useOrganizationId();
+  const [providerResource, setProviderResource] = useState("");
+  const [serviceAccountEmail, setServiceAccountEmail] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+
+  usePageTitle(t("createGcpAccessReviewSourcePage.pageTitle"));
+
+  const { organization, gcpConnectorSetup, accessReviewDrivers }
+    = usePreloadedQuery<CreateGcpAccessReviewSourcePageQuery>(
+      createGcpAccessReviewSourcePageQuery,
+      queryRef,
+    );
+  if (organization.__typename !== "Organization") {
+    throw new Error("Organization not found");
+  }
+
+  const gcpDriver = accessReviewDrivers.find(
+    driver => driver.provider === "GCP",
+  );
+  if (!gcpDriver) {
+    throw new Error("GCP access review driver not found");
+  }
+
+  const connectionId = ConnectionHandler.getConnectionID(
+    organization.id,
+    "AccessReviewConnectionsPage_accessReviewSources",
+  );
+
+  const [createWorkloadIdentityConnector] = useMutation<
+    CreateGcpAccessReviewSourcePageCreateMutation
+  >(createWorkloadIdentityConnectorMutation);
+  const [deleteConnector] = useMutation<
+    CreateGcpAccessReviewSourcePageDeleteMutation
+  >(deleteConnectorMutation);
+  const [createAccessReviewSource] = useMutation<
+    accessReviewSourceMutationsCreateMutation
+  >(createAccessReviewSourceMutation);
+
+  if (!organization.canCreateSource) {
+    return (
+      <Card padded>
+        <p className="text-txt-secondary text-sm">
+          {t("createGcpAccessReviewSourcePage.permissionDenied")}
+        </p>
+      </Card>
+    );
+  }
+
+  const copyValue = (value: string, successKey: string) => {
+    const onCopyFailure = () =>
+      toast({
+        title: t("createGcpAccessReviewSourcePage.messages.copyFailed"),
+        description: t("createGcpAccessReviewSourcePage.errors.copy"),
+        variant: "error",
+      });
+
+    if (!navigator.clipboard?.writeText) {
+      onCopyFailure();
+      return;
+    }
+
+    try {
+      navigator.clipboard.writeText(value).then(
+        () =>
+          toast({
+            title: t("createGcpAccessReviewSourcePage.messages.copied"),
+            description: t(successKey),
+            variant: "success",
+          }),
+        onCopyFailure,
+      );
+    } catch {
+      onCopyFailure();
+    }
+  };
+
+  const providerValid = isGCPWorkloadIdentityProvider(providerResource);
+  const providerInvalid = providerResource.trim() !== "" && !providerValid;
+  const emailValid = isGCPServiceAccountEmail(serviceAccountEmail);
+  const emailInvalid = serviceAccountEmail.trim() !== "" && !emailValid;
+  const formValid = providerValid && emailValid;
+
+  const onSubmit = async () => {
+    if (!formValid) {
+      return;
+    }
+
+    setIsCreating(true);
+
+    try {
+      const created = await createWorkloadIdentityConnector(
+        {
+          variables: {
+            input: {
+              organizationId,
+              provider: "GCP",
+              gcpWorkloadIdentityProvider: providerResource.trim(),
+              gcpServiceAccountEmail: serviceAccountEmail.trim(),
+            },
+          },
+        },
+        { errorToast: t("createGcpAccessReviewSourcePage.errors.create") },
+      );
+      const { id: connectorId, connectionStatus }
+        = created.createWorkloadIdentityConnector.connector;
+
+      const discardConnector = () =>
+        deleteConnector(
+          { variables: { input: { connectorId } } },
+          { errorToast: t("createGcpAccessReviewSourcePage.errors.delete") },
+        );
+
+      if (connectionStatus !== "CONNECTED") {
+        toast({
+          title: t("createGcpAccessReviewSourcePage.messages.error"),
+          description: t(
+            "createGcpAccessReviewSourcePage.errors.disconnected",
+          ),
+          variant: "error",
+        });
+        await discardConnector();
+        return;
+      }
+
+      try {
+        await createAccessReviewSource(
+          {
+            variables: {
+              input: {
+                organizationId,
+                connectorId,
+                name: gcpAccessReviewSourceName(
+                  gcpDriver.displayName,
+                  providerResource,
+                ),
+                csvData: null,
+              },
+            },
+            updater: (store) => {
+              if (connectionId) {
+                prependCreatedSourceEdge(store, connectionId);
+              }
+            },
+          },
+          { errorToast: t("createGcpAccessReviewSourcePage.errors.source") },
+        );
+      } catch {
+        await discardConnector();
+        return;
+      }
+
+      toast({
+        title: t("createGcpAccessReviewSourcePage.messages.success"),
+        description: t("createGcpAccessReviewSourcePage.messages.created"),
+        variant: "success",
+      });
+      void navigate(`/organizations/${organizationId}/access-reviews/connections`);
+    } catch {
+      return;
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const installActions: ActionSplitButtonAction[] = [];
+  if (gcpConnectorSetup.terraformSnippet) {
+    installActions.push({
+      id: "terraform",
+      label: t("createGcpAccessReviewSourcePage.actions.installViaTerraform"),
+      onSelect: () =>
+        copyValue(
+          gcpConnectorSetup.terraformSnippet,
+          "createGcpAccessReviewSourcePage.messages.copiedTerraform",
+        ),
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t("createGcpAccessReviewSourcePage.title")}
+        description={t("createGcpAccessReviewSourcePage.description")}
+      >
+        {installActions.length > 0 && (
+          <ActionSplitButton
+            actions={installActions}
+            chooseAnotherMethodLabel={t(
+              "createGcpAccessReviewSourcePage.actions.chooseAnotherInstallMethod",
+            )}
+          />
+        )}
+      </PageHeader>
+
+      <Card padded>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void onSubmit();
+          }}
+          className="space-y-4"
+        >
+          <Field
+            name="workloadIdentityProvider"
+            label={t(
+              "createGcpAccessReviewSourcePage.fields.workloadIdentityProvider",
+            )}
+            value={providerResource}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setProviderResource(e.target.value)}
+            required
+            placeholder={t(
+              "createGcpAccessReviewSourcePage.fields.workloadIdentityProviderPlaceholder",
+            )}
+            error={
+              providerInvalid
+                ? t("createGcpAccessReviewSourcePage.errors.workloadIdentityProvider")
+                : undefined
+            }
+          />
+          <Field
+            name="serviceAccountEmail"
+            label={t(
+              "createGcpAccessReviewSourcePage.fields.serviceAccountEmail",
+            )}
+            value={serviceAccountEmail}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setServiceAccountEmail(e.target.value)}
+            required
+            placeholder={t(
+              "createGcpAccessReviewSourcePage.fields.serviceAccountEmailPlaceholder",
+            )}
+            error={
+              emailInvalid
+                ? t("createGcpAccessReviewSourcePage.errors.serviceAccountEmail")
+                : undefined
+            }
+          />
+          {(
+            [
+              {
+                name: "issuer",
+                value: gcpConnectorSetup.issuer,
+                successKey:
+                  "createGcpAccessReviewSourcePage.messages.copiedIssuer",
+              },
+              {
+                name: "audience",
+                value: gcpConnectorSetup.audience,
+                successKey:
+                  "createGcpAccessReviewSourcePage.messages.copiedAudience",
+              },
+              {
+                name: "subject",
+                value: gcpConnectorSetup.subject,
+                successKey:
+                  "createGcpAccessReviewSourcePage.messages.copiedSubject",
+              },
+            ] as const
+          ).map(row => (
+            <Field
+              key={row.name}
+              name={row.name}
+              label={t(`createGcpAccessReviewSourcePage.fields.${row.name}`)}
+            >
+              <div className="flex items-center gap-2">
+                <div className="min-w-0 flex-1">
+                  <Input
+                    id={row.name}
+                    name={row.name}
+                    value={row.value}
+                    readOnly
+                    disabled
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  icon={IconSquareBehindSquare2}
+                  onClick={() => copyValue(row.value, row.successKey)}
+                  aria-label={t("createGcpAccessReviewSourcePage.actions.copy")}
+                />
+              </div>
+            </Field>
+          ))}
+
+          <div className="flex items-center justify-between gap-2">
+            <ConnectorDocumentationLink
+              url={gcpDriver.documentationUrl}
+              variant="button"
+            />
+            <div className="flex items-center justify-end gap-2">
+              <Button variant="secondary" asChild>
+                <Link to={`/organizations/${organizationId}/access-reviews/connections`}>
+                  {t("createGcpAccessReviewSourcePage.actions.back")}
+                </Link>
+              </Button>
+              <Button disabled={!formValid || isCreating} type="submit">
+                {t("createGcpAccessReviewSourcePage.actions.connect")}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/access-reviews/connections/CreateGcpAccessReviewSourcePageLoader.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/connections/CreateGcpAccessReviewSourcePageLoader.tsx
@@ -18,52 +18,41 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { lazy } from "@probo/react-lazy";
-import type { AppRoute } from "@probo/routes";
+import { Suspense, useEffect } from "react";
+import { useQueryLoader } from "react-relay";
 
+import type { CreateGcpAccessReviewSourcePageQuery } from "#/__generated__/core/CreateGcpAccessReviewSourcePageQuery.graphql";
 import { PageSkeleton } from "#/components/skeletons/PageSkeleton";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
 
-export const accessReviewRoutes = [
-  {
-    path: "campaigns",
-    Fallback: PageSkeleton,
-    Component: lazy(
-      () => import("./campaigns/AccessReviewCampaignsPageLoader"),
-    ),
-  },
-  {
-    path: "campaigns/:campaignId",
-    Fallback: PageSkeleton,
-    Component: lazy(
-      () => import("./campaigns/CampaignDetailPageLoader"),
-    ),
-  },
-  {
-    path: "connections",
-    Fallback: PageSkeleton,
-    Component: lazy(
-      () => import("./connections/AccessReviewConnectionsPageLoader"),
-    ),
-  },
-  {
-    path: "connections/new/csv",
-    Fallback: PageSkeleton,
-    Component: lazy(
-      () => import("./connections/CreateCsvAccessReviewSourcePageLoader"),
-    ),
-  },
-  {
-    path: "connections/new/aws-workload-identity",
-    Fallback: PageSkeleton,
-    Component: lazy(
-      () => import("./connections/CreateAwsAccessReviewSourcePageLoader"),
-    ),
-  },
-  {
-    path: "connections/new/gcp-workload-identity",
-    Fallback: PageSkeleton,
-    Component: lazy(
-      () => import("./connections/CreateGcpAccessReviewSourcePageLoader"),
-    ),
-  },
-] satisfies AppRoute[];
+import {
+  CreateGcpAccessReviewSourcePage,
+  createGcpAccessReviewSourcePageQuery,
+} from "./CreateGcpAccessReviewSourcePage";
+
+export default function CreateGcpAccessReviewSourcePageLoader() {
+  const organizationId = useOrganizationId();
+  const [queryRef, loadQuery]
+    = useQueryLoader<CreateGcpAccessReviewSourcePageQuery>(
+      createGcpAccessReviewSourcePageQuery,
+    );
+
+  useEffect(() => {
+    loadQuery({ organizationId });
+  }, [loadQuery, organizationId]);
+
+  const currentQueryRef = queryRef != null
+    && queryRef.variables.organizationId === organizationId
+    ? queryRef
+    : null;
+
+  if (currentQueryRef == null) {
+    return <PageSkeleton />;
+  }
+
+  return (
+    <Suspense fallback={<PageSkeleton />}>
+      <CreateGcpAccessReviewSourcePage queryRef={currentQueryRef} />
+    </Suspense>
+  );
+}

--- a/apps/console/src/pages/organizations/access-reviews/connections/_components/AccessReviewSourceProviderListItem.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/connections/_components/AccessReviewSourceProviderListItem.tsx
@@ -18,15 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { Badge, ThirdPartyLogo } from "@probo/ui";
+import { ThirdPartyLogo } from "@probo/ui";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
-import { useNavigate } from "react-router";
 
 import type { AccessReviewSourceProviderListItem_provider$key } from "#/__generated__/core/AccessReviewSourceProviderListItem_provider.graphql";
 
-import { ActionSplitButton } from "../../_components/ActionSplitButton";
+import {
+  ActionSplitButton,
+  type ActionSplitButtonAction,
+} from "../../_components/ActionSplitButton";
 import { APIKeyConnectorDialog } from "../../dialogs/_components/APIKeyConnectorDialog";
 import { ClientCredentialsConnectorDialog } from "../../dialogs/_components/ClientCredentialsConnectorDialog";
 import { ConnectorDocumentationLink } from "../../dialogs/_components/ConnectorDocumentationLink";
@@ -38,7 +40,11 @@ import {
   connectOAuthProvider,
   connectProviderProtocol,
 } from "../../dialogs/_lib/connectorSettings";
-import { type ConnectMethod, connectMethods } from "../_lib/connectMethods";
+import {
+  type ConnectMethod,
+  connectMethods,
+  workloadIdentityPath,
+} from "../_lib/connectMethods";
 
 import { accessReviewSourceSection } from "./variants";
 
@@ -81,7 +87,6 @@ export function AccessReviewSourceProviderListItem({
   connectionId,
 }: AccessReviewSourceProviderListItemProps) {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const provider = useFragment(
     accessReviewSourceProviderListItemFragment,
     providerKey,
@@ -103,8 +108,13 @@ export function AccessReviewSourceProviderListItem({
     = supportsOAuth && provider.provider === "DATADOG";
   const supportsZendeskOAuth
     = supportsOAuth && provider.provider === "ZENDESK";
-  const isComingSoon = provider.provider === "GCP";
-  const methods = connectMethods(provider);
+  const methods = connectMethods({
+    configuredProtocols: provider.configuredProtocols,
+    apiKeySupported: provider.apiKeySupported,
+    apiKeyManaged: provider.apiKeyManaged,
+    clientCredentialsSupported: provider.clientCredentialsSupported,
+    workloadIdentitySupported: provider.workloadIdentitySupported,
+  });
 
   const connectWithOAuth = () => {
     if (provider.provider === "DATADOG") {
@@ -120,7 +130,7 @@ export function AccessReviewSourceProviderListItem({
     }
   };
 
-  const connect = (method: ConnectMethod) => {
+  const connect = (method: Exclude<ConnectMethod, "WORKLOAD_IDENTITY">) => {
     switch (method) {
       case "OAUTH2":
         connectWithOAuth();
@@ -138,18 +148,23 @@ export function AccessReviewSourceProviderListItem({
           method,
         );
         break;
-      case "WORKLOAD_IDENTITY":
-        void navigate(
-          `/organizations/${organizationId}/access-reviews/connections/new/aws-workload-identity`,
-        );
-        break;
     }
   };
-  const actions = methods.map(method => ({
-    id: method,
-    label: t(connectMethodActionLabelKey[method]),
-    onSelect: () => connect(method),
-  }));
+  const actions = methods.flatMap((method): ActionSplitButtonAction[] => {
+    const label = t(connectMethodActionLabelKey[method]);
+    if (method === "WORKLOAD_IDENTITY") {
+      const to = workloadIdentityPath(organizationId, provider.provider);
+      if (!to) {
+        return [];
+      }
+      return [{ id: method, label, to }];
+    }
+    return [{
+      id: method,
+      label,
+      onSelect: () => connect(method),
+    }];
+  });
 
   return (
     <li className={item()}>
@@ -164,22 +179,14 @@ export function AccessReviewSourceProviderListItem({
         <ConnectorDocumentationLink url={provider.documentationUrl} />
       </div>
       <div className={trailing()}>
-        {isComingSoon
-          ? (
-              <Badge variant="info">
-                {t("accessReviewConnectionsPage.comingSoon")}
-              </Badge>
-            )
-          : (
-              <ActionSplitButton
-                actions={actions}
-                chooseAnotherMethodLabel={t(
-                  "addAccessReviewSourceDialog.actions.chooseAnotherMethod",
-                )}
-              />
-            )}
+        <ActionSplitButton
+          actions={actions}
+          chooseAnotherMethodLabel={t(
+            "addAccessReviewSourceDialog.actions.chooseAnotherMethod",
+          )}
+        />
       </div>
-      {!isComingSoon && supportsAPIKey && (
+      {supportsAPIKey && (
         <APIKeyConnectorDialog
           providerKey={activeDialog === "apiKey" ? provider : null}
           organizationId={organizationId}
@@ -188,7 +195,7 @@ export function AccessReviewSourceProviderListItem({
           onSuccess={() => setActiveDialog(null)}
         />
       )}
-      {!isComingSoon && provider.clientCredentialsSupported && (
+      {provider.clientCredentialsSupported && (
         <ClientCredentialsConnectorDialog
           providerKey={activeDialog === "clientCredentials" ? provider : null}
           organizationId={organizationId}
@@ -197,14 +204,14 @@ export function AccessReviewSourceProviderListItem({
           onSuccess={() => setActiveDialog(null)}
         />
       )}
-      {!isComingSoon && supportsDatadogOAuth && (
+      {supportsDatadogOAuth && (
         <DatadogConnectDialog
           providerKey={activeDialog === "datadog" ? provider : null}
           organizationId={organizationId}
           onClose={() => setActiveDialog(null)}
         />
       )}
-      {!isComingSoon && supportsZendeskOAuth && (
+      {supportsZendeskOAuth && (
         <ZendeskConnectDialog
           providerKey={activeDialog === "zendesk" ? provider : null}
           organizationId={organizationId}

--- a/apps/console/src/pages/organizations/access-reviews/connections/_lib/connectMethods.ts
+++ b/apps/console/src/pages/organizations/access-reviews/connections/_lib/connectMethods.ts
@@ -18,7 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { ConnectorProtocol } from "#/__generated__/core/AccessReviewSourceProviderListItem_provider.graphql";
+import type {
+  ConnectorProtocol,
+  ConnectorProvider,
+} from "#/__generated__/core/AccessReviewSourceProviderListItem_provider.graphql";
 
 export type ConnectMethod = ConnectorProtocol | "CLIENT_CREDENTIALS";
 
@@ -62,4 +65,19 @@ export function connectMethods({
   }
 
   return connectMethodPreference.filter(method => supportedMethods.has(method));
+}
+
+const workloadIdentitySlugByProvider = {
+  AWS: "aws-workload-identity",
+  GCP: "gcp-workload-identity",
+} as const;
+
+export function workloadIdentityPath(
+  organizationId: string,
+  provider: ConnectorProvider,
+): string | undefined {
+  if (provider !== "AWS" && provider !== "GCP") {
+    return undefined;
+  }
+  return `/organizations/${organizationId}/access-reviews/connections/new/${workloadIdentitySlugByProvider[provider]}`;
 }

--- a/apps/console/src/pages/organizations/access-reviews/dialogs/_lib/connectorSettings.ts
+++ b/apps/console/src/pages/organizations/access-reviews/dialogs/_lib/connectorSettings.ts
@@ -130,6 +130,41 @@ export function awsAccessReviewSourceName(
   return `${displayName} / ${accountID}`;
 }
 
+const GCP_PROVIDER_RESOURCE_PATTERN
+  = /^(?:https:\/\/iam\.googleapis\.com\/|\/\/iam\.googleapis\.com\/)?projects\/([1-9][0-9]*)\/locations\/global\/workloadIdentityPools\/([a-z0-9][a-z0-9-]{2,30}[a-z0-9])\/providers\/([a-z0-9][a-z0-9-]{2,30}[a-z0-9])\/?$/;
+
+const GCP_SERVICE_ACCOUNT_EMAIL_PATTERN
+  = /^[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z][a-z0-9-]{4,28}[a-z0-9]\.iam\.gserviceaccount\.com$/;
+
+export function isGCPWorkloadIdentityProvider(value: string): boolean {
+  return GCP_PROVIDER_RESOURCE_PATTERN.test(value.trim());
+}
+
+export function isGCPServiceAccountEmail(value: string): boolean {
+  return GCP_SERVICE_ACCOUNT_EMAIL_PATTERN.test(value.trim());
+}
+
+export function gcpProjectNumberFromProvider(value: string): string | null {
+  const match = value.trim().match(GCP_PROVIDER_RESOURCE_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  return match[1] ?? null;
+}
+
+export function gcpAccessReviewSourceName(
+  displayName: string,
+  providerResource: string,
+): string {
+  const projectNumber = gcpProjectNumberFromProvider(providerResource);
+  if (!projectNumber) {
+    return displayName;
+  }
+
+  return `${displayName} / ${projectNumber}`;
+}
+
 export function mapClientCredentialsExtraSettingToField(
   provider: string,
   settingKey: string,

--- a/contrib/terraform/gcp-audit-role/CHANGELOG.md
+++ b/contrib/terraform/gcp-audit-role/CHANGELOG.md
@@ -5,6 +5,17 @@ be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Replace project-wide `roles/logging.viewer` with
+  `roles/logging.viewAccessor` on the `_Required` bucket `_AllLogs`
+  view. The impersonated token can read Admin Activity and the other
+  `_Required` audit logs, not application logs in `_Default`. Apply a
+  Probo release that queries that view before or with this module;
+  applying the module first leaves last login unknown until Probo is
+  upgraded. If Cloud Logging default resource settings moved `_Required`
+  off `global`, set `required_bucket_location`.
+
 ## [0.1.1] - 2026-09-07
 
 ### Changed

--- a/contrib/terraform/gcp-audit-role/README.md
+++ b/contrib/terraform/gcp-audit-role/README.md
@@ -40,10 +40,11 @@ The Google provider must target the project you want to connect. Set
 `project` on the provider, or export `GOOGLE_CLOUD_PROJECT`.
 
 Enable `iam.googleapis.com`, `cloudresourcemanager.googleapis.com`,
-`sts.googleapis.com`, and `iamcredentials.googleapis.com` in that
-project before you apply. Terraform uses the first two. Probo uses STS
-and IAM Credentials to exchange a token and impersonate the service
-account.
+`sts.googleapis.com`, `iamcredentials.googleapis.com`, and
+`logging.googleapis.com` in that project before you apply. Terraform
+uses the first two and Logging to grant the `_Required` view. Probo
+uses STS and IAM Credentials to exchange a token and impersonate the
+service account.
 
 ```hcl
 module "probo_audit" {
@@ -97,7 +98,7 @@ it back.
 | `google_service_account` | `probo-audit` by default. |
 | `roles/iam.securityReviewer` | Project IAM, additive. |
 | `roles/iam.serviceAccountViewer` | Project IAM, additive. |
-| `roles/logging.viewer` | Project IAM, additive. |
+| `roles/logging.viewAccessor` | On `_Required`/`_AllLogs` only, additive. Admin Activity and the other `_Required` audit logs; not `_Default` application logs. |
 | `roles/policyanalyzer.activityAnalysisViewer` | Project IAM, additive. |
 | `roles/iam.workloadIdentityUser` | On the service account, for `principal://…/subject/{probo_subject}` only. |
 
@@ -119,6 +120,8 @@ output descriptions in [`variables.tf`](variables.tf) and
   URL as the JWT `aud`.
 - **The subject condition is exact equality.** A `startsWith` wildcard would
   let any subject this issuer can mint impersonate the service account.
-- **The four project roles are additive members**, not bindings. A binding
-  would replace every other member of that role in the project.
+- **IAM members are additive**, not bindings. A binding would replace
+  every other member of that role in the project or on the log view.
+- **`_Required` is queried in `global` by default.** If default resource
+  settings moved that bucket, set `required_bucket_location` to match.
 - Requires the `google` provider at 5.0 or later.

--- a/contrib/terraform/gcp-audit-role/main.tf
+++ b/contrib/terraform/gcp-audit-role/main.tf
@@ -86,10 +86,13 @@ resource "google_project_iam_member" "service_account_viewer" {
   member  = "serviceAccount:${google_service_account.probo_audit.email}"
 }
 
-resource "google_project_iam_member" "logging_viewer" {
-  project = data.google_project.current.project_id
-  role    = "roles/logging.viewer"
-  member  = "serviceAccount:${google_service_account.probo_audit.email}"
+resource "google_logging_log_view_iam_member" "required_logs" {
+  parent   = "projects/${data.google_project.current.project_id}"
+  location = var.required_bucket_location
+  bucket   = "_Required"
+  name     = "_AllLogs"
+  role     = "roles/logging.viewAccessor"
+  member   = "serviceAccount:${google_service_account.probo_audit.email}"
 }
 
 resource "google_project_iam_member" "policy_analyzer" {

--- a/contrib/terraform/gcp-audit-role/variables.tf
+++ b/contrib/terraform/gcp-audit-role/variables.tf
@@ -88,3 +88,18 @@ variable "provider_id" {
     error_message = "The provider id must be 4-32 characters of [a-z0-9-] and must not start with gcp-."
   }
 }
+
+variable "required_bucket_location" {
+  type        = string
+  default     = "global"
+  description = <<-EOT
+    Location of the project's _Required log bucket. Leave the default unless
+    Cloud Logging default resource settings moved that bucket. Probo queries
+    the same location; a mismatch leaves last login unknown.
+  EOT
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.required_bucket_location))
+    error_message = "The _Required bucket location must be a Cloud Logging location such as global or us-central1."
+  }
+}

--- a/e2e/console/aws_connector_test.go
+++ b/e2e/console/aws_connector_test.go
@@ -196,6 +196,19 @@ func TestCreateWorkloadIdentityConnector(t *testing.T) {
 	})
 }
 
+func TestCreateWorkloadIdentityConnector_MissingRoleARN(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	err := owner.Execute(createWorkloadIdentityConnectorMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"provider":       "AWS",
+		},
+	}, &createWorkloadIdentityConnectorResult{})
+	testutil.RequireErrorCode(t, err, "INVALID")
+}
+
 func TestCreateWorkloadIdentityConnector_InvalidRoleARN(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)

--- a/e2e/console/gcp_connector_test.go
+++ b/e2e/console/gcp_connector_test.go
@@ -1,0 +1,315 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package console_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/testutil"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+)
+
+const (
+	gcpFixtureProviderResource = "projects/123456789012/locations/global/workloadIdentityPools/probo-pool/providers/probo"
+	gcpSecondProviderResource  = "projects/111111111111/locations/global/workloadIdentityPools/probo-pool/providers/probo"
+	gcpFixtureServiceAccount   = "probo-audit@example-project.iam.gserviceaccount.com"
+)
+
+const gcpConnectorSetupQuery = `
+	query($organizationId: ID!) {
+		gcpConnectorSetup(organizationId: $organizationId) {
+			issuer
+			audience
+			subject
+			suggestedServiceAccountName
+			terraformSnippet
+		}
+	}
+`
+
+const createGCPWorkloadIdentityConnectorMutation = `
+	mutation($input: CreateWorkloadIdentityConnectorInput!) {
+		createWorkloadIdentityConnector(input: $input) {
+			connector {
+				id
+				provider
+				protocol
+			}
+		}
+	}
+`
+
+const createGCPWorkloadIdentityConnectorWithStatusMutation = `
+	mutation($input: CreateWorkloadIdentityConnectorInput!) {
+		createWorkloadIdentityConnector(input: $input) {
+			connector {
+				id
+				connectionStatus
+			}
+		}
+	}
+`
+
+type gcpConnectorSetupResult struct {
+	GCPConnectorSetup struct {
+		Issuer                      string `json:"issuer"`
+		Audience                    string `json:"audience"`
+		Subject                     string `json:"subject"`
+		SuggestedServiceAccountName string `json:"suggestedServiceAccountName"`
+		TerraformSnippet            string `json:"terraformSnippet"`
+	} `json:"gcpConnectorSetup"`
+}
+
+func TestGCPConnectorSetup(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	orgID := owner.GetOrganizationID().String()
+
+	var result gcpConnectorSetupResult
+
+	err := owner.Execute(gcpConnectorSetupQuery, map[string]any{
+		"organizationId": orgID,
+	}, &result)
+	require.NoError(t, err)
+
+	setup := result.GCPConnectorSetup
+	assert.Contains(t, setup.Issuer, orgID)
+	assert.Equal(t, cloudgcp.AudienceTemplate, setup.Audience)
+	assert.Equal(t, orgID, setup.Subject)
+	assert.Equal(t, cloudgcp.DefaultServiceAccountName, setup.SuggestedServiceAccountName)
+	assert.Contains(t, setup.TerraformSnippet, setup.Issuer)
+	assert.Contains(t, setup.TerraformSnippet, setup.Subject)
+	assert.Contains(t, setup.TerraformSnippet, cloudgcp.DefaultTerraformModuleSource)
+	assert.Contains(t, setup.TerraformSnippet, cloudgcp.DefaultServiceAccountName)
+}
+
+func TestCreateGCPWorkloadIdentityConnector(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	orgID := owner.GetOrganizationID().String()
+
+	var result createWorkloadIdentityConnectorResult
+
+	err := owner.Execute(createGCPWorkloadIdentityConnectorMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId":              orgID,
+			"provider":                    "GCP",
+			"gcpWorkloadIdentityProvider": gcpFixtureProviderResource,
+			"gcpServiceAccountEmail":      gcpFixtureServiceAccount,
+		},
+	}, &result)
+	require.NoError(t, err)
+
+	connector := result.CreateWorkloadIdentityConnector.Connector
+	assert.NotEmpty(t, connector.ID)
+	assert.Equal(t, "GCP", connector.Provider)
+	assert.Equal(t, "WORKLOAD_IDENTITY", connector.Protocol)
+
+	t.Run("allows a second connector for the same provider", func(t *testing.T) {
+		t.Parallel()
+
+		var second createWorkloadIdentityConnectorResult
+
+		err := owner.Execute(createGCPWorkloadIdentityConnectorMutation, map[string]any{
+			"input": map[string]any{
+				"organizationId":              orgID,
+				"provider":                    "GCP",
+				"gcpWorkloadIdentityProvider": gcpSecondProviderResource,
+				"gcpServiceAccountEmail":      gcpFixtureServiceAccount,
+			},
+		}, &second)
+		require.NoError(t, err)
+
+		secondID := second.CreateWorkloadIdentityConnector.Connector.ID
+		assert.NotEmpty(t, secondID)
+		assert.NotEqual(t, connector.ID, secondID)
+	})
+}
+
+func TestCreateGCPWorkloadIdentityConnector_InvalidProviderResource(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	bogus := "projects/alice/locations/global/workloadIdentityPools/probo-pool/providers/probo"
+
+	err := owner.Execute(createGCPWorkloadIdentityConnectorMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId":              owner.GetOrganizationID().String(),
+			"provider":                    "GCP",
+			"gcpWorkloadIdentityProvider": bogus,
+			"gcpServiceAccountEmail":      gcpFixtureServiceAccount,
+		},
+	}, &createWorkloadIdentityConnectorResult{})
+	testutil.RequireErrorCode(t, err, "INVALID")
+	assert.NotContains(t, err.Error(), bogus)
+	assert.NotContains(t, err.Error(), "alice")
+}
+
+func TestCreateGCPWorkloadIdentityConnector_InvalidServiceAccountEmail(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	bogus := "alice@example.com"
+
+	err := owner.Execute(createGCPWorkloadIdentityConnectorMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId":              owner.GetOrganizationID().String(),
+			"provider":                    "GCP",
+			"gcpWorkloadIdentityProvider": gcpFixtureProviderResource,
+			"gcpServiceAccountEmail":      bogus,
+		},
+	}, &createWorkloadIdentityConnectorResult{})
+	testutil.RequireErrorCode(t, err, "INVALID")
+	assert.NotContains(t, err.Error(), bogus)
+	assert.NotContains(t, err.Error(), "alice")
+}
+
+func TestGCPConnectorConnectionStatus_ImpersonationFailure(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	orgID := owner.GetOrganizationID().String()
+
+	resp, err := owner.Do(createGCPWorkloadIdentityConnectorWithStatusMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId":              orgID,
+			"provider":                    "GCP",
+			"gcpWorkloadIdentityProvider": gcpFixtureProviderResource,
+			"gcpServiceAccountEmail":      gcpFixtureServiceAccount,
+		},
+	})
+	require.NoError(t, err)
+
+	var created createWorkloadIdentityConnectorWithStatusResult
+	require.NoError(t, json.Unmarshal(resp.Data, &created))
+
+	connector := created.CreateWorkloadIdentityConnector.Connector
+	require.NotEmpty(t, connector.ID)
+	assert.Equal(t, "DISCONNECTED", connector.ConnectionStatus)
+
+	payload := resp.DataString()
+	assert.NotContains(t, payload, gcpFixtureProviderResource)
+	assert.NotContains(t, payload, gcpFixtureServiceAccount)
+	assert.NotContains(t, strings.ToLower(payload), "permissiondenied")
+	assert.NotContains(t, strings.ToLower(payload), "accessdenied")
+}
+
+func TestGCPConnector_RBAC(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+	orgID := owner.GetOrganizationID().String()
+
+	t.Run("viewer cannot read setup", func(t *testing.T) {
+		t.Parallel()
+
+		err := viewer.Execute(gcpConnectorSetupQuery, map[string]any{
+			"organizationId": orgID,
+		}, &gcpConnectorSetupResult{})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to read gcp connector setup")
+	})
+
+	t.Run("viewer cannot create connector", func(t *testing.T) {
+		t.Parallel()
+
+		err := viewer.Execute(createGCPWorkloadIdentityConnectorMutation, map[string]any{
+			"input": map[string]any{
+				"organizationId":              orgID,
+				"provider":                    "GCP",
+				"gcpWorkloadIdentityProvider": gcpFixtureProviderResource,
+				"gcpServiceAccountEmail":      gcpFixtureServiceAccount,
+			},
+		}, &createWorkloadIdentityConnectorResult{})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to create gcp connector")
+	})
+
+	t.Run("viewer cannot read connection status", func(t *testing.T) {
+		t.Parallel()
+
+		var created createWorkloadIdentityConnectorResult
+
+		err := owner.Execute(createGCPWorkloadIdentityConnectorMutation, map[string]any{
+			"input": map[string]any{
+				"organizationId":              orgID,
+				"provider":                    "GCP",
+				"gcpWorkloadIdentityProvider": gcpFixtureProviderResource,
+				"gcpServiceAccountEmail":      gcpFixtureServiceAccount,
+			},
+		}, &created)
+		require.NoError(t, err)
+
+		err = viewer.Execute(organizationConnectorStatusQuery, map[string]any{
+			"id": orgID,
+		}, &organizationConnectorStatusResult{})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to read gcp connector status")
+	})
+}
+
+func TestGCPConnector_TenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	org1 := testutil.NewClient(t, testutil.RoleOwner)
+	org2 := testutil.NewClient(t, testutil.RoleOwner)
+	org1ID := org1.GetOrganizationID().String()
+
+	err := org1.Execute(createGCPWorkloadIdentityConnectorMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId":              org1ID,
+			"provider":                    "GCP",
+			"gcpWorkloadIdentityProvider": gcpFixtureProviderResource,
+			"gcpServiceAccountEmail":      gcpFixtureServiceAccount,
+		},
+	}, &createWorkloadIdentityConnectorResult{})
+	require.NoError(t, err)
+
+	t.Run("cannot read setup for another organization", func(t *testing.T) {
+		t.Parallel()
+
+		err := org2.Execute(gcpConnectorSetupQuery, map[string]any{
+			"organizationId": org1ID,
+		}, &gcpConnectorSetupResult{})
+		testutil.RequireForbiddenError(t, err, "org B should not read org A's gcp connector setup")
+	})
+
+	t.Run("cannot create connector in another organization", func(t *testing.T) {
+		t.Parallel()
+
+		err := org2.Execute(createGCPWorkloadIdentityConnectorMutation, map[string]any{
+			"input": map[string]any{
+				"organizationId":              org1ID,
+				"provider":                    "GCP",
+				"gcpWorkloadIdentityProvider": gcpFixtureProviderResource,
+				"gcpServiceAccountEmail":      gcpFixtureServiceAccount,
+			},
+		}, &createWorkloadIdentityConnectorResult{})
+		testutil.RequireForbiddenError(t, err, "org B should not create a connector in org A")
+	})
+
+	t.Run("cannot read connection status from another organization", func(t *testing.T) {
+		t.Parallel()
+
+		err := org2.Execute(organizationConnectorStatusQuery, map[string]any{
+			"id": org1ID,
+		}, &organizationConnectorStatusResult{})
+		testutil.RequireForbiddenError(t, err, "org B should not read org A's connector status")
+	})
+}

--- a/e2e/mcp/gcp_connector_test.go
+++ b/e2e/mcp/gcp_connector_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package mcp_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/testutil"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+)
+
+const (
+	gcpFixtureProviderResource = "projects/123456789012/locations/global/workloadIdentityPools/probo-pool/providers/probo"
+	gcpFixtureServiceAccount   = "probo-audit@example-project.iam.gserviceaccount.com"
+)
+
+func TestMCP_GCPConnector(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	mc := testutil.NewMCPClient(t, owner)
+	orgID := owner.GetOrganizationID().String()
+
+	var setupResult struct {
+		Setup struct {
+			Issuer                      string `json:"issuer"`
+			Audience                    string `json:"audience"`
+			Subject                     string `json:"subject"`
+			SuggestedServiceAccountName string `json:"suggested_service_account_name"`
+			TerraformSnippet            string `json:"terraform_snippet"`
+		} `json:"setup"`
+	}
+	mc.CallToolInto("gcpConnectorSetup", map[string]any{
+		"organization_id": orgID,
+	}, &setupResult)
+	assert.Contains(t, setupResult.Setup.Issuer, orgID)
+	assert.Equal(t, cloudgcp.AudienceTemplate, setupResult.Setup.Audience)
+	assert.Equal(t, orgID, setupResult.Setup.Subject)
+	assert.Equal(t, cloudgcp.DefaultServiceAccountName, setupResult.Setup.SuggestedServiceAccountName)
+	assert.Contains(t, setupResult.Setup.TerraformSnippet, setupResult.Setup.Issuer)
+	assert.Contains(t, setupResult.Setup.TerraformSnippet, cloudgcp.DefaultTerraformModuleSource)
+	assert.Contains(t, setupResult.Setup.TerraformSnippet, cloudgcp.DefaultServiceAccountName)
+
+	tr := mc.CallTool("createWorkloadIdentityConnector", map[string]any{
+		"organization_id":                orgID,
+		"provider":                       "GCP",
+		"gcp_workload_identity_provider": gcpFixtureProviderResource,
+		"gcp_service_account_email":      gcpFixtureServiceAccount,
+	})
+	require.False(t, tr.IsError, "createWorkloadIdentityConnector returned error: %v", tr.Content)
+	require.NotEmpty(t, tr.Content)
+
+	var payload string
+
+	require.NoError(t, json.Unmarshal(tr.Content[0].Text, &payload))
+
+	var createResult struct {
+		Connector struct {
+			ID               string `json:"id"`
+			Provider         string `json:"provider"`
+			Protocol         string `json:"protocol"`
+			ConnectionStatus string `json:"connection_status"`
+		} `json:"connector"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(payload), &createResult))
+	require.NotEmpty(t, createResult.Connector.ID)
+	assert.Equal(t, "GCP", createResult.Connector.Provider)
+	assert.Equal(t, "WORKLOAD_IDENTITY", createResult.Connector.Protocol)
+	assert.Equal(t, "DISCONNECTED", createResult.Connector.ConnectionStatus)
+
+	assert.NotContains(t, payload, gcpFixtureProviderResource)
+	assert.NotContains(t, payload, gcpFixtureServiceAccount)
+	assert.NotContains(t, strings.ToLower(payload), "permissiondenied")
+	assert.NotContains(t, strings.ToLower(payload), "accessdenied")
+}
+
+func TestMCP_GCPConnector_RBAC(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+	viewerMC := testutil.NewMCPClient(t, viewer)
+	orgID := owner.GetOrganizationID().String()
+
+	msg := viewerMC.CallToolExpectToolError("gcpConnectorSetup", map[string]any{
+		"organization_id": orgID,
+	})
+	assert.Contains(t, msg, "permission denied")
+
+	msg = viewerMC.CallToolExpectToolError("createWorkloadIdentityConnector", map[string]any{
+		"organization_id":                orgID,
+		"provider":                       "GCP",
+		"gcp_workload_identity_provider": gcpFixtureProviderResource,
+		"gcp_service_account_email":      gcpFixtureServiceAccount,
+	})
+	assert.Contains(t, msg, "permission denied")
+}
+
+func TestMCP_GCPConnector_TenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	org1 := testutil.NewClient(t, testutil.RoleOwner)
+	org2 := testutil.NewClient(t, testutil.RoleOwner)
+	org2MC := testutil.NewMCPClient(t, org2)
+	org1ID := org1.GetOrganizationID().String()
+
+	msg := org2MC.CallToolExpectToolError("gcpConnectorSetup", map[string]any{
+		"organization_id": org1ID,
+	})
+	assert.NotEmpty(t, msg)
+
+	msg = org2MC.CallToolExpectToolError("createWorkloadIdentityConnector", map[string]any{
+		"organization_id":                org1ID,
+		"provider":                       "GCP",
+		"gcp_workload_identity_provider": gcpFixtureProviderResource,
+		"gcp_service_account_email":      gcpFixtureServiceAccount,
+	})
+	assert.NotEmpty(t, msg)
+}

--- a/packages/n8n-node/nodes/Probo/actions/accessReviewSource/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/accessReviewSource/create.operation.ts
@@ -52,6 +52,30 @@ export const description: INodeProperties[] = [
 		required: true,
 	},
 	{
+		displayName: 'Provider',
+		name: 'provider',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: ['accessReviewSource'],
+				operation: ['create'],
+			},
+		},
+		options: [
+			{
+				name: 'AWS',
+				value: 'AWS',
+			},
+			{
+				name: 'GCP',
+				value: 'GCP',
+			},
+		],
+		default: 'AWS',
+		description: 'Cloud provider for the workload-identity connector',
+		required: true,
+	},
+	{
 		displayName: 'AWS Role ARN',
 		name: 'awsRoleArn',
 		type: 'string',
@@ -59,10 +83,41 @@ export const description: INodeProperties[] = [
 			show: {
 				resource: ['accessReviewSource'],
 				operation: ['create'],
+				provider: ['AWS'],
 			},
 		},
 		default: '',
 		description: 'IAM role ARN, including partition, account, and role name',
+		required: true,
+	},
+	{
+		displayName: 'GCP Workload Identity Provider',
+		name: 'gcpWorkloadIdentityProvider',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['accessReviewSource'],
+				operation: ['create'],
+				provider: ['GCP'],
+			},
+		},
+		default: '',
+		description: 'Workload identity provider resource',
+		required: true,
+	},
+	{
+		displayName: 'GCP Service Account Email',
+		name: 'gcpServiceAccountEmail',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['accessReviewSource'],
+				operation: ['create'],
+				provider: ['GCP'],
+			},
+		},
+		default: '',
+		description: 'Service account email to impersonate',
 		required: true,
 	},
 ];
@@ -73,7 +128,7 @@ export async function execute(
 ): Promise<INodeExecutionData> {
 	const organizationId = this.getNodeParameter('organizationId', itemIndex) as string;
 	const name = this.getNodeParameter('name', itemIndex) as string;
-	const awsRoleArn = this.getNodeParameter('awsRoleArn', itemIndex) as string;
+	const provider = this.getNodeParameter('provider', itemIndex) as string;
 
 	const createConnectorQuery = `
 		mutation CreateWorkloadIdentityConnector($input: CreateWorkloadIdentityConnectorInput!) {
@@ -91,9 +146,21 @@ export async function execute(
 
 	const connectorInput: Record<string, string> = {
 		organizationId,
-		provider: 'AWS',
-		awsRoleArn,
+		provider,
 	};
+
+	if (provider === 'GCP') {
+		connectorInput.gcpWorkloadIdentityProvider = this.getNodeParameter(
+			'gcpWorkloadIdentityProvider',
+			itemIndex,
+		) as string;
+		connectorInput.gcpServiceAccountEmail = this.getNodeParameter(
+			'gcpServiceAccountEmail',
+			itemIndex,
+		) as string;
+	} else {
+		connectorInput.awsRoleArn = this.getNodeParameter('awsRoleArn', itemIndex) as string;
+	}
 
 	const connectorResponse = await proboApiRequest.call(this, createConnectorQuery, {
 		input: connectorInput,

--- a/packages/n8n-node/nodes/Probo/actions/accessReviewSource/setupGcp.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/accessReviewSource/setupGcp.operation.ts
@@ -18,60 +18,48 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import type { INodeProperties } from 'n8n-workflow';
-import * as createOp from './create.operation';
-import * as getAllOp from './getAll.operation';
-import * as setupAwsOp from './setupAws.operation';
-import * as setupGcpOp from './setupGcp.operation';
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
 
 export const description: INodeProperties[] = [
 	{
-		displayName: 'Operation',
-		name: 'operation',
-		type: 'options',
-		noDataExpression: true,
+		displayName: 'Organization ID',
+		name: 'organizationId',
+		type: 'string',
 		displayOptions: {
 			show: {
 				resource: ['accessReviewSource'],
+				operation: ['setupGcp'],
 			},
 		},
-		options: [
-			{
-				name: 'Create',
-				value: 'create',
-				description: 'Create a workload-identity access source',
-				action: 'Create an access review source',
-			},
-			{
-				name: 'Get Many',
-				value: 'getAll',
-				description: 'Get many access review sources',
-				action: 'Get many access review sources',
-			},
-			{
-				name: 'Setup AWS',
-				value: 'setupAws',
-				description: 'Get AWS access source setup values',
-				action: 'Get AWS access source setup',
-			},
-			{
-				name: 'Setup GCP',
-				value: 'setupGcp',
-				description: 'Get GCP access source setup values',
-				action: 'Get GCP access source setup',
-			},
-		],
-		default: 'getAll',
+		default: '',
+		description: 'The ID of the organization',
+		required: true,
 	},
-	...createOp.description,
-	...getAllOp.description,
-	...setupAwsOp.description,
-	...setupGcpOp.description,
 ];
 
-export {
-	createOp as create,
-	getAllOp as getAll,
-	setupAwsOp as setupAws,
-	setupGcpOp as setupGcp,
-};
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const organizationId = this.getNodeParameter('organizationId', itemIndex) as string;
+
+	const query = `
+		query GcpConnectorSetup($organizationId: ID!) {
+			gcpConnectorSetup(organizationId: $organizationId) {
+				issuer
+				audience
+				subject
+				suggestedServiceAccountName
+				terraformSnippet
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { organizationId });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/pkg/accessreview/drivers/gcp_activity.go
+++ b/pkg/accessreview/drivers/gcp_activity.go
@@ -54,6 +54,9 @@ const (
 	gcpLoggingFilterMaxLen         = 18000
 	gcpLoggingOrderByNewest        = "timestamp desc"
 	gcpServiceAccountsResourceMark = "/serviceAccounts/"
+	gcpRequiredBucketLocation      = "global"
+	gcpRequiredBucketID            = "_Required"
+	gcpRequiredViewID              = "_AllLogs"
 )
 
 type gcpPolicyActivityPayload struct {
@@ -278,9 +281,9 @@ func queryGCPAdminActivity(
 		return nil, fmt.Errorf("cannot create gcp logging client: %w", err)
 	}
 
-	resource, err := url.JoinPath("projects", url.PathEscape(session.AccountID()))
+	resource, err := gcpRequiredLogViewName(session.AccountID())
 	if err != nil {
-		return nil, fmt.Errorf("cannot build gcp logging resource name: %w", err)
+		return nil, err
 	}
 
 	since := time.Now().UTC().Add(-gcpActivityLookback)
@@ -556,6 +559,24 @@ func gcpAdminActivityFilter(project string, since time.Time, emails []string) st
 
 func gcpActivityLogName(project string) string {
 	return "projects/" + url.PathEscape(project) + "/logs/" + gcpActivityLogID
+}
+
+func gcpRequiredLogViewName(project string) (string, error) {
+	resource, err := url.JoinPath(
+		"projects",
+		url.PathEscape(project),
+		"locations",
+		gcpRequiredBucketLocation,
+		"buckets",
+		gcpRequiredBucketID,
+		"views",
+		gcpRequiredViewID,
+	)
+	if err != nil {
+		return "", fmt.Errorf("cannot build gcp logging resource name: %w", err)
+	}
+
+	return resource, nil
 }
 
 func gcpActivityTypeParent(project string, activityType string) (string, error) {

--- a/pkg/accessreview/drivers/gcp_activity_test.go
+++ b/pkg/accessreview/drivers/gcp_activity_test.go
@@ -275,6 +275,18 @@ func TestApplyGCPActivity_DoesNotOverwriteKnownAuthMethod(t *testing.T) {
 	assert.Nil(t, records[0].LastLogin)
 }
 
+func TestGcpRequiredLogViewName(t *testing.T) {
+	t.Parallel()
+
+	name, err := gcpRequiredLogViewName("123456789012")
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"projects/123456789012/locations/global/buckets/_Required/views/_AllLogs",
+		name,
+	)
+}
+
 func TestGcpEmailFilterBatches(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/accessreview/errors.go
+++ b/pkg/accessreview/errors.go
@@ -24,11 +24,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/aws/smithy-go"
 	"golang.org/x/oauth2"
+	"google.golang.org/api/googleapi"
 
 	"go.probo.inc/probo/pkg/connector/provider"
 	"go.probo.inc/probo/pkg/coredata"
@@ -240,6 +242,15 @@ func IsProviderVerdict(err error) bool {
 		return true
 	}
 
+	// STS rejects an assertion with 400. The probe's only Google clients
+	// are STS Token and IAM GenerateAccessToken, so 400 is their answer.
+	if apiErr, ok := errors.AsType[*googleapi.Error](err); ok && apiErr != nil {
+		switch apiErr.Code {
+		case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+			return true
+		}
+	}
+
 	return false
 }
 
@@ -250,8 +261,15 @@ func IsProviderVerdict(err error) bool {
 // only there is the provider's own explanation still in hand.
 func IsProbeOperationRefused(err error) bool {
 	rejected, ok := errors.AsType[*provider.CredentialRejectedError](err)
+	if ok && rejected != nil && rejected.OperationRefused {
+		return true
+	}
 
-	return ok && rejected != nil && rejected.OperationRefused
+	if apiErr, ok := errors.AsType[*googleapi.Error](err); ok && apiErr != nil {
+		return apiErr.Code == http.StatusForbidden
+	}
+
+	return false
 }
 
 // ProbeFailureCode reduces a probe failure to a token safe to log. Probe
@@ -278,6 +296,16 @@ func ProbeFailureCode(err error) string {
 	// safe to report where the surrounding message is not.
 	if apiErr, ok := errors.AsType[smithy.APIError](err); ok && apiErr != nil {
 		return fmt.Sprintf("aws_%s", apiErr.ErrorCode())
+	}
+
+	// Status and reason are fixed identifiers; Message and Body can name a
+	// service-account email, so they stay out of the token.
+	if apiErr, ok := errors.AsType[*googleapi.Error](err); ok && apiErr != nil {
+		if len(apiErr.Errors) > 0 && apiErr.Errors[0].Reason != "" {
+			return fmt.Sprintf("gcp_%d_%s", apiErr.Code, apiErr.Errors[0].Reason)
+		}
+
+		return fmt.Sprintf("gcp_%d", apiErr.Code)
 	}
 
 	cause := err

--- a/pkg/accessreview/probe_error_test.go
+++ b/pkg/accessreview/probe_error_test.go
@@ -24,11 +24,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"testing"
 
 	"github.com/aws/smithy-go"
 	"golang.org/x/oauth2"
+	"google.golang.org/api/googleapi"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -105,6 +107,15 @@ func TestProbeFailureCodeIsSafeToLog(t *testing.T) {
 	)
 	assert.Equal(t, "aws_AccessDenied", awsCode)
 	assert.NotContains(t, awsCode, "123456789012")
+
+	// A GCP status and reason are fixed identifiers, so they are reported;
+	// the message around them, which can name a service-account email, is not.
+	gcpCode := accessreview.ProbeFailureCode(
+		gcpImpersonationDenied(http.StatusForbidden, "forbidden"),
+	)
+	assert.Equal(t, "gcp_403_forbidden", gcpCode)
+	assert.NotContains(t, gcpCode, "iam.gserviceaccount.com")
+	assert.Equal(t, "gcp_403", accessreview.ProbeFailureCode(gcpImpersonationDenied(http.StatusForbidden, "")))
 }
 
 // nilMatchingError reports a match while assigning a nil value, which is what
@@ -184,6 +195,9 @@ func TestIsProviderVerdict(t *testing.T) {
 	// A workload identity connector is answered by STS through the SDK, so an
 	// AWS API error is the provider's verdict, not a Probo failure.
 	assert.True(t, accessreview.IsProviderVerdict(fmt.Errorf("cannot reach aws account: %w", &smithy.GenericAPIError{Code: "AccessDenied", Message: "not authorized"})))
+	assert.True(t, accessreview.IsProviderVerdict(gcpImpersonationDenied(http.StatusForbidden, "forbidden")))
+	assert.True(t, accessreview.IsProviderVerdict(gcpImpersonationDenied(http.StatusBadRequest, "")))
+	assert.False(t, accessreview.IsProviderVerdict(gcpImpersonationDenied(http.StatusInternalServerError, "")))
 
 	// Probo never got as far as asking. Defaulting these to "ours" keeps a
 	// settings decode or a request we could not build in the error budget,
@@ -205,4 +219,40 @@ func TestIsProviderVerdict(t *testing.T) {
 	assert.False(t, accessreview.IsProviderVerdict(
 		&url.Error{Op: "parse", URL: "://bad", Err: errors.New("missing protocol scheme")},
 	))
+}
+
+func TestIsProbeOperationRefused_GCPImpersonationDenied(t *testing.T) {
+	t.Parallel()
+
+	denied := accessreview.NewProbeError(
+		coredata.ConnectorProviderGCP,
+		gcpImpersonationDenied(http.StatusForbidden, "forbidden"),
+	)
+	assert.True(t, accessreview.IsProbeOperationRefused(denied))
+
+	rejected := accessreview.NewProbeError(
+		coredata.ConnectorProviderGCP,
+		gcpImpersonationDenied(http.StatusBadRequest, ""),
+	)
+	assert.False(t, accessreview.IsProbeOperationRefused(rejected))
+}
+
+func gcpImpersonationDenied(status int, reason string) error {
+	const email = "ci@my-project.iam.gserviceaccount.com"
+
+	message := "Permission 'iam.serviceAccounts.getAccessToken' denied on resource " +
+		"'projects/-/serviceAccounts/" + email + "' (or it may not exist)."
+
+	apiErr := &googleapi.Error{
+		Code:    status,
+		Message: message,
+	}
+	if reason != "" {
+		apiErr.Errors = []googleapi.ErrorItem{{Reason: reason, Message: message}}
+	}
+
+	return fmt.Errorf(
+		"cannot reach gcp project: %w",
+		fmt.Errorf("cannot impersonate gcp service account: %w", apiErr),
+	)
 }

--- a/pkg/cmd/access-review/source/create/create.go
+++ b/pkg/cmd/access-review/source/create/create.go
@@ -48,7 +48,7 @@ mutation($input: CreateAccessReviewSourceInput!) {
 }
 `
 
-	createAWSConnectorMutation = `
+	createWorkloadIdentityConnectorMutation = `
 mutation($input: CreateWorkloadIdentityConnectorInput!) {
   createWorkloadIdentityConnector(input: $input) {
     connector {
@@ -81,7 +81,7 @@ type (
 		} `json:"createAccessReviewSource"`
 	}
 
-	createAWSConnectorResponse struct {
+	createWorkloadIdentityConnectorResponse struct {
 		CreateWorkloadIdentityConnector struct {
 			Connector struct {
 				ID               string `json:"id"`
@@ -93,11 +93,13 @@ type (
 
 func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	var (
-		flagOrg         string
-		flagName        string
-		flagCSVFile     string
-		flagConnectorID string
-		flagRoleARN     string
+		flagOrg                         string
+		flagName                        string
+		flagCSVFile                     string
+		flagConnectorID                 string
+		flagRoleARN                     string
+		flagGCPWorkloadIdentityProvider string
+		flagGCPServiceAccountEmail      string
 	)
 
 	cmd := &cobra.Command{
@@ -110,7 +112,12 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
   prb access-review source create --name "GitHub" --connector-id <connector-id>
 
   # Create an AWS workload-identity access source
-  prb access-review source create --name "AWS prod" --aws-role-arn arn:aws:iam::123456789012:role/ProboAudit`,
+  prb access-review source create --name "AWS prod" --aws-role-arn arn:aws:iam::123456789012:role/ProboAudit
+
+  # Create a GCP workload-identity access source
+  prb access-review source create --name "GCP prod" \
+    --gcp-workload-identity-provider projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo \
+    --gcp-service-account-email probo-audit@my-project.iam.gserviceaccount.com`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := f.Config()
@@ -143,6 +150,29 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 
 			if flagRoleARN != "" {
 				connectorID, status, err := createAWSConnector(client, flagOrg, flagRoleARN)
+				if err != nil {
+					return err
+				}
+
+				createdConnectorID = connectorID
+				flagConnectorID = connectorID
+
+				if status != connectionStatusConnected {
+					return abandonCreatedConnector(
+						client,
+						createdConnectorID,
+						fmt.Errorf("connector is %s", status),
+					)
+				}
+			}
+
+			if flagGCPWorkloadIdentityProvider != "" {
+				connectorID, status, err := createGCPConnector(
+					client,
+					flagOrg,
+					flagGCPWorkloadIdentityProvider,
+					flagGCPServiceAccountEmail,
+				)
 				if err != nil {
 					return err
 				}
@@ -214,9 +244,30 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagCSVFile, "csv-file", "", "Path to CSV file with access data")
 	cmd.Flags().StringVar(&flagConnectorID, "connector-id", "", "Connector ID to use as data source")
 	cmd.Flags().StringVar(&flagRoleARN, "aws-role-arn", "", "IAM role ARN")
+	cmd.Flags().StringVar(
+		&flagGCPWorkloadIdentityProvider,
+		"gcp-workload-identity-provider",
+		"",
+		"GCP workload identity provider resource",
+	)
+	cmd.Flags().StringVar(
+		&flagGCPServiceAccountEmail,
+		"gcp-service-account-email",
+		"",
+		"GCP service account email to impersonate",
+	)
 
 	_ = cmd.MarkFlagRequired("name")
-	cmd.MarkFlagsMutuallyExclusive("csv-file", "connector-id", "aws-role-arn")
+	cmd.MarkFlagsMutuallyExclusive(
+		"csv-file",
+		"connector-id",
+		"aws-role-arn",
+		"gcp-workload-identity-provider",
+	)
+	cmd.MarkFlagsRequiredTogether(
+		"gcp-workload-identity-provider",
+		"gcp-service-account-email",
+	)
 
 	return cmd
 }
@@ -226,18 +277,46 @@ func createAWSConnector(
 	orgID string,
 	roleARN string,
 ) (string, string, error) {
-	input := map[string]any{
-		"organizationId": orgID,
-		"provider":       "AWS",
-		"awsRoleArn":     roleARN,
-	}
+	return createWorkloadIdentityConnector(
+		client,
+		map[string]any{
+			"organizationId": orgID,
+			"provider":       "AWS",
+			"awsRoleArn":     roleARN,
+		},
+	)
+}
 
-	data, err := client.Do(createAWSConnectorMutation, map[string]any{"input": input})
+func createGCPConnector(
+	client *api.Client,
+	orgID string,
+	providerResource string,
+	serviceAccountEmail string,
+) (string, string, error) {
+	return createWorkloadIdentityConnector(
+		client,
+		map[string]any{
+			"organizationId":              orgID,
+			"provider":                    "GCP",
+			"gcpWorkloadIdentityProvider": providerResource,
+			"gcpServiceAccountEmail":      serviceAccountEmail,
+		},
+	)
+}
+
+func createWorkloadIdentityConnector(
+	client *api.Client,
+	input map[string]any,
+) (string, string, error) {
+	data, err := client.Do(
+		createWorkloadIdentityConnectorMutation,
+		map[string]any{"input": input},
+	)
 	if err != nil {
 		return "", "", err
 	}
 
-	var resp createAWSConnectorResponse
+	var resp createWorkloadIdentityConnectorResponse
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return "", "", fmt.Errorf("cannot parse response: %w", err)
 	}

--- a/pkg/cmd/access-review/source/setup-gcp/setup_gcp.go
+++ b/pkg/cmd/access-review/source/setup-gcp/setup_gcp.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package setupgcp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const setupQuery = `
+query($organizationId: ID!) {
+  gcpConnectorSetup(organizationId: $organizationId) {
+    issuer
+    audience
+    subject
+    suggestedServiceAccountName
+    terraformSnippet
+  }
+}
+`
+
+type setupResponse struct {
+	GCPConnectorSetup struct {
+		Issuer                      string `json:"issuer"`
+		Audience                    string `json:"audience"`
+		Subject                     string `json:"subject"`
+		SuggestedServiceAccountName string `json:"suggestedServiceAccountName"`
+		TerraformSnippet            string `json:"terraformSnippet"`
+	} `json:"gcpConnectorSetup"`
+}
+
+func NewCmdSetupGCP(f *cmdutil.Factory) *cobra.Command {
+	var flagOrg string
+
+	cmd := &cobra.Command{
+		Use:   "setup-gcp",
+		Short: "Show GCP access source setup values",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			if flagOrg == "" {
+				flagOrg = hc.Organization
+			}
+
+			if flagOrg == "" {
+				return fmt.Errorf("organization is required; pass --org or set a default with 'prb auth login'")
+			}
+
+			data, err := client.Do(setupQuery, map[string]any{"organizationId": flagOrg})
+			if err != nil {
+				return err
+			}
+
+			var resp setupResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			return cmdutil.PrintJSON(f.IOStreams.Out, resp.GCPConnectorSetup)
+		},
+	}
+
+	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
+
+	return cmd
+}

--- a/pkg/cmd/access-review/source/source.go
+++ b/pkg/cmd/access-review/source/source.go
@@ -26,6 +26,7 @@ import (
 	"go.probo.inc/probo/pkg/cmd/access-review/source/delete"
 	"go.probo.inc/probo/pkg/cmd/access-review/source/list"
 	setupaws "go.probo.inc/probo/pkg/cmd/access-review/source/setup-aws"
+	setupgcp "go.probo.inc/probo/pkg/cmd/access-review/source/setup-gcp"
 	"go.probo.inc/probo/pkg/cmd/access-review/source/update"
 	"go.probo.inc/probo/pkg/cmd/access-review/source/view"
 	"go.probo.inc/probo/pkg/cmd/cmdutil"
@@ -43,6 +44,7 @@ func NewCmdSource(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(update.NewCmdUpdate(f))
 	cmd.AddCommand(delete.NewCmdDelete(f))
 	cmd.AddCommand(setupaws.NewCmdSetupAWS(f))
+	cmd.AddCommand(setupgcp.NewCmdSetupGCP(f))
 
 	return cmd
 }

--- a/pkg/probo/workload_identity_settings.go
+++ b/pkg/probo/workload_identity_settings.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package probo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+type (
+	// WorkloadIdentitySettingsInput is the provider-specific fields needed to
+	// persist a workload-identity connector. Surfaces extract these from their
+	// own input types.
+	WorkloadIdentitySettingsInput struct {
+		Provider                    coredata.ConnectorProvider
+		AWSRoleARN                  string
+		GCPWorkloadIdentityProvider string
+		GCPServiceAccountEmail      string
+	}
+)
+
+var (
+	// ErrMarshalWorkloadIdentitySettings is returned when validated settings
+	// cannot be serialized. Surfaces must map it to an opaque internal error.
+	ErrMarshalWorkloadIdentitySettings = errors.New("cannot marshal workload identity settings")
+)
+
+// MarshalWorkloadIdentitySettings validates provider-specific workload-identity
+// fields and returns the JSON persisted on Connector.RawSettings.
+func MarshalWorkloadIdentitySettings(input WorkloadIdentitySettingsInput) ([]byte, error) {
+	switch input.Provider {
+	case coredata.ConnectorProviderAWS:
+		if input.AWSRoleARN == "" {
+			return nil, fmt.Errorf("awsRoleArn is required")
+		}
+
+		settings, err := cloudaws.NewConnectorSettings(input.AWSRoleARN)
+		if err != nil {
+			return nil, err
+		}
+
+		return marshalWorkloadIdentitySettings(settings)
+	case coredata.ConnectorProviderGCP:
+		if input.GCPWorkloadIdentityProvider == "" || input.GCPServiceAccountEmail == "" {
+			return nil, fmt.Errorf("gcpWorkloadIdentityProvider and gcpServiceAccountEmail are required")
+		}
+
+		validated, err := cloudgcp.NewConnectorSettings(
+			input.GCPWorkloadIdentityProvider,
+			input.GCPServiceAccountEmail,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		settings := coredata.GCPConnectorSettings{
+			WorkloadIdentityProvider: validated.WorkloadIdentityProvider,
+			ServiceAccountEmail:      validated.ServiceAccountEmail,
+		}
+
+		return marshalWorkloadIdentitySettings(settings)
+	default:
+		return nil, fmt.Errorf("provider does not support workload identity")
+	}
+}
+
+func marshalWorkloadIdentitySettings(settings any) ([]byte, error) {
+	raw, err := json.Marshal(settings)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrMarshalWorkloadIdentitySettings, err)
+	}
+
+	return raw, nil
+}

--- a/pkg/probo/workload_identity_settings_test.go
+++ b/pkg/probo/workload_identity_settings_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package probo_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/probo"
+)
+
+const (
+	testAWSRoleARN        = "arn:aws:iam::123456789012:role/ProboAudit"
+	testGCPProvider       = "projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo"
+	testGCPServiceAccount = "probo-audit@my-project.iam.gserviceaccount.com"
+)
+
+func TestMarshalWorkloadIdentitySettings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("aws marshals role_arn", func(t *testing.T) {
+		t.Parallel()
+
+		raw, err := probo.MarshalWorkloadIdentitySettings(
+			probo.WorkloadIdentitySettingsInput{
+				Provider:   coredata.ConnectorProviderAWS,
+				AWSRoleARN: testAWSRoleARN,
+			},
+		)
+		require.NoError(t, err)
+
+		var got map[string]string
+		require.NoError(t, json.Unmarshal(raw, &got))
+		assert.Equal(
+			t,
+			map[string]string{"role_arn": testAWSRoleARN},
+			got,
+		)
+	})
+
+	t.Run("gcp marshals canonical fields", func(t *testing.T) {
+		t.Parallel()
+
+		raw, err := probo.MarshalWorkloadIdentitySettings(
+			probo.WorkloadIdentitySettingsInput{
+				Provider:                    coredata.ConnectorProviderGCP,
+				GCPWorkloadIdentityProvider: "https://iam.googleapis.com/" + testGCPProvider,
+				GCPServiceAccountEmail:      "  " + testGCPServiceAccount + "  ",
+			},
+		)
+		require.NoError(t, err)
+
+		var got map[string]string
+		require.NoError(t, json.Unmarshal(raw, &got))
+		assert.Equal(
+			t,
+			map[string]string{
+				"workload_identity_provider": testGCPProvider,
+				"service_account_email":      testGCPServiceAccount,
+			},
+			got,
+		)
+	})
+
+	t.Run("refuses a missing aws role arn", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := probo.MarshalWorkloadIdentitySettings(
+			probo.WorkloadIdentitySettingsInput{
+				Provider: coredata.ConnectorProviderAWS,
+			},
+		)
+		require.Error(t, err)
+		assert.Equal(t, "awsRoleArn is required", err.Error())
+		assert.NotErrorIs(t, err, probo.ErrMarshalWorkloadIdentitySettings)
+	})
+
+	t.Run("refuses missing gcp fields", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			provider string
+			email    string
+		}{
+			{name: "empty provider", email: testGCPServiceAccount},
+			{name: "empty email", provider: testGCPProvider},
+			{name: "both empty"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				_, err := probo.MarshalWorkloadIdentitySettings(
+					probo.WorkloadIdentitySettingsInput{
+						Provider:                    coredata.ConnectorProviderGCP,
+						GCPWorkloadIdentityProvider: tt.provider,
+						GCPServiceAccountEmail:      tt.email,
+					},
+				)
+				require.Error(t, err)
+				assert.Equal(
+					t,
+					"gcpWorkloadIdentityProvider and gcpServiceAccountEmail are required",
+					err.Error(),
+				)
+				assert.NotErrorIs(t, err, probo.ErrMarshalWorkloadIdentitySettings)
+			})
+		}
+	})
+
+	t.Run("refuses an unsupported provider", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := probo.MarshalWorkloadIdentitySettings(
+			probo.WorkloadIdentitySettingsInput{
+				Provider: coredata.ConnectorProviderGitHub,
+			},
+		)
+		require.Error(t, err)
+		assert.Equal(t, "provider does not support workload identity", err.Error())
+		assert.NotErrorIs(t, err, probo.ErrMarshalWorkloadIdentitySettings)
+	})
+
+	t.Run("refuses an invalid aws role arn", func(t *testing.T) {
+		t.Parallel()
+
+		raw := "arn:aws:iam::123456789012:user/alice"
+
+		_, err := probo.MarshalWorkloadIdentitySettings(
+			probo.WorkloadIdentitySettingsInput{
+				Provider:   coredata.ConnectorProviderAWS,
+				AWSRoleARN: raw,
+			},
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "awsRoleArn is not an IAM role ARN")
+		assert.NotContains(t, err.Error(), raw)
+		assert.NotErrorIs(t, err, probo.ErrMarshalWorkloadIdentitySettings)
+	})
+
+	t.Run("refuses an invalid gcp provider resource", func(t *testing.T) {
+		t.Parallel()
+
+		raw := "projects/not-a-number/locations/global/workloadIdentityPools/probo/providers/probo"
+
+		_, err := probo.MarshalWorkloadIdentitySettings(
+			probo.WorkloadIdentitySettingsInput{
+				Provider:                    coredata.ConnectorProviderGCP,
+				GCPWorkloadIdentityProvider: raw,
+				GCPServiceAccountEmail:      testGCPServiceAccount,
+			},
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "workloadIdentityProvider is not a workload identity provider resource")
+		assert.NotContains(t, err.Error(), raw)
+		assert.NotErrorIs(t, err, probo.ErrMarshalWorkloadIdentitySettings)
+	})
+}

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -975,6 +975,9 @@ func (impl *Implm) Run(
 				CloudFormationTemplateURL: impl.cfg.IdentityFederation.CloudFormationTemplateURL,
 				TerraformModuleSource:     impl.cfg.IdentityFederation.TerraformModuleSource,
 			},
+			GCPConnectorInstall: cloudgcp.ConnectorInstallConfig{
+				TerraformModuleSource: impl.cfg.IdentityFederation.GCPTerraformModuleSource,
+			},
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -35,6 +35,7 @@ import (
 	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/certmanager"
 	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/complianceportal/management"
 	"go.probo.inc/probo/pkg/complianceportal/visitor"
 	"go.probo.inc/probo/pkg/connector"
@@ -109,6 +110,7 @@ type (
 		// IdentityFederationIssuer is nil when identity federation is disabled.
 		IdentityFederationIssuer *identityfederation.Issuer
 		AWSConnectorInstall      cloudaws.ConnectorInstallConfig
+		GCPConnectorInstall      cloudgcp.ConnectorInstallConfig
 	}
 
 	MCPConfig struct {
@@ -272,6 +274,7 @@ func NewServer(cfg Config) (*Server, error) {
 			cfg.ITAM,
 			cfg.IdentityFederationIssuer,
 			cfg.AWSConnectorInstall,
+			cfg.GCPConnectorInstall,
 		),
 		cookieBannerHandler: cookiebanner_v1.NewMux(
 			cfg.Logger.Named("cookiebanner.v1"),
@@ -305,6 +308,7 @@ func NewServer(cfg Config) (*Server, error) {
 			cfg.BaseURL,
 			cfg.IdentityFederationIssuer,
 			cfg.AWSConnectorInstall,
+			cfg.GCPConnectorInstall,
 		),
 		slackHandler: slack_v1.NewMux(
 			cfg.Logger.Named("slack.v1"),

--- a/pkg/server/api/console/v1/base_resolvers.go
+++ b/pkg/server/api/console/v1/base_resolvers.go
@@ -15,6 +15,7 @@ import (
 	"go.probo.inc/probo/pkg/accessreview"
 	"go.probo.inc/probo/pkg/agentexecution"
 	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/complianceportal/management"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
@@ -778,6 +779,30 @@ func (r *queryResolver) AWSConnectorSetup(ctx context.Context, organizationID gi
 	}
 
 	return newAWSConnectorSetup(setup), nil
+}
+
+// GCPConnectorSetup is the resolver for the gcpConnectorSetup field.
+func (r *queryResolver) GCPConnectorSetup(ctx context.Context, organizationID gid.GID) (*types.GCPConnectorSetup, error) {
+	if _, err := r.authorize(ctx, organizationID, probo.ActionConnectorCreate); err != nil {
+		return nil, err
+	}
+
+	if r.identityFederation == nil {
+		return nil, gqlutils.Invalidf(ctx, "identity federation is not configured in this deployment")
+	}
+
+	setup, err := cloudgcp.ConnectorSetupFor(
+		r.identityFederation,
+		organizationID,
+		r.gcpConnectorInstall,
+	)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot build gcp connector setup", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return newGCPConnectorSetup(setup), nil
 }
 
 // CrispVerificationCode is the resolver for the crispVerificationCode field. It

--- a/pkg/server/api/console/v1/connector_resolvers.go
+++ b/pkg/server/api/console/v1/connector_resolvers.go
@@ -7,12 +7,10 @@ package console_v1
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
 	"go.gearno.de/kit/log"
-	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
 	"go.probo.inc/probo/pkg/connector"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/probo"
@@ -200,20 +198,9 @@ func (r *mutationResolver) CreateWorkloadIdentityConnector(ctx context.Context, 
 		return nil, gqlutils.Invalidf(ctx, "identity federation is not configured in this deployment")
 	}
 
-	if input.Provider != coredata.ConnectorProviderAWS {
-		return nil, gqlutils.Invalidf(ctx, "provider does not support workload identity")
-	}
-
-	settings, err := cloudaws.NewConnectorSettings(input.AWSRoleArn)
+	raw, err := r.workloadIdentitySettings(ctx, input)
 	if err != nil {
-		return nil, gqlutils.Invalid(ctx, err)
-	}
-
-	raw, err := json.Marshal(settings)
-	if err != nil {
-		r.logger.ErrorCtx(ctx, "cannot marshal aws connector settings", log.Error(err))
-
-		return nil, gqlutils.Internal(ctx)
+		return nil, err
 	}
 
 	cnnctr, err := r.probo.Connectors.Create(ctx, scope, probo.CreateConnectorRequest{

--- a/pkg/server/api/console/v1/graphql/base.graphql
+++ b/pkg/server/api/console/v1/graphql/base.graphql
@@ -51,6 +51,8 @@ type Query {
     accessReviewDrivers: [ConnectorProviderInfo!]! @goField(forceResolver: true)
     awsConnectorSetup(organizationId: ID!): AWSConnectorSetup!
         @goField(forceResolver: true)
+    gcpConnectorSetup(organizationId: ID!): GCPConnectorSetup!
+        @goField(forceResolver: true)
     crispVerificationCode(organizationId: ID!, websiteId: String!): String!
         @goField(forceResolver: true)
     probotIdentityBindPreview(token: String!): ProbotIdentityBindPreview!

--- a/pkg/server/api/console/v1/graphql/connector.graphql
+++ b/pkg/server/api/console/v1/graphql/connector.graphql
@@ -219,6 +219,14 @@ type AWSConnectorSetup {
     cloudFormationQuickCreateURL: String!
 }
 
+type GCPConnectorSetup {
+    issuer: String!
+    audience: String!
+    subject: String!
+    suggestedServiceAccountName: String!
+    terraformSnippet: String!
+}
+
 type ConnectorProviderSettingInfo {
     key: String!
     label: String!
@@ -386,7 +394,9 @@ type CreateClientCredentialsConnectorPayload {
 input CreateWorkloadIdentityConnectorInput {
     organizationId: ID!
     provider: ConnectorProvider!
-    awsRoleArn: String!
+    awsRoleArn: String
+    gcpWorkloadIdentityProvider: String
+    gcpServiceAccountEmail: String
 }
 
 type CreateWorkloadIdentityConnectorPayload {

--- a/pkg/server/api/console/v1/graphql_handler.go
+++ b/pkg/server/api/console/v1/graphql_handler.go
@@ -29,6 +29,7 @@ import (
 	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/certmanager"
 	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/complianceportal/management"
 	"go.probo.inc/probo/pkg/connector"
 	"go.probo.inc/probo/pkg/connector/provider"
@@ -79,6 +80,7 @@ func NewGraphQLHandler(
 	complianceMessages ComplianceMessages,
 	identityFederation *identityfederation.Issuer,
 	awsConnectorInstall cloudaws.ConnectorInstallConfig,
+	gcpConnectorInstall cloudgcp.ConnectorInstallConfig,
 ) http.Handler {
 	config := schema.Config{
 		Resolvers: &Resolver{
@@ -106,6 +108,7 @@ func NewGraphQLHandler(
 			logger:                  logger,
 			identityFederation:      identityFederation,
 			awsConnectorInstall:     awsConnectorInstall,
+			gcpConnectorInstall:     gcpConnectorInstall,
 			probotIdentityBindings:  probotIdentityBindings,
 			slackbotInstallations:   slackbotInstallations,
 			botDeliveryDestinations: botDeliveryDestinations,

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -32,6 +32,7 @@ import (
 	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/certmanager"
 	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/complianceportal/management"
 	"go.probo.inc/probo/pkg/connector"
 	"go.probo.inc/probo/pkg/connector/provider"
@@ -97,6 +98,7 @@ type (
 		tokenSecret             string
 		identityFederation      *identityfederation.Issuer
 		awsConnectorInstall     cloudaws.ConnectorInstallConfig
+		gcpConnectorInstall     cloudgcp.ConnectorInstallConfig
 		probotIdentityBindings  *identitybinding.Service
 		slackbotInstallations   *slackchannel.InstallationService
 		botDeliveryDestinations BotDeliveryDestinations
@@ -133,6 +135,7 @@ func NewMux(
 	itamSvc *itam.Service,
 	identityFederation *identityfederation.Issuer,
 	awsConnectorInstall cloudaws.ConnectorInstallConfig,
+	gcpConnectorInstall cloudgcp.ConnectorInstallConfig,
 ) *chi.Mux {
 	r := chi.NewMux()
 
@@ -166,6 +169,7 @@ func NewMux(
 		complianceMessages,
 		identityFederation,
 		awsConnectorInstall,
+		gcpConnectorInstall,
 	)
 
 	r.Group(func(r chi.Router) {

--- a/pkg/server/api/mcp/v1/resolver.go
+++ b/pkg/server/api/mcp/v1/resolver.go
@@ -34,6 +34,7 @@ import (
 	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/certmanager"
 	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/complianceportal/management"
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/coredata"
@@ -73,6 +74,7 @@ type Resolver struct {
 	baseURL             *baseurl.BaseURL
 	identityFederation  *identityfederation.Issuer
 	awsConnectorInstall cloudaws.ConnectorInstallConfig
+	gcpConnectorInstall cloudgcp.ConnectorInstallConfig
 }
 
 func markdownToProseMirrorJSON(markdown string) (string, error) {

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -15,6 +15,7 @@ import (
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/accessreview"
 	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/complianceportal/management"
 	"go.probo.inc/probo/pkg/connector"
 	"go.probo.inc/probo/pkg/cookiebanner"
@@ -9371,20 +9372,9 @@ func (r *Resolver) CreateWorkloadIdentityConnectorTool(ctx context.Context, req 
 		return nil, types.CreateWorkloadIdentityConnectorOutput{}, fmt.Errorf("identity federation is not configured in this deployment")
 	}
 
-	if input.Provider != coredata.ConnectorProviderAWS {
-		return nil, types.CreateWorkloadIdentityConnectorOutput{}, fmt.Errorf("provider does not support workload identity")
-	}
-
-	settings, err := cloudaws.NewConnectorSettings(input.AwsRoleArn)
+	raw, err := r.workloadIdentitySettings(ctx, input)
 	if err != nil {
 		return nil, types.CreateWorkloadIdentityConnectorOutput{}, err
-	}
-
-	raw, err := json.Marshal(settings)
-	if err != nil {
-		r.logger.ErrorCtx(ctx, "cannot marshal aws connector settings", log.Error(err))
-
-		return nil, types.CreateWorkloadIdentityConnectorOutput{}, fmt.Errorf("internal server error")
 	}
 
 	cnnctr, err := r.proboSvc.Connectors.Create(ctx, scope, probo.CreateConnectorRequest{
@@ -9405,6 +9395,31 @@ func (r *Resolver) CreateWorkloadIdentityConnectorTool(ctx context.Context, req 
 			cnnctr,
 			r.connectorConnectionStatus(ctx, scope, cnnctr.ID),
 		),
+	}, nil
+}
+
+func (r *Resolver) GcpConnectorSetupTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GcpConnectorSetupInput) (*mcp.CallToolResult, types.GcpConnectorSetupOutput, error) {
+	if _, err := r.Authorize(ctx, input.OrganizationID, probo.ActionConnectorCreate); err != nil {
+		return nil, types.GcpConnectorSetupOutput{}, err
+	}
+
+	if r.identityFederation == nil {
+		return nil, types.GcpConnectorSetupOutput{}, fmt.Errorf("identity federation is not configured in this deployment")
+	}
+
+	setup, err := cloudgcp.ConnectorSetupFor(
+		r.identityFederation,
+		input.OrganizationID,
+		r.gcpConnectorInstall,
+	)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot build gcp connector setup", log.Error(err))
+
+		return nil, types.GcpConnectorSetupOutput{}, fmt.Errorf("internal server error")
+	}
+
+	return nil, types.GcpConnectorSetupOutput{
+		Setup: types.NewGCPConnectorSetup(setup),
 	}, nil
 }
 

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -10122,10 +10122,53 @@ components:
         setup:
           $ref: "#/components/schemas/AWSConnectorSetup"
 
+    GCPConnectorSetup:
+      type: object
+      required:
+        - issuer
+        - audience
+        - subject
+        - suggested_service_account_name
+        - terraform_snippet
+      properties:
+        issuer:
+          type: string
+          description: Organization issuer URL
+        audience:
+          type: string
+          description: Token audience template
+        subject:
+          type: string
+          description: Token subject
+        suggested_service_account_name:
+          type: string
+          description: Default service account name
+        terraform_snippet:
+          type: string
+          description: Terraform module block with issuer, subject and service account name filled
+
+    GCPConnectorSetupMCPInput:
+      type: object
+      required:
+        - organization_id
+      properties:
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+
+    GCPConnectorSetupMCPOutput:
+      type: object
+      required:
+        - setup
+      properties:
+        setup:
+          $ref: "#/components/schemas/GCPConnectorSetup"
+
     WorkloadIdentityConnectorProvider:
       type: string
       enum:
         - AWS
+        - GCP
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.ConnectorProvider
       description: Connector provider that supports workload identity
 
@@ -10134,17 +10177,40 @@ components:
       required:
         - organization_id
         - provider
-        - aws_role_arn
+      oneOf:
+        - title: AWS
+          properties:
+            provider:
+              type: string
+              enum:
+                - AWS
+          required:
+            - aws_role_arn
+        - title: GCP
+          properties:
+            provider:
+              type: string
+              enum:
+                - GCP
+          required:
+            - gcp_workload_identity_provider
+            - gcp_service_account_email
       properties:
         organization_id:
           $ref: "#/components/schemas/GID"
           description: Organization ID
         provider:
           $ref: "#/components/schemas/WorkloadIdentityConnectorProvider"
-          description: Connector provider (AWS)
+          description: Connector provider (AWS or GCP)
         aws_role_arn:
           type: string
-          description: IAM role ARN, including partition, account, and role name
+          description: IAM role ARN, including partition, account, and role name. Required when provider is AWS.
+        gcp_workload_identity_provider:
+          type: string
+          description: Workload identity provider resource. Required when provider is GCP.
+        gcp_service_account_email:
+          type: string
+          description: Service account email to impersonate. Required when provider is GCP.
 
     CreateWorkloadIdentityConnectorMCPOutput:
       type: object
@@ -17743,9 +17809,21 @@ tools:
       $ref: "#/components/schemas/AWSConnectorSetupMCPInput"
     outputSchema:
       $ref: "#/components/schemas/AWSConnectorSetupMCPOutput"
+  - name: gcpConnectorSetup
+    title: GCP Connector Setup
+    description: Return issuer, subject, audience template and deploy artifacts for connecting a GCP project
+    hints:
+      readonly: true
+      destructive: false
+      idempotent: true
+      openWorld: false
+    inputSchema:
+      $ref: "#/components/schemas/GCPConnectorSetupMCPInput"
+    outputSchema:
+      $ref: "#/components/schemas/GCPConnectorSetupMCPOutput"
   - name: createWorkloadIdentityConnector
     title: Create Workload Identity Connector
-    description: Create a workload-identity connector (AWS) and report whether the audit role can be assumed
+    description: Create a workload-identity connector (AWS or GCP) and report whether the audit identity can be assumed
     hints:
       readonly: false
       destructive: false

--- a/pkg/server/api/mcp/v1/types/connector.go
+++ b/pkg/server/api/mcp/v1/types/connector.go
@@ -22,6 +22,7 @@ package types
 
 import (
 	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/coredata"
 )
 
@@ -43,5 +44,15 @@ func NewAWSConnectorSetup(setup cloudaws.ConnectorSetup) *AWSConnectorSetup {
 		SuggestedRoleName:            setup.SuggestedRoleName,
 		TerraformSnippet:             setup.TerraformSnippet,
 		CloudFormationQuickCreateURL: setup.CloudFormationQuickCreateURL,
+	}
+}
+
+func NewGCPConnectorSetup(setup cloudgcp.ConnectorSetup) *GCPConnectorSetup {
+	return &GCPConnectorSetup{
+		Issuer:                      setup.Issuer,
+		Audience:                    setup.Audience,
+		Subject:                     setup.Subject,
+		SuggestedServiceAccountName: setup.SuggestedServiceAccountName,
+		TerraformSnippet:            setup.TerraformSnippet,
 	}
 }

--- a/pkg/server/api/mcp/v1/v1_handler.go
+++ b/pkg/server/api/mcp/v1/v1_handler.go
@@ -32,6 +32,7 @@ import (
 	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/certmanager"
 	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/complianceportal/management"
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/filemanager"
@@ -66,6 +67,7 @@ func NewMux(
 	baseURL *baseurl.BaseURL,
 	identityFederation *identityfederation.Issuer,
 	awsConnectorInstall cloudaws.ConnectorInstallConfig,
+	gcpConnectorInstall cloudgcp.ConnectorInstallConfig,
 ) *chi.Mux {
 	logger = logger.Named("mcp.v1")
 
@@ -88,6 +90,7 @@ func NewMux(
 		baseURL:             baseURL,
 		identityFederation:  identityFederation,
 		awsConnectorInstall: awsConnectorInstall,
+		gcpConnectorInstall: gcpConnectorInstall,
 	}
 
 	mcpServer := server.New(resolver, mcpgenmcp.WithRecoverFunc(mcputils.NewRecoverFunc(logger)))

--- a/pkg/server/api/mcp/v1/workload_identity.go
+++ b/pkg/server/api/mcp/v1/workload_identity.go
@@ -18,62 +18,39 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package console_v1
+package mcp_v1
 
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"go.gearno.de/kit/log"
 	"go.gearno.de/x/ref"
-	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
-	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/probo"
-	"go.probo.inc/probo/pkg/server/api/console/v1/types"
-	"go.probo.inc/probo/pkg/server/gqlutils"
+	"go.probo.inc/probo/pkg/server/api/mcp/v1/types"
 )
-
-func newAWSConnectorSetup(setup cloudaws.ConnectorSetup) *types.AWSConnectorSetup {
-	return &types.AWSConnectorSetup{
-		Issuer:                       setup.Issuer,
-		Audience:                     setup.Audience,
-		Subject:                      setup.Subject,
-		SuggestedRoleName:            setup.SuggestedRoleName,
-		TerraformSnippet:             setup.TerraformSnippet,
-		CloudFormationQuickCreateURL: setup.CloudFormationQuickCreateURL,
-	}
-}
-
-func newGCPConnectorSetup(setup cloudgcp.ConnectorSetup) *types.GCPConnectorSetup {
-	return &types.GCPConnectorSetup{
-		Issuer:                      setup.Issuer,
-		Audience:                    setup.Audience,
-		Subject:                     setup.Subject,
-		SuggestedServiceAccountName: setup.SuggestedServiceAccountName,
-		TerraformSnippet:            setup.TerraformSnippet,
-	}
-}
 
 func (r *Resolver) workloadIdentitySettings(
 	ctx context.Context,
-	input types.CreateWorkloadIdentityConnectorInput,
+	input *types.CreateWorkloadIdentityConnectorInput,
 ) ([]byte, error) {
 	raw, err := probo.MarshalWorkloadIdentitySettings(
 		probo.WorkloadIdentitySettingsInput{
 			Provider:                    input.Provider,
-			AWSRoleARN:                  ref.UnrefOrZero(input.AWSRoleArn),
-			GCPWorkloadIdentityProvider: ref.UnrefOrZero(input.GCPWorkloadIdentityProvider),
-			GCPServiceAccountEmail:      ref.UnrefOrZero(input.GCPServiceAccountEmail),
+			AWSRoleARN:                  ref.UnrefOrZero(input.AwsRoleArn),
+			GCPWorkloadIdentityProvider: ref.UnrefOrZero(input.GcpWorkloadIdentityProvider),
+			GCPServiceAccountEmail:      ref.UnrefOrZero(input.GcpServiceAccountEmail),
 		},
 	)
 	if err != nil {
 		if errors.Is(err, probo.ErrMarshalWorkloadIdentitySettings) {
 			r.logger.ErrorCtx(ctx, "cannot marshal workload identity connector settings", log.Error(err))
 
-			return nil, gqlutils.Internal(ctx)
+			return nil, fmt.Errorf("internal server error")
 		}
 
-		return nil, gqlutils.Invalid(ctx, err)
+		return nil, err
 	}
 
 	return raw, nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -34,6 +34,7 @@ import (
 	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/certmanager"
 	cloudaws "go.probo.inc/probo/pkg/cloud/aws"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/complianceportal/management"
 	"go.probo.inc/probo/pkg/complianceportal/visitor"
 	"go.probo.inc/probo/pkg/connector"
@@ -106,6 +107,7 @@ type Config struct {
 	// identity federation issuer is disabled, in which case no /federation route exists.
 	IdentityFederationIssuer *identityfederation.Issuer
 	AWSConnectorInstall      cloudaws.ConnectorInstallConfig
+	GCPConnectorInstall      cloudgcp.ConnectorInstallConfig
 }
 
 type Server struct {
@@ -162,6 +164,7 @@ func NewServer(cfg Config) (*Server, error) {
 		Logger:                   cfg.Logger.Named("api"),
 		IdentityFederationIssuer: cfg.IdentityFederationIssuer,
 		AWSConnectorInstall:      cfg.AWSConnectorInstall,
+		GCPConnectorInstall:      cfg.GCPConnectorInstall,
 	}
 
 	apiServer, err := api.NewServer(apiCfg)


### PR DESCRIPTION
Phases 1-4 already persist and probe a GCP connector. Customers still had no setup query, create fields, or console page. This adds gcpConnectorSetup and GCP fields on the shared WIF create path across GraphQL, MCP, CLI, and n8n, plus a dedicated connect page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes end-to-end GCP workload-identity setup and access-source creation across GraphQL, MCP, CLI, n8n, and the console, replacing the GCP coming-soon entry. Restricts GCP audit reads to the `_Required` log view. AWS creation still works, and failed GCP impersonation surfaces a disconnected connector that clients delete.

### Other **`+43`** **`-11`**

- Grants `roles/logging.viewAccessor` on the `_Required/_AllLogs` view instead of project-wide `roles/logging.viewer`.
- Adds a `required_bucket_location` variable for projects whose `_Required` bucket moved off `global`.
- Apply a Probo release paired with this module; applying the module first leaves last login unknown until Probo is upgraded.

### Service **`+152`** **`-3`**

- Adds shared workload-identity settings marshaling with provider-specific validation and passes the configured GCP Terraform module source into setup generation.
- Queries the `_Required/_AllLogs` view and classifies Google API errors as provider verdicts so probe failure codes stay safe to log.

### GraphQL API **`+93`** **`-16`**

- Adds `gcpConnectorSetup` returning issuer, audience, subject, a suggested service account name, and a Terraform snippet.
- `awsRoleArn` is now optional and validated per provider.

### MCP **`+182`** **`-16`**

- Adds the `gcpConnectorSetup` tool and GCP inputs to `createWorkloadIdentityConnector`.

### prb (CLI) **`+202`** **`-16`**

- Adds `source setup-gcp` plus GCP creation flags, and deletes the connector when its connection check fails.

### App: console **`+785`** **`-81`**

- Adds a GCP connect page that validates inputs, shows copyable setup values and Terraform, and deletes failed connectors; `ActionSplitButton` routes internal `to` links.

### Package: n8n-node **`+150`** **`-5`**

- Adds a Setup GCP operation and provider-specific create fields, showing the AWS role field only for AWS.

### Tests **`+711`** **`-0`**

- Covers setup and creation, invalid inputs, disconnected status, RBAC, tenant isolation, missing AWS role validation, shared settings marshaling, safe probe failure codes, and the required-view query.

<sup>Written for commit 2927e37c778b0cf57449bf052432c29db7e2de0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

