### PR TITLE
Fix auth email links sandbox proofing

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1241,20 +1241,26 @@
     "title": "Sign up",
     "description": "Enter your information to create an account",
     "alreadyHaveAccount": "Already have an account?",
+    "checkEmail": {
+      "title": "Check your email",
+      "description": "We sent a confirmation link to {{email}}.",
+      "resend": "Didn't receive the email?"
+    },
     "messages": { "created": "Account created successfully" },
     "errors": { "failed": "Sign up failed" },
     "unavailable": { "title": "Registration unavailable", "description": "New account registration is currently disabled. Please contact your administrator or reach out to Probo for assistance." },
     "fields": { "fullName": "Full Name", "fullNamePlaceholder": "John Doe", "email": "Email", "emailPlaceholder": "name@example.com", "password": "Password" },
-    "actions": { "backToLogin": "Back to login", "creating": "Creating account...", "signUpWithEmail": "Sign up with email", "logIn": "Log in here" }
+    "actions": { "backToLogin": "Back to login", "creating": "Creating account...", "signUpWithEmail": "Sign up with email", "logIn": "Log in here", "resend": "Resend confirmation email" }
   },
   "verifyEmailPage": {
     "pageTitle": "Confirm Email",
     "title": "Email Confirmation",
     "description": "Confirm your email address to complete registration",
+    "continueDescription": "Click continue to confirm your email and sign in.",
     "messages": { "confirmed": "Your email has been confirmed successfully", "confirmedWithExclamation": "Your email has been confirmed successfully!" },
     "errors": { "confirm": "Failed to confirm email" },
     "fields": { "token": "Confirmation Token", "tokenPlaceholder": "Enter your confirmation token", "tokenHelp": "The token has been automatically filled from the URL if available" },
-    "actions": { "proceedToLogin": "Proceed to Login", "confirming": "Confirming...", "confirm": "Confirm Email", "backToLogin": "Back to Login" }
+    "actions": { "proceedToLogin": "Proceed to Login", "confirming": "Confirming...", "confirm": "Confirm Email", "continue": "Continue", "backToLogin": "Back to Login" }
   },
   "passwordSignInPage": {
     "title": "Login with Email",

--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1113,7 +1113,7 @@
     "description": "Click continue to activate your account.",
     "activating": "Activating your account…",
     "messages": { "activated": "Account activated successfully." },
-    "errors": { "activationFailed": "Activation failed" },
+    "errors": { "activationFailed": "Activation failed", "missingToken": "Please use the activation link from your email" },
     "actions": { "continue": "Continue", "goBack": "Go back" }
   },
   "consentPage": {
@@ -1190,7 +1190,7 @@
     "description": "Set a password for your account, with at least 8 characters",
     "alreadyHaveAccount": "Already have an account?",
     "messages": { "created": "Account created successfully" },
-    "errors": { "creationFailed": "Password creation failed" },
+    "errors": { "creationFailed": "Password creation failed", "missingToken": "Please use the password setup link from your email" },
     "fields": { "password": "Password" },
     "actions": { "save": "Save", "logIn": "Log in here" }
   },
@@ -1232,7 +1232,7 @@
     "description": "Enter your new password to reset your account",
     "rememberPassword": "Remember your password?",
     "messages": { "reset": "Password reset successfully" },
-    "errors": { "resetFailed": "Reset failed", "invalidToken": "Invalid or missing reset token", "reset": "Password reset failed" },
+    "errors": { "resetFailed": "Reset failed", "invalidToken": "Please use the reset link from your email", "reset": "Password reset failed" },
     "fields": { "newPassword": "New Password", "confirmPassword": "Confirm Password" },
     "actions": { "resetting": "Resetting password...", "reset": "Reset password", "logIn": "Log in here" }
   },
@@ -1258,7 +1258,7 @@
     "description": "Confirm your email address to complete registration",
     "continueDescription": "Click continue to confirm your email and sign in.",
     "messages": { "confirmed": "Your email has been confirmed successfully", "confirmedWithExclamation": "Your email has been confirmed successfully!" },
-    "errors": { "confirm": "Failed to confirm email" },
+    "errors": { "confirm": "Failed to confirm email", "tokenRequired": "Please enter your confirmation token" },
     "fields": { "token": "Confirmation Token", "tokenPlaceholder": "Enter your confirmation token", "tokenHelp": "The token has been automatically filled from the URL if available" },
     "actions": { "proceedToLogin": "Proceed to Login", "confirming": "Confirming...", "confirm": "Confirm Email", "continue": "Continue", "backToLogin": "Back to Login" }
   },

--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1110,10 +1110,11 @@
   "activateAccountPage": {
     "pageTitle": "Activate Account",
     "title": "Account Activation",
+    "description": "Click continue to activate your account.",
     "activating": "Activating your account…",
     "messages": { "activated": "Account activated successfully." },
     "errors": { "activationFailed": "Activation failed" },
-    "actions": { "goBack": "Go back" }
+    "actions": { "continue": "Continue", "goBack": "Go back" }
   },
   "consentPage": {
     "pageTitle": "Authorize Application",
@@ -3112,6 +3113,12 @@
     "unnamed": "Unnamed contact",
     "emptyValue": "—",
     "actions": { "edit": "Edit", "delete": "Delete" }
+  },
+  "magicLinkPage": {
+    "pageTitle": "Continue sign-in",
+    "title": "Continue sign-in",
+    "description": "Click continue to finish signing in.",
+    "actions": { "continue": "Continue" }
   },
   "magicLinkForm": {
     "errors": { "send": "Cannot send magic link" },

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -1638,7 +1638,8 @@
       "activated": "Compte activé avec succès."
     },
     "errors": {
-      "activationFailed": "Échec de l’activation"
+      "activationFailed": "Échec de l’activation",
+      "missingToken": "Veuillez utiliser le lien d’activation envoyé par e-mail"
     },
     "actions": {
       "continue": "Continuer",
@@ -1737,7 +1738,8 @@
       "created": "Compte créé avec succès"
     },
     "errors": {
-      "creationFailed": "Échec de la création du mot de passe"
+      "creationFailed": "Échec de la création du mot de passe",
+      "missingToken": "Veuillez utiliser le lien de création de mot de passe envoyé par e-mail"
     },
     "fields": {
       "password": "Mot de passe"
@@ -1833,7 +1835,7 @@
     },
     "errors": {
       "resetFailed": "Échec de la réinitialisation",
-      "invalidToken": "Jeton de réinitialisation invalide ou manquant",
+      "invalidToken": "Veuillez utiliser le lien de réinitialisation envoyé par e-mail",
       "reset": "Échec de la réinitialisation du mot de passe"
     },
     "fields": {
@@ -1891,7 +1893,8 @@
       "confirmedWithExclamation": "Votre e-mail a été confirmé avec succès !"
     },
     "errors": {
-      "confirm": "Échec de la confirmation de l’e-mail"
+      "confirm": "Échec de la confirmation de l’e-mail",
+      "tokenRequired": "Veuillez saisir votre jeton de confirmation"
     },
     "fields": {
       "token": "Jeton de confirmation",

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -1851,6 +1851,11 @@
     "title": "Inscription",
     "description": "Saisissez vos informations pour créer un compte",
     "alreadyHaveAccount": "Vous avez déjà un compte ?",
+    "checkEmail": {
+      "title": "Vérifiez votre e-mail",
+      "description": "Nous avons envoyé un lien de confirmation à {{email}}.",
+      "resend": "Vous n’avez pas reçu l’e-mail ?"
+    },
     "messages": {
       "created": "Compte créé avec succès"
     },
@@ -1872,13 +1877,15 @@
       "backToLogin": "Retour à la connexion",
       "creating": "Création du compte...",
       "signUpWithEmail": "S’inscrire avec e-mail",
-      "logIn": "Connectez-vous ici"
+      "logIn": "Connectez-vous ici",
+      "resend": "Renvoyer l’e-mail de confirmation"
     }
   },
   "verifyEmailPage": {
     "pageTitle": "Confirmer l’e-mail",
     "title": "Confirmation de l’e-mail",
     "description": "Confirmez votre adresse e-mail pour finaliser votre inscription",
+    "continueDescription": "Cliquez sur continuer pour confirmer votre e-mail et vous connecter.",
     "messages": {
       "confirmed": "Votre e-mail a été confirmé avec succès",
       "confirmedWithExclamation": "Votre e-mail a été confirmé avec succès !"
@@ -1895,6 +1902,7 @@
       "proceedToLogin": "Continuer vers la connexion",
       "confirming": "Confirmation...",
       "confirm": "Confirmer l’e-mail",
+      "continue": "Continuer",
       "backToLogin": "Retour à la connexion"
     }
   },

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -1632,6 +1632,7 @@
   "activateAccountPage": {
     "pageTitle": "Activer le compte",
     "title": "Activation du compte",
+    "description": "Cliquez sur continuer pour activer votre compte.",
     "activating": "Activation de votre compte…",
     "messages": {
       "activated": "Compte activé avec succès."
@@ -1640,6 +1641,7 @@
       "activationFailed": "Échec de l’activation"
     },
     "actions": {
+      "continue": "Continuer",
       "goBack": "Retour"
     }
   },
@@ -5966,6 +5968,12 @@
       "edit": "Modifier",
       "delete": "Supprimer"
     }
+  },
+  "magicLinkPage": {
+    "pageTitle": "Continuer la connexion",
+    "title": "Continuer la connexion",
+    "description": "Cliquez sur continuer pour terminer la connexion.",
+    "actions": { "continue": "Continuer" }
   },
   "magicLinkForm": {
     "errors": {

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -1632,6 +1632,7 @@
   "activateAccountPage": {
     "pageTitle": "Account activeren",
     "title": "Accountactivering",
+    "description": "Klik op doorgaan om uw account te activeren.",
     "activating": "Uw account wordt geactiveerd…",
     "messages": {
       "activated": "Account succesvol geactiveerd."
@@ -1640,6 +1641,7 @@
       "activationFailed": "Activering mislukt"
     },
     "actions": {
+      "continue": "Doorgaan",
       "goBack": "Terug"
     }
   },
@@ -5959,6 +5961,12 @@
       "edit": "Bewerken",
       "delete": "Verwijderen"
     }
+  },
+  "magicLinkPage": {
+    "pageTitle": "Doorgaan met inloggen",
+    "title": "Doorgaan met inloggen",
+    "description": "Klik op doorgaan om het inloggen te voltooien.",
+    "actions": { "continue": "Doorgaan" }
   },
   "magicLinkForm": {
     "errors": {

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -1851,6 +1851,11 @@
     "title": "Registreren",
     "description": "Voer uw gegevens in om een account aan te maken",
     "alreadyHaveAccount": "Heeft u al een account?",
+    "checkEmail": {
+      "title": "Controleer uw e-mail",
+      "description": "We hebben een bevestigingslink gestuurd naar {{email}}.",
+      "resend": "Geen e-mail ontvangen?"
+    },
     "messages": {
       "created": "Account succesvol aangemaakt"
     },
@@ -1872,13 +1877,15 @@
       "backToLogin": "Terug naar inloggen",
       "creating": "Account aanmaken...",
       "signUpWithEmail": "Registreren met e-mail",
-      "logIn": "Hier inloggen"
+      "logIn": "Hier inloggen",
+      "resend": "Bevestigingsmail opnieuw versturen"
     }
   },
   "verifyEmailPage": {
     "pageTitle": "E-mail bevestigen",
     "title": "E-mailbevestiging",
     "description": "Bevestig uw e-mailadres om de registratie te voltooien",
+    "continueDescription": "Klik op doorgaan om uw e-mail te bevestigen en in te loggen.",
     "messages": {
       "confirmed": "Uw e-mail is succesvol bevestigd",
       "confirmedWithExclamation": "Uw e-mail is succesvol bevestigd!"
@@ -1895,6 +1902,7 @@
       "proceedToLogin": "Doorgaan naar inloggen",
       "confirming": "Bevestigen...",
       "confirm": "E-mail bevestigen",
+      "continue": "Doorgaan",
       "backToLogin": "Terug naar inloggen"
     }
   },

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -1638,7 +1638,8 @@
       "activated": "Account succesvol geactiveerd."
     },
     "errors": {
-      "activationFailed": "Activering mislukt"
+      "activationFailed": "Activering mislukt",
+      "missingToken": "Gebruik de activeringslink uit uw e-mail"
     },
     "actions": {
       "continue": "Doorgaan",
@@ -1737,7 +1738,8 @@
       "created": "Account succesvol aangemaakt"
     },
     "errors": {
-      "creationFailed": "Aanmaken van wachtwoord mislukt"
+      "creationFailed": "Aanmaken van wachtwoord mislukt",
+      "missingToken": "Gebruik de wachtwoordinstellink uit uw e-mail"
     },
     "fields": {
       "password": "Wachtwoord"
@@ -1833,7 +1835,7 @@
     },
     "errors": {
       "resetFailed": "Reset mislukt",
-      "invalidToken": "Ongeldige of ontbrekende resettoken",
+      "invalidToken": "Gebruik de resetlink uit uw e-mail",
       "reset": "Opnieuw instellen van wachtwoord mislukt"
     },
     "fields": {
@@ -1891,7 +1893,8 @@
       "confirmedWithExclamation": "Uw e-mail is succesvol bevestigd!"
     },
     "errors": {
-      "confirm": "Bevestigen van e-mail mislukt"
+      "confirm": "Bevestigen van e-mail mislukt",
+      "tokenRequired": "Voer uw bevestigingstoken in"
     },
     "fields": {
       "token": "Bevestigingstoken",

--- a/apps/console/src/pages/iam/auth/ActivateAccountPage.tsx
+++ b/apps/console/src/pages/iam/auth/ActivateAccountPage.tsx
@@ -21,11 +21,11 @@
 import { formatError, type GraphQLError } from "@probo/helpers";
 import { usePageTitle } from "@probo/hooks";
 import { useToast } from "@probo/ui";
+import { Button } from "@probo/ui/src/v2/Button/Button";
 import { Link } from "@probo/ui/src/v2/Link/Link";
-import { Spinner } from "@probo/ui/src/v2/Spinner/Spinner";
 import { Heading } from "@probo/ui/src/v2/typography/Heading";
 import { Text } from "@probo/ui/src/v2/typography/Text";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { useNavigate, useSearchParams } from "react-router";
@@ -50,15 +50,20 @@ export default function ActivateAccountPage() {
   const { toast } = useToast();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const submittedRef = useRef<boolean>(false);
+  const submittedRef = useRef(false);
   const safeContinueUrl = useSafeContinueUrl();
+  const token = searchParams.get("token")?.trim() ?? "";
 
   usePageTitle(t("activateAccountPage.pageTitle"));
 
-  const [activateAccount] = useMutation<ActivateAccountPageMutation>(activateAccountMutation);
+  const [activateAccount, isActivating] = useMutation<ActivateAccountPageMutation>(activateAccountMutation);
 
-  const handleActivateAccount = useCallback((token: string) => {
-    if (submittedRef.current) return;
+  const handleActivateAccount = useCallback(() => {
+    if (submittedRef.current || token === "") {
+      return;
+    }
+
+    submittedRef.current = true;
 
     activateAccount({
       variables: {
@@ -75,6 +80,8 @@ export default function ActivateAccountPage() {
               return;
             }
           }
+
+          submittedRef.current = false;
           toast({
             title: t("activateAccountPage.errors.activationFailed"),
             description: formatError(t("activateAccountPage.errors.activationFailed"), errors),
@@ -126,6 +133,7 @@ export default function ActivateAccountPage() {
         }, { replace: true });
       },
       onError: (e) => {
+        submittedRef.current = false;
         toast({
           title: t("activateAccountPage.errors.activationFailed"),
           description: e.message,
@@ -133,29 +141,31 @@ export default function ActivateAccountPage() {
         });
       },
     });
-  }, [t, toast, activateAccount, navigate, safeContinueUrl]);
-
-  useEffect(() => {
-    const token = searchParams.get("token");
-    if (!submittedRef.current && token) {
-      void handleActivateAccount(token.trim());
-      submittedRef.current = true;
-    }
-  }, [handleActivateAccount, searchParams]);
+  }, [t, toast, activateAccount, navigate, safeContinueUrl, token]);
 
   return (
     <div className="flex w-full flex-col gap-8">
-      <div className="flex flex-col items-center gap-4">
-        <Spinner size={3} aria-label={t("activateAccountPage.activating")} />
-        <div className="flex flex-col gap-1">
-          <Heading level={1} size={4} weight="medium" align="center" highContrast>
-            {t("activateAccountPage.title")}
-          </Heading>
-          <Text size={2} align="center" className="block">
-            {t("activateAccountPage.activating")}
-          </Text>
-        </div>
+      <div className="flex flex-col gap-1">
+        <Heading level={1} size={4} weight="medium" align="center" highContrast>
+          {t("activateAccountPage.title")}
+        </Heading>
+        <Text size={2} align="center" className="block">
+          {t("activateAccountPage.description")}
+        </Text>
       </div>
+      <Button
+        type="button"
+        variant="solid"
+        color="neutral"
+        highContrast
+        size={3}
+        className="w-full"
+        loading={isActivating}
+        disabled={token === ""}
+        onClick={handleActivateAccount}
+      >
+        {t("activateAccountPage.actions.continue")}
+      </Button>
       <Text align="center" size={2} className="block">
         <Link to="/auth/login">
           {t("activateAccountPage.actions.goBack")}

--- a/apps/console/src/pages/iam/auth/ActivateAccountPage.tsx
+++ b/apps/console/src/pages/iam/auth/ActivateAccountPage.tsx
@@ -59,7 +59,16 @@ export default function ActivateAccountPage() {
   const [activateAccount, isActivating] = useMutation<ActivateAccountPageMutation>(activateAccountMutation);
 
   const handleActivateAccount = useCallback(() => {
-    if (submittedRef.current || token === "") {
+    if (submittedRef.current) {
+      return;
+    }
+
+    if (token === "") {
+      toast({
+        title: t("activateAccountPage.errors.activationFailed"),
+        description: t("activateAccountPage.errors.missingToken"),
+        variant: "error",
+      });
       return;
     }
 
@@ -161,7 +170,6 @@ export default function ActivateAccountPage() {
         size={3}
         className="w-full"
         loading={isActivating}
-        disabled={token === ""}
         onClick={handleActivateAccount}
       >
         {t("activateAccountPage.actions.continue")}

--- a/apps/console/src/pages/iam/auth/CreatePasswordPage.tsx
+++ b/apps/console/src/pages/iam/auth/CreatePasswordPage.tsx
@@ -52,13 +52,23 @@ export default function CreatePasswordPage() {
   usePageTitle(t("createPasswordPage.pageTitle"));
 
   const [createPassword, isCreatingPassword] = useMutation<CreatePasswordPageMutation>(createPasswordMutation);
+  const token = searchParams.get("token")?.trim() ?? "";
 
   const onSubmit = (password: string) => {
+    if (token === "") {
+      toast({
+        title: t("createPasswordPage.errors.creationFailed"),
+        description: t("createPasswordPage.errors.missingToken"),
+        variant: "error",
+      });
+      return;
+    }
+
     createPassword({
       variables: {
         input: {
           password,
-          token: searchParams.get("token") ?? "",
+          token,
         },
       },
       onCompleted: (_, e) => {

--- a/apps/console/src/pages/iam/auth/MagicLinkPage.tsx
+++ b/apps/console/src/pages/iam/auth/MagicLinkPage.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { usePageTitle } from "@probo/hooks";
+import { Button } from "@probo/ui/src/v2/Button/Button";
+import { ButtonLink } from "@probo/ui/src/v2/Button/ButtonLink";
+import { Heading } from "@probo/ui/src/v2/typography/Heading";
+import { Text } from "@probo/ui/src/v2/typography/Text";
+import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router";
+
+export default function MagicLinkPage() {
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token")?.trim() ?? "";
+
+  usePageTitle(t("magicLinkPage.pageTitle"));
+
+  return (
+    <div className="flex w-full flex-col gap-8">
+      <div className="flex flex-col gap-1">
+        <Heading level={1} size={4} weight="medium" align="center" highContrast>
+          {t("magicLinkPage.title")}
+        </Heading>
+        <Text size={2} align="center" className="block">
+          {t("magicLinkPage.description")}
+        </Text>
+      </div>
+
+      {token === ""
+        ? (
+            <ButtonLink
+              to="/auth/login"
+              variant="solid"
+              color="neutral"
+              highContrast
+              size={3}
+              className="w-full"
+            >
+              {t("auth.actions.signIn")}
+            </ButtonLink>
+          )
+        : (
+            <form
+              method="POST"
+              action="/api/connect/v1/magic-link/verify"
+              className="flex flex-col"
+            >
+              <input type="hidden" name="token" value={token} />
+              <Button
+                type="submit"
+                variant="solid"
+                color="neutral"
+                highContrast
+                size={3}
+                className="w-full"
+              >
+                {t("magicLinkPage.actions.continue")}
+              </Button>
+            </form>
+          )}
+    </div>
+  );
+}

--- a/apps/console/src/pages/iam/auth/ResendVerificationEmailPage.tsx
+++ b/apps/console/src/pages/iam/auth/ResendVerificationEmailPage.tsx
@@ -31,10 +31,19 @@ import { Text } from "@probo/ui/src/v2/typography/Text";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
-import { useSearchParams } from "react-router";
+import { useLocation } from "react-router";
 import { graphql } from "relay-runtime";
 
 import type { ResendVerificationEmailPageMutation } from "#/__generated__/iam/ResendVerificationEmailPageMutation.graphql";
+
+function emailFromLocationState(state: unknown): string {
+  if (state == null || typeof state !== "object" || !("email" in state)) {
+    return "";
+  }
+
+  const { email } = state;
+  return typeof email === "string" ? email : "";
+}
 
 const resendVerificationEmailMutation = graphql`
   mutation ResendVerificationEmailPageMutation($input: ResendVerificationEmailInput!) {
@@ -47,7 +56,8 @@ const resendVerificationEmailMutation = graphql`
 export default function ResendVerificationEmailPage() {
   const { toast } = useToast();
   const { t } = useTranslation();
-  const [searchParams] = useSearchParams();
+  const location = useLocation();
+  const defaultEmail = emailFromLocationState(location.state);
 
   usePageTitle(t("resendVerificationEmailPage.pageTitle"));
 
@@ -153,7 +163,7 @@ export default function ResendVerificationEmailPage() {
             type="email"
             name="email"
             required
-            defaultValue={searchParams.get("email") ?? ""}
+            defaultValue={defaultEmail}
             placeholder={t("resendVerificationEmailPage.fields.emailPlaceholder")}
           />
           <Field.Error className="text-1 text-red-11" />

--- a/apps/console/src/pages/iam/auth/ResetPasswordPage.tsx
+++ b/apps/console/src/pages/iam/auth/ResetPasswordPage.tsx
@@ -48,7 +48,7 @@ export default function ResetPasswordPage() {
   const { toast } = useToast();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const token = searchParams.get("token");
+  const token = searchParams.get("token")?.trim() ?? "";
 
   usePageTitle(t("resetPasswordPage.pageTitle"));
 
@@ -57,7 +57,7 @@ export default function ResetPasswordPage() {
   );
 
   const onSubmit = (password: string) => {
-    if (!token) {
+    if (token === "") {
       toast({
         title: t("resetPasswordPage.errors.resetFailed"),
         description: t("resetPasswordPage.errors.invalidToken"),

--- a/apps/console/src/pages/iam/auth/SignUpPage.tsx
+++ b/apps/console/src/pages/iam/auth/SignUpPage.tsx
@@ -29,10 +29,9 @@ import { TextField } from "@probo/ui/src/v2/form/TextField";
 import { Link } from "@probo/ui/src/v2/Link/Link";
 import { Heading } from "@probo/ui/src/v2/typography/Heading";
 import { Text } from "@probo/ui/src/v2/typography/Text";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation, usePreloadedQuery, useQueryLoader } from "react-relay";
-import { useNavigate } from "react-router";
 import { graphql } from "relay-runtime";
 
 import type { SignUpPageMutation } from "#/__generated__/iam/SignUpPageMutation.graphql";
@@ -57,7 +56,7 @@ const signUpMutation = graphql`
 function SignUpPageContent(props: { queryRef: NonNullable<ReturnType<typeof useQueryLoader<SignUpPageQuery>>[0]> }) {
   const { t } = useTranslation();
   const { toast } = useToast();
-  const navigate = useNavigate();
+  const [signedUpEmail, setSignedUpEmail] = useState("");
 
   usePageTitle(t("signUpPage.pageTitle"));
 
@@ -84,11 +83,11 @@ function SignUpPageContent(props: { queryRef: NonNullable<ReturnType<typeof useQ
           return;
         }
 
+        setSignedUpEmail(email);
         toast({
           title: t("common.success"), description: t("signUpPage.messages.created"),
           variant: "success",
         });
-        void navigate("/", { replace: true });
       },
       onError: (e) => {
         toast({
@@ -99,6 +98,37 @@ function SignUpPageContent(props: { queryRef: NonNullable<ReturnType<typeof useQ
       },
     });
   };
+
+  if (signedUpEmail !== "") {
+    const resendSearch = new URLSearchParams({ email: signedUpEmail }).toString();
+
+    return (
+      <div className="flex w-full flex-col gap-8">
+        <div className="flex flex-col gap-1">
+          <Heading level={1} size={4} weight="medium" align="center" highContrast>
+            {t("signUpPage.checkEmail.title")}
+          </Heading>
+          <Text size={2} align="center" className="block">
+            {t("signUpPage.checkEmail.description", { email: signedUpEmail })}
+          </Text>
+        </div>
+
+        <Text align="center" size={2} className="block">
+          {t("signUpPage.checkEmail.resend")}
+          {" "}
+          <Link to={{ pathname: "/auth/resend-verification-email", search: `?${resendSearch}` }}>
+            {t("signUpPage.actions.resend")}
+          </Link>
+        </Text>
+
+        <Text align="center" size={2} className="block">
+          <Link to="/auth/login">
+            {t("signUpPage.actions.backToLogin")}
+          </Link>
+        </Text>
+      </div>
+    );
+  }
 
   if (!data.signUpEnabled) {
     return (

--- a/apps/console/src/pages/iam/auth/SignUpPage.tsx
+++ b/apps/console/src/pages/iam/auth/SignUpPage.tsx
@@ -32,6 +32,7 @@ import { Text } from "@probo/ui/src/v2/typography/Text";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation, usePreloadedQuery, useQueryLoader } from "react-relay";
+import { useSearchParams } from "react-router";
 import { graphql } from "relay-runtime";
 
 import type { SignUpPageMutation } from "#/__generated__/iam/SignUpPageMutation.graphql";
@@ -56,6 +57,7 @@ const signUpMutation = graphql`
 function SignUpPageContent(props: { queryRef: NonNullable<ReturnType<typeof useQueryLoader<SignUpPageQuery>>[0]> }) {
   const { t } = useTranslation();
   const { toast } = useToast();
+  const [searchParams] = useSearchParams();
   const [signedUpEmail, setSignedUpEmail] = useState("");
 
   usePageTitle(t("signUpPage.pageTitle"));
@@ -100,7 +102,8 @@ function SignUpPageContent(props: { queryRef: NonNullable<ReturnType<typeof useQ
   };
 
   if (signedUpEmail !== "") {
-    const resendSearch = new URLSearchParams({ email: signedUpEmail }).toString();
+    const loginSearch = searchParams.toString();
+    const authSearch = loginSearch === "" ? "" : "?" + loginSearch;
 
     return (
       <div className="flex w-full flex-col gap-8">
@@ -116,13 +119,24 @@ function SignUpPageContent(props: { queryRef: NonNullable<ReturnType<typeof useQ
         <Text align="center" size={2} className="block">
           {t("signUpPage.checkEmail.resend")}
           {" "}
-          <Link to={{ pathname: "/auth/resend-verification-email", search: `?${resendSearch}` }}>
+          <Link
+            to={{
+              pathname: "/auth/resend-verification-email",
+              search: authSearch,
+            }}
+            state={{ email: signedUpEmail }}
+          >
             {t("signUpPage.actions.resend")}
           </Link>
         </Text>
 
         <Text align="center" size={2} className="block">
-          <Link to="/auth/login">
+          <Link
+            to={{
+              pathname: "/auth/login",
+              search: authSearch,
+            }}
+          >
             {t("signUpPage.actions.backToLogin")}
           </Link>
         </Text>

--- a/apps/console/src/pages/iam/auth/VerifyEmailPage.tsx
+++ b/apps/console/src/pages/iam/auth/VerifyEmailPage.tsx
@@ -61,7 +61,7 @@ export default function VerifyEmailPage() {
     if (token === "") {
       toast({
         title: t("common.error"),
-        description: t("verifyEmailPage.fields.token"),
+        description: t("verifyEmailPage.errors.tokenRequired"),
         variant: "error",
       });
       return;

--- a/apps/console/src/pages/iam/auth/VerifyEmailPage.tsx
+++ b/apps/console/src/pages/iam/auth/VerifyEmailPage.tsx
@@ -59,6 +59,11 @@ export default function VerifyEmailPage() {
 
   const handleSubmit = useCallback((token: string) => {
     if (token === "") {
+      toast({
+        title: t("common.error"),
+        description: t("verifyEmailPage.fields.token"),
+        variant: "error",
+      });
       return;
     }
 

--- a/apps/console/src/pages/iam/auth/VerifyEmailPage.tsx
+++ b/apps/console/src/pages/iam/auth/VerifyEmailPage.tsx
@@ -24,19 +24,18 @@ import { formatError, type GraphQLError } from "@probo/helpers";
 import { usePageTitle } from "@probo/hooks";
 import { useToast } from "@probo/ui";
 import { Button } from "@probo/ui/src/v2/Button/Button";
-import { ButtonLink } from "@probo/ui/src/v2/Button/ButtonLink";
 import { TextField } from "@probo/ui/src/v2/form/TextField";
 import { Link } from "@probo/ui/src/v2/Link/Link";
-import { Spinner } from "@probo/ui/src/v2/Spinner/Spinner";
 import { Heading } from "@probo/ui/src/v2/typography/Heading";
 import { Text } from "@probo/ui/src/v2/typography/Text";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { useSearchParams } from "react-router";
 import { graphql } from "relay-runtime";
 
 import type { VerifyEmailPageMutation } from "#/__generated__/iam/VerifyEmailPageMutation.graphql";
+import { usePostAuthRedirectUrl } from "#/hooks/usePostAuthRedirectUrl";
 
 const verifyEmailMutation = graphql`
   mutation VerifyEmailPageMutation($input: VerifyEmailInput!) {
@@ -51,26 +50,26 @@ export default function VerifyEmailPage() {
   const { toast } = useToast();
   const [searchParams] = useSearchParams();
   const queryToken = searchParams.get("token")?.trim() ?? "";
-  const autoStartedRef = useRef(false);
+  const postAuthRedirectUrl = usePostAuthRedirectUrl();
 
   usePageTitle(t("verifyEmailPage.pageTitle"));
-
-  const [isConfirmed, setIsConfirmed] = useState(false);
-  const [hasFailed, setHasFailed] = useState(false);
 
   const [verifyEmail, isVerifying]
     = useMutation<VerifyEmailPageMutation>(verifyEmailMutation);
 
   const handleSubmit = useCallback((token: string) => {
+    if (token === "") {
+      return;
+    }
+
     verifyEmail({
       variables: {
         input: {
-          token: token.trim(),
+          token,
         },
       },
       onCompleted: (_, errors) => {
         if (errors && !errors.some(error => (error as GraphQLError).extensions?.code === "EMAIL_ALREADY_VERIFIED")) {
-          setHasFailed(true);
           toast({
             title: t("common.error"), description: formatError(t("verifyEmailPage.errors.confirm"), errors),
             variant: "error",
@@ -78,30 +77,16 @@ export default function VerifyEmailPage() {
           return;
         }
 
-        setIsConfirmed(true);
-        toast({
-          title: t("common.success"), description: t("verifyEmailPage.messages.confirmed"),
-          variant: "success",
-        });
+        window.location.href = postAuthRedirectUrl;
       },
       onError: (err) => {
-        setHasFailed(true);
         toast({
           title: t("common.error"), description: err.message || t("verifyEmailPage.errors.confirm"),
           variant: "error",
         });
       },
     });
-  }, [t, toast, verifyEmail]);
-
-  useEffect(() => {
-    if (queryToken === "" || autoStartedRef.current) {
-      return;
-    }
-
-    autoStartedRef.current = true;
-    handleSubmit(queryToken);
-  }, [handleSubmit, queryToken]);
+  }, [t, toast, verifyEmail, postAuthRedirectUrl]);
 
   return (
     <div className="flex w-full flex-col gap-8">
@@ -110,82 +95,72 @@ export default function VerifyEmailPage() {
           {t("verifyEmailPage.title")}
         </Heading>
         <Text size={2} align="center" className="block">
-          {t("verifyEmailPage.description")}
+          {queryToken === ""
+            ? t("verifyEmailPage.description")
+            : t("verifyEmailPage.continueDescription")}
         </Text>
       </div>
 
-      {isConfirmed
+      {queryToken === ""
         ? (
-            <div className="flex flex-col gap-5">
-              <Text align="center" color="green" highContrast className="block">
-                {t("verifyEmailPage.messages.confirmedWithExclamation")}
-              </Text>
-              <ButtonLink
-                to="/auth/login"
+            <Form
+              className="flex flex-col gap-5"
+              onFormSubmit={(values) => {
+                handleSubmit(String(values.token ?? "").trim());
+              }}
+            >
+              <Field.Root name="token" className="flex flex-col gap-1.5">
+                <Field.Label className="text-1 font-medium text-sand-12">
+                  {t("verifyEmailPage.fields.token")}
+                </Field.Label>
+                <TextField
+                  type="text"
+                  name="token"
+                  required
+                  placeholder={t("verifyEmailPage.fields.tokenPlaceholder")}
+                  disabled={isVerifying}
+                />
+                <Field.Description className="text-1 text-sand-11">
+                  {t("verifyEmailPage.fields.tokenHelp")}
+                </Field.Description>
+                <Field.Error className="text-1 text-red-11" />
+              </Field.Root>
+
+              <Button
+                type="submit"
                 variant="solid"
                 color="neutral"
                 highContrast
                 size={3}
                 className="w-full"
+                loading={isVerifying}
               >
-                {t("verifyEmailPage.actions.proceedToLogin")}
-              </ButtonLink>
-            </div>
+                {t("verifyEmailPage.actions.confirm")}
+              </Button>
+            </Form>
           )
-        : queryToken !== "" && !hasFailed
-          ? (
-              <div className="flex flex-col items-center gap-4">
-                <Spinner size={3} aria-label={t("verifyEmailPage.actions.confirming")} />
-                <Text size={2} align="center" className="block">
-                  {t("verifyEmailPage.actions.confirming")}
-                </Text>
-              </div>
-            )
-          : (
-              <Form
-                className="flex flex-col gap-5"
-                onFormSubmit={(values) => {
-                  handleSubmit(String(values.token ?? ""));
-                }}
-              >
-                <Field.Root name="token" className="flex flex-col gap-1.5">
-                  <Field.Label className="text-1 font-medium text-sand-12">
-                    {t("verifyEmailPage.fields.token")}
-                  </Field.Label>
-                  <TextField
-                    type="text"
-                    name="token"
-                    required
-                    placeholder={t("verifyEmailPage.fields.tokenPlaceholder")}
-                    disabled={isVerifying}
-                  />
-                  <Field.Description className="text-1 text-sand-11">
-                    {t("verifyEmailPage.fields.tokenHelp")}
-                  </Field.Description>
-                  <Field.Error className="text-1 text-red-11" />
-                </Field.Root>
+        : (
+            <Button
+              type="button"
+              variant="solid"
+              color="neutral"
+              highContrast
+              size={3}
+              className="w-full"
+              loading={isVerifying}
+              onClick={() => {
+                handleSubmit(queryToken);
+              }}
+            >
+              {t("verifyEmailPage.actions.continue")}
+            </Button>
+          )}
 
-                <Button
-                  type="submit"
-                  variant="solid"
-                  color="neutral"
-                  highContrast
-                  size={3}
-                  className="w-full"
-                  loading={isVerifying}
-                >
-                  {t("verifyEmailPage.actions.confirm")}
-                </Button>
-              </Form>
-            )}
-
-      {!isConfirmed && (
-        <Text align="center" size={2} className="block">
-          <Link to="/auth/login">
-            {t("verifyEmailPage.actions.backToLogin")}
-          </Link>
-        </Text>
-      )}
+      <Text align="center" size={2} className="block">
+        <Link to="/auth/login">
+          {t("verifyEmailPage.actions.backToLogin")}
+        </Link>
+      </Text>
     </div>
   );
 }

--- a/apps/console/src/pages/iam/auth/VerifyEmailPage.tsx
+++ b/apps/console/src/pages/iam/auth/VerifyEmailPage.tsx
@@ -20,16 +20,17 @@
 
 import { Field } from "@base-ui/react/field";
 import { Form } from "@base-ui/react/form";
-import { formatError } from "@probo/helpers";
+import { formatError, type GraphQLError } from "@probo/helpers";
 import { usePageTitle } from "@probo/hooks";
 import { useToast } from "@probo/ui";
 import { Button } from "@probo/ui/src/v2/Button/Button";
 import { ButtonLink } from "@probo/ui/src/v2/Button/ButtonLink";
 import { TextField } from "@probo/ui/src/v2/form/TextField";
 import { Link } from "@probo/ui/src/v2/Link/Link";
+import { Spinner } from "@probo/ui/src/v2/Spinner/Spinner";
 import { Heading } from "@probo/ui/src/v2/typography/Heading";
 import { Text } from "@probo/ui/src/v2/typography/Text";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "react-relay";
 import { useSearchParams } from "react-router";
@@ -49,15 +50,18 @@ export default function VerifyEmailPage() {
   const { t } = useTranslation();
   const { toast } = useToast();
   const [searchParams] = useSearchParams();
+  const queryToken = searchParams.get("token")?.trim() ?? "";
+  const autoStartedRef = useRef(false);
 
   usePageTitle(t("verifyEmailPage.pageTitle"));
 
   const [isConfirmed, setIsConfirmed] = useState(false);
+  const [hasFailed, setHasFailed] = useState(false);
 
   const [verifyEmail, isVerifying]
     = useMutation<VerifyEmailPageMutation>(verifyEmailMutation);
 
-  const handleSubmit = (token: string) => {
+  const handleSubmit = useCallback((token: string) => {
     verifyEmail({
       variables: {
         input: {
@@ -65,7 +69,8 @@ export default function VerifyEmailPage() {
         },
       },
       onCompleted: (_, errors) => {
-        if (errors) {
+        if (errors && !errors.some(error => (error as GraphQLError).extensions?.code === "EMAIL_ALREADY_VERIFIED")) {
+          setHasFailed(true);
           toast({
             title: t("common.error"), description: formatError(t("verifyEmailPage.errors.confirm"), errors),
             variant: "error",
@@ -80,13 +85,23 @@ export default function VerifyEmailPage() {
         });
       },
       onError: (err) => {
+        setHasFailed(true);
         toast({
           title: t("common.error"), description: err.message || t("verifyEmailPage.errors.confirm"),
           variant: "error",
         });
       },
     });
-  };
+  }, [t, toast, verifyEmail]);
+
+  useEffect(() => {
+    if (queryToken === "" || autoStartedRef.current) {
+      return;
+    }
+
+    autoStartedRef.current = true;
+    handleSubmit(queryToken);
+  }, [handleSubmit, queryToken]);
 
   return (
     <div className="flex w-full flex-col gap-8">
@@ -117,44 +132,52 @@ export default function VerifyEmailPage() {
               </ButtonLink>
             </div>
           )
-        : (
-            <Form
-              className="flex flex-col gap-5"
-              onFormSubmit={(values) => {
-                handleSubmit(String(values.token ?? ""));
-              }}
-            >
-              <Field.Root name="token" className="flex flex-col gap-1.5">
-                <Field.Label className="text-1 font-medium text-sand-12">
-                  {t("verifyEmailPage.fields.token")}
-                </Field.Label>
-                <TextField
-                  type="text"
-                  name="token"
-                  required
-                  defaultValue={searchParams.get("token") ?? ""}
-                  placeholder={t("verifyEmailPage.fields.tokenPlaceholder")}
-                  disabled={isVerifying}
-                />
-                <Field.Description className="text-1 text-sand-11">
-                  {t("verifyEmailPage.fields.tokenHelp")}
-                </Field.Description>
-                <Field.Error className="text-1 text-red-11" />
-              </Field.Root>
-
-              <Button
-                type="submit"
-                variant="solid"
-                color="neutral"
-                highContrast
-                size={3}
-                className="w-full"
-                loading={isVerifying}
+        : queryToken !== "" && !hasFailed
+          ? (
+              <div className="flex flex-col items-center gap-4">
+                <Spinner size={3} aria-label={t("verifyEmailPage.actions.confirming")} />
+                <Text size={2} align="center" className="block">
+                  {t("verifyEmailPage.actions.confirming")}
+                </Text>
+              </div>
+            )
+          : (
+              <Form
+                className="flex flex-col gap-5"
+                onFormSubmit={(values) => {
+                  handleSubmit(String(values.token ?? ""));
+                }}
               >
-                {t("verifyEmailPage.actions.confirm")}
-              </Button>
-            </Form>
-          )}
+                <Field.Root name="token" className="flex flex-col gap-1.5">
+                  <Field.Label className="text-1 font-medium text-sand-12">
+                    {t("verifyEmailPage.fields.token")}
+                  </Field.Label>
+                  <TextField
+                    type="text"
+                    name="token"
+                    required
+                    placeholder={t("verifyEmailPage.fields.tokenPlaceholder")}
+                    disabled={isVerifying}
+                  />
+                  <Field.Description className="text-1 text-sand-11">
+                    {t("verifyEmailPage.fields.tokenHelp")}
+                  </Field.Description>
+                  <Field.Error className="text-1 text-red-11" />
+                </Field.Root>
+
+                <Button
+                  type="submit"
+                  variant="solid"
+                  color="neutral"
+                  highContrast
+                  size={3}
+                  className="w-full"
+                  loading={isVerifying}
+                >
+                  {t("verifyEmailPage.actions.confirm")}
+                </Button>
+              </Form>
+            )}
 
       {!isConfirmed && (
         <Text align="center" size={2} className="block">

--- a/apps/console/src/pages/iam/auth/sign-in/PasswordSignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/PasswordSignInPage.tsx
@@ -80,8 +80,14 @@ export default function PasswordSignInPage() {
             e => (e as GraphQLError).extensions?.code === "EMAIL_NOT_VERIFIED",
           );
           if (emailNotVerified) {
-            const search = new URLSearchParams({ email: emailValue }).toString();
-            void navigate(`/auth/resend-verification-email?${search}`);
+            const loginSearch = searchParams.toString();
+            void navigate(
+              {
+                pathname: "/auth/resend-verification-email",
+                search: loginSearch === "" ? "" : "?" + loginSearch,
+              },
+              { state: { email: emailValue } },
+            );
             return;
           }
 

--- a/apps/console/src/pages/iam/organizations/AssumePage.tsx
+++ b/apps/console/src/pages/iam/organizations/AssumePage.tsx
@@ -19,6 +19,8 @@
 // SOFTWARE.
 
 import { UnAuthenticatedError } from "@probo/relay";
+import { Heading } from "@probo/ui/src/v2/typography/Heading";
+import { Text } from "@probo/ui/src/v2/typography/Text";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { type PreloadedQuery, useMutation, usePreloadedQuery } from "react-relay";
@@ -29,8 +31,6 @@ import type { AssumePageMutation } from "#/__generated__/iam/AssumePageMutation.
 import type { AssumePageQuery } from "#/__generated__/iam/AssumePageQuery.graphql";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
-
-import AuthLayout from "../auth/AuthLayout";
 
 const assumeMutation = graphql`
   mutation AssumePageMutation(
@@ -123,15 +123,15 @@ export function AssumePage(props: { queryRef: PreloadedQuery<AssumePageQuery> })
   }, [organizationId, navigate, assumeOrganizationSession, safeContinueUrl, searchParams, viewer.ssoLoginURL]);
 
   return (
-    <AuthLayout>
-      <div className="space-y-6 w-full max-w-md mx-auto pt-8">
-        <div className="space-y-2 text-center">
-          <h1 className="text-3xl font-bold">{t("assumePage.title")}</h1>
-          <p className="text-txt-tertiary">
-            {t("assumePage.description")}
-          </p>
-        </div>
+    <div className="flex w-full flex-col gap-8">
+      <div className="flex flex-col gap-1">
+        <Heading level={1} size={4} weight="medium" align="center" highContrast>
+          {t("assumePage.title")}
+        </Heading>
+        <Text size={2} align="center" className="block">
+          {t("assumePage.description")}
+        </Text>
       </div>
-    </AuthLayout>
+    </div>
   );
 }

--- a/apps/console/src/pages/iam/organizations/AssumePageLoader.tsx
+++ b/apps/console/src/pages/iam/organizations/AssumePageLoader.tsx
@@ -18,16 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { CenteredLayoutSkeleton } from "@probo/ui";
 import { useEffect } from "react";
 import { useQueryLoader } from "react-relay";
 
 import type { AssumePageQuery } from "#/__generated__/iam/AssumePageQuery.graphql";
-import { IAMRelayProvider } from "#/providers/IAMRelayProvider";
 
 import { AssumePage, assumePageQuery } from "./AssumePage";
 
-function AssumePageQueryLoader() {
+export default function AssumePageLoader() {
   const [queryRef, loadQuery] = useQueryLoader<AssumePageQuery>(assumePageQuery);
 
   useEffect(() => {
@@ -35,16 +33,8 @@ function AssumePageQueryLoader() {
   }, [loadQuery]);
 
   if (!queryRef) {
-    return <CenteredLayoutSkeleton />;
+    return null;
   }
 
   return <AssumePage queryRef={queryRef} />;
-}
-
-export default function AssumePageLoader() {
-  return (
-    <IAMRelayProvider>
-      <AssumePageQueryLoader />
-    </IAMRelayProvider>
-  );
 }

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -183,8 +183,14 @@ const routes = [
     path: "/organizations/:organizationId",
     children: [
       {
-        path: "assume",
-        Component: lazy(() => import("./pages/iam/organizations/AssumePageLoader")),
+        Component: lazy(() => import("./pages/iam/auth/AuthLayout")),
+        Fallback: AuthLayoutSkeleton,
+        children: [
+          {
+            path: "assume",
+            Component: lazy(() => import("./pages/iam/organizations/AssumePageLoader")),
+          },
+        ],
       },
       {
         Component: lazy(

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -89,6 +89,10 @@ const routes = [
         Component: lazy(() => import("./pages/iam/auth/VerifyEmailPage")),
       },
       {
+        path: "magic-link",
+        Component: lazy(() => import("./pages/iam/auth/MagicLinkPage")),
+      },
+      {
         path: "resend-verification-email",
         Component: lazy(
           () => import("./pages/iam/auth/ResendVerificationEmailPage"),

--- a/e2e/console/email_verification_test.go
+++ b/e2e/console/email_verification_test.go
@@ -29,6 +29,30 @@ import (
 	"go.probo.inc/probo/e2e/internal/testutil"
 )
 
+const (
+	signUpMutation = `
+		mutation($input: SignUpInput!) {
+			signUp(input: $input) {
+				identity { id }
+			}
+		}
+	`
+
+	verifyEmailMutation = `
+		mutation($input: VerifyEmailInput!) {
+			verifyEmail(input: $input) {
+				success
+			}
+		}
+	`
+
+	viewerQuery = `
+		query {
+			viewer { id }
+		}
+	`
+)
+
 func TestEmailVerification_PasswordSignInRequiresVerifiedEmail(t *testing.T) {
 	t.Parallel()
 
@@ -40,14 +64,6 @@ func TestEmailVerification_PasswordSignInRequiresVerifiedEmail(t *testing.T) {
 	email := fmt.Sprintf("unverified-%s@e2e.probo.test", uniqueID)
 	password := "TestPassword123!"
 	fullName := fmt.Sprintf("Unverified User %s", uniqueID)
-
-	const signUpMutation = `
-		mutation($input: SignUpInput!) {
-			signUp(input: $input) {
-				identity { id }
-			}
-		}
-	`
 
 	var signUpResult struct {
 		SignUp struct {
@@ -84,9 +100,11 @@ func TestEmailVerification_PasswordSignInRequiresVerifiedEmail(t *testing.T) {
 	)
 
 	newUser.Step(
-		"signs out of the signup session",
+		"is not signed in after signup",
 		func() error {
-			client.SignOut()
+			err := client.ExecuteConnectShouldFail(viewerQuery, nil)
+			testutil.RequireErrorCode(t, err, "UNAUTHENTICATED")
+
 			return nil
 		},
 	)
@@ -120,14 +138,6 @@ func TestEmailVerification_PasswordSignInRequiresVerifiedEmail(t *testing.T) {
 		},
 	)
 
-	const verifyMutation = `
-		mutation($input: VerifyEmailInput!) {
-			verifyEmail(input: $input) {
-				success
-			}
-		}
-	`
-
 	var verifyResult struct {
 		VerifyEmail struct {
 			Success bool `json:"success"`
@@ -135,10 +145,10 @@ func TestEmailVerification_PasswordSignInRequiresVerifiedEmail(t *testing.T) {
 	}
 
 	newUser.Step(
-		"verifies their email address",
+		"verifies their email address and is signed in",
 		func() error {
 			err := client.ExecuteConnect(
-				verifyMutation,
+				verifyEmailMutation,
 				map[string]any{
 					"input": map[string]any{
 						"token": token,
@@ -154,12 +164,88 @@ func TestEmailVerification_PasswordSignInRequiresVerifiedEmail(t *testing.T) {
 				return fmt.Errorf("verify email returned success=false")
 			}
 
+			var viewer struct {
+				Viewer struct {
+					ID string `json:"id"`
+				} `json:"viewer"`
+			}
+
+			if err := client.ExecuteConnect(viewerQuery, nil, &viewer); err != nil {
+				return fmt.Errorf("expected a session after first verify: %w", err)
+			}
+
+			if viewer.Viewer.ID != signUpResult.SignUp.Identity.ID {
+				return fmt.Errorf(
+					"viewer %q does not match signed-up identity %q",
+					viewer.Viewer.ID,
+					signUpResult.SignUp.Identity.ID,
+				)
+			}
+
 			return nil
 		},
 	)
 
 	newUser.Step(
-		"signs in with their verified email",
+		"can verify the same token again without error",
+		func() error {
+			verifyResult.VerifyEmail.Success = false
+
+			err := client.ExecuteConnect(
+				verifyEmailMutation,
+				map[string]any{
+					"input": map[string]any{
+						"token": token,
+					},
+				},
+				&verifyResult,
+			)
+			if err != nil {
+				return fmt.Errorf("replay verify email failed: %w", err)
+			}
+
+			if !verifyResult.VerifyEmail.Success {
+				return fmt.Errorf("replay verify email returned success=false")
+			}
+
+			return nil
+		},
+	)
+
+	replay := world.NewUnauthenticatedActor("replay client")
+	replayClient := replay.Client()
+
+	replay.Step(
+		"cannot open a session by replaying the confirmation token",
+		func() error {
+			verifyResult.VerifyEmail.Success = false
+
+			err := replayClient.ExecuteConnect(
+				verifyEmailMutation,
+				map[string]any{
+					"input": map[string]any{
+						"token": token,
+					},
+				},
+				&verifyResult,
+			)
+			if err != nil {
+				return fmt.Errorf("replay verify from a new client failed: %w", err)
+			}
+
+			if !verifyResult.VerifyEmail.Success {
+				return fmt.Errorf("replay verify from a new client returned success=false")
+			}
+
+			err = replayClient.ExecuteConnectShouldFail(viewerQuery, nil)
+			testutil.RequireErrorCode(t, err, "UNAUTHENTICATED")
+
+			return nil
+		},
+	)
+
+	newUser.Step(
+		"can still sign in with their verified email",
 		func() error {
 			if err := client.SignIn(email, password); err != nil {
 				return fmt.Errorf("cannot sign in after email verification: %w", err)

--- a/e2e/internal/testutil/client.go
+++ b/e2e/internal/testutil/client.go
@@ -543,9 +543,7 @@ func (c *Client) SignInWithMagicLink(email string) {
 	c.postConnectMagicLink(email, continueURL)
 
 	token := c.pollForLinkToken(fmt.Sprintf("to:%s subject:\"Connect to\"", email))
-	verifyURL := c.baseURL + "/api/connect/v1/magic-link/verify?token=" + url.QueryEscape(token)
-
-	resp := c.redirectHTTPResponse(c.httpClient, verifyURL)
+	resp := c.postConnectMagicLinkVerify(c.httpClient, token)
 	require.Equal(
 		c.T,
 		http.StatusFound,
@@ -740,9 +738,17 @@ func (c *Client) connectViaCIMD(email string) {
 	c.postConnectMagicLink(email, continueURL)
 
 	token := c.pollForLinkToken(fmt.Sprintf("to:%s", email))
-	verifyURL := c.baseURL + "/api/connect/v1/magic-link/verify?token=" + url.QueryEscape(token)
-
-	resumeAuthorizeURL := c.redirectLocation(c.proboHTTPClient, verifyURL)
+	verifyResp := c.postConnectMagicLinkVerify(c.proboHTTPClient, token)
+	require.Equal(
+		c.T,
+		http.StatusFound,
+		verifyResp.StatusCode,
+		"magic-link verify must redirect after opening a session",
+	)
+	resumeAuthorizeURL := resolveRedirectURL(
+		c.baseURL+"/api/connect/v1/magic-link/verify",
+		verifyResp.Header.Get("Location"),
+	)
 	require.Contains(c.T, resumeAuthorizeURL, "/api/connect/v1/oauth2/authorize")
 
 	authorizeResp := c.redirectHTTPResponse(c.proboHTTPClient, resumeAuthorizeURL)
@@ -795,6 +801,45 @@ func (c *Client) postConnectMagicLink(email, continueURL string) {
 	defer func() { _ = resp.Body.Close() }()
 
 	require.Equal(c.T, http.StatusNoContent, resp.StatusCode, "magic-link send must return 204")
+}
+
+func (c *Client) postConnectMagicLinkVerify(httpClient *http.Client, token string) *OAuth2HTTPResponse {
+	c.T.Helper()
+
+	body := url.Values{}
+	body.Set("token", token)
+
+	noRedirectClient := &http.Client{
+		Jar:       httpClient.Jar,
+		Timeout:   httpClient.Timeout,
+		Transport: httpClient.Transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		c.baseURL+"/api/connect/v1/magic-link/verify",
+		strings.NewReader(body.Encode()),
+	)
+	require.NoError(c.T, err)
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := noRedirectClient.Do(req)
+	require.NoError(c.T, err, "magic-link verify request failed")
+
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(c.T, err)
+
+	return &OAuth2HTTPResponse{
+		StatusCode: resp.StatusCode,
+		Header:     resp.Header,
+		Body:       respBody,
+	}
 }
 
 func (c *Client) GetNoRedirect(rawURL string) *OAuth2HTTPResponse {

--- a/e2e/internal/testutil/client.go
+++ b/e2e/internal/testutil/client.go
@@ -809,15 +809,6 @@ func (c *Client) postConnectMagicLinkVerify(httpClient *http.Client, token strin
 	body := url.Values{}
 	body.Set("token", token)
 
-	noRedirectClient := &http.Client{
-		Jar:       httpClient.Jar,
-		Timeout:   httpClient.Timeout,
-		Transport: httpClient.Transport,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-
 	req, err := http.NewRequest(
 		http.MethodPost,
 		c.baseURL+"/api/connect/v1/magic-link/verify",
@@ -827,7 +818,7 @@ func (c *Client) postConnectMagicLinkVerify(httpClient *http.Client, token strin
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := noRedirectClient.Do(req)
+	resp, err := noRedirectHTTPClient(httpClient).Do(req)
 	require.NoError(c.T, err, "magic-link verify request failed")
 
 	defer func() { _ = resp.Body.Close() }()
@@ -866,22 +857,24 @@ func (c *Client) redirectLocation(client *http.Client, rawURL string) string {
 	return resolveRedirectURL(rawURL, location)
 }
 
-func (c *Client) redirectHTTPResponse(client *http.Client, rawURL string) *OAuth2HTTPResponse {
-	c.T.Helper()
-
-	noRedirectClient := &http.Client{
-		Jar:       client.Jar,
-		Timeout:   client.Timeout,
-		Transport: client.Transport,
+func noRedirectHTTPClient(httpClient *http.Client) *http.Client {
+	return &http.Client{
+		Jar:       httpClient.Jar,
+		Timeout:   httpClient.Timeout,
+		Transport: httpClient.Transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 	}
+}
+
+func (c *Client) redirectHTTPResponse(client *http.Client, rawURL string) *OAuth2HTTPResponse {
+	c.T.Helper()
 
 	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
 	require.NoError(c.T, err)
 
-	resp, err := noRedirectClient.Do(req)
+	resp, err := noRedirectHTTPClient(client).Do(req)
 	require.NoError(c.T, err, "request to %s failed", rawURL)
 
 	defer func() { _ = resp.Body.Close() }()

--- a/pkg/coredata/identity.go
+++ b/pkg/coredata/identity.go
@@ -155,6 +155,53 @@ LIMIT 1;
 	return nil
 }
 
+// LoadByIDForUpdate is LoadByID under FOR UPDATE so concurrent
+// VerifyEmail calls serialize the verified-flag transition.
+func (i *Identity) LoadByIDForUpdate(
+	ctx context.Context,
+	conn pg.Tx,
+	identityID gid.GID,
+) error {
+	q := `
+SELECT
+    id,
+    email_address,
+    full_name,
+    hashed_password,
+    email_address_verified,
+    saml_subject,
+    locale,
+    created_at,
+    updated_at
+FROM
+    identities
+WHERE
+    id = @identity_id
+LIMIT 1
+FOR UPDATE;
+`
+
+	args := pgx.StrictNamedArgs{"identity_id": identityID}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query identity: %w", err)
+	}
+
+	identity, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[Identity])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect identity: %w", err)
+	}
+
+	*i = identity
+
+	return nil
+}
+
 // AuthorizationAttributes loads the minimal authorization attributes for policy condition evaluation.
 // It is intentionally lightweight and does not populate the Identity struct.
 func (i *Identity) AuthorizationAttributes(

--- a/pkg/iam/account_service.go
+++ b/pkg/iam/account_service.go
@@ -202,7 +202,7 @@ func (s AccountService) VerifyEmail(ctx context.Context, token string) (*coredat
 	err = s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			err := identity.LoadByID(ctx, tx, payload.Data.IdentityID)
+			err := identity.LoadByIDForUpdate(ctx, tx, payload.Data.IdentityID)
 			if err != nil {
 				if err == coredata.ErrResourceNotFound {
 					return NewIdentityNotFoundError(payload.Data.IdentityID)

--- a/pkg/iam/account_service.go
+++ b/pkg/iam/account_service.go
@@ -188,17 +188,20 @@ func (s AccountService) ChangeEmail(ctx context.Context, identityID gid.GID, req
 	)
 }
 
-func (s AccountService) VerifyEmail(ctx context.Context, token string) error {
+func (s AccountService) VerifyEmail(ctx context.Context, token string) (*coredata.Identity, bool, error) {
 	payload, err := statelesstoken.ValidateToken[EmailConfirmationData](s.tokenSecret, TokenTypeEmailConfirmation, token)
 	if err != nil {
-		return NewInvalidTokenError()
+		return nil, false, NewInvalidTokenError()
 	}
 
-	return s.pg.WithTx(
+	var (
+		identity      = &coredata.Identity{}
+		newlyVerified bool
+	)
+
+	err = s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			identity := &coredata.Identity{}
-
 			err := identity.LoadByID(ctx, tx, payload.Data.IdentityID)
 			if err != nil {
 				if err == coredata.ErrResourceNotFound {
@@ -213,7 +216,7 @@ func (s AccountService) VerifyEmail(ctx context.Context, token string) error {
 			}
 
 			if identity.EmailAddressVerified {
-				return NewEmailAlreadyVerifiedError()
+				return nil
 			}
 
 			identity.EmailAddressVerified = true
@@ -224,9 +227,16 @@ func (s AccountService) VerifyEmail(ctx context.Context, token string) error {
 				return fmt.Errorf("cannot update identity: %w", err)
 			}
 
+			newlyVerified = true
+
 			return nil
 		},
 	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return identity, newlyVerified, nil
 }
 
 func (s AccountService) ResendVerificationEmail(ctx context.Context, email mail.Addr) error {

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -357,35 +357,31 @@ func (s AuthService) SendPasswordResetInstructionByEmail(
 func (s AuthService) CreateIdentityWithPassword(
 	ctx context.Context,
 	req *CreateIdentityWithPasswordRequest,
-) (*coredata.Identity, *coredata.Session, error) {
+) (*coredata.Identity, error) {
 	if s.disableSignup { // TODO Rename this one to disableSignup
-		return nil, nil, NewErrSignupDisabled()
+		return nil, NewErrSignupDisabled()
 	}
 
 	if err := req.Validate(); err != nil {
-		return nil, nil, fmt.Errorf("invalid request: %w", err)
+		return nil, fmt.Errorf("invalid request: %w", err)
 	}
 
 	hashedPassword, err := s.hp.HashPassword([]byte(req.Password))
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot hash password: %w", err)
+		return nil, fmt.Errorf("cannot hash password: %w", err)
 	}
 
-	var (
-		now = time.Now()
+	now := time.Now()
 
-		identity = &coredata.Identity{
-			ID:                   gid.New(gid.NilTenant, coredata.IdentityEntityType),
-			EmailAddress:         req.Email,
-			FullName:             req.FullName,
-			HashedPassword:       hashedPassword,
-			EmailAddressVerified: false,
-			CreatedAt:            now,
-			UpdatedAt:            now,
-		}
-
-		session = coredata.NewRootSession(identity.ID, coredata.AuthMethodPassword, 24*time.Hour*7)
-	)
+	identity := &coredata.Identity{
+		ID:                   gid.New(gid.NilTenant, coredata.IdentityEntityType),
+		EmailAddress:         req.Email,
+		FullName:             req.FullName,
+		HashedPassword:       hashedPassword,
+		EmailAddressVerified: false,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
 
 	confirmationToken, err := statelesstoken.NewToken(
 		s.tokenSecret,
@@ -394,14 +390,14 @@ func (s AuthService) CreateIdentityWithPassword(
 		EmailConfirmationData{IdentityID: identity.ID, Email: identity.EmailAddress},
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot generate confirmation token: %w", err)
+		return nil, fmt.Errorf("cannot generate confirmation token: %w", err)
 	}
 
 	emailPresenter := emails.NewPresenter(s.baseURL, req.FullName)
 
 	subject, textBody, htmlBody, err := emailPresenter.RenderConfirmEmail(ctx, "/auth/verify-email", confirmationToken)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot render confirmation email: %w", err)
+		return nil, fmt.Errorf("cannot render confirmation email: %w", err)
 	}
 
 	confirmationEmail := coredata.NewEmail(
@@ -429,15 +425,14 @@ func (s AuthService) CreateIdentityWithPassword(
 				return fmt.Errorf("cannot insert email: %w", err)
 			}
 
-			if err := session.Insert(ctx, tx); err != nil {
-				return fmt.Errorf("cannot insert session: %w", err)
-			}
-
 			return nil
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
 
-	return identity, session, err
+	return identity, nil
 }
 
 func (s AuthService) OpenSessionWithSAML(ctx context.Context, identityID gid.GID) (*coredata.Session, error) {

--- a/pkg/iam/errors.go
+++ b/pkg/iam/errors.go
@@ -98,16 +98,6 @@ func (e ErrIdentityAlreadyExists) Error() string {
 	return fmt.Sprintf("identity %q already exists", e.EmailAddress.String())
 }
 
-type ErrEmailAlreadyVerified struct{ message string }
-
-func NewEmailAlreadyVerifiedError() error {
-	return &ErrEmailAlreadyVerified{"email already verified"}
-}
-
-func (e ErrEmailAlreadyVerified) Error() string {
-	return e.message
-}
-
 type ErrEmailNotVerified struct{ message string }
 
 func NewEmailNotVerifiedError() error {

--- a/pkg/server/api/connect/v1/magic_link_handler.go
+++ b/pkg/server/api/connect/v1/magic_link_handler.go
@@ -23,6 +23,7 @@ package connect_v1
 import (
 	"errors"
 	"net/http"
+	"net/url"
 
 	"go.gearno.de/kit/httpserver"
 	"go.gearno.de/kit/log"
@@ -33,6 +34,8 @@ import (
 	"go.probo.inc/probo/pkg/securecookie"
 	"go.probo.inc/probo/pkg/server/api/authn"
 )
+
+const magicLinkConfirmPath = "/auth/magic-link"
 
 type MagicLinkHandler struct {
 	iam           *iam.Service
@@ -103,7 +106,7 @@ func (h *MagicLinkHandler) SendHandler(w http.ResponseWriter, r *http.Request) {
 
 	req := &iam.SendMagicLinkRequest{
 		Email:            emailAddr,
-		URLPath:          "/api/connect/v1/magic-link/verify",
+		URLPath:          magicLinkConfirmPath,
 		MagicLinkBaseURL: &proboURL,
 		Continue:         &safeContinue,
 	}
@@ -122,10 +125,34 @@ func (h *MagicLinkHandler) SendHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// ConfirmRedirectHandler is GET /magic-link/verify. Scanners prefetch GET
+// URLs, so this must not consume the token.
+func (h *MagicLinkHandler) ConfirmRedirectHandler(w http.ResponseWriter, r *http.Request) {
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		h.redirectAuthError(w, r, authErrorMagicLinkInvalid, "")
+
+		return
+	}
+
+	redirectURL := url.URL{
+		Path:     magicLinkConfirmPath,
+		RawQuery: url.Values{"token": {token}}.Encode(),
+	}
+
+	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+}
+
 func (h *MagicLinkHandler) VerifyHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	token := r.URL.Query().Get("token")
+	if err := r.ParseForm(); err != nil {
+		h.redirectAuthError(w, r, authErrorMagicLinkInvalid, "")
+
+		return
+	}
+
+	token := r.FormValue("token")
 	if token == "" {
 		h.redirectAuthError(w, r, authErrorMagicLinkInvalid, "")
 

--- a/pkg/server/api/connect/v1/magic_link_handler_test.go
+++ b/pkg/server/api/connect/v1/magic_link_handler_test.go
@@ -106,3 +106,64 @@ func TestMagicLinkHandler_SendHandler_Validation(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 	})
 }
+
+func TestMagicLinkHandler_ConfirmRedirectHandler(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestMagicLinkHandler(t)
+
+	t.Run("redirects to confirm page without consuming", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/api/connect/v1/magic-link/verify?token=abc.def",
+			nil,
+		)
+		rec := httptest.NewRecorder()
+
+		handler.ConfirmRedirectHandler(rec, req)
+
+		assert.Equal(t, http.StatusFound, rec.Code)
+		assert.Equal(t, "/auth/magic-link?token=abc.def", rec.Header().Get("Location"))
+	})
+
+	t.Run("rejects missing token", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/api/connect/v1/magic-link/verify", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ConfirmRedirectHandler(rec, req)
+
+		assert.Equal(t, http.StatusFound, rec.Code)
+
+		location, err := url.Parse(rec.Header().Get("Location"))
+		assert.NoError(t, err)
+		assert.Equal(t, "/auth/error", location.Path)
+		assert.Equal(t, "magic_link_invalid", location.Query().Get("error"))
+	})
+}
+
+func TestMagicLinkHandler_VerifyHandler_Validation(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestMagicLinkHandler(t)
+
+	t.Run("rejects missing token", func(t *testing.T) {
+		t.Parallel()
+
+		rec := postMagicLinkForm(
+			t,
+			handler.VerifyHandler,
+			url.Values{},
+		)
+
+		assert.Equal(t, http.StatusFound, rec.Code)
+
+		location, err := url.Parse(rec.Header().Get("Location"))
+		assert.NoError(t, err)
+		assert.Equal(t, "/auth/error", location.Path)
+		assert.Equal(t, "magic_link_invalid", location.Query().Get("error"))
+	})
+}

--- a/pkg/server/api/connect/v1/resolver.go
+++ b/pkg/server/api/connect/v1/resolver.go
@@ -137,7 +137,8 @@ func NewMux(
 	router.Get("/oidc/{provider}/callback", oidcHandler.CallbackHandler)
 
 	r.Post("/magic-link/send", magicLinkHandler.SendHandler)
-	r.Get("/magic-link/verify", magicLinkHandler.VerifyHandler)
+	r.Get("/magic-link/verify", magicLinkHandler.ConfirmRedirectHandler)
+	r.Post("/magic-link/verify", magicLinkHandler.VerifyHandler)
 
 	// SCIM 2.0 endpoints - these use their own bearer token authentication
 	scimServer := NewSCIMServer(scimHandler)

--- a/pkg/server/api/connect/v1/session_resolvers.go
+++ b/pkg/server/api/connect/v1/session_resolvers.go
@@ -308,7 +308,7 @@ func (r *mutationResolver) VerifyEmail(ctx context.Context, input types.VerifyEm
 		}
 
 		if _, ok := errors.AsType[*iam.ErrEmailAlreadyVerified](err); ok {
-			return nil, gqlutils.Conflict(ctx, err)
+			return nil, gqlutils.EmailAlreadyVerified(ctx, err)
 		}
 
 		if _, ok := errors.AsType[*iam.ErrIdentityNotFound](err); ok {

--- a/pkg/server/api/connect/v1/session_resolvers.go
+++ b/pkg/server/api/connect/v1/session_resolvers.go
@@ -111,7 +111,7 @@ func (r *mutationResolver) SignIn(ctx context.Context, input types.SignInInput) 
 
 // SignUp is the resolver for the signUp field.
 func (r *mutationResolver) SignUp(ctx context.Context, input types.SignUpInput) (*types.SignUpPayload, error) {
-	identity, session, err := r.iam.AuthService.CreateIdentityWithPassword(
+	identity, err := r.iam.AuthService.CreateIdentityWithPassword(
 		ctx,
 		&iam.CreateIdentityWithPasswordRequest{
 			Email:    input.Email,
@@ -132,9 +132,6 @@ func (r *mutationResolver) SignUp(ctx context.Context, input types.SignUpInput) 
 
 		return nil, gqlutils.Internal(ctx)
 	}
-
-	w := gqlutils.HTTPResponseWriterFromContext(ctx)
-	r.sessionCookie.Set(w, session)
 
 	return &types.SignUpPayload{
 		Identity: types.NewIdentity(identity),
@@ -297,7 +294,7 @@ func (r *mutationResolver) ResetPassword(ctx context.Context, input types.ResetP
 
 // VerifyEmail is the resolver for the verifyEmail field.
 func (r *mutationResolver) VerifyEmail(ctx context.Context, input types.VerifyEmailInput) (*types.VerifyEmailPayload, error) {
-	err := r.iam.AccountService.VerifyEmail(ctx, input.Token)
+	identity, newlyVerified, err := r.iam.AccountService.VerifyEmail(ctx, input.Token)
 	if err != nil {
 		if _, ok := errors.AsType[*iam.ErrInvalidToken](err); ok {
 			return nil, gqlutils.Invalid(ctx, err)
@@ -307,10 +304,6 @@ func (r *mutationResolver) VerifyEmail(ctx context.Context, input types.VerifyEm
 			return nil, gqlutils.Invalid(ctx, err)
 		}
 
-		if _, ok := errors.AsType[*iam.ErrEmailAlreadyVerified](err); ok {
-			return nil, gqlutils.EmailAlreadyVerified(ctx, err)
-		}
-
 		if _, ok := errors.AsType[*iam.ErrIdentityNotFound](err); ok {
 			return nil, gqlutils.NotFound(ctx, err)
 		}
@@ -318,6 +311,36 @@ func (r *mutationResolver) VerifyEmail(ctx context.Context, input types.VerifyEm
 		r.logger.ErrorCtx(ctx, "cannot verify email", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)
+	}
+
+	if newlyVerified {
+		session := authn.SessionFromContext(ctx)
+
+		switch {
+		case session == nil:
+			session, err = r.iam.AuthService.OpenSessionWithPassword(ctx, identity.ID)
+			if err != nil {
+				r.logger.ErrorCtx(ctx, "cannot create session", log.Error(err))
+
+				return nil, gqlutils.Internal(ctx)
+			}
+		case session.IdentityID != identity.ID:
+			if err := r.iam.SessionService.CloseSession(ctx, session.ID); err != nil {
+				r.logger.ErrorCtx(ctx, "cannot close session", log.Error(err))
+
+				return nil, gqlutils.Internal(ctx)
+			}
+
+			session, err = r.iam.AuthService.OpenSessionWithPassword(ctx, identity.ID)
+			if err != nil {
+				r.logger.ErrorCtx(ctx, "cannot create session", log.Error(err))
+
+				return nil, gqlutils.Internal(ctx)
+			}
+		}
+
+		w := gqlutils.HTTPResponseWriterFromContext(ctx)
+		r.sessionCookie.Set(w, session)
 	}
 
 	return &types.VerifyEmailPayload{

--- a/pkg/server/gqlutils/errors.go
+++ b/pkg/server/gqlutils/errors.go
@@ -106,6 +106,16 @@ func AccountAlreadyActivated(ctx context.Context, err error) *gqlerror.Error {
 	}
 }
 
+func EmailAlreadyVerified(ctx context.Context, err error) *gqlerror.Error {
+	return &gqlerror.Error{
+		Message: err.Error(),
+		Path:    graphql.GetPath(ctx),
+		Extensions: map[string]any{
+			"code": "EMAIL_ALREADY_VERIFIED",
+		},
+	}
+}
+
 // MembershipRequired reports that the identity is authenticated but belongs to
 // no organization on an instance where signup is disabled. It is distinct from
 // FORBIDDEN so the frontend can offer a sign-out screen instead of rendering a

--- a/pkg/server/gqlutils/errors.go
+++ b/pkg/server/gqlutils/errors.go
@@ -106,16 +106,6 @@ func AccountAlreadyActivated(ctx context.Context, err error) *gqlerror.Error {
 	}
 }
 
-func EmailAlreadyVerified(ctx context.Context, err error) *gqlerror.Error {
-	return &gqlerror.Error{
-		Message: err.Error(),
-		Path:    graphql.GetPath(ctx),
-		Extensions: map[string]any{
-			"code": "EMAIL_ALREADY_VERIFIED",
-		},
-	}
-}
-
 // MembershipRequired reports that the identity is authenticated but belongs to
 // no organization on an instance where signup is disabled. It is distinct from
 // FORBIDDEN so the frontend can offer a sign-out screen instead of rendering a

--- a/pkg/server/mailactions/confirm.go
+++ b/pkg/server/mailactions/confirm.go
@@ -49,17 +49,14 @@ func confirmGetHandler() http.HandlerFunc {
 		renderPage(
 			w,
 			http.StatusOK,
-			// The confirmation should happen too quickly for the user to notice.
-			// This content is only shown as a fallback.
 			page{
 				Title:   "Confirm subscription",
 				Heading: "Confirm your subscription",
-				Body:    "Your confirmation should be processed automatically. If it isn’t, click the button below to confirm that you want to receive updates.",
+				Body:    "Click the button below to confirm that you want to receive updates.",
 				Form: &form{
-					ActionURL:  template.URL("?token=" + url.QueryEscape(token)),
-					Button:     "Confirm subscription",
-					AutoSubmit: true,
-					Danger:     false,
+					ActionURL: template.URL("?token=" + url.QueryEscape(token)),
+					Button:    "Confirm subscription",
+					Danger:    false,
 				},
 			},
 		)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops email scanners from burning one-time auth tokens by consuming them only on POST after an explicit Continue click. Signup now requires email verification before opening a session, and verification is idempotent so replaying a token stays safe.

### Coredata **`+47`** **`-0`**

- `LoadByIDForUpdate` locks the identity row so concurrent first-verifies can't both mint sessions.

### GraphQL API **`+67`** **`-19`**

- GET `/api/connect/v1/magic-link/verify` redirects to `/auth/magic-link` without consuming the token; POST performs the actual verification.
- `verifyEmail` opens a session only on first verification; replays return success without creating one.
- The mail subscription confirm page removed auto-submit so scanners cannot confirm subscriptions.

### Service **`+37`** **`-42`**

- `VerifyEmail` returns the identity and whether it was newly verified.
- `CreateIdentityWithPassword` no longer creates a session.
- Removed the `ErrEmailAlreadyVerified` error since replay is now success.

### App: console **`+344`** **`-121`**

- Signup shows a check-your-email step with resend and back-to-login links instead of navigating to `/`.
- Verify email, account activation, and a new magic-link confirm page all require an explicit Continue click.
- Empty-token toasts now tell users to type the token or open the link from their email.
- The resend-verification address travels via router state instead of the URL query string.
- The assume page now renders inside the auth layout with matching chrome.
- Added English, French, and Dutch strings for the new flows.

### Tests **`+220`** **`-35`**

- E2E tests assert signup leaves the user unauthenticated, first verify signs them in, replaying the token from the same client succeeds, and a new client cannot open a session.
- Handler tests cover the GET redirect without token consumption and POST validation.

<sup>Written for commit 6b8445f319987be4702dd6d4b7fe246194e07e94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

