### PR TITLE
Allow HTTP as a tracker pattern source

### DIFF
--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -12429,7 +12429,7 @@ components:
           description: Pattern description
         source:
           type: string
-          enum: [SCRIPT, PRE_EXISTING, EXTENSION]
+          enum: [SCRIPT, PRE_EXISTING, HTTP, EXTENSION]
           description: How the pattern was discovered
         excluded:
           type: boolean


### PR DESCRIPTION
## Problem

`listTrackerPatterns` returns an error rather than data once any pattern in the requested page has source `HTTP`:

```
marshaling output: json: error calling MarshalJSON for type
types.TrackerPatternSource: invalid TrackerPatternSource value: "HTTP"
```

`specification.yaml` describes the same concept twice and the two disagree:

- **TrackerPattern** (line 12432): `enum: [SCRIPT, PRE_EXISTING, EXTENSION]`
- **DetectedTracker** (line 15323): `enum: [SCRIPT, PRE_EXISTING, HTTP, EXTENSION]`, with `go.probo.inc/mcpgen/type: coredata.CookieSource`

`coredata.CookieSource` defines all four, and a cookie observed from a `Set-Cookie` header is stored as `HTTP`, so probod cannot serialise a value it wrote itself.

The failure is page-dependent, which makes it look intermittent: a category lists fine until one `HTTP` pattern lands in the page being fetched, and from then on it cannot be read at all. `size: 5` succeeded on the same category where full pagination failed.

Reproduced on v0.275.0; the enum is unchanged on `main`.

## Change

Add `HTTP` to the tracker pattern source enum so it matches `coredata.CookieSource` and the detected tracker schema. Regenerating produces `TrackerPatternSourceHTTP`, and the marshaller accepts the stored value.

**A more durable fix would be to annotate this schema with `go.probo.inc/mcpgen/type: coredata.CookieSource`**, the way DetectedTracker does, so the two can never drift again. I kept to the one-line enum change because that annotation removes the generated `TrackerPatternSource` type, which `pkg/server/api/mcp/v1/types/tracker_pattern.go:35` casts to — happy to make that change instead if you would prefer it.

## Testing

- `make pkg/server/api/mcp/v1/types/types.go` regenerates cleanly; `TrackerPatternSourceHTTP` is emitted and handled in the marshal switch.
- `go build ./pkg/server/api/mcp/v1/...` passes.
- Behaviour confirmed against a live v0.275.0 instance: the same category that errored on full pagination has patterns with source `HTTP` (visible over GraphQL, which serialises them correctly).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `HTTP` to the tracker pattern source enum so `listTrackerPatterns` serializes patterns stored with that source. Previously any page containing an `HTTP` pattern failed with `invalid TrackerPatternSource value: "HTTP"`; now those pages read normally.

### MCP **`+1`** **`-1`**

- Aligns the `TrackerPattern` source enum with `coredata.CookieSource` and the `DetectedTracker` schema so a stored `HTTP` value can be marshaled.
- Regenerating types emits `TrackerPatternSourceHTTP` and handles it in the marshal switch.

<sup>Written for commit 41fc5be879a7b8d2be9071803885bd0ed8edddf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

