### PR TITLE
Check a pasted key against its provider's prefix

### DIFF
--- a/e2e/console/access_review_test.go
+++ b/e2e/console/access_review_test.go
@@ -1665,8 +1665,8 @@ func TestAccessReviewSource_MultipleConnectionsPerProvider(t *testing.T) {
 		return ids
 	}
 
-	firstConnector := createConnector("test-key-brex-a")
-	secondConnector := createConnector("test-key-brex-b")
+	firstConnector := createConnector("bxt_test-key-brex-a")
+	secondConnector := createConnector("bxt_test-key-brex-b")
 	require.NotEqual(t, firstConnector, secondConnector)
 
 	firstSource, firstCreated := createSource("Brex A", firstConnector)
@@ -1740,7 +1740,7 @@ func TestAccessReviewSource_MultipleConnectionsPerProvider(t *testing.T) {
 
 	// Relinking a source to a fresh connector deletes the abandoned one:
 	// the relink removed its only owner.
-	thirdConnector := createConnector("test-key-brex-c")
+	thirdConnector := createConnector("bxt_test-key-brex-c")
 
 	err = owner.Execute(updateQuery, map[string]any{
 		"input": map[string]any{

--- a/e2e/console/connector_rbac_test.go
+++ b/e2e/console/connector_rbac_test.go
@@ -44,7 +44,7 @@ func TestCreateAPIKeyConnector_RBAC(t *testing.T) {
 			"input": map[string]any{
 				"organizationId": viewer.GetOrganizationID().String(),
 				"provider":       "BREX",
-				"apiKey":         "test-key",
+				"apiKey":         "bxt_test-key",
 			},
 		})
 		testutil.RequireForbiddenError(t, err, "viewer should not be able to create connector")

--- a/e2e/console/connector_test.go
+++ b/e2e/console/connector_test.go
@@ -190,9 +190,10 @@ func TestAccessReviewDrivers(t *testing.T) {
 	assert.Nil(t, docURLByProvider["SENTRY"], "SENTRY has no doc page, documentationUrl must be null")
 
 	// apiKeyFormat is what the connect dialog checks the pasted key against and
-	// shows as its placeholder, so it has to reach the client. Langfuse is the
-	// only provider declaring one; Sentry carries the null case, on the same
-	// Contains-first reasoning as the doc URL above.
+	// shows as its placeholder, so it has to reach the client. Langfuse pins
+	// that projection; the per-provider shapes belong to the registry's own
+	// tests. Sentry carries the null case, on the same Contains-first reasoning
+	// as the doc URL above.
 	require.Contains(t, keyFormatByProvider, "LANGFUSE")
 
 	if format := keyFormatByProvider["LANGFUSE"]; assert.NotNil(t, format) {
@@ -256,7 +257,7 @@ func TestCreateAPIKeyConnector(t *testing.T) {
 		"input": map[string]any{
 			"organizationId": orgID,
 			"provider":       "BREX",
-			"apiKey":         "test-key-123",
+			"apiKey":         "bxt_test-key-123",
 		},
 	}, &result)
 	require.NoError(t, err)
@@ -481,7 +482,7 @@ func TestDeleteConnector(t *testing.T) {
 		"input": map[string]any{
 			"organizationId": orgID,
 			"provider":       "BREX",
-			"apiKey":         "key-to-delete",
+			"apiKey":         "bxt_key-to-delete",
 		},
 	}, &createResult)
 	require.NoError(t, err)

--- a/e2e/console/scim_test.go
+++ b/e2e/console/scim_test.go
@@ -382,7 +382,7 @@ func TestSCIMConfiguration_RefusesSourceHeldConnector(t *testing.T) {
 		"input": map[string]any{
 			"organizationId": orgID,
 			"provider":       "BREX",
-			"apiKey":         "test-key-brex-scim-refusal",
+			"apiKey":         "bxt_test-key-brex-scim-refusal",
 		},
 	}, &connectorResult)
 	require.NoError(t, err)

--- a/pkg/connector/provider/anthropic.go
+++ b/pkg/connector/provider/anthropic.go
@@ -35,7 +35,8 @@ func anthropicRegistration() *Registration {
 		DisplayName:      "Anthropic",
 		DocumentationURL: accessReviewDocsURL("anthropic"),
 		APIKey: &APIKeyConfig{
-			Auth: APIKeyAuth{Mode: APIKeyAuthHeader, Name: "x-api-key"},
+			Auth:      APIKeyAuth{Mode: APIKeyAuthHeader, Name: "x-api-key"},
+			KeyFormat: apiKeyPrefix("sk-ant-", "sk-ant-…"),
 		},
 		Endpoints: Endpoints{
 			// Every Admin API endpoint the driver calls shares the /v1
@@ -47,7 +48,10 @@ func anthropicRegistration() *Registration {
 		// 400 when both headers are present. APIKeyHeader makes the
 		// APIKeyConnection send x-api-key instead of Bearer. There is no
 		// third-party OAuth2 flow for the Admin API, so this is API-key
-		// only and takes a single admin key (sk-ant-admin...) per org.
+		// only and takes a single key per org: an Admin API key
+		// (sk-ant-admin...), or a personal or service account key scoped to
+		// no workspace, both of which Anthropic documents as reaching the
+		// member endpoints.
 		Probe: probeAnthropic,
 		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
 			return drivers.NewAnthropicDriver(c, ep.APIBase), nil

--- a/pkg/connector/provider/brevo.go
+++ b/pkg/connector/provider/brevo.go
@@ -35,7 +35,8 @@ func brevoRegistration() *Registration {
 		DisplayName:      "Brevo",
 		DocumentationURL: accessReviewDocsURL("brevo"),
 		APIKey: &APIKeyConfig{
-			Auth: APIKeyAuth{Mode: APIKeyAuthHeader, Name: "api-key"},
+			Auth:      APIKeyAuth{Mode: APIKeyAuthHeader, Name: "api-key"},
+			KeyFormat: apiKeyPrefix("xkeysib-", "xkeysib-…"),
 		},
 		// Brevo authenticates with an API key sent in the api-key header
 		// rather than Authorization: Bearer. APIKeyHeader makes the

--- a/pkg/connector/provider/brex.go
+++ b/pkg/connector/provider/brex.go
@@ -49,7 +49,9 @@ func brexRegistration() *Registration {
 		OAuth2: &OAuth2Config{
 			Scopes: []string{"openid", "offline_access", "users.readonly", "companies.readonly"},
 		},
-		APIKey: &APIKeyConfig{},
+		APIKey: &APIKeyConfig{
+			KeyFormat: apiKeyPrefix("bxt_", "bxt_…"),
+		},
 		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
 			return drivers.NewBrexDriver(c, ep.APIBase), nil
 		},

--- a/pkg/connector/provider/calcom.go
+++ b/pkg/connector/provider/calcom.go
@@ -34,7 +34,9 @@ func calComRegistration() *Registration {
 		Provider:         coredata.ConnectorProviderCalCom,
 		DisplayName:      "Cal.com",
 		DocumentationURL: accessReviewDocsURL("calcom"),
-		APIKey:           &APIKeyConfig{},
+		APIKey: &APIKeyConfig{
+			KeyFormat: apiKeyPrefix("cal_", "cal_live_…"),
+		},
 		Endpoints: Endpoints{
 			Auth:    "https://app.cal.com/auth/oauth2/authorize",
 			Token:   "https://api.cal.com/v2/auth/oauth2/token",

--- a/pkg/connector/provider/clickhouse.go
+++ b/pkg/connector/provider/clickhouse.go
@@ -23,11 +23,18 @@ package provider
 import (
 	"context"
 	"net/http"
+	"regexp"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/accessreview/drivers"
 	"go.probo.inc/probo/pkg/coredata"
 )
+
+// clickhouseKeyPattern asserts the separator and nothing else: neither half
+// carries a prefix, so what the check can catch is a customer who pasted the
+// key ID or the secret on its own, which the Basic transport would encode as a
+// credential with no password and no way to tell from a dead key.
+var clickhouseKeyPattern = regexp.MustCompile(`^[^:]+:[\s\S]`)
 
 func clickhouseRegistration() *Registration {
 	return &Registration{
@@ -36,6 +43,10 @@ func clickhouseRegistration() *Registration {
 		DocumentationURL: accessReviewDocsURL("clickhouse"),
 		APIKey: &APIKeyConfig{
 			Auth: APIKeyAuth{Mode: APIKeyAuthBasicUserPass},
+			KeyFormat: &KeyFormat{
+				Pattern: clickhouseKeyPattern,
+				Example: "keyId:keySecret",
+			},
 		},
 		// ClickHouse Cloud's control-plane API authenticates with HTTP Basic
 		// auth where the credential is keyId:keySecret. APIKeyBasicAuthUserPass

--- a/pkg/connector/provider/dotfile.go
+++ b/pkg/connector/provider/dotfile.go
@@ -36,7 +36,8 @@ func dotfileRegistration() *Registration {
 		DisplayName:      "Dotfile",
 		DocumentationURL: accessReviewDocsURL("dotfile"),
 		APIKey: &APIKeyConfig{
-			Auth: APIKeyAuth{Mode: APIKeyAuthHeader, Name: "X-DOTFILE-API-KEY"},
+			Auth:      APIKeyAuth{Mode: APIKeyAuthHeader, Name: "X-DOTFILE-API-KEY"},
+			KeyFormat: apiKeyPrefix("dotkey.", "dotkey.…"),
 		},
 		// Dotfile authenticates with the API key in the X-DOTFILE-API-KEY
 		// header rather than Authorization: Bearer. APIKeyHeader makes the

--- a/pkg/connector/provider/key_format_test.go
+++ b/pkg/connector/provider/key_format_test.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/connector/provider"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+// keyTail stands in for the random part of a key: long, mixed case, and using
+// every separator providers put in one. A pattern that rejects it is asserting
+// something about the random part, which is the way this check locks out a
+// customer holding a perfectly good key.
+const keyTail = "AbCdEf0123456789-_.+/=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func TestAPIKeyFormatInvariants(t *testing.T) {
+	t.Parallel()
+
+	r := provider.NewBuiltinRegistry()
+
+	for _, reg := range r.All() {
+		if reg.APIKey == nil || reg.APIKey.KeyFormat == nil {
+			continue
+		}
+
+		t.Run(string(reg.Provider), func(t *testing.T) {
+			t.Parallel()
+
+			format := reg.APIKey.KeyFormat
+
+			// Register already refuses an example its own pattern rejects.
+			// Asserting it through ValidateAPIKey covers the path the console
+			// actually takes, where the example is the placeholder.
+			assert.NoError(
+				t,
+				r.ValidateAPIKey(reg.Provider, format.Example),
+				"the example shown to the customer must pass its own check",
+			)
+
+			assert.Error(
+				t,
+				r.ValidateAPIKey(reg.Provider, ""),
+				"an empty field must not read as a well-formed key",
+			)
+		})
+	}
+}
+
+func TestAPIKeyFormatsAcceptAndReject(t *testing.T) {
+	t.Parallel()
+
+	// One row per provider that declares a shape. accepted holds a key whose
+	// random part is deliberately awkward, because the pattern must assert the
+	// prefix and the separator and nothing else. rejected holds the prefix on
+	// its own wherever the shape has one, which is a key the customer stopped
+	// copying too early, and what the provider's own documentation says cannot
+	// work here, so the check earns its keep by naming the problem at paste
+	// time instead of returning a generic 401 a campaign later.
+	cases := []struct {
+		provider coredata.ConnectorProvider
+		accepted []string
+		rejected []string
+	}{
+		{
+			provider: coredata.ConnectorProviderAnthropic,
+			// The Admin API takes an unscoped personal or service account
+			// key as well as an admin key, so sk-ant- is the whole of what
+			// every credential that can work here shares. The version
+			// segment sits outside the prefix either way.
+			accepted: []string{"sk-ant-admin01-" + keyTail, "sk-ant-admin99-" + keyTail, "sk-ant-api03-" + keyTail},
+			rejected: []string{"sk-ant-", "sk-admin-" + keyTail, keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderBrevo,
+			accepted: []string{"xkeysib-" + keyTail},
+			rejected: []string{"xkeysib-", keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderBrex,
+			accepted: []string{"bxt_" + keyTail},
+			rejected: []string{"bxt_", keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderCalCom,
+			// Live and test keys part company only after the prefix they
+			// share.
+			accepted: []string{"cal_live_" + keyTail, "cal_" + keyTail},
+			rejected: []string{"cal_", keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderClickHouse,
+			// Neither half carries a prefix, so the separator is all there is
+			// to assert; a secret holding a colon of its own still passes.
+			accepted: []string{"keyid:" + keyTail, "keyid:secret:with:colons", "keyid:sec\rret"},
+			rejected: []string{"keyid", keyTail, ":secret", "keyid:"},
+		},
+		{
+			provider: coredata.ConnectorProviderDotfile,
+			accepted: []string{"dotkey." + keyTail + "." + keyTail},
+			// The dot is a literal, not a wildcard.
+			rejected: []string{"dotkey.", "dotkeyx" + keyTail, keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderLangfuse,
+			// Langfuse mints organization and project keys with the same two
+			// prefixes, so both pairs are well formed here and only one of
+			// them can list an organization's members. The pattern must not
+			// pretend to know which; the probe finds out.
+			accepted: []string{"pk-lf-" + keyTail + ":sk-lf-" + keyTail, "pk-lf-1111:sk-lf-2222"},
+			rejected: []string{
+				"pk-lf-1111",
+				"sk-lf-2222",
+				"sk-lf-2222:pk-lf-1111",
+				"pk-lf-1111 sk-lf-2222",
+				"pk-lf-1111:",
+				":sk-lf-2222",
+				"pk-lf-:sk-lf-",
+				"pk-lf-1111:sk-lf-2222:extra",
+				"sk-ant-api03-abcdef",
+			},
+		},
+		{
+			provider: coredata.ConnectorProviderMetabase,
+			accepted: []string{"mb_" + keyTail},
+			rejected: []string{"mb_", keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderOpenAI,
+			accepted: []string{"sk-admin-" + keyTail},
+			// A project key cannot reach the organization endpoints.
+			rejected: []string{"sk-admin-", "sk-proj-" + keyTail, "sk-ant-admin01-" + keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderQovery,
+			// Both organization token classes ride the same Token scheme.
+			accepted: []string{"qov_" + keyTail, "sk-qov-01-" + keyTail},
+			// The Console's own credential is a JWT sent as Bearer.
+			rejected: []string{"qov_", "sk-qov-", "eyJhbGciOiJSUzI1NiJ9.e30.sig", keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderResend,
+			// apiKeyPrefix builds thirteen of these patterns the same way, so
+			// this one case pins the helper: what follows the prefix is not
+			// the check's business, line terminators included.
+			accepted: []string{"re_" + keyTail, "re_\r" + keyTail},
+			rejected: []string{"re_", keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderSendGrid,
+			accepted: []string{"SG." + keyTail},
+			// The dot is a literal, not a wildcard.
+			rejected: []string{"SG.", "SGx" + keyTail, keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderSupabase,
+			accepted: []string{"sbp_" + keyTail},
+			// Project keys authenticate one project, not the Management API.
+			rejected: []string{"sbp_", "sb_secret_" + keyTail, "sb_publishable_" + keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderTailscale,
+			accepted: []string{"tskey-api-" + keyTail},
+			// The other tskey- credentials onboard a device or need an OAuth
+			// exchange first.
+			rejected: []string{"tskey-api-", "tskey-auth-" + keyTail, "tskey-client-" + keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderTally,
+			accepted: []string{"tly-" + keyTail},
+			rejected: []string{"tly-", keyTail},
+		},
+		{
+			provider: coredata.ConnectorProviderUpCloud,
+			accepted: []string{"ucat_" + keyTail},
+			rejected: []string{"ucat_", keyTail},
+		},
+	}
+
+	r := provider.NewBuiltinRegistry()
+
+	covered := make(map[coredata.ConnectorProvider]bool, len(cases))
+	for _, tc := range cases {
+		covered[tc.provider] = true
+	}
+
+	// A pattern is a hard block on a paying customer's paste, so the next
+	// provider to declare one arrives here rather than shipping unexercised.
+	for _, reg := range r.All() {
+		if reg.APIKey != nil && reg.APIKey.KeyFormat != nil {
+			assert.True(t, covered[reg.Provider], "provider %s declares a key shape with no case here", reg.Provider)
+		}
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.provider), func(t *testing.T) {
+			t.Parallel()
+
+			// ValidateAPIKey passes anything for a provider that declares no
+			// shape, so a stale row here would sail through the accepted loop
+			// below rather than fail. Check the row is real first.
+			reg, ok := r.Get(tc.provider)
+			require.True(t, ok, "provider must be registered")
+			require.NotNil(t, reg.APIKey, "provider must offer the API-key path")
+			require.NotNil(t, reg.APIKey.KeyFormat, "provider must declare a key shape")
+
+			for _, key := range tc.accepted {
+				assert.NoError(t, r.ValidateAPIKey(tc.provider, key), "key %q must be accepted", key)
+			}
+
+			for _, key := range tc.rejected {
+				err := r.ValidateAPIKey(tc.provider, key)
+				if !assert.Error(t, err, "key %q must be rejected", key) {
+					continue
+				}
+
+				// The rejection has to say what to paste instead, and must
+				// never repeat the credential back: it travels to the console
+				// as a GraphQL error.
+				assert.Contains(t, err.Error(), reg.APIKey.KeyFormat.Example)
+
+				// A rejected key that is part of the example is no secret, and
+				// the message names the example on purpose.
+				if key != "" && !strings.Contains(reg.APIKey.KeyFormat.Example, key) {
+					assert.NotContains(t, err.Error(), key)
+				}
+			}
+		})
+	}
+}

--- a/pkg/connector/provider/langfuse_test.go
+++ b/pkg/connector/provider/langfuse_test.go
@@ -63,63 +63,6 @@ func TestLangfuseRegistrationMetadata(t *testing.T) {
 	assert.Equal(t, "pk-lf-…:sk-lf-…", reg.APIKey.KeyFormat.Example)
 }
 
-func TestLangfuseKeyFormat(t *testing.T) {
-	t.Parallel()
-
-	// The check exists to catch a credential that was pasted wrong, which is
-	// otherwise indistinguishable from a dead one: the transport base64s the
-	// value verbatim, so a missing half authenticates as nothing.
-	//
-	// What it must NOT do is claim to know the key's scope. Langfuse mints
-	// organization and project keys with the same prefixes, so the first two
-	// cases below are both well-formed and only one of them can list an
-	// organization's members. Only the provider can say which.
-	cases := []struct {
-		name string
-		key  string
-		want bool
-	}{
-		{name: "organization key pair", key: "pk-lf-1111:sk-lf-2222", want: true},
-		{name: "project key pair is well formed too", key: "pk-lf-3333:sk-lf-4444", want: true},
-		{name: "public key alone", key: "pk-lf-1111"},
-		{name: "secret key alone", key: "sk-lf-2222"},
-		{name: "halves pasted in the wrong order", key: "sk-lf-2222:pk-lf-1111"},
-		{name: "separated by something else", key: "pk-lf-1111 sk-lf-2222"},
-		{name: "missing the secret half", key: "pk-lf-1111:"},
-		{name: "missing the public half", key: ":sk-lf-2222"},
-		{name: "prefixes only", key: "pk-lf-:sk-lf-"},
-		{name: "a third colon", key: "pk-lf-1111:sk-lf-2222:extra"},
-		{name: "both pairs pasted at once", key: "pk-lf-1111:sk-lf-2222:pk-lf-3333:sk-lf-4444"},
-		{name: "some other provider's key", key: "sk-ant-api03-abcdef"},
-		{name: "empty", key: ""},
-	}
-
-	r := provider.NewBuiltinRegistry()
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			err := r.ValidateAPIKey(coredata.ConnectorProviderLangfuse, tc.key)
-
-			if tc.want {
-				require.NoError(t, err)
-
-				return
-			}
-
-			require.Error(t, err)
-			// The message reaches the customer, so it shows the shape it
-			// wanted and never what they pasted.
-			assert.Contains(t, err.Error(), "pk-lf-…:sk-lf-…")
-
-			if tc.key != "" {
-				assert.NotContains(t, err.Error(), tc.key)
-			}
-		})
-	}
-}
-
 // langfuseRoundTripFunc answers a probe with a canned response.
 type langfuseRoundTripFunc func(*http.Request) (*http.Response, error)
 

--- a/pkg/connector/provider/metabase.go
+++ b/pkg/connector/provider/metabase.go
@@ -42,6 +42,7 @@ func metabaseRegistration() *Registration {
 			ExtraSettings: []ExtraSetting{
 				{Key: "instanceUrl", Label: "Instance URL", Required: true},
 			},
+			KeyFormat: apiKeyPrefix("mb_", "mb_…"),
 		},
 		BuildProbeURL: buildMetabaseProbeURL,
 		NewDriver: func(_ context.Context, c *http.Client, conn *coredata.Connector, _ *log.Logger, _ Endpoints) (drivers.Driver, error) {

--- a/pkg/connector/provider/openai.go
+++ b/pkg/connector/provider/openai.go
@@ -38,7 +38,9 @@ func openaiRegistration() *Registration {
 			APIBase: "https://api.openai.com/v1",
 			Probe:   "https://api.openai.com/v1/organization/users?limit=1",
 		},
-		APIKey: &APIKeyConfig{},
+		APIKey: &APIKeyConfig{
+			KeyFormat: apiKeyPrefix("sk-admin-", "sk-admin-…"),
+		},
 		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
 			return drivers.NewOpenAIDriver(c, ep.APIBase), nil
 		},

--- a/pkg/connector/provider/qovery.go
+++ b/pkg/connector/provider/qovery.go
@@ -24,11 +24,17 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/accessreview/drivers"
 	"go.probo.inc/probo/pkg/coredata"
 )
+
+// qoveryKeyPattern covers both organization token classes, which ride the
+// same Token scheme: a regular API token and a policy token. What it turns
+// away is the Console's own JWT, which the API takes only as a Bearer.
+var qoveryKeyPattern = regexp.MustCompile(`^(?:qov_|sk-qov-)[\s\S]`)
 
 func qoveryRegistration() *Registration {
 	return &Registration{
@@ -39,6 +45,10 @@ func qoveryRegistration() *Registration {
 			Auth: APIKeyAuth{Mode: APIKeyAuthScheme, Name: "Token"},
 			ExtraSettings: []ExtraSetting{
 				{Key: "organizationId", Label: "Organization ID", Required: true},
+			},
+			KeyFormat: &KeyFormat{
+				Pattern: qoveryKeyPattern,
+				Example: "qov_… or sk-qov-…",
 			},
 		},
 		BuildProbeURL: buildQoveryProbeURL,

--- a/pkg/connector/provider/registry.go
+++ b/pkg/connector/provider/registry.go
@@ -114,8 +114,10 @@ func (r *Registry) Register(reg *Registration) error {
 	}
 
 	// A key format describes what the customer pastes, so a Probo-held key has
-	// nothing to describe, and an example that its own pattern rejects would
-	// tell the customer to paste what the check then refuses.
+	// nothing to describe; a pattern not written with a leading ^ would pass a
+	// key with anything in front of it, since ValidateAPIKey matches
+	// unanchored; and an example its own pattern rejects would tell the
+	// customer to paste what the check then refuses.
 	if reg.APIKey != nil && reg.APIKey.KeyFormat != nil {
 		if reg.IsManagedAPIKey() {
 			return fmt.Errorf("cannot register connector provider %q: a managed API key has no customer-supplied key to shape", reg.Provider)
@@ -124,6 +126,14 @@ func (r *Registry) Register(reg *Registration) error {
 		format := reg.APIKey.KeyFormat
 		if format.Pattern == nil || format.Example == "" {
 			return fmt.Errorf("cannot register connector provider %q: KeyFormat needs both a Pattern and an Example", reg.Provider)
+		}
+
+		// The pattern's source, not its language: an anchored pattern can
+		// still absorb what precedes it, as ClickHouse's separator-only shape
+		// does. What this catches is the omission that matters, and it rules
+		// out \A along with it, which the browser cannot read.
+		if !strings.HasPrefix(format.Pattern.String(), "^") {
+			return fmt.Errorf("cannot register connector provider %q: KeyFormat pattern must be written starting with ^", reg.Provider)
 		}
 
 		if !format.Pattern.MatchString(format.Example) {

--- a/pkg/connector/provider/registry_test.go
+++ b/pkg/connector/provider/registry_test.go
@@ -235,8 +235,8 @@ func TestRegistry_Register(t *testing.T) {
 	})
 
 	// A KeyFormat is a promise to the customer, shown as the field's
-	// placeholder and echoed in the rejection: Register refuses the two ways
-	// that promise can be a lie.
+	// placeholder and echoed in the rejection: Register refuses every way that
+	// promise can be a lie.
 	t.Run("KeyFormat rules", func(t *testing.T) {
 		t.Parallel()
 
@@ -252,6 +252,15 @@ func TestRegistry_Register(t *testing.T) {
 					},
 				},
 				want: "example does not match its own pattern",
+			},
+			"pattern not written with a leading caret": {
+				apiKey: &provider.APIKeyConfig{
+					KeyFormat: &provider.KeyFormat{
+						Pattern: regexp.MustCompile(`sk-admin-`),
+						Example: "sk-admin-…",
+					},
+				},
+				want: "must be written starting with ^",
 			},
 			"example missing": {
 				apiKey: &provider.APIKeyConfig{

--- a/pkg/connector/provider/resend.go
+++ b/pkg/connector/provider/resend.go
@@ -46,7 +46,9 @@ func resendRegistration() *Registration {
 			Token:   "https://api.resend.com/oauth/token",
 			Probe:   "https://api.resend.com/domains",
 		},
-		APIKey: &APIKeyConfig{},
+		APIKey: &APIKeyConfig{
+			KeyFormat: apiKeyPrefix("re_", "re_…"),
+		},
 		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
 			return drivers.NewResendDriver(c, ep.APIBase), nil
 		},

--- a/pkg/connector/provider/sendgrid.go
+++ b/pkg/connector/provider/sendgrid.go
@@ -38,7 +38,9 @@ func sendgridRegistration() *Registration {
 			Probe:   "https://api.sendgrid.com/v3/teammates?limit=1&offset=0",
 			APIBase: "https://api.sendgrid.com/v3",
 		},
-		APIKey: &APIKeyConfig{},
+		APIKey: &APIKeyConfig{
+			KeyFormat: apiKeyPrefix("SG.", "SG.…"),
+		},
 		NewDriver: func(_ context.Context, c *http.Client, _ *coredata.Connector, logger *log.Logger, ep Endpoints) (drivers.Driver, error) {
 			return drivers.NewSendGridDriver(c, logger.Named("sendgrid"), ep.APIBase), nil
 		},

--- a/pkg/connector/provider/supabase.go
+++ b/pkg/connector/provider/supabase.go
@@ -43,6 +43,7 @@ func supabaseRegistration() *Registration {
 			ExtraSettings: []ExtraSetting{
 				{Key: "organizationSlug", Label: "Organization Slug", Required: true},
 			},
+			KeyFormat: apiKeyPrefix("sbp_", "sbp_…"),
 		},
 		NewDriver: func(_ context.Context, c *http.Client, conn *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
 			s, err := coredata.ConnectorSettings[coredata.SupabaseConnectorSettings](conn)

--- a/pkg/connector/provider/tailscale.go
+++ b/pkg/connector/provider/tailscale.go
@@ -34,7 +34,9 @@ func tailscaleRegistration() *Registration {
 		Provider:         coredata.ConnectorProviderTailscale,
 		DisplayName:      "Tailscale",
 		DocumentationURL: accessReviewDocsURL("tailscale"),
-		APIKey:           &APIKeyConfig{},
+		APIKey: &APIKeyConfig{
+			KeyFormat: apiKeyPrefix("tskey-api-", "tskey-api-…"),
+		},
 		Endpoints: Endpoints{
 			Probe:   "https://api.tailscale.com/api/v2/tailnet/-/users",
 			APIBase: "https://api.tailscale.com/api/v2",

--- a/pkg/connector/provider/tally.go
+++ b/pkg/connector/provider/tally.go
@@ -41,7 +41,9 @@ func tallyRegistration() *Registration {
 			Probe:   "https://api.tally.so/users/me",
 			APIBase: "https://api.tally.so",
 		},
-		APIKey: &APIKeyConfig{},
+		APIKey: &APIKeyConfig{
+			KeyFormat: apiKeyPrefix("tly-", "tly-…"),
+		},
 		NewDriver: func(_ context.Context, c *http.Client, conn *coredata.Connector, _ *log.Logger, ep Endpoints) (drivers.Driver, error) {
 			s, err := coredata.ConnectorSettings[coredata.TallyConnectorSettings](conn)
 			if err != nil {

--- a/pkg/connector/provider/types.go
+++ b/pkg/connector/provider/types.go
@@ -256,10 +256,14 @@ type APIKeyConfig struct {
 	KeyFormat *KeyFormat
 }
 
-// KeyFormat is a paste check, not an authenticity check: it catches a
-// half-copied credential or a missing separator, never a key that is
-// well-formed and wrong. It is data rather than a closure because both sides of
-// the API evaluate it.
+// KeyFormat is the shape the customer has to paste: the prefix that marks the
+// one credential this connector can use, and the separator where the credential
+// joins two halves. So it catches a credential pasted wrong, and one of the
+// provider's other credential classes that could never have worked here. It
+// cannot catch a key of the right class that is dead, revoked or too narrowly
+// scoped, which is what the probe is for.
+//
+// It is data rather than a closure because both sides of the API evaluate it.
 type KeyFormat struct {
 	// Pattern asserts the prefix and the separator, and nothing else. It must
 	// not constrain the length or the alphabet of the random part: a provider
@@ -271,6 +275,9 @@ type KeyFormat struct {
 	// character classes, quantifiers, anchors, alternation and (?:. A pattern
 	// the browser will not compile costs the client-side check and nothing
 	// more: the server applies the rule either way.
+	//
+	// . is not one of them, since the two exclude different line terminators
+	// from it. Write [\s\S] where any character will do.
 	Pattern *regexp.Regexp
 
 	// Example is the shape shown to the customer, as the field's placeholder
@@ -279,6 +286,19 @@ type KeyFormat struct {
 	// check refuses. It stands in for the pattern, which is unreadable to the
 	// people who need to act on it, so it carries no real key material.
 	Example string
+}
+
+// apiKeyPrefix is the KeyFormat of a provider that mints every key with one
+// fixed prefix. It quotes and anchors the prefix and asks for one character
+// after it, so a registration cannot reach past the prefix into the random
+// part and a key copied no further than the prefix is not well formed. Stop
+// the prefix short of any version segment the provider can bump; Example still
+// shows the whole of today's shape.
+func apiKeyPrefix(prefix, example string) *KeyFormat {
+	return &KeyFormat{
+		Pattern: regexp.MustCompile("^" + regexp.QuoteMeta(prefix) + "[\\s\\S]"),
+		Example: example,
+	}
 }
 
 // ManagedAPIKey is the Probo-held variant of the API-key path. Nesting it under

--- a/pkg/connector/provider/upcloud.go
+++ b/pkg/connector/provider/upcloud.go
@@ -34,7 +34,9 @@ func upcloudRegistration() *Registration {
 		Provider:         coredata.ConnectorProviderUpCloud,
 		DisplayName:      "UpCloud",
 		DocumentationURL: accessReviewDocsURL("upcloud"),
-		APIKey:           &APIKeyConfig{},
+		APIKey: &APIKeyConfig{
+			KeyFormat: apiKeyPrefix("ucat_", "ucat_…"),
+		},
 		Endpoints: Endpoints{
 			// Every endpoint the driver calls lives under the same /1.3
 			// prefix, so the version segment stays in APIBase.

--- a/pkg/server/api/console/v1/crisp_test.go
+++ b/pkg/server/api/console/v1/crisp_test.go
@@ -217,20 +217,23 @@ func TestResolveAPIKeyConnectorCredential(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	// Sentry declares no key shape, so it is what exercises the pass-through
+	// branch: anything non-empty is the customer's to get wrong. Giving Sentry
+	// a shape one day fails these two, which is where to look.
 	t.Run("non-managed requires a key", func(t *testing.T) {
 		t.Parallel()
 
-		_, errNil := configured.resolveAPIKeyConnectorCredential(coredata.ConnectorProviderTally, nil)
+		_, errNil := configured.resolveAPIKeyConnectorCredential(coredata.ConnectorProviderSentry, nil)
 		require.EqualError(t, errNil, "apiKey is required")
 
-		_, errEmpty := configured.resolveAPIKeyConnectorCredential(coredata.ConnectorProviderTally, &empty)
+		_, errEmpty := configured.resolveAPIKeyConnectorCredential(coredata.ConnectorProviderSentry, &empty)
 		require.EqualError(t, errEmpty, "apiKey is required")
 	})
 
 	t.Run("non-managed returns the client key", func(t *testing.T) {
 		t.Parallel()
 
-		key, err := configured.resolveAPIKeyConnectorCredential(coredata.ConnectorProviderTally, &clientKey)
+		key, err := configured.resolveAPIKeyConnectorCredential(coredata.ConnectorProviderSentry, &clientKey)
 		require.NoError(t, err)
 		assert.Equal(t, "customer-key", key)
 	})


### PR DESCRIPTION
Follow-up to #1857, which introduced `KeyFormat` and left Langfuse as the only
provider declaring one. This walks the other 45 API-key providers and gives a
shape to the fifteen whose keys have one.

## What the check is for

A key pasted into a connect dialog reaches the provider whatever it is, and
comes back as the same generic rejection whether it was half copied, was the
wrong kind of credential, or is simply dead. A prefix separates the first two
cases from the third, in the dialog and again at create.

It cannot separate a live key from a dead one. That is the probe's job, and
`NOT_AUTHORIZED` from #1857 is what says so.

## Which providers, and why not the rest

**Declaring a shape (15):** Anthropic `sk-ant-`, Brevo `xkeysib-`, Brex `bxt_`,
Cal.com `cal_`, ClickHouse Cloud (the colon joining the two halves), Dotfile
`dotkey.`, Metabase `mb_`, OpenAI `sk-admin-`, Qovery `qov_` or `sk-qov-`,
Resend `re_`, SendGrid `SG.`, Supabase `sbp_`, Tailscale `tskey-api-`, Tally
`tly-`, UpCloud `ucat_`.

Every one comes from the provider's own current documentation. The bar is high
because the check is a hard block: a pattern that is wrong locks a customer out
of connecting a key that works, with no way around it. A pattern that is loose
costs nothing.

**Declaring nothing, on purpose.** A provider that adopted a prefix later and
kept the keys minted before it is excluded, because one of those older keys is
still a good key: Cloudflare, Grafana, Mercury, Neon, Notion, PostHog and
Segment. Grafana is the sharpest case, migrating an API key onto a service
account with its original `eyJrIjoi` value intact while the connector reaches
self-hosted instances old enough to still hold one.

Cursor, GitHub, HubSpot, Okta, OpenRouter, Render, Sentry and Square document
no prefix for the credential this connector needs. Railway and Scaleway mint a
bare UUID, which is length and alphabet rather than shape, and the type
forbids asserting either.

## Shape of the change

`apiKeyPrefix(prefix, example)` quotes the prefix into the pattern, so a
registration cannot reach past it into the random part. That makes the
over-constraint the type warns about structurally unreachable for thirteen of
the fifteen; ClickHouse Cloud and Qovery need a written pattern and say why.

The prefix stops short of anything the provider can change under it. A version
segment, first: `sk-ant-`, not `sk-ant-admin01-`. And whatever separates two
credential classes the connector accepts equally, which is the same rule seen
from the other side.

`Register` now also refuses an unanchored pattern, next to the three KeyFormat
rules it already enforced, since `ValidateAPIKey` matches unanchored.

The Langfuse key-shape test folds into one table covering every provider that
declares a shape, with a guard so the next provider to declare one cannot skip
it. The e2e Brex fixtures gain the prefix they now have to carry.

Docs are a separate PR on probo.com: the pages for Brex, Cal.com, Dotfile and
Qovery never named a prefix, and the access-review overview now says once what
the check does and what it does not.

## Review

Three passes, each of which caught something the others did not.

`/review-as-gearnode` found the commit was not green: six e2e fixtures create
Brex connectors with keys like `test-key-123` and assert `require.NoError`. It
also caught Grafana violating the exclusion rule this PR states.

Fable found Anthropic. The Admin API accepts three credentials, including a
personal or service account key scoped to no workspace, which is
`sk-ant-api03-`. The original `sk-ant-admin` would have blocked those, and the
test asserted the lockout. It also turned up Mercury's pre-prefix token format
and OpenRouter's undocumented management-key class, both now excluded, and
Qovery's `sk-qov-` policy token, now admitted. Two providers it found that I
had skipped, Dotfile and Cal.com, are in on its evidence.

Codex ran last against the corrected commit.

## Worth its own ticket, untouched here

The Anthropic docs page says a standard Console key "will not work", which
Anthropic's own documentation contradicts for a key scoped to no workspace.
Correcting it needs a live check rather than a doc read, and the page's advice
to create an admin key is still the safest thing to tell a reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018a6yiyvNDjyB81MiUnmp2x
