### PR TITLE
Bump fast-uri and qs for security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13502,9 +13502,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -19052,13 +19052,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "@langchain/classic": "1.0.41",
     "@langchain/community": "1.1.29",
     "browserslist": "^4.28.7",
+    "fast-uri": "^3.1.6",
     "nanoid": "^3.3.18",
+    "qs": "^6.16.0",
     "rimraf": "^6.1.3",
     "typescript": "npm:@typescript/typescript6@~6.0.2"
   },


### PR DESCRIPTION
Force patched resolutions of the transitive AJV and n8n dependencies. fast-uri 3.1.6+ rejects a decoded scheme outside the RFC 3986 grammar (GHSA-jqff-g426-hqxp / CVE-2026-76172). qs 6.16.0 closes the array-limit bypass and isBuffer DoS (GHSA-x5fp-wj9c-mxmx, GHSA-4mjr-xmp4-gh2g).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates transitive `fast-uri` from 3.1.5 to 3.1.7 and `qs` from 6.15.2 to 6.16.0 to address known URI parsing, array-limit bypass, and `isBuffer` DoS vulnerabilities. The changes only affect dependency resolution and introduce no application-code behavior changes.

### Other **`+10`** **`-7`**

Adds top-level dependency constraints so AJV and n8n resolve patched versions, and updates the lockfile with the new package integrity data and `qs` dependency requirements.

<sup>Written for commit bc2006ee1bd2b591010f39c9f634454a456ff16c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

