### PR TITLE
Honour the cookie category list filter

### DIFF
--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5810,7 +5810,12 @@ func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallTo
 
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieCategoryOrderField]{Field: coredata.CookieCategoryOrderFieldRank, Direction: page.OrderDirectionAsc})
 
-	categories, err := r.cookieBanner.ListCategoriesForBanner(ctx, scope, input.CookieBannerID, cursor, coredata.NewCookieCategoryFilter(new(coredata.CookieCategoryKindUncategorised)))
+	excludeKind := new(coredata.CookieCategoryKindUncategorised)
+	if input.Filter != nil {
+		excludeKind = input.Filter.ExcludeKind
+	}
+
+	categories, err := r.cookieBanner.ListCategoriesForBanner(ctx, scope, input.CookieBannerID, cursor, coredata.NewCookieCategoryFilter(excludeKind))
 	if err != nil {
 		panic(fmt.Errorf("cannot list cookie categories: %w", err))
 	}

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -12916,7 +12916,7 @@ components:
           properties:
             exclude_kind:
               $ref: "#/components/schemas/CookieCategoryKind"
-              description: Exclude categories of this kind. Defaults to UNCATEGORISED when omitted.
+              description: Exclude categories of this kind. UNCATEGORISED is excluded when no filter object is given; pass an empty filter object to exclude nothing.
 
     ListCookieCategoriesOutput:
       type: object


### PR DESCRIPTION
## Problem

`ListCookieCategoriesTool` builds its filter from a hardcoded exclusion and never reads `input.Filter`:

```go
coredata.NewCookieCategoryFilter(new(coredata.CookieCategoryKindUncategorised))
```

So the `exclude_kind` parameter the tool documents does nothing. Two consequences:

- Passing `exclude_kind: NORMAL` still returns the NORMAL categories.
- No argument reveals the `UNCATEGORISED` category, since the exclusion is unconditional.

The second one bites hardest. `UNCATEGORISED` is where every newly detected tracker lands and nothing auto-clears it, so automation that enumerates categories over MCP and then calls `listTrackerPatterns` / `listTrackerResources` per category **cannot see a newly detected tracker at all** — and reports zero findings rather than failing. We hit this with a scheduled job that reported "no findings" while 116 trackers sat untriaged; the same walk left a retention job with nothing to delete. GraphQL and the console return the category correctly, so the divergence is MCP-only.

Reproduced against v0.275.0, same banner and token. The same expression is present unchanged at v0.276.0 and on `main`, so the defect is not version-specific:

```
MCP  listCookieCategories(cookie_banner_id: <id>)
     -> 4 categories (Necessary, Analytics, Advertising, Functional)
     following next_cursor returns an empty page, so it is not paging

GQL  node(id: <id>) { ... on CookieBanner { categories(first: 50) { edges { node { name kind } } } } }
     -> 5, including { name: "Uncategorised", kind: "UNCATEGORISED" }
```

## Change

Read the filter when one is supplied:

- **No filter object** — unchanged: `UNCATEGORISED` is excluded, so existing callers keep the documented default.
- **`filter: { exclude_kind: X }`** — excludes X, as documented.
- **`filter: {}`** — excludes nothing. This is the escape hatch for enumerating every category; without it there is no way to list `UNCATEGORISED`, because every other kind is in use and excluding one to see another loses data.

The spec description is updated to state the empty-filter behaviour. I kept the default rather than inverting it, since the description documents it deliberately and changing it would alter existing consumers' results.

## Testing

- `make pkg/server/api/mcp/v1/types/types.go` regenerates cleanly against the edited spec.
- `go build` and `go vet` pass on `./pkg/server/api/mcp/v1/`; `gofmt` clean.
- The resolver has no existing unit coverage and exercising it needs a database, so the behaviour change is by inspection plus the live reproduction above. Happy to add an e2e case if you point me at the right harness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `ListCookieCategoriesTool` honour the documented `exclude_kind` filter parameter. The filter was previously hardcoded to exclude `UNCATEGORISED`, so callers couldn't exclude other kinds and there was no way to list `UNCATEGORISED` categories — where newly detected trackers land, meaning MCP automation walking categories missed them entirely. An empty filter object now excludes nothing, providing an escape hatch to enumerate every category.

### MCP **`+7`** **`-2`**

- Reads `input.Filter.ExcludeKind` when a filter object is supplied; omitting the filter keeps the existing `UNCATEGORISED` default exclusion so current callers are unaffected.
- Passing `filter: {}` excludes nothing, which is the only way to surface `UNCATEGORISED` categories.
- Updates the spec description for `exclude_kind` to document the empty-filter behaviour.

<sup>Written for commit f75f428f1823ccaa07dcb53d9c7b217503a6640e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

