### PR TITLE
Delete document mappings before organization

### DIFF
--- a/e2e/console/document_relations_test.go
+++ b/e2e/console/document_relations_test.go
@@ -99,6 +99,28 @@ func linkMeasureToDocument(
 	require.NoError(t, err)
 }
 
+func linkRiskToMeasure(
+	t *testing.T,
+	owner *testutil.Client,
+	riskID, measureID string,
+) {
+	t.Helper()
+
+	_, err := owner.Do(`
+		mutation($input: CreateRiskMeasureMappingInput!) {
+			createRiskMeasureMapping(input: $input) {
+				riskEdge { node { id } }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"riskId":    riskID,
+			"measureId": measureID,
+		},
+	})
+	require.NoError(t, err)
+}
+
 func linkRiskToDocument(
 	t *testing.T,
 	owner *testutil.Client,

--- a/e2e/console/organization_relations_test.go
+++ b/e2e/console/organization_relations_test.go
@@ -202,6 +202,11 @@ func populateOrganizationRelationGraph(
 		WithAccessReviewSourceIDs([]string{g.accessReviewSourceID}).
 		Create()
 
+	linkControlToDocument(t, owner, g.controlID, g.documentID)
+	linkMeasureToDocument(t, owner, g.measureID, g.documentID)
+	linkRiskToDocument(t, owner, g.riskID, g.documentID)
+	linkRiskToMeasure(t, owner, g.riskID, g.measureID)
+
 	return g
 }
 

--- a/pkg/coredata/control_document.go
+++ b/pkg/coredata/control_document.go
@@ -148,3 +148,29 @@ WHERE
 
 	return nil
 }
+
+func (cp *ControlDocuments) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM controls_documents
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete control document mappings: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/measure_document.go
+++ b/pkg/coredata/measure_document.go
@@ -148,3 +148,29 @@ WHERE
 
 	return nil
 }
+
+func (md *MeasureDocuments) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM measures_documents
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete measure document mappings: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/risk_document.go
+++ b/pkg/coredata/risk_document.go
@@ -136,3 +136,29 @@ WHERE
 
 	return nil
 }
+
+func (rp *RiskDocuments) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM risks_documents
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete risk document mappings: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/risk_mesure.go
+++ b/pkg/coredata/risk_mesure.go
@@ -107,3 +107,29 @@ WHERE
 
 	return err
 }
+
+func (rm *RiskMeasures) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM risks_measures
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete risk measure mappings: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -947,8 +947,25 @@ func deleteOrganizationDependencies(
 	organizationID gid.GID,
 ) error {
 	// These tables restrict deleting a membership profile that still owns
-	// them, or a risk that is still linked to a scenario. They must be
+	// them, a risk that is still linked to a scenario or measure, or a
+	// document that is still linked from a mapping table. They must be
 	// removed before organizations cascade-deletes those rows.
+	if err := new(coredata.ControlDocuments).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete control document mappings: %w", err)
+	}
+
+	if err := new(coredata.RiskDocuments).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete risk document mappings: %w", err)
+	}
+
+	if err := new(coredata.MeasureDocuments).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete measure document mappings: %w", err)
+	}
+
+	if err := new(coredata.RiskMeasures).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete risk measure mappings: %w", err)
+	}
+
 	if err := new(coredata.TreatmentPlanEvents).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
 		return fmt.Errorf("cannot delete treatment plan events: %w", err)
 	}


### PR DESCRIPTION
Deleting an organization cascaded into documents
while control, risk, and measure mappings still
referenced them. Remove those rows first so the
existing restrict foreign keys do not fire.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Organization deletion now removes control-document, risk-document, measure-document, and risk-measure mappings before the organization cascade. This prevents the existing restrict foreign keys from blocking deletion when those mappings reference rows deleted by the cascade.

### Tests **`+27`** **`-0`**

- Extends the organization relation graph with all four mapping types and adds a risk-measure mapping helper.

### Coredata **`+104`** **`-0`**

- Adds scoped `DeleteByOrganizationID` methods for each mapping repository.

### Service **`+18`** **`-1`**

- Runs mapping cleanup in the existing dependency transaction before organization deletion.

<sup>Written for commit 3e5c4b63255c5195474136372f7053357c2cfb65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

