### PR TITLE
Tell a refused operation from a refused credential

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1676,7 +1676,7 @@
     "actions": { "back": "Back", "create": "Create" }
   },
   "accessReviewSourceRow": {
-    "sources": { "csv": "CSV", "googleWorkspace": "Google Workspace", "microsoft365": "Microsoft 365", "linear": "Linear", "slack": "Slack", "metabase": "Metabase", "signoz": "SigNoz", "cursor": "Cursor", "github": "GitHub", "cloudflare": "Cloudflare", "authentik": "authentik" },
+    "sources": { "csv": "CSV" },
     "errors": { "delete": "Failed to delete access source", "configure": "Failed to configure source" },
     "messages": { "error": "Error", "success": "Success", "organizationUpdated": "Organization updated." },
     "deleteConfirmation": "This will permanently delete \"{{name}}\". This action cannot be undone.",
@@ -1695,7 +1695,9 @@
         "reconnectTitle": "{{provider}} is disconnected",
         "credentialsTitle": "{{provider}} credentials are invalid",
         "reconnectDescription": "Reconnect this source to restore access to organizations.",
-        "credentialsDescription": "Probo cannot access organizations with the current credentials. Check this source's credentials and permissions."
+        "credentialsDescription": "Probo cannot read this source with the current credentials. Check the credentials and the permissions they carry on {{provider}}.",
+        "notAuthorizedTitle": "{{provider}} refused this request",
+        "notAuthorizedDescription": "{{provider}} accepted the credential but refused the request Probo made. Check the permissions this credential has on {{provider}}, and whether your plan includes the API Probo uses."
       }
     }
   },

--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -1802,7 +1802,7 @@
     "apiKeyDescription": "Enter the API key for {{provider}} to connect it as an access source.",
     "apiKey": "API Key",
     "messages": { "connectionFailed": "Connection failed", "copyFailed": "Copy failed", "copied": "Copied to clipboard" },
-    "errors": { "managedConnect": "Failed to connect provider. Please check your settings and verification code, then try again.", "apiKeyConnect": "Failed to connect provider. Please check your API key and try again.", "copy": "Copy the verification code manually.", "generateCode": "Couldn't generate a verification code. Check the Website ID and try again." },
+    "errors": { "managedConnect": "Failed to connect provider. Please check your settings and verification code, then try again.", "apiKeyConnect": "Failed to connect provider. Please check your API key and try again.", "apiKeyFormat": "This does not look like the expected key. Expected form: {{example}}", "copy": "Copy the verification code manually.", "generateCode": "Couldn't generate a verification code. Check the Website ID and try again." },
     "verificationCode": { "label": "Verification code", "description": "Paste this code into the Probo plugin settings for this website in your Crisp dashboard, then click Connect. It proves you control this website.", "enterWebsiteId": "Enter your Website ID above to get your verification code.", "generating": "Generating code..." },
     "actions": { "copy": "Copy", "retry": "Retry", "connect": "Connect", "connecting": "Connecting..." }
   },

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -3077,6 +3077,7 @@
     "errors": {
       "managedConnect": "Échec de la connexion du fournisseur. Vérifiez vos paramètres et votre code de vérification, puis réessayez.",
       "apiKeyConnect": "Échec de la connexion du fournisseur. Vérifiez votre clé API et réessayez.",
+      "apiKeyFormat": "Cela ne ressemble pas à la clé attendue. Forme attendue : {{example}}",
       "copy": "Copiez le code de vérification manuellement.",
       "generateCode": "Impossible de générer un code de vérification. Vérifiez l’identifiant du site et réessayez."
     },

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -2770,19 +2770,7 @@
     }
   },
   "accessReviewSourceRow": {
-    "sources": {
-      "csv": "CSV",
-      "googleWorkspace": "Google Workspace",
-      "microsoft365": "Microsoft 365",
-      "linear": "Linear",
-      "slack": "Slack",
-      "metabase": "Metabase",
-      "signoz": "SigNoz",
-      "cursor": "Cursor",
-      "github": "GitHub",
-      "cloudflare": "Cloudflare",
-      "authentik": "authentik"
-    },
+    "sources": { "csv": "CSV" },
     "errors": {
       "delete": "Échec de la suppression de la source d’accès",
       "configure": "Échec de la configuration de la source"
@@ -2811,7 +2799,9 @@
         "reconnectTitle": "{{provider}} est déconnecté",
         "credentialsTitle": "Les identifiants de {{provider}} sont invalides",
         "reconnectDescription": "Reconnectez cette source pour rétablir l’accès aux organisations.",
-        "credentialsDescription": "Probo ne peut pas accéder aux organisations avec les identifiants actuels. Vérifiez les identifiants et les permissions de cette source."
+        "credentialsDescription": "Probo ne peut pas lire cette source avec les identifiants actuels. Vérifiez les identifiants et les permissions dont ils disposent sur {{provider}}.",
+        "notAuthorizedTitle": "{{provider}} a refusé cette requête",
+        "notAuthorizedDescription": "{{provider}} a accepté les identifiants mais a refusé la requête envoyée par Probo. Vérifiez les permissions dont ils disposent sur {{provider}}, et si votre offre inclut l’API utilisée par Probo."
       }
     }
   },

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -3081,6 +3081,7 @@
     "errors": {
       "managedConnect": "Verbinden met provider mislukt. Controleer uw instellingen en verificatiecode en probeer het opnieuw.",
       "apiKeyConnect": "Verbinden met provider mislukt. Controleer uw API-sleutel en probeer het opnieuw.",
+      "apiKeyFormat": "Dit lijkt niet op de verwachte sleutel. Verwachte vorm: {{example}}",
       "copy": "Kopieer de verificatiecode handmatig.",
       "generateCode": "Kan geen verificatiecode genereren. Controleer de Website-ID en probeer het opnieuw."
     },

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -2774,19 +2774,7 @@
     }
   },
   "accessReviewSourceRow": {
-    "sources": {
-      "csv": "CSV",
-      "googleWorkspace": "Google Workspace",
-      "microsoft365": "Microsoft 365",
-      "linear": "Linear",
-      "slack": "Slack",
-      "metabase": "Metabase",
-      "signoz": "SigNoz",
-      "cursor": "Cursor",
-      "github": "GitHub",
-      "cloudflare": "Cloudflare",
-      "authentik": "authentik"
-    },
+    "sources": { "csv": "CSV" },
     "errors": {
       "delete": "Verwijderen van toegangsbron mislukt",
       "configure": "Configureren van bron mislukt"
@@ -2815,7 +2803,9 @@
         "reconnectTitle": "{{provider}} is niet verbonden",
         "credentialsTitle": "De inloggegevens van {{provider}} zijn ongeldig",
         "reconnectDescription": "Verbind deze bron opnieuw om de toegang tot organisaties te herstellen.",
-        "credentialsDescription": "Probo heeft met de huidige inloggegevens geen toegang tot organisaties. Controleer de inloggegevens en rechten van deze bron."
+        "credentialsDescription": "Probo kan deze bron niet lezen met de huidige inloggegevens. Controleer de inloggegevens en de rechten die ze bij {{provider}} hebben.",
+        "notAuthorizedTitle": "{{provider}} heeft dit verzoek geweigerd",
+        "notAuthorizedDescription": "{{provider}} accepteert de inloggegevens, maar weigerde het verzoek van Probo. Controleer de rechten die ze bij {{provider}} hebben en of uw abonnement de API bevat die Probo gebruikt."
       }
     }
   },

--- a/apps/console/src/pages/organizations/access-reviews/_components/AccessReviewSourceListItem.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/_components/AccessReviewSourceListItem.tsx
@@ -50,6 +50,7 @@ import type { AccessReviewSourceListItemOrganizationsUnavailable_source$key } fr
 import type { AccessReviewSourceListItemOrgsQuery } from "#/__generated__/core/AccessReviewSourceListItemOrgsQuery.graphql";
 
 import { accessReviewSourceSection } from "../connections/_components/variants";
+import { ConnectorDocumentationLink } from "../dialogs/_components/ConnectorDocumentationLink";
 import { buildConnectorInitiateURL } from "../dialogs/_lib/connectorSettings";
 
 function canReconnectConnector(
@@ -65,6 +66,8 @@ const fragment = graphql`
     connectorId
     connector {
       provider
+      displayName
+      documentationUrl
       protocol
       canReconnect
       oauth2Scopes
@@ -123,7 +126,7 @@ const organizationsEmptyFragment = graphql`
   fragment AccessReviewSourceListItemOrganizationsEmpty_source on AccessReviewSource {
     selectedOrganization
     connector {
-      provider
+      displayName
     }
     providerOrganizations {
       remediationUrl
@@ -135,10 +138,7 @@ const organizationsEmptyFragment = graphql`
 const organizationsUnavailableFragment = graphql`
   fragment AccessReviewSourceListItemOrganizationsUnavailable_source on AccessReviewSource {
     connector {
-      provider
-      protocol
-      canReconnect
-      oauth2Scopes
+      displayName
     }
   }
 `;
@@ -171,38 +171,13 @@ type Props = {
   organizationId: string;
 };
 
+// A source with no connector is the manual CSV one; every other name comes from
+// the provider registry, where provider names are already maintained.
 function sourceLabel(
-  connectorProvider: string | null | undefined,
+  connector: { displayName: string } | null | undefined,
   t: (key: string) => string,
 ): string {
-  if (!connectorProvider) {
-    return t("accessReviewSourceRow.sources.csv");
-  }
-
-  switch (connectorProvider) {
-    case "GOOGLE_WORKSPACE":
-      return t("accessReviewSourceRow.sources.googleWorkspace");
-    case "MICROSOFT_365":
-      return t("accessReviewSourceRow.sources.microsoft365");
-    case "LINEAR":
-      return t("accessReviewSourceRow.sources.linear");
-    case "SLACK":
-      return t("accessReviewSourceRow.sources.slack");
-    case "METABASE":
-      return t("accessReviewSourceRow.sources.metabase");
-    case "SIGNOZ":
-      return t("accessReviewSourceRow.sources.signoz");
-    case "CURSOR":
-      return t("accessReviewSourceRow.sources.cursor");
-    case "GITHUB":
-      return t("accessReviewSourceRow.sources.github");
-    case "CLOUDFLARE":
-      return t("accessReviewSourceRow.sources.cloudflare");
-    case "AUTHENTIK":
-      return t("accessReviewSourceRow.sources.authentik");
-    default:
-      return connectorProvider;
-  }
+  return connector?.displayName ?? t("accessReviewSourceRow.sources.csv");
 }
 
 export function AccessReviewSourceListItem({
@@ -322,14 +297,14 @@ export function AccessReviewSourceListItem({
   const showOrgSelector
     = accessSource.needsConfiguration || accessSource.selectedOrganization;
   const canReconnect = canReconnectConnector(accessSource.connector);
-  const showReconnect
-    = canReconnect
-      && (accessSource.connectionStatus === "DISCONNECTED"
-        || accessSource.connectionStatus === "RECONNECT_REQUIRED");
-  const showStandaloneIssue
-    = (accessSource.connectionStatus === "DISCONNECTED"
-      || accessSource.connectionStatus === "RECONNECT_REQUIRED")
-    && !showOrgSelector;
+  // Stated as what a healthy source is, not as a list of the ways it can
+  // break: a status added to the enum after this bundle shipped would match
+  // no branch of such a list and silently render nothing at all for a source
+  // that is in fact broken. An unrecognised one is treated as DISCONNECTED is.
+  const hasConnectionIssue
+    = accessSource.connectionStatus !== "CONNECTED"
+      && accessSource.connectionStatus !== "NOT_APPLICABLE";
+  const showStandaloneIssue = hasConnectionIssue && !showOrgSelector;
 
   return (
     <li className={item()}>
@@ -365,14 +340,19 @@ export function AccessReviewSourceListItem({
             <InlineOrgSelect
               accessReviewSourceId={accessSource.id}
               onSelect={handleOrgChange}
-              reconnectUrl={reconnectUrl}
+              provider={sourceLabel(accessSource.connector, t)}
+              connectionStatus={accessSource.connectionStatus}
+              reconnectUrl={canReconnect ? reconnectUrl : null}
+              documentationUrl={accessSource.connector?.documentationUrl ?? null}
             />
           </Suspense>
         )}
         {showStandaloneIssue && (
           <SourceConnectionIssue
-            provider={sourceLabel(accessSource.connector?.provider, t)}
-            reconnectUrl={showReconnect ? reconnectUrl : null}
+            provider={sourceLabel(accessSource.connector, t)}
+            connectionStatus={accessSource.connectionStatus}
+            reconnectUrl={canReconnect ? reconnectUrl : null}
+            documentationUrl={accessSource.connector?.documentationUrl ?? null}
           />
         )}
         {accessSource.canDelete && (
@@ -398,10 +378,16 @@ export function AccessReviewSourceListItem({
 function InlineOrgSelect({
   accessReviewSourceId,
   onSelect,
+  provider,
+  connectionStatus,
   reconnectUrl,
+  documentationUrl,
 }: {
   accessReviewSourceId: string;
+  provider: string;
+  connectionStatus: string;
   reconnectUrl: string | null;
+  documentationUrl: string | null;
   onSelect: (slug: string) => void;
 }) {
   const { t } = useTranslation();
@@ -441,7 +427,22 @@ function InlineOrgSelect({
     // submitting one could only ever return "does not support organization
     // configuration". Show what the callback captured, read-only; changing it
     // means reconnecting.
+    // A captured organization is still worth showing, but not instead of a
+    // refusal: this branch owns the whole trailing cell, so the parent's
+    // standalone issue is suppressed here and a broken source would otherwise
+    // render as nothing but an organization name.
     case "NOT_APPLICABLE":
+      if (connectionStatus !== "CONNECTED") {
+        return (
+          <SourceConnectionIssue
+            provider={provider}
+            connectionStatus={connectionStatus}
+            reconnectUrl={reconnectUrl}
+            documentationUrl={documentationUrl}
+          />
+        );
+      }
+
       return <CapturedOrganization sourceKey={source} />;
     case "EMPTY":
       return (
@@ -453,18 +454,42 @@ function InlineOrgSelect({
       return (
         <ProviderOrganizationsUnavailable
           sourceKey={source}
+          connectionStatus={connectionStatus}
           reconnectUrl={reconnectUrl}
+          documentationUrl={documentationUrl}
         />
       );
   }
 }
 
+// The three ways a source can be unusable, told apart because the customer
+// fixes each somewhere else: a grant to re-authorize, a credential to
+// re-paste, or — when the provider took the credential and refused the
+// operation anyway — a plan or a role to change at the provider, which no
+// amount of re-pasting reaches.
+type ConnectionIssueVariant = "reconnect" | "notAuthorized" | "credentials";
+
+function connectionIssueVariant(
+  connectionStatus: string,
+  reconnectUrl: string | null,
+): ConnectionIssueVariant {
+  if (connectionStatus === "NOT_AUTHORIZED") {
+    return "notAuthorized";
+  }
+
+  return reconnectUrl ? "reconnect" : "credentials";
+}
+
 function SourceConnectionIssue({
   provider,
+  connectionStatus,
   reconnectUrl,
+  documentationUrl,
 }: {
   provider: string;
+  connectionStatus: string;
   reconnectUrl: string | null;
+  documentationUrl: string | null;
 }) {
   const { t } = useTranslation();
   const {
@@ -475,29 +500,22 @@ function SourceConnectionIssue({
     issueDescription,
   } = accessReviewSourceSection();
 
+  const unavailable = "accessReviewSourceRow.organizations.unavailable";
+  const variant = connectionIssueVariant(connectionStatus, reconnectUrl);
+
   return (
     <div className={issue()}>
       <IconWarning size={16} className={issueIcon()} />
       <div className={issueContent()}>
         <p className={issueTitle()}>
-          {reconnectUrl
-            ? t("accessReviewSourceRow.organizations.unavailable.reconnectTitle", {
-                provider,
-              })
-            : t(
-                "accessReviewSourceRow.organizations.unavailable.credentialsTitle",
-                { provider },
-              )}
+          {t(`${unavailable}.${variant}Title`, { provider })}
         </p>
         <p className={issueDescription()}>
-          {reconnectUrl
-            ? t(
-                "accessReviewSourceRow.organizations.unavailable.reconnectDescription",
-              )
-            : t(
-                "accessReviewSourceRow.organizations.unavailable.credentialsDescription",
-              )}
+          {t(`${unavailable}.${variant}Description`, { provider })}
         </p>
+        {variant !== "reconnect" && (
+          <ConnectorDocumentationLink url={documentationUrl} />
+        )}
       </div>
       {reconnectUrl && (
         <Button variant="primary" asChild>
@@ -522,7 +540,7 @@ function ProviderOrganizationsEmpty({
 }) {
   const { t } = useTranslation();
   const source = useFragment(organizationsEmptyFragment, sourceKey);
-  const providerLabel = sourceLabel(source.connector?.provider ?? null, t);
+  const providerLabel = sourceLabel(source.connector, t);
   const remediationUrl = source.providerOrganizations.remediationUrl;
 
   return (
@@ -563,20 +581,24 @@ function ProviderOrganizationsEmpty({
 // affordance offered is reconnecting the connector.
 function ProviderOrganizationsUnavailable({
   sourceKey,
+  connectionStatus,
   reconnectUrl,
+  documentationUrl,
 }: {
   sourceKey: AccessReviewSourceListItemOrganizationsUnavailable_source$key;
+  connectionStatus: string;
   reconnectUrl: string | null;
+  documentationUrl: string | null;
 }) {
   const { t } = useTranslation();
   const source = useFragment(organizationsUnavailableFragment, sourceKey);
-  const providerLabel = sourceLabel(source.connector?.provider ?? null, t);
-  const canReconnect = canReconnectConnector(source.connector);
 
   return (
     <SourceConnectionIssue
-      provider={providerLabel}
-      reconnectUrl={canReconnect ? reconnectUrl : null}
+      provider={sourceLabel(source.connector, t)}
+      connectionStatus={connectionStatus}
+      reconnectUrl={reconnectUrl}
+      documentationUrl={documentationUrl}
     />
   );
 }

--- a/apps/console/src/pages/organizations/access-reviews/dialogs/_components/APIKeyConnectorDialog.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/dialogs/_components/APIKeyConnectorDialog.tsx
@@ -29,7 +29,7 @@ import {
   useDialogRef,
   useToast,
 } from "@probo/ui";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFragment, useMutation, useRelayEnvironment } from "react-relay";
 import { fetchQuery, graphql } from "relay-runtime";
@@ -61,6 +61,10 @@ const apiKeyConnectorDialogFragment = graphql`
       key
       label
       required
+    }
+    apiKeyFormat {
+      pattern
+      example
     }
   }
 `;
@@ -119,6 +123,10 @@ export function APIKeyConnectorDialog({
   const environment = useRelayEnvironment();
 
   const [apiKeyValue, setApiKeyValue] = useState("");
+  // The shape check is shown once the customer has left the field or tried to
+  // connect. Judging a key while it is still being typed would mark every
+  // partial paste as wrong.
+  const [apiKeyBlurred, setApiKeyBlurred] = useState(false);
   const [extraSettingValues, setExtraSettingValues] = useState<Record<string, string>>({});
   const [isConnectingAPIKey, setIsConnectingAPIKey] = useState(false);
   const [crispCode, setCrispCode] = useState<CrispCodeState | null>(null);
@@ -202,11 +210,38 @@ export function APIKeyConnectorDialog({
     };
   }, [environment, isCrispManaged, crispWebsiteId, organizationId, crispRetry]);
 
+  // The provider states the shape it mints keys in; the server applies the
+  // same rule at create, so this is what saves a round trip, not what enforces
+  // it. A pattern that will not compile here is treated as no check at all —
+  // the server still has the real one.
+  const apiKeyPattern = useMemo(() => {
+    const pattern = provider?.apiKeyFormat?.pattern;
+    if (!pattern) {
+      return null;
+    }
+
+    try {
+      return new RegExp(pattern);
+    } catch {
+      return null;
+    }
+  }, [provider?.apiKeyFormat?.pattern]);
+
+  const trimmedAPIKey = apiKeyValue.trim();
+  const apiKeyMalformed
+    = !!apiKeyPattern && trimmedAPIKey !== "" && !apiKeyPattern.test(trimmedAPIKey);
+
   const connectAPIKeyProvider = () => {
     // Managed providers (Model B, e.g. Crisp) supply no customer key: the
     // server injects Probo's own credential, so only the extra settings
     // are required.
-    if (!provider || (!provider.apiKeyManaged && !apiKeyValue.trim())) {
+    if (!provider || (!provider.apiKeyManaged && !trimmedAPIKey)) {
+      return;
+    }
+
+    if (apiKeyMalformed) {
+      setApiKeyBlurred(true);
+
       return;
     }
 
@@ -241,6 +276,7 @@ export function APIKeyConnectorDialog({
           () => {
             setIsConnectingAPIKey(false);
             setApiKeyValue("");
+            setApiKeyBlurred(false);
             setExtraSettingValues({});
             setCrispCode(null);
             dialogRef.current?.close();
@@ -332,6 +368,7 @@ export function APIKeyConnectorDialog({
         // Reset on dismiss so the next open starts fresh (the imperative
         // close() on success does not fire onClose, so success resets inline).
         setApiKeyValue("");
+        setApiKeyBlurred(false);
         setExtraSettingValues({});
         setCrispCode(null);
         setIsConnectingAPIKey(false);
@@ -365,6 +402,15 @@ export function APIKeyConnectorDialog({
               type="password"
               value={apiKeyValue}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setApiKeyValue(e.target.value)}
+              onBlur={() => setApiKeyBlurred(true)}
+              placeholder={provider?.apiKeyFormat?.example}
+              error={
+                apiKeyBlurred && apiKeyMalformed && provider?.apiKeyFormat
+                  ? t("apiKeyConnectorDialog.errors.apiKeyFormat", {
+                      example: provider.apiKeyFormat.example,
+                    })
+                  : undefined
+              }
               required
               autoFocus
             />

--- a/e2e/console/connector_test.go
+++ b/e2e/console/connector_test.go
@@ -48,6 +48,10 @@ func TestAccessReviewDrivers(t *testing.T) {
 					label
 					required
 				}
+				apiKeyFormat {
+					pattern
+					example
+				}
 				clientCredentialsExtraSettings {
 					key
 					label
@@ -69,6 +73,11 @@ func TestAccessReviewDrivers(t *testing.T) {
 		Required bool   `json:"required"`
 	}
 
+	type keyFormat struct {
+		Pattern string `json:"pattern"`
+		Example string `json:"example"`
+	}
+
 	var result struct {
 		AccessReviewDrivers []struct {
 			Provider                       string        `json:"provider"`
@@ -79,6 +88,7 @@ func TestAccessReviewDrivers(t *testing.T) {
 			APIKeySupported                bool          `json:"apiKeySupported"`
 			ClientCredentialsSupported     bool          `json:"clientCredentialsSupported"`
 			APIKeyExtraSettings            []settingInfo `json:"apiKeyExtraSettings"`
+			APIKeyFormat                   *keyFormat    `json:"apiKeyFormat"`
 			ClientCredentialsExtraSettings []settingInfo `json:"clientCredentialsExtraSettings"`
 			WorkloadIdentitySupported      bool          `json:"workloadIdentitySupported"`
 			WorkloadIdentityExtraSettings  []settingInfo `json:"workloadIdentityExtraSettings"`
@@ -91,6 +101,7 @@ func TestAccessReviewDrivers(t *testing.T) {
 
 	providerNames := make(map[string]bool)
 	docURLByProvider := make(map[string]*string)
+	keyFormatByProvider := make(map[string]*keyFormat)
 	protocolsByProvider := make(map[string][]string)
 	apiKeySettingKeys := make(map[string][]string)
 	clientCredentialsSettingKeys := make(map[string][]string)
@@ -105,6 +116,7 @@ func TestAccessReviewDrivers(t *testing.T) {
 		assert.NotNil(t, info.WorkloadIdentityExtraSettings)
 		providerNames[info.Provider] = true
 		docURLByProvider[info.Provider] = info.DocumentationURL
+		keyFormatByProvider[info.Provider] = info.APIKeyFormat
 		protocolsByProvider[info.Provider] = info.ConfiguredProtocols
 		workloadIdentitySupported[info.Provider] = info.WorkloadIdentitySupported
 		assert.Equal(t, slices.Contains(info.ConfiguredProtocols, "OAUTH2"), info.OAuthConfigured)
@@ -176,6 +188,20 @@ func TestAccessReviewDrivers(t *testing.T) {
 	// field is really null, which would let the null path rot unnoticed.
 	require.Contains(t, docURLByProvider, "SENTRY")
 	assert.Nil(t, docURLByProvider["SENTRY"], "SENTRY has no doc page, documentationUrl must be null")
+
+	// apiKeyFormat is what the connect dialog checks the pasted key against and
+	// shows as its placeholder, so it has to reach the client. Langfuse is the
+	// only provider declaring one; Sentry carries the null case, on the same
+	// Contains-first reasoning as the doc URL above.
+	require.Contains(t, keyFormatByProvider, "LANGFUSE")
+
+	if format := keyFormatByProvider["LANGFUSE"]; assert.NotNil(t, format) {
+		assert.Equal(t, `^pk-lf-[^:]+:sk-lf-[^:]+$`, format.Pattern)
+		assert.Equal(t, "pk-lf-…:sk-lf-…", format.Example)
+	}
+
+	require.Contains(t, keyFormatByProvider, "SENTRY")
+	assert.Nil(t, keyFormatByProvider["SENTRY"], "SENTRY declares no key shape, apiKeyFormat must be null")
 
 	t.Run("viewer can list access review drivers", func(t *testing.T) {
 		t.Parallel()
@@ -274,6 +300,74 @@ func TestCreateAPIKeyConnectorSentryMissingSlug(t *testing.T) {
 		},
 	})
 	testutil.RequireErrorCode(t, err, "INVALID", "missing sentryOrganizationSlug must return INVALID not INTERNAL")
+}
+
+// TestCreateAPIKeyConnectorMalformedKey asserts that a key whose shape its
+// provider could never have minted is refused before anything is written.
+// Langfuse pastes two keys as one colon-joined string and the transport
+// base64s it verbatim, so half a credential is otherwise stored and then
+// authenticates as nothing.
+func TestCreateAPIKeyConnectorMalformedKey(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	orgID := owner.GetOrganizationID().String()
+
+	const query = `
+		mutation($input: CreateAPIKeyConnectorInput!) {
+			createAPIKeyConnector(input: $input) {
+				connector { id }
+			}
+		}
+	`
+
+	_, err := owner.Do(query, map[string]any{
+		"input": map[string]any{
+			"organizationId": orgID,
+			"provider":       "LANGFUSE",
+			// The public half alone: the colon and the secret key are missing.
+			"apiKey":          "pk-lf-11111111-2222-3333-4444-555555555555",
+			"langfuseBaseUrl": "https://cloud.langfuse.com",
+		},
+	})
+	testutil.RequireErrorCode(t, err, "INVALID", "a half-pasted key must return INVALID, not create a connector")
+}
+
+// TestCreateAPIKeyConnectorLangfuseKeyPair asserts the counterpart: a
+// well-formed pair is accepted. It says nothing about the key working —
+// only Langfuse can judge that, and it is not called here.
+func TestCreateAPIKeyConnectorLangfuseKeyPair(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	orgID := owner.GetOrganizationID().String()
+
+	const query = `
+		mutation($input: CreateAPIKeyConnectorInput!) {
+			createAPIKeyConnector(input: $input) {
+				connector { id provider }
+			}
+		}
+	`
+
+	var result struct {
+		CreateAPIKeyConnector struct {
+			Connector struct {
+				ID       string `json:"id"`
+				Provider string `json:"provider"`
+			} `json:"connector"`
+		} `json:"createAPIKeyConnector"`
+	}
+
+	err := owner.Execute(query, map[string]any{
+		"input": map[string]any{
+			"organizationId":  orgID,
+			"provider":        "LANGFUSE",
+			"apiKey":          "pk-lf-11111111-2222-3333-4444-555555555555:sk-lf-66666666-7777-8888-9999-000000000000",
+			"langfuseBaseUrl": "https://cloud.langfuse.com",
+		},
+	}, &result)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.CreateAPIKeyConnector.Connector.ID)
+	assert.Equal(t, "LANGFUSE", result.CreateAPIKeyConnector.Connector.Provider)
 }
 
 // TestCreateAPIKeyConnectorSentryRoundTrip asserts that supplying

--- a/e2e/console/connector_test.go
+++ b/e2e/console/connector_test.go
@@ -199,12 +199,17 @@ func TestCreateAPIKeyConnector(t *testing.T) {
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 	orgID := owner.GetOrganizationID().String()
 
+	// displayName and documentationUrl are selected here and connectionStatus
+	// is not: the first two read the provider registration, while the third
+	// would probe Brex live from a test.
 	const query = `
 		mutation($input: CreateAPIKeyConnectorInput!) {
 			createAPIKeyConnector(input: $input) {
 				connector {
 					id
 					provider
+					displayName
+					documentationUrl
 				}
 			}
 		}
@@ -213,8 +218,10 @@ func TestCreateAPIKeyConnector(t *testing.T) {
 	var result struct {
 		CreateAPIKeyConnector struct {
 			Connector struct {
-				ID       string `json:"id"`
-				Provider string `json:"provider"`
+				ID               string  `json:"id"`
+				Provider         string  `json:"provider"`
+				DisplayName      string  `json:"displayName"`
+				DocumentationURL *string `json:"documentationUrl"`
 			} `json:"connector"`
 		} `json:"createAPIKeyConnector"`
 	}
@@ -231,6 +238,14 @@ func TestCreateAPIKeyConnector(t *testing.T) {
 	connector := result.CreateAPIKeyConnector.Connector
 	assert.NotEmpty(t, connector.ID)
 	assert.Equal(t, "BREX", connector.Provider)
+	// The name a user reads, which is the registration's and not the enum.
+	assert.Equal(t, "Brex", connector.DisplayName)
+	require.NotNil(t, connector.DocumentationURL)
+	assert.Equal(
+		t,
+		"https://www.probo.com/docs/product/access-review/brex",
+		*connector.DocumentationURL,
+	)
 }
 
 // TestCreateAPIKeyConnectorSentryMissingSlug asserts that creating a

--- a/pkg/accessreview/errors.go
+++ b/pkg/accessreview/errors.go
@@ -243,6 +243,17 @@ func IsProviderVerdict(err error) bool {
 	return false
 }
 
+// IsProbeOperationRefused reports whether a probe failure is the provider
+// accepting the credential and then refusing what was asked of it — a plan
+// that excludes the endpoint, a role without the permission — rather than
+// refusing the credential itself. The two are told apart at the probe, because
+// only there is the provider's own explanation still in hand.
+func IsProbeOperationRefused(err error) bool {
+	rejected, ok := errors.AsType[*provider.CredentialRejectedError](err)
+
+	return ok && rejected != nil && rejected.OperationRefused
+}
+
 // ProbeFailureCode reduces a probe failure to a token safe to log. Probe
 // errors wrap text Probo does not control (an OAuth error_description, a
 // response body, a customer's self-hosted host), so anything unrecognised

--- a/pkg/accessreview/errors_test.go
+++ b/pkg/accessreview/errors_test.go
@@ -22,10 +22,12 @@ package accessreview_test
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.probo.inc/probo/pkg/accessreview"
+	"go.probo.inc/probo/pkg/connector/provider"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 )
@@ -113,4 +115,46 @@ func TestMissingOAuthScopesError(t *testing.T) {
 		err.Error(),
 	)
 	assert.ErrorIs(t, err, accessreview.ErrMissingOAuthScopes)
+}
+
+func TestProbeUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "refused operation",
+			err: accessreview.NewProbeError(
+				coredata.ConnectorProviderLangfuse,
+				&provider.CredentialRejectedError{StatusCode: http.StatusForbidden, OperationRefused: true},
+			),
+			want: true,
+		},
+		{
+			name: "refused credential",
+			err: accessreview.NewProbeError(
+				coredata.ConnectorProviderLangfuse,
+				&provider.CredentialRejectedError{StatusCode: http.StatusUnauthorized},
+			),
+		},
+		{
+			name: "a host answering with a page is not an authorization verdict",
+			err: accessreview.NewProbeError(
+				coredata.ConnectorProviderMetabase,
+				&provider.NotAnAPIEndpointError{StatusCode: http.StatusOK},
+			),
+		},
+		{name: "no failure at all", err: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, accessreview.IsProbeOperationRefused(tc.err))
+		})
+	}
 }

--- a/pkg/connector/provider/langfuse.go
+++ b/pkg/connector/provider/langfuse.go
@@ -21,6 +21,7 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -51,8 +52,9 @@ func langfuseRegistration() *Registration {
 		// BuildProbeURL derives the probe endpoint from the per-connection
 		// base URL (the host is regional/self-hosted, so a static ProbeURL
 		// cannot express it); the transport attaches the Basic credential
-		// and a dead key returns 401/403.
-		BuildProbeURL: buildLangfuseProbeURL,
+		// and a dead key returns 401/403, which ClassifyRejection tells apart.
+		BuildProbeURL:     buildLangfuseProbeURL,
+		ClassifyRejection: classifyLangfuseRejection,
 		//
 		// No NewNameResolver: the memberships endpoint carries no
 		// organization name, so the source keeps its generic name.
@@ -70,4 +72,19 @@ func langfuseRegistration() *Registration {
 			return drivers.NewLangfuseDriver(c, baseURL), nil
 		},
 	}
+}
+
+// langfuseOrganizationKeyRequired is how Langfuse refuses a key that
+// authenticates but is scoped to a project rather than to the organization.
+const langfuseOrganizationKeyRequired = "Organization-scoped API key required"
+
+// classifyLangfuseRejection tells Langfuse's two 403s apart. The memberships
+// endpoint checks the key's scope before the organization's plan, and a
+// customer whose plan lacks the admin-api entitlement never sees the
+// organization API-keys tab at all, so the common failure is a pasted project
+// key: a wrong credential, which the customer fixes by pasting the right one.
+// Everything else the endpoint refuses is the plan gate, which no credential
+// can satisfy.
+func classifyLangfuseRejection(body []byte) bool {
+	return !bytes.Contains(body, []byte(langfuseOrganizationKeyRequired))
 }

--- a/pkg/connector/provider/langfuse.go
+++ b/pkg/connector/provider/langfuse.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/accessreview/drivers"
@@ -40,6 +41,10 @@ func langfuseRegistration() *Registration {
 			Auth: APIKeyAuth{Mode: APIKeyAuthBasicUserPass},
 			ExtraSettings: []ExtraSetting{
 				{Key: "baseUrl", Label: "Base URL", Required: true},
+			},
+			KeyFormat: &KeyFormat{
+				Pattern: langfuseKeyPattern,
+				Example: "pk-lf-…:sk-lf-…",
 			},
 		},
 		// Langfuse's organization-scoped public API authenticates with HTTP
@@ -79,12 +84,14 @@ func langfuseRegistration() *Registration {
 const langfuseOrganizationKeyRequired = "Organization-scoped API key required"
 
 // classifyLangfuseRejection tells Langfuse's two 403s apart. The memberships
-// endpoint checks the key's scope before the organization's plan, and a
-// customer whose plan lacks the admin-api entitlement never sees the
-// organization API-keys tab at all, so the common failure is a pasted project
-// key: a wrong credential, which the customer fixes by pasting the right one.
-// Everything else the endpoint refuses is the plan gate, which no credential
-// can satisfy.
+// endpoint checks the key's scope before the plan, so a wrong-scope key is
+// reported as the credential problem it is; anything else it refuses is the
+// plan gate, which no credential can satisfy.
 func classifyLangfuseRejection(body []byte) bool {
 	return !bytes.Contains(body, []byte(langfuseOrganizationKeyRequired))
 }
+
+// langfuseKeyPattern is the colon-joined pair the Basic transport needs. Both
+// scopes carry these same prefixes, so it says nothing about whether the key
+// is organization-scoped.
+var langfuseKeyPattern = regexp.MustCompile(`^pk-lf-[^:]+:sk-lf-[^:]+$`)

--- a/pkg/connector/provider/langfuse_test.go
+++ b/pkg/connector/provider/langfuse_test.go
@@ -23,6 +23,9 @@ package provider_test
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,6 +58,99 @@ func TestLangfuseRegistrationMetadata(t *testing.T) {
 	// Single-tenant API-key provider: no picker, no name resolver.
 	assert.Nil(t, reg.NewNameResolver, "langfuse must not wire a name resolver")
 	assert.Nil(t, reg.SetOrganizationSettings, "langfuse must not wire a picker store")
+	require.NotNil(t, reg.ClassifyRejection, "langfuse must tell its two 403s apart")
+}
+
+// langfuseRoundTripFunc answers a probe with a canned response.
+type langfuseRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f langfuseRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestLangfuseProbeClassifiesRejection(t *testing.T) {
+	t.Parallel()
+
+	// The bodies are Langfuse's own, from
+	// web/src/pages/api/public/organizations/memberships/index.ts. It checks
+	// the key's scope before the organization's plan, and a plan without the
+	// admin-api entitlement hides the organization API-keys tab altogether —
+	// so a customer who cannot reach the entitlement pastes a project key and
+	// gets the scope error, which is a credential they can still fix.
+	cases := []struct {
+		name         string
+		status       int
+		body         string
+		wantRejected bool
+		wantRefused  bool
+	}{
+		{
+			name:         "project key instead of organization key is a bad credential",
+			status:       http.StatusForbidden,
+			body:         `{"error":"Invalid API key. Organization-scoped API key required for this operation."}`,
+			wantRejected: true,
+		},
+		{
+			name:         "plan gate is a refused operation",
+			status:       http.StatusForbidden,
+			body:         `{"error":"This feature is not available on your current plan."}`,
+			wantRejected: true,
+			wantRefused:  true,
+		},
+		{
+			name:         "dead key is a bad credential",
+			status:       http.StatusUnauthorized,
+			body:         `{"error":"Invalid credentials. Confirm that you've configured the correct host."}`,
+			wantRejected: true,
+		},
+		{
+			name:   "a listable organization is connected",
+			status: http.StatusOK,
+			body:   `{"memberships":[]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := provider.NewBuiltinRegistry()
+
+			raw, err := json.Marshal(&coredata.LangfuseConnectorSettings{
+				BaseURL: "https://cloud.langfuse.com",
+			})
+			require.NoError(t, err)
+
+			client := &http.Client{Transport: langfuseRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				assert.Equal(t, "/api/public/organizations/memberships", req.URL.Path)
+
+				return &http.Response{
+					StatusCode: tc.status,
+					Body:       io.NopCloser(strings.NewReader(tc.body)),
+					Header:     make(http.Header),
+				}, nil
+			})}
+
+			err = r.ProbeConnection(
+				context.Background(),
+				client,
+				&coredata.Connector{
+					Provider:    coredata.ConnectorProviderLangfuse,
+					RawSettings: raw,
+				},
+			)
+
+			if !tc.wantRejected {
+				require.NoError(t, err)
+
+				return
+			}
+
+			var rejected *provider.CredentialRejectedError
+
+			require.ErrorAs(t, err, &rejected)
+			assert.Equal(t, tc.status, rejected.StatusCode)
+			assert.Equal(t, tc.wantRefused, rejected.OperationRefused)
+		})
+	}
 }
 
 func TestLangfuseNewDriver(t *testing.T) {

--- a/pkg/connector/provider/langfuse_test.go
+++ b/pkg/connector/provider/langfuse_test.go
@@ -59,6 +59,65 @@ func TestLangfuseRegistrationMetadata(t *testing.T) {
 	assert.Nil(t, reg.NewNameResolver, "langfuse must not wire a name resolver")
 	assert.Nil(t, reg.SetOrganizationSettings, "langfuse must not wire a picker store")
 	require.NotNil(t, reg.ClassifyRejection, "langfuse must tell its two 403s apart")
+	require.NotNil(t, reg.APIKey.KeyFormat, "langfuse must declare the shape of a pasted key")
+	assert.Equal(t, "pk-lf-…:sk-lf-…", reg.APIKey.KeyFormat.Example)
+}
+
+func TestLangfuseKeyFormat(t *testing.T) {
+	t.Parallel()
+
+	// The check exists to catch a credential that was pasted wrong, which is
+	// otherwise indistinguishable from a dead one: the transport base64s the
+	// value verbatim, so a missing half authenticates as nothing.
+	//
+	// What it must NOT do is claim to know the key's scope. Langfuse mints
+	// organization and project keys with the same prefixes, so the first two
+	// cases below are both well-formed and only one of them can list an
+	// organization's members. Only the provider can say which.
+	cases := []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{name: "organization key pair", key: "pk-lf-1111:sk-lf-2222", want: true},
+		{name: "project key pair is well formed too", key: "pk-lf-3333:sk-lf-4444", want: true},
+		{name: "public key alone", key: "pk-lf-1111"},
+		{name: "secret key alone", key: "sk-lf-2222"},
+		{name: "halves pasted in the wrong order", key: "sk-lf-2222:pk-lf-1111"},
+		{name: "separated by something else", key: "pk-lf-1111 sk-lf-2222"},
+		{name: "missing the secret half", key: "pk-lf-1111:"},
+		{name: "missing the public half", key: ":sk-lf-2222"},
+		{name: "prefixes only", key: "pk-lf-:sk-lf-"},
+		{name: "a third colon", key: "pk-lf-1111:sk-lf-2222:extra"},
+		{name: "both pairs pasted at once", key: "pk-lf-1111:sk-lf-2222:pk-lf-3333:sk-lf-4444"},
+		{name: "some other provider's key", key: "sk-ant-api03-abcdef"},
+		{name: "empty", key: ""},
+	}
+
+	r := provider.NewBuiltinRegistry()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := r.ValidateAPIKey(coredata.ConnectorProviderLangfuse, tc.key)
+
+			if tc.want {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			// The message reaches the customer, so it shows the shape it
+			// wanted and never what they pasted.
+			assert.Contains(t, err.Error(), "pk-lf-…:sk-lf-…")
+
+			if tc.key != "" {
+				assert.NotContains(t, err.Error(), tc.key)
+			}
+		})
+	}
 }
 
 // langfuseRoundTripFunc answers a probe with a canned response.

--- a/pkg/connector/provider/probe.go
+++ b/pkg/connector/provider/probe.go
@@ -64,7 +64,7 @@ func (r *Registry) ProbeConnection(
 	}
 
 	if reg.Probe != nil {
-		return reg.Probe(ctx, httpClient, conn, reg.Endpoints)
+		return classifyRejection(reg, reg.Probe(ctx, httpClient, conn, reg.Endpoints))
 	}
 
 	probeURL := reg.Endpoints.Probe
@@ -77,7 +77,28 @@ func (r *Registry) ProbeConnection(
 		probeURL = built
 	}
 
-	return probeGET(ctx, httpClient, probeURL)
+	return classifyRejection(reg, probeGET(ctx, httpClient, probeURL))
+}
+
+// classifyRejection lets a registration read the provider's own explanation of
+// a rejection the status alone cannot settle. Only a 403 is ambiguous: 401 is
+// always the credential, and an extra status a provider rejects on is one it
+// chose precisely because it is unambiguous. The error is refined in place so
+// that whatever a provider's Probe wrapped it in survives, and the body is
+// dropped either way — no caller past this point may read provider text.
+func classifyRejection(reg *Registration, err error) error {
+	rejected, ok := errors.AsType[*CredentialRejectedError](err)
+	if !ok || rejected == nil {
+		return err
+	}
+
+	if reg.ClassifyRejection != nil && rejected.StatusCode == http.StatusForbidden {
+		rejected.OperationRefused = reg.ClassifyRejection(rejected.body)
+	}
+
+	rejected.body = nil
+
+	return err
 }
 
 // ProbeCloudConnection is ProbeConnection for a workload identity connector,
@@ -141,12 +162,38 @@ func probePOSTJSON(
 
 // CredentialRejectedError reports that the provider refused the credential,
 // carrying the status separately so callers can log it without the message.
+//
+// OperationRefused separates the two rejections a customer fixes differently: a
+// credential the provider will not accept at all (a dead key, the wrong kind
+// of key) from one it accepts before refusing what was asked of it (a plan
+// that excludes the endpoint, a role without the permission). The status
+// decides it — 401 is the credential, 403 is the refusal — unless the provider
+// explains itself in the body and its registration reads that explanation.
+//
+// Deliberately not named for HTTP's own word: 401 is the status called
+// Unauthorized, and this is the bit that is true for 403.
 type CredentialRejectedError struct {
-	StatusCode int
+	StatusCode       int
+	OperationRefused bool
+
+	// body is the provider's own explanation, held only until ProbeConnection
+	// has run the registration's ClassifyRejection over it. Provider-controlled
+	// text, so it stays unexported and out of Error().
+	body []byte
 }
 
 func (e *CredentialRejectedError) Error() string {
 	return fmt.Sprintf("credential rejected: status %d", e.StatusCode)
+}
+
+// newCredentialRejected builds the rejection a status implies, so that the
+// "403 is the authorization, everything else is the credential" rule lives in
+// one place rather than at each site that answers a provider's refusal.
+func newCredentialRejected(statusCode int) *CredentialRejectedError {
+	return &CredentialRejectedError{
+		StatusCode:       statusCode,
+		OperationRefused: statusCode == http.StatusForbidden,
+	}
 }
 
 // NotAnAPIEndpointError reports that the probe reached a server that answered
@@ -163,11 +210,18 @@ func (e *NotAnAPIEndpointError) Error() string {
 	)
 }
 
+// rejectionBodyLimit caps what a provider's explanation of a rejection can
+// cost: enough for the one-line JSON error a rejection carries, never enough
+// for a page.
+const rejectionBodyLimit = 4 << 10
+
 // doProbeRequest executes a probe request and maps the status to a verdict:
 // 401/403 always mean the credential is rejected, any 2xx/other status means
 // connected. extraReject lets a provider add statuses that also mean a hard
 // rejection (e.g. OpenRouter's 404 for a non-organization key); pass none for
-// the default 401/403-only contract.
+// the default 401/403-only contract. A rejection is the credential's fault
+// unless the status is 403, which means the provider got far enough to refuse
+// the operation instead.
 //
 // A 2xx that answers with an HTML document is rejected: only there does the
 // status lie.
@@ -189,7 +243,14 @@ func doProbeRequest(httpClient *http.Client, req *http.Request, extraReject ...i
 	if resp.StatusCode == http.StatusUnauthorized ||
 		resp.StatusCode == http.StatusForbidden ||
 		slices.Contains(extraReject, resp.StatusCode) {
-		return &CredentialRejectedError{StatusCode: resp.StatusCode}
+		rejected := newCredentialRejected(resp.StatusCode)
+
+		// Only a 403 is ever reclassified, so only a 403 body is worth keeping.
+		if resp.StatusCode == http.StatusForbidden {
+			rejected.body, _ = io.ReadAll(io.LimitReader(resp.Body, rejectionBodyLimit))
+		}
+
+		return rejected
 	}
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 && respondsWithHTML(resp.Body) {
@@ -590,7 +651,7 @@ func probeRailway(
 	}()
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return &CredentialRejectedError{StatusCode: resp.StatusCode}
+		return newCredentialRejected(resp.StatusCode)
 	}
 
 	// The errors-array rule below is Railway's documented rejection, and it
@@ -616,7 +677,7 @@ func probeRailway(
 	// Railway answers 200 with an errors array rather than a 401, so this is
 	// a rejection too and must classify the same way.
 	if len(parsed.Errors) > 0 || parsed.Data.Me == nil {
-		return &CredentialRejectedError{StatusCode: resp.StatusCode}
+		return newCredentialRejected(resp.StatusCode)
 	}
 
 	return nil

--- a/pkg/connector/provider/probe_test.go
+++ b/pkg/connector/provider/probe_test.go
@@ -23,6 +23,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -399,13 +400,18 @@ func TestProbeRailway(t *testing.T) {
 		// a credential rejection: reporting a 502 that way would tell a
 		// customer to reconnect a working token.
 		wantCredentialRejected bool
+		// wantRefused holds Railway to the same reading of a 403 as
+		// every provider probed through doProbeRequest: the credential was
+		// taken and the operation refused.
+		wantRefused bool
 	}{
-		{"valid token", http.StatusOK, `{"data":{"me":{"id":"u-1"}}}`, false, false},
-		{"rejected token (200 + errors)", http.StatusOK, `{"errors":[{"message":"Not Authorized"}],"data":null}`, true, true},
-		{"null me", http.StatusOK, `{"data":{"me":null}}`, true, true},
-		{"unauthorized status", http.StatusUnauthorized, ``, true, true},
-		{"upstream outage", http.StatusBadGateway, `<html>502 Bad Gateway</html>`, true, false},
-		{"rate limited", http.StatusTooManyRequests, `{"errors":[{"message":"rate limited"}]}`, true, false},
+		{"valid token", http.StatusOK, `{"data":{"me":{"id":"u-1"}}}`, false, false, false},
+		{"rejected token (200 + errors)", http.StatusOK, `{"errors":[{"message":"Not Authorized"}],"data":null}`, true, true, false},
+		{"null me", http.StatusOK, `{"data":{"me":null}}`, true, true, false},
+		{"unauthorized status", http.StatusUnauthorized, ``, true, true, false},
+		{"forbidden status", http.StatusForbidden, ``, true, true, true},
+		{"upstream outage", http.StatusBadGateway, `<html>502 Bad Gateway</html>`, true, false, false},
+		{"rate limited", http.StatusTooManyRequests, `{"errors":[{"message":"rate limited"}]}`, true, false, false},
 	}
 
 	for _, tc := range cases {
@@ -438,8 +444,12 @@ func TestProbeRailway(t *testing.T) {
 
 			require.Error(t, err)
 
-			_, isCredentialRejected := errors.AsType[*CredentialRejectedError](err)
+			rejected, isCredentialRejected := errors.AsType[*CredentialRejectedError](err)
 			assert.Equal(t, tc.wantCredentialRejected, isCredentialRejected)
+
+			if isCredentialRejected {
+				assert.Equal(t, tc.wantRefused, rejected.OperationRefused)
+			}
 		})
 	}
 }
@@ -644,6 +654,218 @@ func TestDoProbeRequest_RejectsHTMLBody(t *testing.T) {
 			assert.Equal(t, tc.status, notAPI.StatusCode)
 		})
 	}
+}
+
+func TestDoProbeRequest_RefusalVerdict(t *testing.T) {
+	t.Parallel()
+
+	// The two rejections a customer fixes in different places: a credential
+	// the provider will not take at all, and one it takes before refusing the
+	// operation. An extra status a provider opts into is the former — it
+	// opted in precisely because the status is unambiguous there.
+	cases := []struct {
+		name        string
+		status      int
+		extraReject []int
+		wantRefused bool
+	}{
+		{name: "unauthorized status is the credential", status: http.StatusUnauthorized},
+		{name: "forbidden status is the authorization", status: http.StatusForbidden, wantRefused: true},
+		{
+			name:        "opted-in status stays the credential",
+			status:      http.StatusNotFound,
+			extraReject: []int{http.StatusNotFound},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &http.Client{Transport: probeRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: tc.status,
+					Body:       io.NopCloser(strings.NewReader(`{"error":"nope"}`)),
+					Header:     make(http.Header),
+				}, nil
+			})}
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.test/api/user", nil)
+			require.NoError(t, err)
+
+			var rejected *CredentialRejectedError
+
+			require.ErrorAs(t, doProbeRequest(client, req, tc.extraReject...), &rejected)
+			assert.Equal(t, tc.status, rejected.StatusCode)
+			assert.Equal(t, tc.wantRefused, rejected.OperationRefused)
+
+			// Only a 403 is ever reclassified, so only a 403 pays to keep the
+			// provider's explanation.
+			if tc.status == http.StatusForbidden {
+				assert.Equal(t, `{"error":"nope"}`, string(rejected.body))
+			} else {
+				assert.Nil(t, rejected.body)
+			}
+		})
+	}
+
+	t.Run("a talkative provider is cut off at the limit", func(t *testing.T) {
+		t.Parallel()
+
+		// The hosts this reads from are customer-supplied for Langfuse,
+		// Metabase and SigNoz, so the body is bounded rather than trusted.
+		client := &http.Client{Transport: probeRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader(strings.Repeat("a", rejectionBodyLimit*3))),
+				Header:     make(http.Header),
+			}, nil
+		})}
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.test/api/user", nil)
+		require.NoError(t, err)
+
+		var rejected *CredentialRejectedError
+
+		require.ErrorAs(t, doProbeRequest(client, req), &rejected)
+		assert.Len(t, rejected.body, rejectionBodyLimit)
+	})
+}
+
+func TestClassifyRejection(t *testing.T) {
+	t.Parallel()
+
+	// The classifier only ever sees a 403, and its verdict replaces the one
+	// the status gave. Anything else — a 401, a failure that is not a
+	// rejection, a provider that registers no classifier — is left alone.
+	// Every case carries a body, so the assertion that classification drops it
+	// has something to drop, and a classifier can prove it was handed one.
+	const explanation = `{"error":"this feature is not available on your plan"}`
+
+	forbidden := func() *CredentialRejectedError {
+		return &CredentialRejectedError{
+			StatusCode:       http.StatusForbidden,
+			OperationRefused: true,
+			body:             []byte(explanation),
+		}
+	}
+
+	cases := []struct {
+		name           string
+		reg            *Registration
+		err            error
+		wantRefused    bool
+		wantClassified bool
+	}{
+		{
+			name:        "no classifier leaves the status verdict",
+			reg:         &Registration{},
+			err:         forbidden(),
+			wantRefused: true,
+		},
+		{
+			name:           "classifier can demote a forbidden to a bad credential",
+			reg:            &Registration{ClassifyRejection: func([]byte) bool { return false }},
+			err:            forbidden(),
+			wantRefused:    false,
+			wantClassified: true,
+		},
+		{
+			name: "classifier is not consulted on a 401",
+			reg:  &Registration{ClassifyRejection: func([]byte) bool { return true }},
+			err: &CredentialRejectedError{
+				StatusCode: http.StatusUnauthorized,
+				body:       []byte(explanation),
+			},
+			wantRefused: false,
+		},
+		{
+			name:           "a wrapped rejection is still refined",
+			reg:            &Registration{ClassifyRejection: func([]byte) bool { return false }},
+			err:            fmt.Errorf("probe: %w", forbidden()),
+			wantRefused:    false,
+			wantClassified: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var classified []byte
+
+			if inner := tc.reg.ClassifyRejection; inner != nil {
+				tc.reg.ClassifyRejection = func(body []byte) bool {
+					classified = body
+
+					return inner(body)
+				}
+			}
+
+			var rejected *CredentialRejectedError
+
+			require.ErrorAs(t, classifyRejection(tc.reg, tc.err), &rejected)
+			assert.Equal(t, tc.wantRefused, rejected.OperationRefused)
+			assert.Nil(t, rejected.body, "provider text must not outlive classification")
+
+			if tc.wantClassified {
+				assert.Equal(t, explanation, string(classified), "the classifier reads the provider's explanation")
+			} else {
+				assert.Nil(t, classified)
+			}
+		})
+	}
+
+	// Seven providers answer through a custom Probe closure, and that branch of
+	// ProbeConnection is the only other place a rejection carrying provider
+	// text can escape. Driven through the registry, not classifyRejection, so
+	// removing the call at either branch fails here.
+	t.Run("a custom Probe closure is classified too", func(t *testing.T) {
+		t.Parallel()
+
+		r := NewRegistry()
+		require.NoError(t, r.Register(&Registration{
+			Provider:    coredata.ConnectorProviderSlack,
+			DisplayName: "Slack",
+			Probe: func(_ context.Context, httpClient *http.Client, _ *coredata.Connector, _ Endpoints) error {
+				req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.test/api/user", nil)
+				if err != nil {
+					return err
+				}
+
+				return fmt.Errorf("slack probe: %w", doProbeRequest(httpClient, req))
+			},
+			ClassifyRejection: func([]byte) bool { return false },
+		}))
+
+		client := &http.Client{Transport: probeRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"go away"}`)),
+				Header:     make(http.Header),
+			}, nil
+		})}
+
+		err := r.ProbeConnection(
+			context.Background(),
+			client,
+			&coredata.Connector{Provider: coredata.ConnectorProviderSlack},
+		)
+
+		var rejected *CredentialRejectedError
+
+		require.ErrorAs(t, err, &rejected)
+		assert.False(t, rejected.OperationRefused, "the registration's classifier must reach a custom Probe's rejection")
+		assert.Nil(t, rejected.body, "provider text must not outlive classification")
+	})
+
+	t.Run("passes a non-rejection through untouched", func(t *testing.T) {
+		t.Parallel()
+
+		notAPI := &NotAnAPIEndpointError{StatusCode: http.StatusOK}
+		assert.Same(t, notAPI, classifyRejection(&Registration{}, notAPI))
+		assert.NoError(t, classifyRejection(&Registration{}, nil))
+	})
 }
 
 func TestDoProbeRequest_CredentialRejectionWinsOverMarkup(t *testing.T) {

--- a/pkg/connector/provider/registry.go
+++ b/pkg/connector/provider/registry.go
@@ -113,6 +113,24 @@ func (r *Registry) Register(reg *Registration) error {
 		}
 	}
 
+	// A key format describes what the customer pastes, so a Probo-held key has
+	// nothing to describe, and an example that its own pattern rejects would
+	// tell the customer to paste what the check then refuses.
+	if reg.APIKey != nil && reg.APIKey.KeyFormat != nil {
+		if reg.IsManagedAPIKey() {
+			return fmt.Errorf("cannot register connector provider %q: a managed API key has no customer-supplied key to shape", reg.Provider)
+		}
+
+		format := reg.APIKey.KeyFormat
+		if format.Pattern == nil || format.Example == "" {
+			return fmt.Errorf("cannot register connector provider %q: KeyFormat needs both a Pattern and an Example", reg.Provider)
+		}
+
+		if !format.Pattern.MatchString(format.Example) {
+			return fmt.Errorf("cannot register connector provider %q: KeyFormat example does not match its own pattern", reg.Provider)
+		}
+	}
+
 	// A Probo-held key ignores any customer credential, so pairing it with the
 	// client-credentials path would advertise a credential field whose value is
 	// silently discarded. Its former conflict with a customer-supplied API key
@@ -342,6 +360,28 @@ func (r *Registry) NewAPIKeyConnection(
 	}
 
 	return conn
+}
+
+// ValidateAPIKey checks a customer-pasted key against the shape its provider
+// declares, if it declares one. A provider with no KeyFormat, or one whose key
+// Probo supplies itself, accepts anything here and lets the connection check
+// be the judge. The error reaches the customer, so it names the expected shape
+// and never the key.
+func (r *Registry) ValidateAPIKey(p coredata.ConnectorProvider, key string) error {
+	reg, ok := r.Get(p)
+	if !ok || reg.APIKey == nil || reg.APIKey.KeyFormat == nil {
+		return nil
+	}
+
+	if !reg.APIKey.KeyFormat.Pattern.MatchString(key) {
+		return fmt.Errorf(
+			"apiKey does not look like a %s key: expected the form %s",
+			reg.DisplayName,
+			reg.APIKey.KeyFormat.Example,
+		)
+	}
+
+	return nil
 }
 
 // SetManagedAPIKey records the Probo-supplied API key for a

--- a/pkg/connector/provider/registry_test.go
+++ b/pkg/connector/provider/registry_test.go
@@ -23,6 +23,7 @@ package provider_test
 import (
 	"context"
 	"net/http"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -226,6 +227,62 @@ func TestRegistry_Register(t *testing.T) {
 					Provider:    coredata.ConnectorProviderSlack,
 					DisplayName: "Slack",
 					APIKey:      &provider.APIKeyConfig{Auth: tc.auth},
+				})
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.want)
+			})
+		}
+	})
+
+	// A KeyFormat is a promise to the customer, shown as the field's
+	// placeholder and echoed in the rejection: Register refuses the two ways
+	// that promise can be a lie.
+	t.Run("KeyFormat rules", func(t *testing.T) {
+		t.Parallel()
+
+		for name, tc := range map[string]struct {
+			apiKey *provider.APIKeyConfig
+			want   string
+		}{
+			"example its own pattern rejects": {
+				apiKey: &provider.APIKeyConfig{
+					KeyFormat: &provider.KeyFormat{
+						Pattern: regexp.MustCompile(`^pk-lf-.+:sk-lf-.+$`),
+						Example: "sk-lf-…",
+					},
+				},
+				want: "example does not match its own pattern",
+			},
+			"example missing": {
+				apiKey: &provider.APIKeyConfig{
+					KeyFormat: &provider.KeyFormat{Pattern: regexp.MustCompile(`.`)},
+				},
+				want: "needs both a Pattern and an Example",
+			},
+			"pattern missing": {
+				apiKey: &provider.APIKeyConfig{
+					KeyFormat: &provider.KeyFormat{Example: "pk-lf-…"},
+				},
+				want: "needs both a Pattern and an Example",
+			},
+			"shape declared for a key the customer never types": {
+				apiKey: &provider.APIKeyConfig{
+					Managed: &provider.ManagedAPIKey{},
+					KeyFormat: &provider.KeyFormat{
+						Pattern: regexp.MustCompile(`^k-.+$`),
+						Example: "k-…",
+					},
+				},
+				want: "no customer-supplied key to shape",
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				err := provider.NewRegistry().Register(&provider.Registration{
+					Provider:    coredata.ConnectorProviderSlack,
+					DisplayName: "Slack",
+					APIKey:      tc.apiKey,
 				})
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.want)

--- a/pkg/connector/provider/types.go
+++ b/pkg/connector/provider/types.go
@@ -23,6 +23,7 @@ package provider
 import (
 	"context"
 	"net/http"
+	"regexp"
 
 	"go.gearno.de/kit/log"
 
@@ -247,6 +248,37 @@ type APIKeyConfig struct {
 	// Orthogonal to Auth, which still selects how the injected key goes on the
 	// wire.
 	Managed *ManagedAPIKey
+
+	// KeyFormat is the shape a customer-pasted key must have. Nil for a
+	// provider whose keys have no shape worth asserting — an opaque token is
+	// the common case, and a guess at its format would reject valid keys the
+	// day the provider mints a new one.
+	KeyFormat *KeyFormat
+}
+
+// KeyFormat is a paste check, not an authenticity check: it catches a
+// half-copied credential or a missing separator, never a key that is
+// well-formed and wrong. It is data rather than a closure because both sides of
+// the API evaluate it.
+type KeyFormat struct {
+	// Pattern asserts the prefix and the separator, and nothing else. It must
+	// not constrain the length or the alphabet of the random part: a provider
+	// that changes those would otherwise lock out customers holding valid
+	// keys, with no way around it.
+	//
+	// The console compiles this same source as a JavaScript RegExp. The two
+	// dialects only overlap, so keep to what both read the same way — literals,
+	// character classes, quantifiers, anchors, alternation and (?:. A pattern
+	// the browser will not compile costs the client-side check and nothing
+	// more: the server applies the rule either way.
+	Pattern *regexp.Regexp
+
+	// Example is the shape shown to the customer, as the field's placeholder
+	// and in the rejection message. Register enforces that it matches Pattern,
+	// so the two cannot drift into telling the customer to paste something the
+	// check refuses. It stands in for the pattern, which is unreadable to the
+	// people who need to act on it, so it carries no real key material.
+	Example string
 }
 
 // ManagedAPIKey is the Probo-held variant of the API-key path. Nesting it under

--- a/pkg/connector/provider/types.go
+++ b/pkg/connector/provider/types.go
@@ -152,6 +152,16 @@ type Registration struct {
 	// ProbeURL and BuildProbeURL when set. It receives the registration's
 	// resolved Endpoints for the same reason BuildProbeURL does.
 	Probe func(context.Context, *http.Client, *coredata.Connector, Endpoints) error
+	// ClassifyRejection refines a 403 by reading the provider's own
+	// explanation of it: it reports whether the provider accepted the
+	// credential and refused the operation (true, the customer fixes the plan
+	// or the permissions) or refused the credential itself (false, the
+	// customer fixes the key). Nil for a provider that does not explain
+	// itself, which leaves 403 meaning refused-operation.
+	//
+	// It receives the response body and must map it onto that one bit:
+	// provider text is never carried any further than this closure.
+	ClassifyRejection func(body []byte) bool
 
 	// Factory closures — wired by Stages 2 and 3.
 	// NewDriver and NewNameResolver receive the registration's resolved

--- a/pkg/server/api/console/v1/access_review_campaign_resolvers.go
+++ b/pkg/server/api/console/v1/access_review_campaign_resolvers.go
@@ -583,6 +583,8 @@ func (r *accessReviewSourceResolver) ConnectionStatus(ctx context.Context, obj *
 		return types.AccessReviewSourceConnectionStatusConnected, nil
 	case types.ConnectorConnectionStatusReconnectRequired:
 		return types.AccessReviewSourceConnectionStatusReconnectRequired, nil
+	case types.ConnectorConnectionStatusNotAuthorized:
+		return types.AccessReviewSourceConnectionStatusNotAuthorized, nil
 	default:
 		return types.AccessReviewSourceConnectionStatusDisconnected, nil
 	}

--- a/pkg/server/api/console/v1/base_resolvers.go
+++ b/pkg/server/api/console/v1/base_resolvers.go
@@ -739,6 +739,7 @@ func (r *queryResolver) AccessReviewDrivers(ctx context.Context) ([]*types.Conne
 			ClientCredentialsSupported:     clientCredentialsSupported,
 			Oauth2Scopes:                   scopes,
 			APIKeyExtraSettings:            connectorProviderSettingInfos(reg.APIKeyExtraSettings()),
+			APIKeyFormat:                   connectorAPIKeyFormat(reg),
 			ClientCredentialsExtraSettings: connectorProviderSettingInfos(reg.ClientCredentialsExtraSettings()),
 			WorkloadIdentitySupported:      workloadIdentityReady,
 			WorkloadIdentityExtraSettings:  connectorProviderSettingInfos(reg.WorkloadIdentityExtraSettings()),

--- a/pkg/server/api/console/v1/connector_connection_status.go
+++ b/pkg/server/api/console/v1/connector_connection_status.go
@@ -55,16 +55,26 @@ func (r *Resolver) connectorConnectionStatus(
 		field := log.String("connector_id", connectorID.String())
 
 		if probeErr, ok := errors.AsType[*accessreview.ProbeError](err); ok && probeErr != nil {
-			// Not Probo's failure, so not in the error budget.
+			// The provider took the credential and refused the operation: the
+			// customer has a plan or a role to fix, not a key to re-paste.
+			status := types.ConnectorConnectionStatusDisconnected
+			if accessreview.IsProbeOperationRefused(err) {
+				status = types.ConnectorConnectionStatusNotAuthorized
+			}
+
+			// Not Probo's failure, so not in the error budget. The status is
+			// logged rather than spelled into the message, which would then
+			// have to agree with what is returned below.
 			r.logger.WarnCtx(
 				ctx,
-				"connector credential probe failed, reporting disconnected",
+				"connector credential probe failed",
 				field,
 				log.String("provider", probeErr.Provider.String()),
 				log.String("probe_failure", accessreview.ProbeFailureCode(err)),
+				log.String("connection_status", string(status)),
 			)
 
-			return types.ConnectorConnectionStatusDisconnected, nil
+			return status, nil
 		}
 
 		// A database read, a decrypt, a deployment without identity

--- a/pkg/server/api/console/v1/connector_provider_info.go
+++ b/pkg/server/api/console/v1/connector_provider_info.go
@@ -46,6 +46,20 @@ func connectorProviderSettingInfos(settings []provider.ExtraSetting) []*types.Co
 	return out
 }
 
+// connectorAPIKeyFormat surfaces the shape a provider expects a pasted key to
+// have, so the connect form can check it as the customer leaves the field and
+// show it as the field's placeholder. Nil for a provider that declares none.
+func connectorAPIKeyFormat(reg *provider.Registration) *types.ConnectorAPIKeyFormat {
+	if reg.APIKey == nil || reg.APIKey.KeyFormat == nil {
+		return nil
+	}
+
+	return &types.ConnectorAPIKeyFormat{
+		Pattern: reg.APIKey.KeyFormat.Pattern.String(),
+		Example: reg.APIKey.KeyFormat.Example,
+	}
+}
+
 func connectorProtocols(protocols []connector.ProtocolType) []coredata.ConnectorProtocol {
 	out := make([]coredata.ConnectorProtocol, 0, len(protocols))
 	for _, protocol := range protocols {

--- a/pkg/server/api/console/v1/connector_resolvers.go
+++ b/pkg/server/api/console/v1/connector_resolvers.go
@@ -67,6 +67,25 @@ func (r *connectorResolver) ConnectionStatus(ctx context.Context, obj *types.Con
 	return status, nil
 }
 
+// DisplayName is the resolver for the displayName field.
+func (r *connectorResolver) DisplayName(ctx context.Context, obj *types.Connector) (string, error) {
+	return r.providerRegistry.ProviderDisplayName(obj.Provider), nil
+}
+
+// DocumentationURL is the resolver for the documentationUrl field.
+//
+// The same page ConnectorProviderInfo advertises before connecting, repeated
+// on the connector so a source whose connection went wrong can point at the
+// prerequisites — plan, role, key kind — that explain why.
+func (r *connectorResolver) DocumentationURL(ctx context.Context, obj *types.Connector) (*string, error) {
+	reg, ok := r.providerRegistry.Get(obj.Provider)
+	if !ok || reg.DocumentationURL == "" {
+		return nil, nil
+	}
+
+	return new(reg.DocumentationURL), nil
+}
+
 // CreateAPIKeyConnector is the resolver for the createAPIKeyConnector field.
 func (r *mutationResolver) CreateAPIKeyConnector(ctx context.Context, input types.CreateAPIKeyConnectorInput) (*types.CreateAPIKeyConnectorPayload, error) {
 	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionConnectorCreate)

--- a/pkg/server/api/console/v1/connector_settings.go
+++ b/pkg/server/api/console/v1/connector_settings.go
@@ -59,11 +59,21 @@ func (r *Resolver) resolveAPIKeyConnectorCredential(provider coredata.ConnectorP
 		return "", nil
 	}
 
-	if clientKey == nil || *clientKey == "" {
+	if clientKey == nil || strings.TrimSpace(*clientKey) == "" {
 		return "", fmt.Errorf("apiKey is required")
 	}
 
-	return *clientKey, nil
+	// A key is copied out of a provider's UI, so it arrives with whatever the
+	// clipboard picked up. Several transports encode the credential verbatim,
+	// where a trailing newline is an authentication failure the customer has
+	// no way to see.
+	key := strings.TrimSpace(*clientKey)
+
+	if err := r.providerRegistry.ValidateAPIKey(provider, key); err != nil {
+		return "", err
+	}
+
+	return key, nil
 }
 
 // newAPIKeyConnection builds an API-key connection for provider, filling the auth

--- a/pkg/server/api/console/v1/crisp_test.go
+++ b/pkg/server/api/console/v1/crisp_test.go
@@ -234,6 +234,41 @@ func TestResolveAPIKeyConnectorCredential(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "customer-key", key)
 	})
+
+	// A key is copied out of a provider's UI, so it arrives with whatever the
+	// clipboard picked up. The trim is what catches that, and only the trim:
+	// a shape pattern cannot, because [^:] matches a newline and Go's $ is
+	// end-of-text, so "pk-lf-a:sk-lf-b\n" satisfies Langfuse's own pattern.
+	t.Run("surrounding whitespace is trimmed off the key", func(t *testing.T) {
+		t.Parallel()
+
+		pasted := " pk-lf-1111:sk-lf-2222\n"
+
+		key, err := configured.resolveAPIKeyConnectorCredential(coredata.ConnectorProviderLangfuse, &pasted)
+		require.NoError(t, err)
+		assert.Equal(t, "pk-lf-1111:sk-lf-2222", key)
+	})
+
+	t.Run("a key of only whitespace is no key", func(t *testing.T) {
+		t.Parallel()
+
+		blank := "   "
+
+		_, err := configured.resolveAPIKeyConnectorCredential(coredata.ConnectorProviderLangfuse, &blank)
+		require.EqualError(t, err, "apiKey is required")
+	})
+
+	// The trim runs before the shape check, which is what lets a pasted key
+	// with a trailing newline reach the provider at all.
+	t.Run("a key of the wrong shape is refused", func(t *testing.T) {
+		t.Parallel()
+
+		half := " pk-lf-1111\n"
+
+		_, err := configured.resolveAPIKeyConnectorCredential(coredata.ConnectorProviderLangfuse, &half)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pk-lf-…:sk-lf-…")
+	})
 }
 
 // verifyCrispOwnershipWith is the #1b create-time ownership gate. This pins its

--- a/pkg/server/api/console/v1/graphql/access_review_campaign.graphql
+++ b/pkg/server/api/console/v1/graphql/access_review_campaign.graphql
@@ -239,6 +239,11 @@ input AccessReviewCampaignSourceFetchAttemptOrder {
 enum AccessReviewSourceConnectionStatus {
     CONNECTED
     DISCONNECTED
+    """
+    NOT_AUTHORIZED mirrors ConnectorConnectionStatus.NOT_AUTHORIZED: the
+    provider accepted the credential and refused the operation anyway.
+    """
+    NOT_AUTHORIZED
     RECONNECT_REQUIRED
     NOT_APPLICABLE
 }

--- a/pkg/server/api/console/v1/graphql/connector.graphql
+++ b/pkg/server/api/console/v1/graphql/connector.graphql
@@ -181,6 +181,14 @@ type ConnectorProviderInfo {
     """
     apiKeyExtraSettings: [ConnectorProviderSettingInfo!]!
     """
+    apiKeyFormat is the shape a pasted API key must have, for the connect form
+    to check as the customer leaves the field and to show as its placeholder.
+    Null when the provider's keys have no shape worth asserting, which is the
+    common case. The create mutation applies the same rule, so a client that
+    skips this check is refused rather than trusted.
+    """
+    apiKeyFormat: ConnectorAPIKeyFormat
+    """
     clientCredentialsExtraSettings lists the settings the client-credentials
     connect form must render and submit. A provider offering both paths
     (1Password) returns different fields here than in apiKeyExtraSettings,
@@ -215,6 +223,27 @@ type ConnectorProviderSettingInfo {
     key: String!
     label: String!
     required: Boolean!
+}
+
+"""
+The shape of a pasted API key. It catches a half-copied credential, never a
+well-formed key that is simply the wrong one — only the provider can answer
+that, which is what connectionStatus is for.
+"""
+type ConnectorAPIKeyFormat {
+    """
+    pattern is an RE2 regular expression asserting the key's prefix and
+    separator, and deliberately nothing about the random part. It is written to
+    the subset RE2 and JavaScript read alike; a client that cannot compile it
+    should skip its own check rather than reject the key, since the server
+    applies the same rule on create.
+    """
+    pattern: String!
+    """
+    example is the shape to show the customer — as the field's placeholder and
+    in the rejection message. It matches pattern, and carries no real key.
+    """
+    example: String!
 }
 
 input ConnectorFilter {

--- a/pkg/server/api/console/v1/graphql/connector.graphql
+++ b/pkg/server/api/console/v1/graphql/connector.graphql
@@ -224,13 +224,22 @@ input ConnectorFilter {
 """
 Why a connector's credential is or is not usable right now.
 
-DISCONNECTED covers every reason the credential did not work — revoked,
-expired, a role Probo cannot assume, a provider outage — because the
-underlying failure wraps provider-controlled text and stays server-side.
+DISCONNECTED covers every reason the credential itself did not work —
+revoked, expired, a role Probo cannot assume, a provider outage — because
+the underlying failure wraps provider-controlled text and stays
+server-side. A credential the provider took before refusing the operation
+is NOT_AUTHORIZED instead: a different thing for the customer to fix.
 """
 enum ConnectorConnectionStatus {
     CONNECTED
     DISCONNECTED
+    """
+    NOT_AUTHORIZED means the provider accepted the credential and refused the
+    operation anyway — a plan that excludes the endpoint, a role without the
+    permission. Supplying another credential does not fix it, so it is kept
+    apart from DISCONNECTED.
+    """
+    NOT_AUTHORIZED
     RECONNECT_REQUIRED
 }
 
@@ -246,6 +255,16 @@ type Connector {
     it on a single connector, or on the one a mutation just returned.
     """
     connectionStatus: ConnectorConnectionStatus! @goField(forceResolver: true)
+    """
+    displayName is the provider's own name as it should be shown to a user
+    ("Google Workspace", not GOOGLE_WORKSPACE).
+    """
+    displayName: String! @goField(forceResolver: true)
+    """
+    documentationUrl is the public probo.com docs page for connecting this
+    provider as an access source, or null when no doc page exists yet.
+    """
+    documentationUrl: String @goField(forceResolver: true)
     createdAt: Datetime!
 }
 

--- a/pkg/server/api/mcp/v1/connector_connection_status.go
+++ b/pkg/server/api/mcp/v1/connector_connection_status.go
@@ -36,9 +36,11 @@ import (
 // scopes against the current registration.
 //
 // MCP has no lazy field resolution, so this runs eagerly wherever a Connector
-// is built. Every failure collapses to DISCONNECTED: the underlying error
-// wraps provider-controlled text and customer-chosen hosts, and stays in the
-// logs rather than travelling to the client.
+// is built. A provider that accepted the credential and refused the operation
+// reports NOT_AUTHORIZED; every other failure collapses to DISCONNECTED,
+// because the underlying error wraps provider-controlled text and
+// customer-chosen hosts, and stays in the logs rather than travelling to the
+// client.
 func (r *Resolver) connectorConnectionStatus(
 	ctx context.Context,
 	scope coredata.Scoper,
@@ -48,16 +50,22 @@ func (r *Resolver) connectorConnectionStatus(
 		field := log.String("connector_id", connectorID.String())
 
 		if probeErr, ok := errors.AsType[*accessreview.ProbeError](err); ok && probeErr != nil {
+			status := types.ConnectorConnectionStatusDISCONNECTED
+			if accessreview.IsProbeOperationRefused(err) {
+				status = types.ConnectorConnectionStatusNOTAUTHORIZED
+			}
+
 			// Not Probo's failure, so not in the error budget.
 			r.logger.WarnCtx(
 				ctx,
-				"connector credential probe failed, reporting disconnected",
+				"connector credential probe failed",
 				field,
 				log.String("provider", probeErr.Provider.String()),
 				log.String("probe_failure", accessreview.ProbeFailureCode(err)),
+				log.String("connection_status", string(status)),
 			)
 
-			return types.ConnectorConnectionStatusDISCONNECTED
+			return status
 		}
 
 		r.logger.ErrorCtx(

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -10043,10 +10043,14 @@ components:
         - CONNECTED
         - DISCONNECTED
         - RECONNECT_REQUIRED
+        - NOT_AUTHORIZED
       description: >-
-        Whether the connector credential is usable right now. DISCONNECTED
-        covers every reason it did not work, because the underlying failure
-        wraps provider-controlled text and stays server-side.
+        Whether the connector credential is usable right now. NOT_AUTHORIZED
+        means the provider accepted the credential and refused the operation,
+        which the customer fixes on their plan or their roles rather than by
+        supplying another credential. DISCONNECTED covers every other reason it
+        did not work, because the underlying failure wraps provider-controlled
+        text and stays server-side.
 
     Connector:
       type: object


### PR DESCRIPTION
Connecting Langfuse as an access-review source could report invalid credentials
when the credentials were perfectly valid.

Langfuse's organization memberships endpoint has three rejection branches, in
this source order: a dead key answers **401**; a project-scoped key answers
**403** with `Invalid API key. Organization-scoped API key required for this
operation.`; and a plan without the `admin-api` entitlement answers **403** with
`This feature is not available on your current plan.` Probo folded 401 and 403
into one bodyless verdict and dropped the response body, so all three rendered
as *"LANGFUSE credentials are invalid — Probo cannot access organizations with
the current credentials"*: the org-picker's wording on a provider that has no
picker, naming the raw enum. Google Workspace, Vercel, OpenAI and Metabase all
answer 403 for a permission the credential cannot supply either, and said the
same thing.

## Tell a refused operation from a refused credential

`CredentialRejectedError` now carries which of the two it is — 401 is the
credential, 403 is the authorization — built through one constructor so the
rule lives in a single place, and a registration may supply
`ClassifyRejection(body []byte) bool` to correct that reading from the
provider's own explanation. The body is read bounded, kept unexported, and
dropped before the error leaves the probe, so provider text never reaches a log
or a client. Langfuse uses it to send its wrong-key-scope 403 back to the
credential side.

The verdict travels to the console and MCP as `NOT_AUTHORIZED`, rendered as a
refused request pointing at the plan and the permissions, with a link to the
provider's setup guide. The source row also takes the provider name from the
registry rather than an eleven-case switch, which is what put `LANGFUSE` on
screen; every entry in it was byte-identical to the registry's own name, so the
switch and its thirty locale keys are gone.

## Check the shape of a pasted API key

Nothing checked what arrived in the API key field. Half a credential, the two
halves in the wrong order, or a trailing newline from the clipboard were all
stored and sent, and the provider's 401 was indistinguishable from a revoked
key. Langfuse is the sharp case: its two keys are pasted as one colon-joined
string that the Basic transport base64s verbatim.

A provider may now declare that shape as a pattern and an example — data, not a
closure, because both sides of the API need it. The connect dialog checks it as
the field loses focus and shows the example as the placeholder; the create
resolver checks it again, because a client-side check saves a round trip but can
never be the gate. The resolver also trims the pasted key, which the pattern
cannot substitute for: `[^:]` matches a newline and Go's `$` is end-of-text, so
a trailing newline satisfies the pattern and only the trim removes it.
`Register` refuses a shape on a key Probo supplies itself, and an example its
own pattern would reject.

The pattern asserts the prefix and the separator and nothing else: constraining
the random part would reject valid keys the day a provider mints a new format.
For the same reason only Langfuse declares one.

It stays a paste check. Langfuse mints organization-scoped and project-scoped
keys as `pk-lf-<uuid>:sk-lf-<uuid>` alike and records the scope in its own
database, so no inspection of the string can tell them apart — the connection
check remains the only thing that can. Two test cases are named for that.

## Notes for review

- Every provider answering 403 now reports `NOT_AUTHORIZED` rather than
  `DISCONNECTED`. The four that do so in practice are genuine authorization
  refusals (an admin scope, a team role, an admin key, an admin session). The
  copy does not claim a new credential cannot help, since for an API-key
  provider minting one with the permission is exactly the fix, and it names no
  cause narrower than 403 itself — most probes are whoami endpoints, and a
  self-hosted instance has no plan. The Reconnect button is kept for a
  reconnectable connector, because re-consenting as an administrator is how an
  OAuth 403 gets resolved.
- The console reads connection status by what a healthy source is, not by
  listing the ways it can break, so a status added to the enum later warns
  instead of silently rendering nothing.
- MCP's `Connector` did not get `displayName`/`documentationUrl`: the status is
  synced across all surfaces, but those two are console presentation and would
  need the provider registry injected into the MCP resolver for a single
  AWS-only output. Happy to add it if that reads as drift.

Separately worth a ticket, both untouched here: a wrong Langfuse base URL
returns 404 with an HTML body, which the probe only rejects on 2xx, so it
reports CONNECTED and fails later in the sync worker; and `prb access-review
source probe` with its n8n counterpart send a `probeConnector` mutation that
does not exist in the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018a6yiyvNDjyB81MiUnmp2x
