### PR TITLE
Add S3NS universe support to GCP connectors

### DIFF
--- a/apps/console/src/pages/organizations/access-reviews/dialogs/_lib/connectorSettings.ts
+++ b/apps/console/src/pages/organizations/access-reviews/dialogs/_lib/connectorSettings.ts
@@ -131,10 +131,10 @@ export function awsAccessReviewSourceName(
 }
 
 const GCP_PROVIDER_RESOURCE_PATTERN
-  = /^(?:https:\/\/iam\.googleapis\.com\/|\/\/iam\.googleapis\.com\/)?projects\/([1-9][0-9]*)\/locations\/global\/workloadIdentityPools\/([a-z0-9][a-z0-9-]{2,30}[a-z0-9])\/providers\/([a-z0-9][a-z0-9-]{2,30}[a-z0-9])\/?$/;
+  = /^(?:(?:https:)?\/\/iam\.(?:googleapis\.com|s3nsapis\.fr)\/)?projects\/([1-9][0-9]*)\/locations\/global\/workloadIdentityPools\/([a-z0-9][a-z0-9-]{2,30}[a-z0-9])\/providers\/([a-z0-9][a-z0-9-]{2,30}[a-z0-9])\/?$/;
 
 const GCP_SERVICE_ACCOUNT_EMAIL_PATTERN
-  = /^[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z][a-z0-9-]{4,28}[a-z0-9]\.iam\.gserviceaccount\.com$/;
+  = /^[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z][a-z0-9-]{4,28}[a-z0-9](?:\.s3ns)?\.iam\.gserviceaccount\.com$/;
 
 export function isGCPWorkloadIdentityProvider(value: string): boolean {
   return GCP_PROVIDER_RESOURCE_PATTERN.test(value.trim());

--- a/contrib/terraform/gcp-audit-role/README.md
+++ b/contrib/terraform/gcp-audit-role/README.md
@@ -125,3 +125,20 @@ output descriptions in [`variables.tf`](variables.tf) and
 - **`_Required` is queried in `global` by default.** If default resource
   settings moved that bucket, set `required_bucket_location` to match.
 - Requires the `google` provider at 5.0 or later.
+
+## Cloud de Confiance (S3NS)
+
+S3NS is a separate Google Cloud universe. Set the universe on the **root**
+provider; this module does not configure it. Project IDs carry the `s3ns:`
+prefix. Workload identity principals still use `iam.googleapis.com`.
+
+```hcl
+provider "google" {
+  project         = "s3ns:my-project"
+  universe_domain = "s3nsapis.fr"
+}
+```
+
+The service account email this module creates ends in
+`.s3ns.iam.gserviceaccount.com`. Paste that email when you create the
+connector so Probo dials `*.s3nsapis.fr`.

--- a/packages/n8n-node/nodes/Probo/actions/accessReviewSource/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/accessReviewSource/create.operation.ts
@@ -102,7 +102,7 @@ export const description: INodeProperties[] = [
 			},
 		},
 		default: '',
-		description: 'Workload identity provider resource',
+		description: 'Workload identity provider resource, including the S3NS IAM host when applicable',
 		required: true,
 	},
 	{
@@ -117,7 +117,7 @@ export const description: INodeProperties[] = [
 			},
 		},
 		default: '',
-		description: 'Service account email to impersonate',
+		description: 'Service account email to impersonate, including the universe-specific suffix',
 		required: true,
 	},
 ];

--- a/pkg/accessreview/drivers/gcp_activity.go
+++ b/pkg/accessreview/drivers/gcp_activity.go
@@ -32,7 +32,6 @@ import (
 	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/coredata"
 	cloudlogging "google.golang.org/api/logging/v2"
-	"google.golang.org/api/option"
 	policyanalyzer "google.golang.org/api/policyanalyzer/v1"
 )
 
@@ -139,11 +138,7 @@ func queryGCPPolicyAnalyzer(
 	ctx context.Context,
 	session *cloudgcp.Session,
 ) (map[string]time.Time, map[string]bool, error) {
-	svc, err := policyanalyzer.NewService(
-		ctx,
-		option.WithHTTPClient(session.HTTPClient()),
-		option.WithoutAuthentication(),
-	)
+	svc, err := policyanalyzer.NewService(ctx, session.ServiceOptions()...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot create gcp policy analyzer client: %w", err)
 	}
@@ -272,11 +267,7 @@ func queryGCPAdminActivity(
 		return nil, nil
 	}
 
-	svc, err := cloudlogging.NewService(
-		ctx,
-		option.WithHTTPClient(session.HTTPClient()),
-		option.WithoutAuthentication(),
-	)
+	svc, err := cloudlogging.NewService(ctx, session.ServiceOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create gcp logging client: %w", err)
 	}

--- a/pkg/accessreview/drivers/gcp_iam.go
+++ b/pkg/accessreview/drivers/gcp_iam.go
@@ -30,7 +30,6 @@ import (
 	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	iam "google.golang.org/api/iam/v1"
-	"google.golang.org/api/option"
 )
 
 const (
@@ -73,11 +72,7 @@ const (
 )
 
 func listProjectIAMPrincipals(ctx context.Context, session *cloudgcp.Session) ([]gcpIdentity, error) {
-	svc, err := cloudresourcemanager.NewService(
-		ctx,
-		option.WithHTTPClient(session.HTTPClient()),
-		option.WithoutAuthentication(),
-	)
+	svc, err := cloudresourcemanager.NewService(ctx, session.ServiceOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create gcp resource manager client: %w", err)
 	}
@@ -198,11 +193,7 @@ func skipGCPPrincipal(member string) bool {
 }
 
 func listProjectServiceAccounts(ctx context.Context, session *cloudgcp.Session) ([]gcpServiceAccount, error) {
-	svc, err := iam.NewService(
-		ctx,
-		option.WithHTTPClient(session.HTTPClient()),
-		option.WithoutAuthentication(),
-	)
+	svc, err := iam.NewService(ctx, session.ServiceOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create gcp iam client: %w", err)
 	}
@@ -304,11 +295,7 @@ func attachUserManagedKeys(
 	session *cloudgcp.Session,
 	identities []gcpIdentity,
 ) error {
-	svc, err := iam.NewService(
-		ctx,
-		option.WithHTTPClient(session.HTTPClient()),
-		option.WithoutAuthentication(),
-	)
+	svc, err := iam.NewService(ctx, session.ServiceOptions()...)
 	if err != nil {
 		return fmt.Errorf("cannot create gcp iam client: %w", err)
 	}

--- a/pkg/accessreview/drivers/gcp_iam_test.go
+++ b/pkg/accessreview/drivers/gcp_iam_test.go
@@ -243,15 +243,3 @@ func TestUnionGCPIdentities_IncludesUnboundServiceAccount(t *testing.T) {
 	require.NotNil(t, unbound.Disabled)
 	assert.True(t, *unbound.Disabled)
 }
-
-func TestProjectIDFromServiceAccountEmail(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(
-		t,
-		"my-project",
-		projectIDFromServiceAccountEmail("probo-audit@my-project.iam.gserviceaccount.com"),
-	)
-	assert.Empty(t, projectIDFromServiceAccountEmail("alice@example.com"))
-	assert.Empty(t, projectIDFromServiceAccountEmail(""))
-}

--- a/pkg/accessreview/drivers/gcp_mfa.go
+++ b/pkg/accessreview/drivers/gcp_mfa.go
@@ -28,7 +28,6 @@ import (
 	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	"go.probo.inc/probo/pkg/coredata"
 	admin "google.golang.org/api/admin/directory/v1"
-	"google.golang.org/api/option"
 )
 
 func fetchGCPMFA(
@@ -41,11 +40,7 @@ func fetchGCPMFA(
 		return nil, nil
 	}
 
-	svc, err := admin.NewService(
-		ctx,
-		option.WithHTTPClient(session.HTTPClient()),
-		option.WithoutAuthentication(),
-	)
+	svc, err := admin.NewService(ctx, session.ServiceOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create gcp admin directory client: %w", err)
 	}

--- a/pkg/accessreview/drivers/gcp_name.go
+++ b/pkg/accessreview/drivers/gcp_name.go
@@ -28,10 +28,7 @@ import (
 	"go.gearno.de/kit/log"
 	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
-	"google.golang.org/api/option"
 )
-
-const gcpServiceAccountEmailSuffix = ".iam.gserviceaccount.com"
 
 // gcpNameResolver names the connected project for the source-name worker.
 // The official display name is preferred, then the connected project's
@@ -80,7 +77,7 @@ func (r *gcpNameResolver) ResolveInstanceName(ctx context.Context) (string, erro
 		}
 	}
 
-	if id := projectIDFromServiceAccountEmail(r.serviceAccountEmail); id != "" {
+	if id, ok := cloudgcp.ProjectIDFromServiceAccountEmail(r.serviceAccountEmail); ok && id != "" {
 		return id, nil
 	}
 
@@ -88,11 +85,7 @@ func (r *gcpNameResolver) ResolveInstanceName(ctx context.Context) (string, erro
 }
 
 func (r *gcpNameResolver) getProject(ctx context.Context) (*cloudresourcemanager.Project, error) {
-	svc, err := cloudresourcemanager.NewService(
-		ctx,
-		option.WithHTTPClient(r.session.HTTPClient()),
-		option.WithoutAuthentication(),
-	)
+	svc, err := cloudresourcemanager.NewService(ctx, r.session.ServiceOptions()...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create gcp resource manager client: %w", err)
 	}
@@ -103,17 +96,4 @@ func (r *gcpNameResolver) getProject(ctx context.Context) (*cloudresourcemanager
 	}
 
 	return project, nil
-}
-
-func projectIDFromServiceAccountEmail(email string) string {
-	_, host, ok := strings.Cut(strings.TrimSpace(email), "@")
-	if !ok {
-		return ""
-	}
-
-	if !strings.HasSuffix(host, gcpServiceAccountEmailSuffix) {
-		return ""
-	}
-
-	return strings.TrimSuffix(host, gcpServiceAccountEmailSuffix)
 }

--- a/pkg/cloud/gcp/session.go
+++ b/pkg/cloud/gcp/session.go
@@ -23,9 +23,9 @@
 // customer's audit service account.
 //
 // Probo holds no GCP credential for any customer. It mints a short-lived
-// assertion (pkg/identityfederation), exchanges it at sts.googleapis.com, and
-// impersonates the customer's service account. The customer revokes by
-// deleting the workload identity binding.
+// assertion (pkg/identityfederation), exchanges it at STS in the project's
+// universe, and impersonates the customer's service account. The customer
+// revokes by deleting the workload identity binding.
 package gcp
 
 import (
@@ -70,6 +70,7 @@ type (
 		provider               providerResource
 		serviceAccountEmail    string
 		accountID              string
+		universeDomain         string
 		stsEndpoint            string
 		iamCredentialsEndpoint string
 	}
@@ -120,6 +121,11 @@ func NewSession(
 		return nil, fmt.Errorf("cannot open gcp session: %w", err)
 	}
 
+	universe, err := inferUniverse(parsed, email)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open gcp session: %w", err)
+	}
+
 	httpClient := httpclient.DefaultPooledClient(httpclient.WithSSRFProtection())
 
 	session := &Session{
@@ -129,6 +135,7 @@ func NewSession(
 		provider:            parsed,
 		serviceAccountEmail: email,
 		accountID:           parsed.projectNumber,
+		universeDomain:      universe,
 	}
 	session.authorizedClient = authorizeSession(httpClient, session)
 
@@ -147,10 +154,12 @@ func WithHTTPClient(httpClient *http.Client) SessionOption {
 // Production uses NewSession, which obtains credentials through WIF.
 func NewSessionFromToken(projectNumber, accessToken string, opts ...SessionOption) *Session {
 	session := &Session{
-		httpClient: httpclient.DefaultPooledClient(httpclient.WithSSRFProtection()),
-		token:      &oauth2.Token{AccessToken: accessToken},
-		accountID:  projectNumber,
+		httpClient:     httpclient.DefaultPooledClient(httpclient.WithSSRFProtection()),
+		token:          &oauth2.Token{AccessToken: accessToken},
+		accountID:      projectNumber,
+		universeDomain: CommercialUniverse,
 	}
+
 	for _, opt := range opts {
 		opt(session)
 	}
@@ -175,6 +184,32 @@ func (s *Session) AccountID() string {
 // context.
 func (s *Session) HTTPClient() *http.Client {
 	return s.authorizedClient
+}
+
+// UniverseDomain is the Google Cloud universe this session dials:
+// googleapis.com (commercial) or s3nsapis.fr (S3NS). JWT audiences stay on
+// iam.googleapis.com in every universe; only HTTP hosts change.
+func (s *Session) UniverseDomain() string {
+	if s.universeDomain == "" {
+		return CommercialUniverse
+	}
+
+	return s.universeDomain
+}
+
+// ServiceOptions are the client options every Google API client on this
+// session must use: the impersonated HTTP client, no ADC, and the universe
+// domain so hosts resolve to this universe rather than always public GCP.
+func (s *Session) ServiceOptions() []option.ClientOption {
+	return s.serviceOptions(s.HTTPClient())
+}
+
+func (s *Session) serviceOptions(httpClient *http.Client) []option.ClientOption {
+	return []option.ClientOption{
+		option.WithHTTPClient(httpClient),
+		option.WithoutAuthentication(),
+		option.WithUniverseDomain(s.UniverseDomain()),
+	}
 }
 
 // CheckAccess reports whether this session can actually reach its project.
@@ -245,10 +280,7 @@ func (s *Session) mintAssertion(ctx context.Context) (string, error) {
 }
 
 func (s *Session) exchangeAssertion(ctx context.Context, assertion string) (*oauth2.Token, error) {
-	opts := []option.ClientOption{
-		option.WithHTTPClient(s.httpClient),
-		option.WithoutAuthentication(),
-	}
+	opts := s.serviceOptions(s.httpClient)
 	if s.stsEndpoint != "" {
 		opts = append(opts, option.WithEndpoint(s.stsEndpoint))
 	}
@@ -290,10 +322,7 @@ func (s *Session) impersonate(ctx context.Context, federated *oauth2.Token) (*oa
 		return nil, err
 	}
 
-	opts := []option.ClientOption{
-		option.WithHTTPClient(authorizeClient(s.httpClient, oauth2.StaticTokenSource(federated))),
-		option.WithoutAuthentication(),
-	}
+	opts := s.serviceOptions(authorizeClient(s.httpClient, oauth2.StaticTokenSource(federated)))
 	if s.iamCredentialsEndpoint != "" {
 		opts = append(opts, option.WithEndpoint(s.iamCredentialsEndpoint))
 	}

--- a/pkg/cloud/gcp/session_test.go
+++ b/pkg/cloud/gcp/session_test.go
@@ -76,7 +76,23 @@ func TestNewSession(t *testing.T) {
 
 	assert.Equal(t, cloud.GCP, session.Cloud())
 	assert.Equal(t, "123456789012", session.AccountID(), "account comes from the provider resource")
+	assert.Equal(t, cloudgcp.CommercialUniverse, session.UniverseDomain())
 	assert.NotNil(t, session.HTTPClient())
+}
+
+func TestNewSession_S3NSUniverse(t *testing.T) {
+	t.Parallel()
+
+	session, err := cloudgcp.NewSession(
+		testIssuer(t),
+		testOrganizationID(),
+		testProviderResource,
+		testS3NSServiceAccount,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, cloudgcp.S3NSUniverse, session.UniverseDomain())
+	assert.Equal(t, "123456789012", session.AccountID())
 }
 
 func TestNewSessionFromToken(t *testing.T) {
@@ -86,6 +102,7 @@ func TestNewSessionFromToken(t *testing.T) {
 
 	assert.Equal(t, cloud.GCP, session.Cloud())
 	assert.Equal(t, "123456789012", session.AccountID())
+	assert.Equal(t, cloudgcp.CommercialUniverse, session.UniverseDomain())
 	assert.NotNil(t, session.HTTPClient())
 
 	err := session.CheckAccess(context.Background())
@@ -118,6 +135,20 @@ func TestNewSession_Validation(t *testing.T) {
 			serviceAccountEmail: "alice@example.com",
 			wantMessage:         "serviceAccountEmail is not a service account email",
 			forbidden:           "alice@example.com",
+		},
+		{
+			name:                "unsupported universe host",
+			providerResource:    "https://iam.example.com/" + testProviderResource,
+			serviceAccountEmail: testServiceAccount,
+			wantMessage:         "not a supported GCP universe",
+			forbidden:           "example.com",
+		},
+		{
+			name:                "s3ns host with commercial email",
+			providerResource:    "https://iam.s3nsapis.fr/" + testProviderResource,
+			serviceAccountEmail: testServiceAccount,
+			wantMessage:         "name different GCP universes",
+			forbidden:           testServiceAccount,
 		},
 	}
 

--- a/pkg/cloud/gcp/settings.go
+++ b/pkg/cloud/gcp/settings.go
@@ -27,22 +27,20 @@ import (
 	"strings"
 )
 
-const (
-	iamHost = "iam.googleapis.com"
-)
-
 var (
 	errInvalidProviderResource    = errors.New("workloadIdentityProvider is not a workload identity provider resource")
 	errInvalidServiceAccountEmail = errors.New("serviceAccountEmail is not a service account email")
 
 	providerResourcePattern = regexp.MustCompile(
-		`^(?:https://iam\.googleapis\.com/|//iam\.googleapis\.com/)?` +
+		`^(?:(?:https:)?//([^/]+)/)?` +
 			`/?projects/([1-9][0-9]*)` +
 			`/locations/global` +
 			`/workloadIdentityPools/([a-z0-9][a-z0-9-]{2,30}[a-z0-9])` +
 			`/providers/([a-z0-9][a-z0-9-]{2,30}[a-z0-9])/?$`,
 	)
-	serviceAccountEmailPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z][a-z0-9-]{4,28}[a-z0-9]\.iam\.gserviceaccount\.com$`)
+	serviceAccountEmailPattern = regexp.MustCompile(
+		`^[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z][a-z0-9-]{4,28}[a-z0-9](?:\.s3ns)?\.iam\.gserviceaccount\.com$`,
+	)
 )
 
 type (
@@ -54,6 +52,7 @@ type (
 	}
 
 	providerResource struct {
+		iamHost       string
 		projectNumber string
 		poolID        string
 		providerID    string
@@ -74,6 +73,10 @@ func NewConnectorSettings(providerResource, serviceAccountEmail string) (Connect
 		return ConnectorSettings{}, fmt.Errorf("cannot create gcp connector: %w", err)
 	}
 
+	if _, err := inferUniverse(parsed, email); err != nil {
+		return ConnectorSettings{}, fmt.Errorf("cannot create gcp connector: %w", err)
+	}
+
 	return ConnectorSettings{
 		WorkloadIdentityProvider: canonicalProviderResource(parsed),
 		ServiceAccountEmail:      email,
@@ -86,10 +89,16 @@ func parseProviderResource(raw string) (providerResource, error) {
 		return providerResource{}, errInvalidProviderResource
 	}
 
+	host := strings.ToLower(matches[1])
+	if host != "" && !supportedIAMHost(host) {
+		return providerResource{}, errUnsupportedUniverse
+	}
+
 	return providerResource{
-		projectNumber: matches[1],
-		poolID:        matches[2],
-		providerID:    matches[3],
+		iamHost:       host,
+		projectNumber: matches[2],
+		poolID:        matches[3],
+		providerID:    matches[4],
 	}, nil
 }
 

--- a/pkg/cloud/gcp/settings_test.go
+++ b/pkg/cloud/gcp/settings_test.go
@@ -29,8 +29,9 @@ import (
 )
 
 const (
-	testProviderResource = "projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo"
-	testServiceAccount   = "probo-audit@my-project.iam.gserviceaccount.com"
+	testProviderResource   = "projects/123456789012/locations/global/workloadIdentityPools/probo/providers/probo"
+	testServiceAccount     = "probo-audit@my-project.iam.gserviceaccount.com"
+	testS3NSServiceAccount = "probo-audit@my-project.s3ns.iam.gserviceaccount.com"
 )
 
 func TestNewConnectorSettings(t *testing.T) {
@@ -63,6 +64,7 @@ func TestNewConnectorSettings(t *testing.T) {
 		}{
 			{name: "https prefix", resource: "https://iam.googleapis.com/" + testProviderResource},
 			{name: "scheme-relative prefix", resource: "//iam.googleapis.com/" + testProviderResource},
+			{name: "mixed-case iam host", resource: "https://IAM.googleapis.com/" + testProviderResource},
 			{name: "surrounding space", resource: "  " + testProviderResource + "  "},
 			{name: "trailing slash", resource: testProviderResource + "/"},
 		}
@@ -122,5 +124,67 @@ func TestNewConnectorSettings(t *testing.T) {
 		assert.Contains(t, err.Error(), "serviceAccountEmail is not a service account email")
 		assert.NotContains(t, err.Error(), raw)
 		assert.NotContains(t, err.Error(), "alice")
+	})
+
+	t.Run("accepts an s3ns service account email", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			resource string
+		}{
+			{name: "bare resource", resource: testProviderResource},
+			{name: "commercial iam host", resource: "https://iam.googleapis.com/" + testProviderResource},
+			{name: "s3ns https prefix", resource: "https://iam.s3nsapis.fr/" + testProviderResource},
+			{name: "s3ns scheme-relative prefix", resource: "//iam.s3nsapis.fr/" + testProviderResource},
+			{name: "mixed-case s3ns host", resource: "https://IAM.s3nsapis.fr/" + testProviderResource},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				settings, err := cloudgcp.NewConnectorSettings(tt.resource, testS3NSServiceAccount)
+				require.NoError(t, err)
+				assert.Equal(t, testProviderResource, settings.WorkloadIdentityProvider)
+				assert.Equal(t, testS3NSServiceAccount, settings.ServiceAccountEmail)
+			})
+		}
+	})
+
+	t.Run("refuses an s3ns host with a commercial email without echoing them", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			resource string
+		}{
+			{name: "lowercase host", resource: "https://iam.s3nsapis.fr/" + testProviderResource},
+			{name: "mixed-case host", resource: "https://IAM.s3nsapis.fr/" + testProviderResource},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				_, err := cloudgcp.NewConnectorSettings(tt.resource, testServiceAccount)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "name different GCP universes")
+				assert.NotContains(t, err.Error(), tt.resource)
+				assert.NotContains(t, err.Error(), testServiceAccount)
+			})
+		}
+	})
+
+	t.Run("refuses an unsupported universe host without echoing it", func(t *testing.T) {
+		t.Parallel()
+
+		resource := "https://iam.example.com/" + testProviderResource
+
+		_, err := cloudgcp.NewConnectorSettings(resource, testServiceAccount)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a supported GCP universe")
+		assert.NotContains(t, err.Error(), resource)
+		assert.NotContains(t, err.Error(), "example.com")
 	})
 }

--- a/pkg/cloud/gcp/universe.go
+++ b/pkg/cloud/gcp/universe.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package gcp
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	// CommercialUniverse is public Google Cloud. API hosts are
+	// {service}.googleapis.com.
+	CommercialUniverse = "googleapis.com"
+
+	// S3NSUniverse is Cloud de Confiance by S3NS. API hosts are
+	// {service}.s3nsapis.fr.
+	S3NSUniverse = "s3nsapis.fr"
+
+	// iamHost is the FRN host in JWT and STS audiences. S3NS keeps
+	// iam.googleapis.com in resource names; only HTTP API hosts change.
+	iamHost = "iam.googleapis.com"
+
+	s3nsIAMHost = "iam.s3nsapis.fr"
+
+	commercialServiceAccountSuffix = ".iam.gserviceaccount.com"
+	s3nsServiceAccountSuffix       = ".s3ns.iam.gserviceaccount.com"
+)
+
+var (
+	// errUnsupportedUniverse is returned when the provider resource names a
+	// host other than commercial IAM or S3NS IAM.
+	errUnsupportedUniverse = errors.New("workloadIdentityProvider is not a supported GCP universe")
+
+	// errUniverseMismatch is returned when the provider host is S3NS but the
+	// service account email is commercial. The reverse is allowed: S3NS FRNs
+	// still use iam.googleapis.com.
+	errUniverseMismatch = errors.New("workloadIdentityProvider and serviceAccountEmail name different GCP universes")
+)
+
+func supportedIAMHost(host string) bool {
+	switch host {
+	case iamHost, s3nsIAMHost:
+		return true
+	default:
+		return false
+	}
+}
+
+func matchServiceAccountEmail(email string) (string, string, bool) {
+	_, host, ok := strings.Cut(strings.TrimSpace(email), "@")
+	if !ok {
+		return "", "", false
+	}
+
+	if projectID, ok := strings.CutSuffix(host, s3nsServiceAccountSuffix); ok {
+		return projectID, S3NSUniverse, true
+	}
+
+	if projectID, ok := strings.CutSuffix(host, commercialServiceAccountSuffix); ok {
+		return projectID, CommercialUniverse, true
+	}
+
+	return "", "", false
+}
+
+func universeFromServiceAccountEmail(email string) (string, bool) {
+	_, universe, ok := matchServiceAccountEmail(email)
+	return universe, ok
+}
+
+// ProjectIDFromServiceAccountEmail returns the GCP project ID encoded in a
+// commercial or S3NS service-account email. ok is false when the email is
+// not a service account.
+func ProjectIDFromServiceAccountEmail(email string) (string, bool) {
+	projectID, _, ok := matchServiceAccountEmail(email)
+	return projectID, ok
+}
+
+// inferUniverse picks the Google Cloud universe from the service-account
+// email. A pasted iam.googleapis.com host is not a commercial signal: S3NS
+// full resource names keep that host. A pasted iam.s3nsapis.fr host with a
+// commercial email is a mismatch.
+func inferUniverse(p providerResource, email string) (string, error) {
+	fromEmail, ok := universeFromServiceAccountEmail(email)
+	if !ok {
+		return "", errInvalidServiceAccountEmail
+	}
+
+	if p.iamHost == s3nsIAMHost && fromEmail != S3NSUniverse {
+		return "", errUniverseMismatch
+	}
+
+	return fromEmail, nil
+}

--- a/pkg/cloud/gcp/universe_test.go
+++ b/pkg/cloud/gcp/universe_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package gcp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	cloudgcp "go.probo.inc/probo/pkg/cloud/gcp"
+)
+
+func TestProjectIDFromServiceAccountEmail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		email string
+		want  string
+		ok    bool
+	}{
+		{
+			name:  "commercial service account",
+			email: testServiceAccount,
+			want:  "my-project",
+			ok:    true,
+		},
+		{
+			name:  "s3ns service account",
+			email: testS3NSServiceAccount,
+			want:  "my-project",
+			ok:    true,
+		},
+		{
+			name:  "non service account",
+			email: "alice@example.com",
+		},
+		{
+			name: "empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				got, ok := cloudgcp.ProjectIDFromServiceAccountEmail(tt.email)
+				assert.Equal(t, tt.want, got)
+				assert.Equal(t, tt.ok, ok)
+			},
+		)
+	}
+}

--- a/pkg/cmd/access-review/source/create/create.go
+++ b/pkg/cmd/access-review/source/create/create.go
@@ -248,13 +248,13 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 		&flagGCPWorkloadIdentityProvider,
 		"gcp-workload-identity-provider",
 		"",
-		"GCP workload identity provider resource",
+		"GCP workload identity provider resource, including the S3NS IAM host when applicable",
 	)
 	cmd.Flags().StringVar(
 		&flagGCPServiceAccountEmail,
 		"gcp-service-account-email",
 		"",
-		"GCP service account email to impersonate",
+		"GCP service account email to impersonate, including the universe-specific suffix",
 	)
 
 	_ = cmd.MarkFlagRequired("name")

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -10207,10 +10207,10 @@ components:
           description: IAM role ARN, including partition, account, and role name. Required when provider is AWS.
         gcp_workload_identity_provider:
           type: string
-          description: Workload identity provider resource. Required when provider is GCP.
+          description: Workload identity provider resource, including the S3NS IAM host when applicable. Required when provider is GCP.
         gcp_service_account_email:
           type: string
-          description: Service account email to impersonate. Required when provider is GCP.
+          description: Service account email to impersonate, including the universe-specific suffix. Required when provider is GCP.
 
     CreateWorkloadIdentityConnectorMCPOutput:
       type: object


### PR DESCRIPTION
Sovereign Cloud de Confiance projects live on s3nsapis.fr, not googleapis.com. Without a universe, Probo rejected those service account emails and always dialed public GCP.

Infer the universe from the SA suffix the same way AWS infers partition from the role ARN. No new connector field. JWT audiences stay on iam.googleapis.com; API clients pass WithUniverseDomain so hosts resolve to *.s3nsapis.fr.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GCP connectors previously rejected S3NS service-account emails and always dialed public Google Cloud hosts. They now infer the universe from the service-account email and route API clients to S3NS hosts without adding a connector field; JWT audiences remain `iam.googleapis.com`; the provider-resource host additionally validates the universe matches the email suffix.

### Tests **`+169`** **`-14`**

- Covers commercial defaults, S3NS parsing, host validation, universe mismatches, and S3NS project ID extraction.

### MCP **`+2`** **`-2`**

- Clarifies inputs may use the S3NS IAM host and universe-specific service-account suffix.

### prb (CLI) **`+2`** **`-2`**

- Updates flag help for S3NS IAM hosts and service-account suffixes.

### Service **`+181`** **`-78`**

- Centralizes universe-aware client options and validates supported host and email combinations.

### App: console **`+2`** **`-2`**

- Validates `iam.s3nsapis.fr` provider resources and `.s3ns.iam.gserviceaccount.com` emails.

### Package: n8n-node **`+2`** **`-2`**

- Updates node field descriptions for universe-specific provider hosts and service-account emails.

### Other **`+17`** **`-0`**

- Documents root provider configuration, `s3ns:` project IDs, and S3NS service-account setup.

<sup>Written for commit 2b41046d902b976b176b3cbfc97d294b92027b70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

