### PR TITLE
Bump stream-json for a security fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20589,20 +20589,29 @@
       }
     },
     "node_modules/stream-chain": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
-      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-4.2.5.tgz",
+      "integrity": "sha512-Wtyq3bNE3ggLR0v2vftqvuhltym3WbZAkZpfIrkr5F/6vpeUmWmwTgXa16zD87gpahwJ/Qulq3zVfUlgIc0J2A==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
+      }
     },
     "node_modules/stream-json": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
-      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-3.6.0.tgz",
+      "integrity": "sha512-NiJdqxKyau579z/E8vfqcjWfSDWxW/AT99javFXdPXF147Z5za85LRXSHEmSX9TKOakB7gaIccfD0fOIctb7KQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "stream-chain": "^2.2.5"
+        "stream-chain": "^4.2.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
       }
     },
     "node_modules/strictdom": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "nanoid": "^3.3.18",
     "qs": "^6.16.0",
     "rimraf": "^6.1.3",
+    "stream-json": "^3.6.0",
     "typescript": "npm:@typescript/typescript6@~6.0.2"
   },
   "allowScripts": {


### PR DESCRIPTION
Force a patched resolution of the transitive n8n
dependency. stream-json 3.6.0 fixes the O(depth²)
path-filter DoS (GHSA-528h-pc64-c93x / CVE-2026-71429).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force a patched resolution of the transitive n8n dependency. `stream-json` 3.6.0 fixes the O(depth²) path-filter DoS (GHSA-528h-pc64-c93x / CVE-2026-71429).

### Other **`+18`** **`-8`**

- Adds `stream-json` as a direct dependency to pin the patched version.
- Bumps transitive `stream-chain` to 4.2.5, which now requires Node >= 22.

<sup>Written for commit 466c07b8cafd06dd28100aa94de621967c21b1c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

