### PR TITLE
Add audit booking states and firm field

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -839,6 +839,8 @@
   "helpers": {
     "common": { "unknown": "Unknown" },
     "auditState": {
+      "toBook": "To book",
+      "auditBooked": "Audit booked",
       "notStarted": "Not Started",
       "inProgress": "In Progress",
       "completed": "Completed",
@@ -2082,8 +2084,8 @@
     "errors": { "update": "Failed to update audit" },
     "messages": { "success": "Success", "error": "Error", "updated": "Audit updated successfully" },
     "deleteReportConfirmation": "This will permanently delete the audit report \"{{name}}\". This action cannot be undone.",
-    "states": { "not_started": "Not Started", "in_progress": "In Progress", "completed": "Completed", "rejected": "Rejected", "outdated": "Outdated" },
-    "fields": { "name": "Name", "namePlaceholder": "Audit name", "state": "State", "validFrom": "Valid From", "validUntil": "Valid Until", "auditStartDate": "Audit Start Date", "auditEndDate": "Audit End Date" },
+    "states": { "to_book": "To book", "audit_booked": "Audit booked", "not_started": "Not Started", "in_progress": "In Progress", "completed": "Completed", "rejected": "Rejected", "outdated": "Outdated" },
+    "fields": { "name": "Name", "namePlaceholder": "Audit name", "firm": "Audit firm", "firmPlaceholder": "Audit firm", "state": "State", "validFrom": "Valid From", "validUntil": "Valid Until", "auditStartDate": "Audit Start Date", "auditEndDate": "Audit End Date" },
     "actions": { "delete": "Delete", "update": "Update", "updating": "Updating...", "download": "Download" },
     "report": { "title": "Audit Report", "uploaded": "Uploaded {{date}}", "uploadDescription": "Upload the final audit report document (PDF recommended)", "dropzoneDescription": "Only PDF up to 25MB are allowed" }
   },
@@ -2096,7 +2098,7 @@
     "dropzoneOverlay": "Drop a PDF to create an audit with a report",
     "actions": { "addAudit": "Add audit", "delete": "Delete" },
     "columns": { "name": "Name", "framework": "Framework", "state": "State", "validFrom": "Valid From", "validUntil": "Valid Until", "report": "Report" },
-    "states": { "not_started": "Not Started", "in_progress": "In Progress", "completed": "Completed", "rejected": "Rejected", "outdated": "Outdated" },
+    "states": { "to_book": "To book", "audit_booked": "Audit booked", "not_started": "Not Started", "in_progress": "In Progress", "completed": "Completed", "rejected": "Rejected", "outdated": "Outdated" },
     "row": { "untitled": "Untitled", "unknownFramework": "Unknown Framework", "notSet": "Not set", "uploaded": "Uploaded", "notUploaded": "Not uploaded" }
   },
   "createAuditDialog": {
@@ -2106,8 +2108,8 @@
     "errors": { "create": "Failed to create audit" },
     "fileSize": "{{value}} MB",
     "loading": "Loading...",
-    "fields": { "framework": "Framework", "frameworkPlaceholder": "Select a framework", "name": "Name", "namePlaceholder": "Audit name", "state": "State", "validFrom": "Valid From", "validUntil": "Valid Until", "auditStartDate": "Audit Start Date", "auditEndDate": "Audit End Date" },
-    "states": { "not_started": "Not Started", "in_progress": "In Progress", "completed": "Completed", "rejected": "Rejected", "outdated": "Outdated" },
+    "fields": { "framework": "Framework", "frameworkPlaceholder": "Select a framework", "name": "Name", "namePlaceholder": "Audit name", "firm": "Audit firm", "firmPlaceholder": "Audit firm", "state": "State", "validFrom": "Valid From", "validUntil": "Valid Until", "auditStartDate": "Audit Start Date", "auditEndDate": "Audit End Date" },
+    "states": { "to_book": "To book", "audit_booked": "Audit booked", "not_started": "Not Started", "in_progress": "In Progress", "completed": "Completed", "rejected": "Rejected", "outdated": "Outdated" },
     "actions": { "create": "Create" }
   },
   "context": {

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -1302,6 +1302,8 @@
       "unknown": "Inconnu"
     },
     "auditState": {
+      "toBook": "À réserver",
+      "auditBooked": "Audit réservé",
       "notStarted": "Non commencé",
       "inProgress": "En cours",
       "completed": "Terminé",
@@ -3461,6 +3463,8 @@
     },
     "deleteReportConfirmation": "Cette action supprimera définitivement le rapport d’audit « {{name}} ». Cette action est irréversible.",
     "states": {
+      "to_book": "À réserver",
+      "audit_booked": "Audit réservé",
       "not_started": "Non commencé",
       "in_progress": "En cours",
       "completed": "Terminé",
@@ -3470,6 +3474,8 @@
     "fields": {
       "name": "Nom",
       "namePlaceholder": "Nom de l’audit",
+      "firm": "Cabinet d’audit",
+      "firmPlaceholder": "Cabinet d’audit",
       "state": "État",
       "validFrom": "Valide à partir de",
       "validUntil": "Valide jusqu’au",
@@ -3512,6 +3518,8 @@
       "report": "Rapport"
     },
     "states": {
+      "to_book": "À réserver",
+      "audit_booked": "Audit réservé",
       "not_started": "Non commencé",
       "in_progress": "En cours",
       "completed": "Terminé",
@@ -3550,6 +3558,8 @@
       "frameworkPlaceholder": "Sélectionner un référentiel",
       "name": "Nom",
       "namePlaceholder": "Nom de l’audit",
+      "firm": "Cabinet d’audit",
+      "firmPlaceholder": "Cabinet d’audit",
       "state": "État",
       "validFrom": "Valide à partir de",
       "validUntil": "Valide jusqu’au",
@@ -3557,6 +3567,8 @@
       "auditEndDate": "Date de fin de l’audit"
     },
     "states": {
+      "to_book": "À réserver",
+      "audit_booked": "Audit réservé",
       "not_started": "Non commencé",
       "in_progress": "En cours",
       "completed": "Terminé",

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -1302,6 +1302,8 @@
       "unknown": "Onbekend"
     },
     "auditState": {
+      "toBook": "Te boeken",
+      "auditBooked": "Audit geboekt",
       "notStarted": "Niet gestart",
       "inProgress": "In uitvoering",
       "completed": "Voltooid",
@@ -3461,6 +3463,8 @@
     },
     "deleteReportConfirmation": "Hiermee wordt het auditrapport \"{{name}}\" permanent verwijderd. Deze actie kan niet ongedaan worden gemaakt.",
     "states": {
+      "to_book": "Te boeken",
+      "audit_booked": "Audit geboekt",
       "not_started": "Niet gestart",
       "in_progress": "In uitvoering",
       "completed": "Voltooid",
@@ -3470,6 +3474,8 @@
     "fields": {
       "name": "Naam",
       "namePlaceholder": "Auditnaam",
+      "firm": "Auditkantoor",
+      "firmPlaceholder": "Auditkantoor",
       "state": "Status",
       "validFrom": "Geldig vanaf",
       "validUntil": "Geldig tot",
@@ -3512,6 +3518,8 @@
       "report": "Rapport"
     },
     "states": {
+      "to_book": "Te boeken",
+      "audit_booked": "Audit geboekt",
       "not_started": "Niet gestart",
       "in_progress": "In uitvoering",
       "completed": "Voltooid",
@@ -3550,6 +3558,8 @@
       "frameworkPlaceholder": "Selecteer een framework",
       "name": "Naam",
       "namePlaceholder": "Auditnaam",
+      "firm": "Auditkantoor",
+      "firmPlaceholder": "Auditkantoor",
       "state": "Status",
       "validFrom": "Geldig vanaf",
       "validUntil": "Geldig tot",
@@ -3557,6 +3567,8 @@
       "auditEndDate": "Einddatum audit"
     },
     "states": {
+      "to_book": "Te boeken",
+      "audit_booked": "Audit geboekt",
       "not_started": "Niet gestart",
       "in_progress": "In uitvoering",
       "completed": "Voltooid",

--- a/apps/console/src/hooks/graph/AuditGraph.ts
+++ b/apps/console/src/hooks/graph/AuditGraph.ts
@@ -45,6 +45,7 @@ export const auditNodeQuery = graphql`
       ... on Audit {
         id
         name
+        firm
         validity {
           start
           end
@@ -95,6 +96,7 @@ export const createAuditMutation = graphql`
         node {
           id
           name
+          firm
           validity {
             start
             end
@@ -127,6 +129,7 @@ export const updateAuditMutation = graphql`
       audit {
         id
         name
+        firm
         validity {
           start
           end
@@ -202,6 +205,7 @@ export const useCreateAudit = (connectionId: string) => {
     organizationId: string;
     frameworkId: string;
     name?: string | null;
+    firm?: string | null;
     validity?: Period | null;
     auditDates?: Period | null;
     reportKey?: string;
@@ -221,6 +225,7 @@ export const useCreateAudit = (connectionId: string) => {
           organizationId: input.organizationId,
           frameworkId: input.frameworkId,
           name: input.name,
+          firm: input.firm,
           validity: input.validity,
           auditDates: input.auditDates,
           reportKey: input.reportKey,
@@ -242,6 +247,7 @@ export const useUpdateAudit = () => {
   return (input: {
     id: string;
     name?: string | null;
+    firm?: string | null;
     validity?: Period | null;
     auditDates?: Period | null;
     state?: string;
@@ -255,6 +261,7 @@ export const useUpdateAudit = () => {
         input: {
           id: input.id,
           name: input.name,
+          firm: input.firm,
           validity: input.validity,
           auditDates: input.auditDates,
           state: input.state,

--- a/apps/console/src/pages/organizations/audits/AuditDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/audits/AuditDetailsPage.tsx
@@ -67,17 +67,12 @@ import {
 
 const updateAuditSchema = z.object({
   name: z.string().nullable().optional(),
+  firm: z.string().nullable().optional(),
   validFrom: z.string().optional(),
   validUntil: z.string().optional(),
   auditStartDate: z.string().optional(),
   auditEndDate: z.string().optional(),
-  state: z.enum([
-    "NOT_STARTED",
-    "IN_PROGRESS",
-    "COMPLETED",
-    "REJECTED",
-    "OUTDATED",
-  ]),
+  state: z.enum(auditStates),
 });
 
 type Props = {
@@ -104,6 +99,7 @@ export default function AuditDetailsPage(props: Props) {
     = useFormWithSchema(updateAuditSchema, {
       defaultValues: {
         name: auditEntry.name || null,
+        firm: auditEntry.firm || null,
         validFrom: auditEntry.validity?.start?.split("T")[0] || "",
         validUntil: auditEntry.validity?.end?.split("T")[0] || "",
         auditStartDate: auditEntry.auditDates?.start?.split("T")[0] || "",
@@ -125,6 +121,7 @@ export default function AuditDetailsPage(props: Props) {
       await updateAudit({
         id: auditEntry.id,
         name: formData.name || null,
+        firm: formData.firm || null,
         validity: toPeriod(
           formatDatetime(formData.validFrom),
           formatDatetime(formData.validUntil),
@@ -215,6 +212,13 @@ export default function AuditDetailsPage(props: Props) {
             <Input
               {...register("name")}
               placeholder={t("auditDetailsPage.fields.namePlaceholder")}
+            />
+          </Field>
+
+          <Field label={t("auditDetailsPage.fields.firm")}>
+            <Input
+              {...register("firm")}
+              placeholder={t("auditDetailsPage.fields.firmPlaceholder")}
             />
           </Field>
 

--- a/apps/console/src/pages/organizations/audits/dialogs/CreateAuditDialog.tsx
+++ b/apps/console/src/pages/organizations/audits/dialogs/CreateAuditDialog.tsx
@@ -91,23 +91,19 @@ export function CreateAuditDialog({
   const schema = z.object({
     frameworkId: z.string().min(1, t("createAuditDialog.validation.frameworkRequired")),
     name: z.string().optional(),
+    firm: z.string().optional(),
     validFrom: z.string().optional(),
     validUntil: z.string().optional(),
     auditStartDate: z.string().optional(),
     auditEndDate: z.string().optional(),
-    state: z.enum([
-      "NOT_STARTED",
-      "IN_PROGRESS",
-      "COMPLETED",
-      "REJECTED",
-      "OUTDATED",
-    ]),
+    state: z.enum(auditStates),
   });
   const { control, handleSubmit, register, formState, reset }
     = useFormWithSchema(schema, {
       defaultValues: {
         frameworkId: "",
         name: "",
+        firm: "",
         validFrom: "",
         validUntil: "",
         auditStartDate: "",
@@ -125,6 +121,7 @@ export function CreateAuditDialog({
         organizationId,
         frameworkId: data.frameworkId,
         name: data.name || null,
+        firm: data.firm || null,
         validity: toPeriod(
           formatDatetime(data.validFrom),
           formatDatetime(data.validUntil),
@@ -221,6 +218,13 @@ export function CreateAuditDialog({
             />
           </Field>
 
+          <Field label={t("createAuditDialog.fields.firm")}>
+            <Input
+              {...register("firm")}
+              placeholder={t("createAuditDialog.fields.firmPlaceholder")}
+            />
+          </Field>
+
           <ControlledField
             control={control}
             name="state"
@@ -260,11 +264,12 @@ export function CreateAuditDialog({
 type FormSchema = {
   frameworkId: string;
   name?: string;
+  firm?: string;
   validFrom?: string;
   validUntil?: string;
   auditStartDate?: string;
   auditEndDate?: string;
-  state: "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED" | "REJECTED" | "OUTDATED";
+  state: (typeof auditStates)[number];
 };
 
 function FrameworkSelect({

--- a/e2e/console/audit_test.go
+++ b/e2e/console/audit_test.go
@@ -99,6 +99,33 @@ func TestAudit_Create(t *testing.T) {
 			assertField: "state",
 			assertValue: "OUTDATED",
 		},
+		{
+			name: "with TO_BOOK state",
+			input: map[string]any{
+				"name":  "Audit TO_BOOK",
+				"state": "TO_BOOK",
+			},
+			assertField: "state",
+			assertValue: "TO_BOOK",
+		},
+		{
+			name: "with AUDIT_BOOKED state",
+			input: map[string]any{
+				"name":  "Audit AUDIT_BOOKED",
+				"state": "AUDIT_BOOKED",
+			},
+			assertField: "state",
+			assertValue: "AUDIT_BOOKED",
+		},
+		{
+			name: "with firm",
+			input: map[string]any{
+				"name": "Audit with firm",
+				"firm": "A-LIGN",
+			},
+			assertField: "firm",
+			assertValue: "A-LIGN",
+		},
 	}
 
 	for _, tt := range tests {
@@ -110,6 +137,7 @@ func TestAudit_Create(t *testing.T) {
 							node {
 								id
 								name
+								firm
 								state
 							}
 						}
@@ -129,6 +157,7 @@ func TestAudit_Create(t *testing.T) {
 						Node struct {
 							ID    string `json:"id"`
 							Name  string `json:"name"`
+							Firm  string `json:"firm"`
 							State string `json:"state"`
 						} `json:"node"`
 					} `json:"auditEdge"`
@@ -144,6 +173,8 @@ func TestAudit_Create(t *testing.T) {
 			switch tt.assertField {
 			case "name":
 				assert.Equal(t, tt.assertValue, node.Name)
+			case "firm":
+				assert.Equal(t, tt.assertValue, node.Firm)
 			case "state":
 				assert.Equal(t, tt.assertValue, node.State)
 			}
@@ -285,6 +316,13 @@ func TestAudit_Create_Validation(t *testing.T) {
 			name: "name with HTML tags",
 			input: map[string]any{
 				"name": "<script>alert('xss')</script>",
+			},
+			wantErrorContains: "HTML",
+		},
+		{
+			name: "firm with HTML tags",
+			input: map[string]any{
+				"firm": "<script>alert('xss')</script>",
 			},
 			wantErrorContains: "HTML",
 		},
@@ -453,6 +491,45 @@ func TestAudit_Update(t *testing.T) {
 			assertField: "state",
 			assertValue: "OUTDATED",
 		},
+		{
+			name: "update to TO_BOOK state",
+			setup: func() string {
+				return factory.NewAudit(owner, frameworkID).
+					WithName("State Test").
+					Create()
+			},
+			input: func(id string) map[string]any {
+				return map[string]any{"id": id, "state": "TO_BOOK"}
+			},
+			assertField: "state",
+			assertValue: "TO_BOOK",
+		},
+		{
+			name: "update to AUDIT_BOOKED state",
+			setup: func() string {
+				return factory.NewAudit(owner, frameworkID).
+					WithName("State Test").
+					Create()
+			},
+			input: func(id string) map[string]any {
+				return map[string]any{"id": id, "state": "AUDIT_BOOKED"}
+			},
+			assertField: "state",
+			assertValue: "AUDIT_BOOKED",
+		},
+		{
+			name: "update firm",
+			setup: func() string {
+				return factory.NewAudit(owner, frameworkID).
+					WithName("Firm Test").
+					Create()
+			},
+			input: func(id string) map[string]any {
+				return map[string]any{"id": id, "firm": "BSI"}
+			},
+			assertField: "firm",
+			assertValue: "BSI",
+		},
 	}
 
 	for _, tt := range tests {
@@ -465,6 +542,7 @@ func TestAudit_Update(t *testing.T) {
 						audit {
 							id
 							name
+							firm
 							state
 						}
 					}
@@ -476,6 +554,7 @@ func TestAudit_Update(t *testing.T) {
 					Audit struct {
 						ID    string `json:"id"`
 						Name  string `json:"name"`
+						Firm  string `json:"firm"`
 						State string `json:"state"`
 					} `json:"audit"`
 				} `json:"updateAudit"`
@@ -489,6 +568,8 @@ func TestAudit_Update(t *testing.T) {
 			switch tt.assertField {
 			case "name":
 				assert.Equal(t, tt.assertValue, audit.Name)
+			case "firm":
+				assert.Equal(t, tt.assertValue, audit.Firm)
 			case "state":
 				assert.Equal(t, tt.assertValue, audit.State)
 			}
@@ -522,6 +603,14 @@ func TestAudit_Update_Validation(t *testing.T) {
 			setup: func() string { return baseAuditID },
 			input: func(id string) map[string]any {
 				return map[string]any{"id": id, "name": "<script>alert('xss')</script>"}
+			},
+			wantErrorContains: "HTML",
+		},
+		{
+			name:  "firm with HTML tags",
+			setup: func() string { return baseAuditID },
+			input: func(id string) map[string]any {
+				return map[string]any{"id": id, "firm": "<script>alert('xss')</script>"}
 			},
 			wantErrorContains: "HTML",
 		},

--- a/e2e/internal/factory/factory.go
+++ b/e2e/internal/factory/factory.go
@@ -855,6 +855,10 @@ func CreateAudit(c *testutil.Client, frameworkID string, attrs ...Attrs) string 
 		input["state"] = *state
 	}
 
+	if firm := a.getStringPtr("firm"); firm != nil {
+		input["firm"] = *firm
+	}
+
 	var result struct {
 		CreateAudit struct {
 			AuditEdge struct {
@@ -888,6 +892,11 @@ func (b *AuditBuilder) WithName(name string) *AuditBuilder {
 
 func (b *AuditBuilder) WithState(state string) *AuditBuilder {
 	b.attrs["state"] = state
+	return b
+}
+
+func (b *AuditBuilder) WithFirm(firm string) *AuditBuilder {
+	b.attrs["firm"] = firm
 	return b
 }
 

--- a/packages/helpers/src/audits.ts
+++ b/packages/helpers/src/audits.ts
@@ -21,6 +21,8 @@
 type Translator = (s: string) => string;
 
 export const auditStates = [
+  "TO_BOOK",
+  "AUDIT_BOOKED",
   "NOT_STARTED",
   "IN_PROGRESS",
   "COMPLETED",
@@ -30,6 +32,10 @@ export const auditStates = [
 
 export function getAuditStateLabel(t: Translator, state: (typeof auditStates)[number]) {
   switch (state) {
+    case "TO_BOOK":
+      return t("helpers.auditState.toBook");
+    case "AUDIT_BOOKED":
+      return t("helpers.auditState.auditBooked");
     case "NOT_STARTED":
       return t("helpers.auditState.notStarted");
     case "IN_PROGRESS":
@@ -47,6 +53,10 @@ export function getAuditStateLabel(t: Translator, state: (typeof auditStates)[nu
 
 export function getAuditStateVariant(state: (typeof auditStates)[number]) {
   switch (state) {
+    case "TO_BOOK":
+      return "warning";
+    case "AUDIT_BOOKED":
+      return "info";
     case "NOT_STARTED":
       return "neutral";
     case "IN_PROGRESS":

--- a/packages/n8n-node/nodes/Probo/actions/audit/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/audit/create.operation.ts
@@ -71,6 +71,12 @@ export const description: INodeProperties[] = [
 				description: 'The end date of the audit',
 			},
 			{
+				displayName: 'Audit Firm',
+				name: 'firm',
+				type: 'string',
+				default: '',
+			},
+			{
 				displayName: 'Audit Start Date',
 				name: 'auditStartDate',
 				type: 'dateTime',
@@ -90,6 +96,10 @@ export const description: INodeProperties[] = [
 				type: 'options',
 				options: [
 					{
+						name: 'Audit Booked',
+						value: 'AUDIT_BOOKED',
+					},
+					{
 						name: 'Completed',
 						value: 'COMPLETED',
 					},
@@ -108,6 +118,10 @@ export const description: INodeProperties[] = [
 					{
 						name: 'Rejected',
 						value: 'REJECTED',
+					},
+					{
+						name: 'To Book',
+						value: 'TO_BOOK',
 					},
 				],
 				default: 'NOT_STARTED',
@@ -139,6 +153,7 @@ export async function execute(
 	const frameworkId = this.getNodeParameter('frameworkId', itemIndex) as string;
 	const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as {
 		name?: string;
+		firm?: string;
 		state?: string;
 		validFrom?: string;
 		validUntil?: string;
@@ -153,6 +168,7 @@ export async function execute(
 					node {
 						id
 						name
+						firm
 						state
 						validity {
 							start
@@ -176,6 +192,7 @@ export async function execute(
 		frameworkId,
 	};
 	if (additionalFields.name) input.name = additionalFields.name;
+	if (additionalFields.firm) input.firm = additionalFields.firm;
 	if (additionalFields.state) input.state = additionalFields.state;
 	const validity = toPeriod(additionalFields.validFrom, additionalFields.validUntil);
 	if (validity) input.validity = validity;

--- a/packages/n8n-node/nodes/Probo/actions/audit/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/audit/get.operation.ts
@@ -50,6 +50,7 @@ export async function execute(
 				... on Audit {
 					id
 					name
+					firm
 					state
 					validity {
 						start

--- a/packages/n8n-node/nodes/Probo/actions/audit/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/audit/getAll.operation.ts
@@ -85,6 +85,7 @@ export async function execute(
 							node {
 								id
 								name
+								firm
 								state
 								validity {
 									start

--- a/packages/n8n-node/nodes/Probo/actions/audit/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/audit/update.operation.ts
@@ -57,6 +57,12 @@ export const description: INodeProperties[] = [
 				description: 'The end date of the audit',
 			},
 			{
+				displayName: 'Audit Firm',
+				name: 'firm',
+				type: 'string',
+				default: '',
+			},
+			{
 				displayName: 'Audit Start Date',
 				name: 'auditStartDate',
 				type: 'dateTime',
@@ -76,6 +82,10 @@ export const description: INodeProperties[] = [
 				type: 'options',
 				options: [
 					{
+						name: 'Audit Booked',
+						value: 'AUDIT_BOOKED',
+					},
+					{
 						name: 'Completed',
 						value: 'COMPLETED',
 					},
@@ -94,6 +104,10 @@ export const description: INodeProperties[] = [
 					{
 						name: 'Rejected',
 						value: 'REJECTED',
+					},
+					{
+						name: 'To Book',
+						value: 'TO_BOOK',
 					},
 				],
 				default: 'NOT_STARTED',
@@ -124,6 +138,7 @@ export async function execute(
 	const id = this.getNodeParameter('id', itemIndex) as string;
 	const updateFields = this.getNodeParameter('updateFields', itemIndex, {}) as {
 		name?: string;
+		firm?: string;
 		state?: string;
 		validFrom?: string;
 		validUntil?: string;
@@ -137,6 +152,7 @@ export async function execute(
 				audit {
 					id
 					name
+					firm
 					state
 					validity {
 						start
@@ -156,6 +172,7 @@ export async function execute(
 
 	const input: Record<string, unknown> = { id };
 	if (updateFields.name) input.name = updateFields.name;
+	if (updateFields.firm !== undefined) input.firm = updateFields.firm === '' ? null : updateFields.firm;
 	if (updateFields.state) input.state = updateFields.state;
 	const validity = toPeriod(updateFields.validFrom, updateFields.validUntil);
 	if (validity) input.validity = validity;

--- a/pkg/cmd/audit/create/create.go
+++ b/pkg/cmd/audit/create/create.go
@@ -37,6 +37,7 @@ mutation($input: CreateAuditInput!) {
       node {
         id
         name
+        firm
         state
         validity {
           start
@@ -58,6 +59,7 @@ type createResponse struct {
 			Node struct {
 				ID       string `json:"id"`
 				Name     string `json:"name"`
+				Firm     string `json:"firm"`
 				State    string `json:"state"`
 				Validity *struct {
 					Start *string `json:"start"`
@@ -77,6 +79,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 		flagOrg            string
 		flagFramework      string
 		flagName           string
+		flagFirm           string
 		flagState          string
 		flagValidFrom      string
 		flagValidUntil     string
@@ -134,6 +137,8 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 					err := huh.NewSelect[string]().
 						Title("Audit state").
 						Options(
+							huh.NewOption("To Book", "TO_BOOK"),
+							huh.NewOption("Audit Booked", "AUDIT_BOOKED"),
 							huh.NewOption("Not Started", "NOT_STARTED"),
 							huh.NewOption("In Progress", "IN_PROGRESS"),
 							huh.NewOption("Completed", "COMPLETED"),
@@ -159,6 +164,10 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 
 			if flagFramework != "" {
 				input["frameworkId"] = flagFramework
+			}
+
+			if flagFirm != "" {
+				input["firm"] = flagFirm
 			}
 
 			if flagState != "" {
@@ -219,7 +228,8 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
 	cmd.Flags().StringVar(&flagFramework, "framework", "", "Framework ID")
 	cmd.Flags().StringVar(&flagName, "name", "", "Audit name (required)")
-	cmd.Flags().StringVar(&flagState, "state", "", "Audit state: NOT_STARTED, IN_PROGRESS, COMPLETED, REJECTED, OUTDATED")
+	cmd.Flags().StringVar(&flagFirm, "firm", "", "Audit firm")
+	cmd.Flags().StringVar(&flagState, "state", "", "Audit state: TO_BOOK, AUDIT_BOOKED, NOT_STARTED, IN_PROGRESS, COMPLETED, REJECTED, OUTDATED")
 	cmd.Flags().StringVar(&flagValidFrom, "valid-from", "", "Valid from date (e.g. 2026-01-01)")
 	cmd.Flags().StringVar(&flagValidUntil, "valid-until", "", "Valid until date (e.g. 2026-12-31)")
 	cmd.Flags().StringVar(&flagAuditStartDate, "audit-start-date", "", "Audit start date (e.g. 2026-03-01)")

--- a/pkg/cmd/audit/list/list.go
+++ b/pkg/cmd/audit/list/list.go
@@ -40,6 +40,7 @@ query($id: ID!, $first: Int, $after: CursorKey, $orderBy: AuditOrder) {
           node {
             id
             name
+            firm
             state
             validity {
               start
@@ -64,6 +65,7 @@ query($id: ID!, $first: Int, $after: CursorKey, $orderBy: AuditOrder) {
 type audit struct {
 	ID       string `json:"id"`
 	Name     string `json:"name"`
+	Firm     string `json:"firm"`
 	State    string `json:"state"`
 	Validity *struct {
 		Start *string `json:"start"`
@@ -209,6 +211,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				rows = append(rows, []string{
 					a.ID,
 					a.Name,
+					a.Firm,
 					a.State,
 					validFrom,
 					validUntil,
@@ -217,7 +220,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				})
 			}
 
-			t := cmdutil.NewTable("ID", "NAME", "STATE", "VALID FROM", "VALID UNTIL", "AUDIT START", "AUDIT END").Rows(rows...)
+			t := cmdutil.NewTable("ID", "NAME", "FIRM", "STATE", "VALID FROM", "VALID UNTIL", "AUDIT START", "AUDIT END").Rows(rows...)
 
 			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
 

--- a/pkg/cmd/audit/update/update.go
+++ b/pkg/cmd/audit/update/update.go
@@ -35,6 +35,7 @@ mutation($input: UpdateAuditInput!) {
     audit {
       id
       name
+      firm
       state
       validity {
         start
@@ -54,6 +55,7 @@ type updateResponse struct {
 		Audit struct {
 			ID       string `json:"id"`
 			Name     string `json:"name"`
+			Firm     string `json:"firm"`
 			State    string `json:"state"`
 			Validity *struct {
 				Start *string `json:"start"`
@@ -70,6 +72,7 @@ type updateResponse struct {
 func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	var (
 		flagName           string
+		flagFirm           string
 		flagState          string
 		flagValidFrom      string
 		flagValidUntil     string
@@ -106,6 +109,10 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 
 			if cmd.Flags().Changed("name") {
 				input["name"] = flagName
+			}
+
+			if cmd.Flags().Changed("firm") {
+				input["firm"] = flagFirm
 			}
 
 			if cmd.Flags().Changed("state") {
@@ -168,7 +175,8 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flagName, "name", "", "Audit name")
-	cmd.Flags().StringVar(&flagState, "state", "", "Audit state: NOT_STARTED, IN_PROGRESS, COMPLETED, REJECTED, OUTDATED")
+	cmd.Flags().StringVar(&flagFirm, "firm", "", "Audit firm")
+	cmd.Flags().StringVar(&flagState, "state", "", "Audit state: TO_BOOK, AUDIT_BOOKED, NOT_STARTED, IN_PROGRESS, COMPLETED, REJECTED, OUTDATED")
 	cmd.Flags().StringVar(&flagValidFrom, "valid-from", "", "Valid from date (e.g. 2026-01-01)")
 	cmd.Flags().StringVar(&flagValidUntil, "valid-until", "", "Valid until date (e.g. 2026-12-31)")
 	cmd.Flags().StringVar(&flagAuditStartDate, "audit-start-date", "", "Audit start date (e.g. 2026-03-01)")

--- a/pkg/cmd/audit/view/view.go
+++ b/pkg/cmd/audit/view/view.go
@@ -37,6 +37,7 @@ query($id: ID!) {
     ... on Audit {
       id
       name
+      firm
       state
       validity {
         start
@@ -58,6 +59,7 @@ type viewResponse struct {
 		Typename string `json:"__typename"`
 		ID       string `json:"id"`
 		Name     string `json:"name"`
+		Firm     string `json:"firm"`
 		State    string `json:"state"`
 		Validity *struct {
 			Start *string `json:"start"`
@@ -136,6 +138,10 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			_, _ = fmt.Fprintf(out, "%s\n\n", bold.Render(a.Name))
 
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("ID:"), a.ID)
+			if a.Firm != "" {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Firm:"), a.Firm)
+			}
+
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("State:"), a.State)
 
 			if a.Validity != nil && a.Validity.Start != nil && *a.Validity.Start != "" {

--- a/pkg/coredata/audit.go
+++ b/pkg/coredata/audit.go
@@ -38,6 +38,7 @@ type (
 	Audit struct {
 		ID             gid.GID    `db:"id"`
 		Name           *string    `db:"name"`
+		Firm           *string    `db:"firm"`
 		OrganizationID gid.GID    `db:"organization_id"`
 		FrameworkID    gid.GID    `db:"framework_id"`
 		ReportFileID   *gid.GID   `db:"report_file_id"`
@@ -122,6 +123,7 @@ func (a *Audit) LoadByID(
 SELECT
 	id,
 	name,
+	firm,
 	organization_id,
 	framework_id,
 	report_file_id,
@@ -216,6 +218,7 @@ func (a *Audits) LoadByCompliancePortalID(
 SELECT
 	audits.id,
 	audits.name,
+	audits.firm,
 	audits.organization_id,
 	audits.framework_id,
 	audits.report_file_id,
@@ -271,6 +274,7 @@ func (a *Audits) LoadByOrganizationID(
 SELECT
 	id,
 	name,
+	firm,
 	organization_id,
 	framework_id,
 	report_file_id,
@@ -321,6 +325,7 @@ func (a *Audit) Insert(
 INSERT INTO audits (
 	id,
 	name,
+	firm,
 	tenant_id,
 	organization_id,
 	framework_id,
@@ -335,6 +340,7 @@ INSERT INTO audits (
 ) VALUES (
 	@id,
 	@name,
+	@firm,
 	@tenant_id,
 	@organization_id,
 	@framework_id,
@@ -352,6 +358,7 @@ INSERT INTO audits (
 	args := pgx.StrictNamedArgs{
 		"id":               a.ID,
 		"name":             a.Name,
+		"firm":             a.Firm,
 		"tenant_id":        scope.GetTenantID(),
 		"organization_id":  a.OrganizationID,
 		"framework_id":     a.FrameworkID,
@@ -382,6 +389,7 @@ func (a *Audit) Update(
 UPDATE audits
 SET
 	name = @name,
+	firm = @firm,
 	report_file_id = @report_file_id,
 	valid_from = @valid_from,
 	valid_until = @valid_until,
@@ -399,6 +407,7 @@ WHERE
 	args := pgx.StrictNamedArgs{
 		"id":               a.ID,
 		"name":             a.Name,
+		"firm":             a.Firm,
 		"report_file_id":   a.ReportFileID,
 		"valid_from":       a.ValidFrom,
 		"valid_until":      a.ValidUntil,
@@ -455,6 +464,7 @@ WITH audits_by_control AS (
 		a.id,
 		a.tenant_id,
 		a.name,
+		a.firm,
 		a.organization_id,
 		a.framework_id,
 		a.report_file_id,
@@ -475,6 +485,7 @@ WITH audits_by_control AS (
 SELECT
 	id,
 	name,
+	firm,
 	organization_id,
 	framework_id,
 	report_file_id,
@@ -524,6 +535,7 @@ WITH audits_by_finding AS (
 		a.id,
 		a.tenant_id,
 		a.name,
+		a.firm,
 		a.organization_id,
 		a.framework_id,
 		a.report_file_id,
@@ -544,6 +556,7 @@ WITH audits_by_finding AS (
 SELECT
 	id,
 	name,
+	firm,
 	organization_id,
 	framework_id,
 	report_file_id,
@@ -676,6 +689,7 @@ func (a *Audit) LoadByReportFileID(
 SELECT
 	id,
 	name,
+	firm,
 	organization_id,
 	framework_id,
 	report_file_id,
@@ -731,6 +745,7 @@ func (a *Audit) LoadByCompliancePortalIDAndFrameworkID(
 SELECT
 	id,
 	name,
+	firm,
 	organization_id,
 	framework_id,
 	report_file_id,
@@ -792,6 +807,7 @@ func (as *Audits) LoadByReportFileIDs(
 SELECT
 	id,
 	name,
+	firm,
 	organization_id,
 	framework_id,
 	report_file_id,

--- a/pkg/coredata/audit_state.go
+++ b/pkg/coredata/audit_state.go
@@ -28,11 +28,13 @@ import (
 type AuditState string
 
 const (
-	AuditStateNotStarted AuditState = "NOT_STARTED"
-	AuditStateInProgress AuditState = "IN_PROGRESS"
-	AuditStateCompleted  AuditState = "COMPLETED"
-	AuditStateRejected   AuditState = "REJECTED"
-	AuditStateOutdated   AuditState = "OUTDATED"
+	AuditStateToBook      AuditState = "TO_BOOK"
+	AuditStateAuditBooked AuditState = "AUDIT_BOOKED"
+	AuditStateNotStarted  AuditState = "NOT_STARTED"
+	AuditStateInProgress  AuditState = "IN_PROGRESS"
+	AuditStateCompleted   AuditState = "COMPLETED"
+	AuditStateRejected    AuditState = "REJECTED"
+	AuditStateOutdated    AuditState = "OUTDATED"
 )
 
 var (
@@ -43,6 +45,8 @@ var (
 
 func AuditStates() []AuditState {
 	return []AuditState{
+		AuditStateToBook,
+		AuditStateAuditBooked,
 		AuditStateNotStarted,
 		AuditStateInProgress,
 		AuditStateCompleted,
@@ -54,6 +58,8 @@ func AuditStates() []AuditState {
 func (v AuditState) IsValid() bool {
 	switch v {
 	case
+		AuditStateToBook,
+		AuditStateAuditBooked,
 		AuditStateNotStarted,
 		AuditStateInProgress,
 		AuditStateCompleted,

--- a/pkg/coredata/migrations/20260904T073810Z.sql
+++ b/pkg/coredata/migrations/20260904T073810Z.sql
@@ -1,0 +1,22 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.
+
+ALTER TYPE audit_state ADD VALUE IF NOT EXISTS 'TO_BOOK' BEFORE 'NOT_STARTED';
+ALTER TYPE audit_state ADD VALUE IF NOT EXISTS 'AUDIT_BOOKED' AFTER 'TO_BOOK';

--- a/pkg/coredata/migrations/20260904T073821Z.sql
+++ b/pkg/coredata/migrations/20260904T073821Z.sql
@@ -1,0 +1,21 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+-- THE SOFTWARE.
+
+ALTER TABLE audits ADD COLUMN firm TEXT;

--- a/pkg/probo/audit_service.go
+++ b/pkg/probo/audit_service.go
@@ -42,6 +42,7 @@ type (
 		OrganizationID gid.GID
 		FrameworkID    gid.GID
 		Name           *string
+		Firm           *string
 		ValidFrom      *time.Time
 		ValidUntil     *time.Time
 		AuditStartDate *time.Time
@@ -52,6 +53,7 @@ type (
 	UpdateAuditRequest struct {
 		ID             gid.GID
 		Name           **string
+		Firm           **string
 		ValidFrom      *time.Time
 		ValidUntil     *time.Time
 		AuditStartDate *time.Time
@@ -71,6 +73,7 @@ func (car *CreateAuditRequest) Validate() error {
 	v.Check(car.OrganizationID, "organization_id", validator.Required(), validator.GID(coredata.OrganizationEntityType))
 	v.Check(car.FrameworkID, "framework_id", validator.Required(), validator.GID(coredata.FrameworkEntityType))
 	v.Check(car.Name, "name", validator.SafeTextNoNewLine(TitleMaxLength))
+	v.Check(car.Firm, "firm", validator.SafeTextNoNewLine(TitleMaxLength))
 	v.Check(car.ValidUntil, "valid_until", validator.After(car.ValidFrom))
 	v.Check(car.AuditEndDate, "audit_end_date", validator.After(car.AuditStartDate))
 	v.Check(car.State, "state", validator.OneOfSlice(coredata.AuditStates()))
@@ -83,6 +86,7 @@ func (uar *UpdateAuditRequest) Validate() error {
 
 	v.Check(uar.ID, "id", validator.Required(), validator.GID(coredata.AuditEntityType))
 	v.Check(uar.Name, "name", validator.SafeTextNoNewLine(TitleMaxLength))
+	v.Check(uar.Firm, "firm", validator.SafeTextNoNewLine(TitleMaxLength))
 	v.Check(uar.ValidUntil, "valid_until", validator.After(uar.ValidFrom))
 	v.Check(uar.AuditEndDate, "audit_end_date", validator.After(uar.AuditStartDate))
 	v.Check(uar.State, "state", validator.OneOfSlice(coredata.AuditStates()))
@@ -168,6 +172,7 @@ func (s *AuditService) Create(
 	audit := &coredata.Audit{
 		ID:             gid.New(scope.GetTenantID(), coredata.AuditEntityType),
 		Name:           req.Name,
+		Firm:           req.Firm,
 		OrganizationID: req.OrganizationID,
 		FrameworkID:    req.FrameworkID,
 		ValidFrom:      req.ValidFrom,
@@ -229,6 +234,10 @@ func (s *AuditService) Update(
 
 			if req.Name != nil {
 				audit.Name = *req.Name
+			}
+
+			if req.Firm != nil {
+				audit.Firm = *req.Firm
 			}
 
 			if req.ValidFrom != nil {

--- a/pkg/server/api/console/v1/audit_resolvers.go
+++ b/pkg/server/api/console/v1/audit_resolvers.go
@@ -443,6 +443,7 @@ func (r *mutationResolver) CreateAudit(ctx context.Context, input types.CreateAu
 		OrganizationID: input.OrganizationID,
 		FrameworkID:    input.FrameworkID,
 		Name:           input.Name,
+		Firm:           input.Firm,
 		State:          input.State,
 	}
 	req.ValidFrom, req.ValidUntil = types.PeriodInputDates(input.Validity)
@@ -497,6 +498,7 @@ func (r *mutationResolver) UpdateAudit(ctx context.Context, input types.UpdateAu
 	req := probo.UpdateAuditRequest{
 		ID:    input.ID,
 		Name:  gqlutils.UnwrapOmittable(input.Name),
+		Firm:  gqlutils.UnwrapOmittable(input.Firm),
 		State: input.State,
 	}
 	req.ValidFrom, req.ValidUntil = types.PeriodInputDates(input.Validity)

--- a/pkg/server/api/console/v1/graphql/audit.graphql
+++ b/pkg/server/api/console/v1/graphql/audit.graphql
@@ -1,4 +1,8 @@
 enum AuditState @goModel(model: "go.probo.inc/probo/pkg/coredata.AuditState") {
+    TO_BOOK
+        @goEnum(value: "go.probo.inc/probo/pkg/coredata.AuditStateToBook")
+    AUDIT_BOOKED
+        @goEnum(value: "go.probo.inc/probo/pkg/coredata.AuditStateAuditBooked")
     NOT_STARTED
         @goEnum(value: "go.probo.inc/probo/pkg/coredata.AuditStateNotStarted")
     IN_PROGRESS
@@ -155,6 +159,7 @@ input FindingFilter {
 type Audit implements Node {
     id: ID!
     name: String
+    firm: String
     organization: Organization @goField(forceResolver: true)
     framework: Framework @goField(forceResolver: true)
     validity: Period
@@ -286,6 +291,7 @@ input CreateAuditInput {
     organizationId: ID!
     frameworkId: ID!
     name: String
+    firm: String
     validity: PeriodInput
     auditDates: PeriodInput
     state: AuditState
@@ -295,6 +301,7 @@ input CreateAuditInput {
 input UpdateAuditInput {
     id: ID!
     name: String @goField(omittable: true)
+    firm: String @goField(omittable: true)
     validity: PeriodInput
     auditDates: PeriodInput
     state: AuditState

--- a/pkg/server/api/console/v1/types/audit.go
+++ b/pkg/server/api/console/v1/types/audit.go
@@ -78,6 +78,7 @@ func NewAudit(a *coredata.Audit) *Audit {
 		AuditDates: NewPeriod(a.AuditStartDate, a.AuditEndDate),
 		State:      a.State,
 		Name:       a.Name,
+		Firm:       a.Firm,
 		CreatedAt:  a.CreatedAt,
 		UpdatedAt:  a.UpdatedAt,
 	}

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -1533,6 +1533,7 @@ func (r *Resolver) AddAuditTool(ctx context.Context, req *mcp.CallToolRequest, i
 		&probo.CreateAuditRequest{
 			OrganizationID: input.OrganizationID,
 			Name:           input.Name,
+			Firm:           input.Firm,
 			ValidFrom:      validFrom,
 			ValidUntil:     validUntil,
 			AuditStartDate: auditStart,
@@ -1566,6 +1567,7 @@ func (r *Resolver) UpdateAuditTool(ctx context.Context, req *mcp.CallToolRequest
 		&probo.UpdateAuditRequest{
 			ID:             input.ID,
 			Name:           UnwrapOmittable(input.Name),
+			Firm:           UnwrapOmittable(input.Firm),
 			ValidFrom:      validFrom,
 			ValidUntil:     validUntil,
 			AuditStartDate: auditStart,

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -6069,6 +6069,8 @@ components:
     AuditState:
       type: string
       enum:
+        - TO_BOOK
+        - AUDIT_BOOKED
         - NOT_STARTED
         - IN_PROGRESS
         - COMPLETED
@@ -6184,6 +6186,11 @@ components:
             - string
             - "null"
           description: Audit name
+        firm:
+          type:
+            - string
+            - "null"
+          description: Audit firm
         validity:
           $ref: "#/components/schemas/Period"
           description: Certificate validity period
@@ -6313,6 +6320,9 @@ components:
         name:
           type: string
           description: Audit name
+        firm:
+          type: string
+          description: Audit firm
         validity:
           $ref: "#/components/schemas/Period"
           description: Certificate validity period
@@ -6342,6 +6352,10 @@ components:
         name:
           type: ["string", "null"]
           description: Audit name
+          go.probo.inc/mcpgen/omittable: true
+        firm:
+          type: ["string", "null"]
+          description: Audit firm
           go.probo.inc/mcpgen/omittable: true
         validity:
           $ref: "#/components/schemas/Period"

--- a/pkg/server/api/mcp/v1/types/audit.go
+++ b/pkg/server/api/mcp/v1/types/audit.go
@@ -29,6 +29,7 @@ func NewAudit(a *coredata.Audit, file *coredata.File) *Audit {
 	audit := &Audit{
 		ID:             a.ID,
 		Name:           a.Name,
+		Firm:           a.Firm,
 		OrganizationID: a.OrganizationID,
 		FrameworkID:    a.FrameworkID,
 		State:          a.State,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **To book** and **Audit booked** to audit state values, plus an optional **Audit firm** text field.

This lets teams record booking progress and the firm that will run the engagement. The new states sit before Not started so the selector matches that flow.

## Changes

- `TO_BOOK` and `AUDIT_BOOKED` on the `audit_state` enum (coredata, GraphQL, MCP, CLI, n8n, console)
- Optional `firm` column/field on audits, create/update across GraphQL, MCP, CLI, and n8n
- Console create dialog and details page: Audit firm input and the new state options
- E2E coverage for the new states, firm create/update, and HTML validation

## Testing

Automated:

- `go test -run 'TestAudit_Create$|TestAudit_Create_Validation|TestAudit_Update$|TestAudit_Update_Validation' ./e2e/console` — pass
- `go test -run 'TestMCP_Audit_CRUD' ./e2e/mcp` — pass
- Console `tsc --noEmit` — pass
- n8n `n8n-node lint` — pass after collection sort / description fix

Browser (console):

- Created audit “SOC 2 Type II 2026” with firm **A-LIGN** and state **To book**
- Updated the same audit to **Audit booked**; firm persisted

[New Audit dialog with Audit firm A-LIGN and state To book](https://cursor.com/agents/bc-a2d2e963-6253-4a7c-a79c-38dd576cf95a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate_dialog_to_book_and_firm.webp)
[Audit details after create: A-LIGN and To book](https://cursor.com/agents/bc-a2d2e963-6253-4a7c-a79c-38dd576cf95a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdetails_to_book_with_firm.webp)
[Audit details after update: A-LIGN and Audit booked](https://cursor.com/agents/bc-a2d2e963-6253-4a7c-a79c-38dd576cf95a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdetails_audit_booked.webp)
[create-and-update-audit-booking-states.mp4](https://cursor.com/agents/bc-a2d2e963-6253-4a7c-a79c-38dd576cf95a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcreate-and-update-audit-booking-states.mp4)

## Test plan

- [x] Create an audit with state **To book** and an Audit firm
- [x] Update an audit to **Audit booked** and change the firm
- [x] Confirm existing states still work
- [x] Confirm firm can be cleared on update
- [x] Run `e2e/console/audit_test.go` against a migrated database


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-823](https://linear.app/probo/issue/ENG-823/add-audit-booking-states-and-firm-field)

<div><a href="https://cursor.com/agents/bc-a2d2e963-6253-4a7c-a79c-38dd576cf95a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2d2e963-6253-4a7c-a79c-38dd576cf95a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds **To book** and **Audit booked** audit states plus an optional **Audit firm** text field so teams can track booking progress and which firm runs the engagement. The new states sit before Not started so the selector matches that flow. Addresses [ENG-823](https://linear.app/probo/issue/ENG-823/add-audit-booking-states-and-firm-field).

### Coredata **`+70`** **`-5`**

Two migrations add the new enum values before `NOT_STARTED` and the `firm` column to `audits`.

### GraphQL API **`+10`** **`-0`**

`firm` is added to the `Audit` type and both create/update inputs, and the enum exposes the new states.

### MCP **`+17`** **`-0`**

`firm` and the new states are added to the MCP spec and resolvers.

### prb (CLI) **`+30`** **`-3`**

`--firm` flag on create/update, the new state options, and firm shown in list and view output.

### Service **`+9`** **`-0`**

Firm passes through create/update and is validated with the same safe-text rules as `name`.

### App: console **`+62`** **`-20`**

Firm input and the new state options added to the create dialog and details page; translations added for en-US, fr-FR, and nl-NL.

### Package: `helpers` **`+10`** **`-0`**

Shared state list, labels, and badge variants extended.

### Package: `n8n-node` **`+36`** **`-0`**

Create/update operations gain `firm` and the new states; get/getAll return `firm`. An empty firm on update clears the field instead of being ignored.

### Tests **`+98`** **`-0`**

Covers create/update of the new states and firm, HTML validation for firm, and factory support.

<sup>Written for commit 7ac1fbecee3a1fc09c2cc7a5c0aa05881444cc96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

