### PR TITLE
Cut signup cost in the slowest e2e suites

### DIFF
--- a/e2e/console/ai_system_test.go
+++ b/e2e/console/ai_system_test.go
@@ -441,6 +441,8 @@ func TestAiSystem_Create_Validation(t *testing.T) {
 func TestAiSystem_RBAC(t *testing.T) {
 	t.Parallel()
 
+	org := testutil.NewOrganizationRoles(t)
+
 	baseCreateInput := func(client *testutil.Client) map[string]any {
 		return map[string]any{
 			"organizationId":     client.GetOrganizationID().String(),
@@ -456,7 +458,7 @@ func TestAiSystem_RBAC(t *testing.T) {
 		t.Run("owner can create", func(t *testing.T) {
 			t.Parallel()
 
-			owner := testutil.NewClient(t, testutil.RoleOwner)
+			owner := org.Client(t, testutil.RoleOwner)
 
 			_, err := owner.Do(`
 				mutation CreateAiSystem($input: CreateAiSystemInput!) {
@@ -471,8 +473,7 @@ func TestAiSystem_RBAC(t *testing.T) {
 		t.Run("viewer cannot create", func(t *testing.T) {
 			t.Parallel()
 
-			owner := testutil.NewClient(t, testutil.RoleOwner)
-			viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+			viewer := org.Client(t, testutil.RoleViewer)
 
 			_, err := viewer.Do(`
 				mutation CreateAiSystem($input: CreateAiSystemInput!) {
@@ -488,8 +489,8 @@ func TestAiSystem_RBAC(t *testing.T) {
 	t.Run("read", func(t *testing.T) {
 		t.Parallel()
 
-		owner := testutil.NewClient(t, testutil.RoleOwner)
-		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+		owner := org.Client(t, testutil.RoleOwner)
+		viewer := org.Client(t, testutil.RoleViewer)
 		aiSystemID := createAiSystem(t, owner, map[string]any{
 			"name":               "RBAC Read Test",
 			"status":             "ACTIVE",
@@ -520,7 +521,7 @@ func TestAiSystem_RBAC(t *testing.T) {
 		t.Run("owner can update", func(t *testing.T) {
 			t.Parallel()
 
-			owner := testutil.NewClient(t, testutil.RoleOwner)
+			owner := org.Client(t, testutil.RoleOwner)
 			aiSystemID := createAiSystem(t, owner, map[string]any{
 				"name":               "RBAC Update Test",
 				"status":             "ACTIVE",
@@ -545,8 +546,8 @@ func TestAiSystem_RBAC(t *testing.T) {
 		t.Run("viewer cannot update", func(t *testing.T) {
 			t.Parallel()
 
-			owner := testutil.NewClient(t, testutil.RoleOwner)
-			viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+			owner := org.Client(t, testutil.RoleOwner)
+			viewer := org.Client(t, testutil.RoleViewer)
 			aiSystemID := createAiSystem(t, owner, map[string]any{
 				"name":               "RBAC Update Test",
 				"status":             "ACTIVE",
@@ -575,7 +576,7 @@ func TestAiSystem_RBAC(t *testing.T) {
 		t.Run("owner can delete", func(t *testing.T) {
 			t.Parallel()
 
-			owner := testutil.NewClient(t, testutil.RoleOwner)
+			owner := org.Client(t, testutil.RoleOwner)
 			aiSystemID := createAiSystem(t, owner, map[string]any{
 				"name":               "RBAC Delete Test",
 				"status":             "ACTIVE",
@@ -597,8 +598,8 @@ func TestAiSystem_RBAC(t *testing.T) {
 		t.Run("viewer cannot delete", func(t *testing.T) {
 			t.Parallel()
 
-			owner := testutil.NewClient(t, testutil.RoleOwner)
-			viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+			owner := org.Client(t, testutil.RoleOwner)
+			viewer := org.Client(t, testutil.RoleViewer)
 			aiSystemID := createAiSystem(t, owner, map[string]any{
 				"name":               "RBAC Delete Test",
 				"status":             "ACTIVE",

--- a/e2e/console/audit_test.go
+++ b/e2e/console/audit_test.go
@@ -907,9 +907,6 @@ func TestAudit_Timestamps(t *testing.T) {
 		initialCreatedAt := getResult.Node.CreatedAt
 		initialUpdatedAt := getResult.Node.UpdatedAt
 
-		// Wait long enough for timestamp to change (database may have second precision)
-		time.Sleep(1100 * time.Millisecond)
-
 		updateQuery := `
 			mutation UpdateAudit($input: UpdateAuditInput!) {
 				updateAudit(input: $input) {

--- a/e2e/console/business_function_test.go
+++ b/e2e/console/business_function_test.go
@@ -640,8 +640,6 @@ func TestBusinessFunction_Timestamps(t *testing.T) {
 		initialCreatedAt := getResult.Node.CreatedAt
 		initialUpdatedAt := getResult.Node.UpdatedAt
 
-		time.Sleep(1100 * time.Millisecond)
-
 		const updateQuery = `
 			mutation UpdateBusinessFunction($input: UpdateBusinessFunctionInput!) {
 				updateBusinessFunction(input: $input) {
@@ -833,6 +831,8 @@ func TestBusinessFunction_Create_Validation(t *testing.T) {
 func TestBusinessFunction_RBAC(t *testing.T) {
 	t.Parallel()
 
+	org := testutil.NewOrganizationRoles(t)
+
 	baseCreateInput := func(client *testutil.Client) map[string]any {
 		return map[string]any{
 			"organizationId": client.GetOrganizationID().String(),
@@ -845,8 +845,12 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 	}
 
 	t.Run("create", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("owner can create", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
+			t.Parallel()
+
+			owner := org.Client(t, testutil.RoleOwner)
 
 			_, err := owner.Do(`
 				mutation CreateBusinessFunction($input: CreateBusinessFunctionInput!) {
@@ -859,8 +863,9 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 		})
 
 		t.Run("admin can create", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
-			admin := testutil.NewClientInOrg(t, testutil.RoleAdmin, owner)
+			t.Parallel()
+
+			admin := org.Client(t, testutil.RoleAdmin)
 
 			_, err := admin.Do(`
 				mutation CreateBusinessFunction($input: CreateBusinessFunctionInput!) {
@@ -873,8 +878,9 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 		})
 
 		t.Run("viewer cannot create", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
-			viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+			t.Parallel()
+
+			viewer := org.Client(t, testutil.RoleViewer)
 
 			_, err := viewer.Do(`
 				mutation CreateBusinessFunction($input: CreateBusinessFunctionInput!) {
@@ -888,8 +894,12 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 	})
 
 	t.Run("update", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("owner can update", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
+			t.Parallel()
+
+			owner := org.Client(t, testutil.RoleOwner)
 			businessFunctionID := createBusinessFunction(t, owner, map[string]any{
 				"name":           "RBAC Update Test",
 				"classification": "STANDARD",
@@ -914,8 +924,10 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 		})
 
 		t.Run("admin can update", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
-			admin := testutil.NewClientInOrg(t, testutil.RoleAdmin, owner)
+			t.Parallel()
+
+			owner := org.Client(t, testutil.RoleOwner)
+			admin := org.Client(t, testutil.RoleAdmin)
 			businessFunctionID := createBusinessFunction(t, owner, map[string]any{
 				"name":           "RBAC Update Test",
 				"classification": "STANDARD",
@@ -940,8 +952,10 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 		})
 
 		t.Run("viewer cannot update", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
-			viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+			t.Parallel()
+
+			owner := org.Client(t, testutil.RoleOwner)
+			viewer := org.Client(t, testutil.RoleViewer)
 			businessFunctionID := createBusinessFunction(t, owner, map[string]any{
 				"name":           "RBAC Update Test",
 				"classification": "STANDARD",
@@ -967,8 +981,12 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 	})
 
 	t.Run("delete", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("owner can delete", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
+			t.Parallel()
+
+			owner := org.Client(t, testutil.RoleOwner)
 			businessFunctionID := createBusinessFunction(t, owner, map[string]any{
 				"name":           "RBAC Delete Test",
 				"classification": "STANDARD",
@@ -990,8 +1008,10 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 		})
 
 		t.Run("admin can delete", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
-			admin := testutil.NewClientInOrg(t, testutil.RoleAdmin, owner)
+			t.Parallel()
+
+			owner := org.Client(t, testutil.RoleOwner)
+			admin := org.Client(t, testutil.RoleAdmin)
 			businessFunctionID := createBusinessFunction(t, owner, map[string]any{
 				"name":           "RBAC Delete Test",
 				"classification": "STANDARD",
@@ -1013,8 +1033,10 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 		})
 
 		t.Run("viewer cannot delete", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
-			viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+			t.Parallel()
+
+			owner := org.Client(t, testutil.RoleOwner)
+			viewer := org.Client(t, testutil.RoleViewer)
 			businessFunctionID := createBusinessFunction(t, owner, map[string]any{
 				"name":           "RBAC Delete Test",
 				"classification": "STANDARD",
@@ -1037,8 +1059,12 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 	})
 
 	t.Run("read", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("owner can read", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
+			t.Parallel()
+
+			owner := org.Client(t, testutil.RoleOwner)
 			businessFunctionID := createBusinessFunction(t, owner, map[string]any{
 				"name":           "RBAC Read Test",
 				"classification": "STANDARD",
@@ -1066,8 +1092,10 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 		})
 
 		t.Run("admin can read", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
-			admin := testutil.NewClientInOrg(t, testutil.RoleAdmin, owner)
+			t.Parallel()
+
+			owner := org.Client(t, testutil.RoleOwner)
+			admin := org.Client(t, testutil.RoleAdmin)
 			businessFunctionID := createBusinessFunction(t, owner, map[string]any{
 				"name":           "RBAC Read Test",
 				"classification": "STANDARD",
@@ -1095,8 +1123,10 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 		})
 
 		t.Run("viewer can read", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
-			viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+			t.Parallel()
+
+			owner := org.Client(t, testutil.RoleOwner)
+			viewer := org.Client(t, testutil.RoleViewer)
 			businessFunctionID := createBusinessFunction(t, owner, map[string]any{
 				"name":           "RBAC Read Test",
 				"classification": "STANDARD",
@@ -1124,8 +1154,10 @@ func TestBusinessFunction_RBAC(t *testing.T) {
 		})
 
 		t.Run("viewer can list", func(t *testing.T) {
-			owner := testutil.NewClient(t, testutil.RoleOwner)
-			viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+			t.Parallel()
+
+			owner := org.Client(t, testutil.RoleOwner)
+			viewer := org.Client(t, testutil.RoleViewer)
 
 			createBusinessFunction(t, owner, map[string]any{
 				"name":           "RBAC List Test",

--- a/e2e/console/cookie_banner_versioning_test.go
+++ b/e2e/console/cookie_banner_versioning_test.go
@@ -152,9 +152,11 @@ func upsertTranslation(t *testing.T, c *testutil.Client, bannerID, language, tra
 func TestCookieBannerVersioning_NoOpUpdates(t *testing.T) {
 	t.Parallel()
 
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
 	t.Run("UpdateCookieBanner with all original values does not bump version", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner, factory.Attrs{
 			"cookiePolicyUrl":   "https://example.com/cookies",
@@ -189,7 +191,7 @@ func TestCookieBannerVersioning_NoOpUpdates(t *testing.T) {
 
 	t.Run("UpdateCookieBanner with only name change does not bump version", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 		published := publishBanner(t, owner, bannerID)
@@ -225,7 +227,7 @@ func TestCookieBannerVersioning_NoOpUpdates(t *testing.T) {
 
 	t.Run("UpdateCookieCategory with all original values does not bump version", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 		categoryID := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{
@@ -263,7 +265,7 @@ func TestCookieBannerVersioning_NoOpUpdates(t *testing.T) {
 
 	t.Run("ReorderCookieCategory with current rank does not bump version", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 		categoryID := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{
@@ -299,7 +301,7 @@ func TestCookieBannerVersioning_NoOpUpdates(t *testing.T) {
 		// Rank is admin-only metadata; the snapshot is sorted by
 		// (Kind weight, ID), so a rank change is invisible to visitors.
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 		categoryID := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{
@@ -333,7 +335,7 @@ func TestCookieBannerVersioning_NoOpUpdates(t *testing.T) {
 
 	t.Run("UpdateTrackerPattern on visible pattern with same value does not bump version", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 		categoryID := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"slug": "visible-noop"})
@@ -370,9 +372,11 @@ func TestCookieBannerVersioning_NoOpUpdates(t *testing.T) {
 func TestCookieBannerVersioning_ExcludedPattern(t *testing.T) {
 	t.Parallel()
 
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
 	t.Run("Update on excluded pattern does not bump version", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 		categoryID := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"slug": "excl-update"})
@@ -416,7 +420,7 @@ func TestCookieBannerVersioning_ExcludedPattern(t *testing.T) {
 
 	t.Run("Delete of excluded pattern does not bump version", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 		categoryID := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"slug": "excl-delete"})
@@ -448,7 +452,7 @@ func TestCookieBannerVersioning_ExcludedPattern(t *testing.T) {
 
 	t.Run("Move of excluded pattern does not bump version", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 		categoryA := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"slug": "excl-move-a"})
@@ -486,9 +490,11 @@ func TestCookieBannerVersioning_ExcludedPattern(t *testing.T) {
 func TestCookieBannerVersioning_TranslationChangesNeverBump(t *testing.T) {
 	t.Parallel()
 
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
 	t.Run("re-upserting identical JSON does not bump version", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 
@@ -506,7 +512,7 @@ func TestCookieBannerVersioning_TranslationChangesNeverBump(t *testing.T) {
 
 	t.Run("changing translation content does not bump version", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 
@@ -523,7 +529,7 @@ func TestCookieBannerVersioning_TranslationChangesNeverBump(t *testing.T) {
 
 	t.Run("adding a new language does not bump version", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 		published := publishBanner(t, owner, bannerID)
@@ -566,9 +572,11 @@ func reportDetectedCookies(t *testing.T, c *testutil.Client, bannerID string, na
 func TestCookieBannerVersioning_DetectedCookiesNeverBump(t *testing.T) {
 	t.Parallel()
 
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
 	t.Run("reporting detected cookies does not bump version", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 		published := publishBanner(t, owner, bannerID)
@@ -585,9 +593,11 @@ func TestCookieBannerVersioning_DetectedCookiesNeverBump(t *testing.T) {
 func TestCookieBannerVersioning_RealChangesStillBumpVersion(t *testing.T) {
 	t.Parallel()
 
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
 	t.Run("UpdateCookieBanner consent change creates a new draft", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner, factory.Attrs{
 			"consentExpiryDays": 365,
@@ -618,7 +628,7 @@ func TestCookieBannerVersioning_RealChangesStillBumpVersion(t *testing.T) {
 
 	t.Run("UpdateTrackerPattern description change on visible pattern creates a new draft", func(t *testing.T) {
 		t.Parallel()
-		owner := testutil.NewClient(t, testutil.RoleOwner)
+		owner := owner.ForTest(t)
 
 		bannerID := factory.CreateCookieBanner(owner)
 		categoryID := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"slug": "real-change"})

--- a/e2e/console/cookie_consent_rbac_test.go
+++ b/e2e/console/cookie_consent_rbac_test.go
@@ -32,18 +32,21 @@ import (
 func TestCookieConsent_RBAC(t *testing.T) {
 	t.Parallel()
 
+	fixture := setupPublishedCookieBanner(t)
+	viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, fixture.Owner)
+
 	t.Run(
 		"viewer can list consent records",
 		func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupPublishedCookieBanner(t)
-			viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, fixture.Owner)
+			owner := fixture.Owner.ForTest(t)
+			viewer := viewer.ForTest(t)
 
 			visitorID := uniqueCookieBannerVisitorID()
 			created := postCookieConsent(
 				t,
-				fixture.Owner,
+				owner,
 				fixture,
 				visitorID,
 				"ACCEPT_ALL",
@@ -102,12 +105,12 @@ func TestCookieConsent_RBAC(t *testing.T) {
 		func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupPublishedCookieBanner(t)
-			viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, fixture.Owner)
+			owner := fixture.Owner.ForTest(t)
+			viewer := viewer.ForTest(t)
 
 			created := postCookieConsent(
 				t,
-				fixture.Owner,
+				owner,
 				fixture,
 				uniqueCookieBannerVisitorID(),
 				"REJECT_ALL",
@@ -146,12 +149,12 @@ func TestCookieConsent_RBAC(t *testing.T) {
 		func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupPublishedCookieBanner(t)
+			owner := fixture.Owner.ForTest(t)
 			otherOwner := testutil.NewClient(t, testutil.RoleOwner)
 
 			postCookieConsent(
 				t,
-				fixture.Owner,
+				owner,
 				fixture,
 				uniqueCookieBannerVisitorID(),
 				"ACCEPT_ALL",

--- a/e2e/console/datum_test.go
+++ b/e2e/console/datum_test.go
@@ -686,9 +686,6 @@ func TestDatum_Timestamps(t *testing.T) {
 		initialCreatedAt := getResult.Node.CreatedAt
 		initialUpdatedAt := getResult.Node.UpdatedAt
 
-		// Wait long enough for timestamp to change (database may have second precision)
-		time.Sleep(1100 * time.Millisecond)
-
 		updateQuery := `
 			mutation UpdateDatum($input: UpdateDatumInput!) {
 				updateDatum(input: $input) {

--- a/e2e/console/device_enrollment_test.go
+++ b/e2e/console/device_enrollment_test.go
@@ -585,10 +585,12 @@ func setupDeviceEnrollmentClients(t *testing.T) (
 func TestDeviceEnrollment(t *testing.T) {
 	t.Parallel()
 
+	sharedOwner, sharedAdmin, sharedEmployee, sharedViewer, orgID, ownerProfileID := setupDeviceEnrollmentClients(t)
+
 	t.Run("enrollment token can be exchanged once", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrolled := enrollDevice(t, employee, orgID)
 
@@ -603,7 +605,8 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("revoked device enrollment token returns unauthorized", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrolled := enrollDevice(t, employee, orgID)
 
@@ -626,7 +629,8 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("revoked device API key is rejected on heartbeat", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrolled := enrollDevice(t, employee, orgID)
 		status, payload := exchangeEnrollmentToken(t, enrolled.EnrollDevice.EnrollmentToken)
@@ -658,7 +662,8 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("re-enrollment succeeds after revoke with same hardware UUID", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrolled := enrollAndActivateDevice(t, employee, orgID)
 		hardwareUUID := enrolled.EnrollDevice.Device.ID + "-hw"
@@ -692,7 +697,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("owner can enroll device", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, _, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
 
 		enrollDevice(t, owner, orgID)
 	})
@@ -700,7 +705,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("admin can enroll device", func(t *testing.T) {
 		t.Parallel()
 
-		_, admin, _, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		admin := sharedAdmin.ForTest(t)
 
 		enrollDevice(t, admin, orgID)
 	})
@@ -708,7 +713,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("employee can enroll device", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrollDevice(t, employee, orgID)
 	})
@@ -716,7 +721,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("employee permission gate", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		employee := sharedEmployee.ForTest(t)
 
 		var result struct {
 			Node struct {
@@ -730,7 +735,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("employee can read own device", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrolled := enrollDevice(t, employee, orgID)
 
@@ -748,7 +753,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("employee cannot read another users device via node", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, _, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
 
 		employeeA := testutil.NewClientInOrg(t, testutil.RoleEmployee, owner)
 		employeeB := testutil.NewClientInOrg(t, testutil.RoleEmployee, owner)
@@ -764,7 +769,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("employee cannot list org devices", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		employee := sharedEmployee.ForTest(t)
 
 		_, err := employee.Do(listDevicesQuery, map[string]any{"orgId": orgID})
 		testutil.RequireForbiddenError(t, err, "employee should not list org devices")
@@ -799,7 +804,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("employee enrolled devices exclude pending devices", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrolled := enrollDevice(t, employee, orgID)
 
@@ -810,7 +815,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("employee only sees own enrolled devices", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, _, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
 
 		employeeA := testutil.NewClientInOrg(t, testutil.RoleEmployee, owner)
 		employeeB := testutil.NewClientInOrg(t, testutil.RoleEmployee, owner)
@@ -844,7 +849,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("owner can list own enrolled devices", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, _, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
 
 		enrolled := enrollAndActivateDevice(t, owner, orgID)
 
@@ -855,7 +860,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("admin can list own enrolled devices", func(t *testing.T) {
 		t.Parallel()
 
-		_, admin, _, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		admin := sharedAdmin.ForTest(t)
 
 		enrolled := enrollAndActivateDevice(t, admin, orgID)
 
@@ -879,7 +884,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("employee sees device when owner was set with profile id", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, _, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
 
 		employeeA := testutil.NewClientInOrg(t, testutil.RoleEmployee, owner)
 		profileID := employeeA.GetProfileID().String()
@@ -915,7 +920,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("employee cannot revoke device", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrolled := enrollDevice(t, employee, orgID)
 
@@ -930,7 +935,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("employee cannot create device for another user", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employee, _, orgID, ownerProfileID := setupDeviceEnrollmentClients(t)
+		employee := sharedEmployee.ForTest(t)
 
 		_, err := employee.Do(createDeviceMutation, map[string]any{
 			"input": map[string]any{
@@ -944,7 +949,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("viewer cannot enroll device", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, _, viewer, orgID, _ := setupDeviceEnrollmentClients(t)
+		viewer := sharedViewer.ForTest(t)
 
 		_, err := viewer.Do(enrollDeviceMutation, map[string]any{
 			"input": map[string]any{
@@ -957,7 +962,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("unassumed session can poll own enrolledDevice", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrolled := enrollAndActivateDevice(t, employee, orgID)
 		deviceID := enrolled.EnrollDevice.Device.ID
@@ -983,7 +988,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("unassumed session cannot read another users enrolledDevice", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, _, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
 
 		employeeA := testutil.NewClientInOrg(t, testutil.RoleEmployee, owner)
 		employeeB := testutil.NewClientInOrg(t, testutil.RoleEmployee, owner)
@@ -1001,7 +1006,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("enrolledDevice does not disclose foreign org device existence", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employeeA, _, _, _ := setupDeviceEnrollmentClients(t)
+		employeeA := sharedEmployee.ForTest(t)
 		_, _, employeeB, _, orgBID, _ := setupDeviceEnrollmentClients(t)
 
 		enrolledB := enrollDevice(t, employeeB, orgBID)
@@ -1023,7 +1028,7 @@ func TestDeviceEnrollment(t *testing.T) {
 	t.Run("owner retains admin access", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, _, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
 
 		created := createDevice(t, owner, orgID, nil)
 
@@ -1070,10 +1075,12 @@ func TestDeviceEnrollment(t *testing.T) {
 func TestDeviceDelete(t *testing.T) {
 	t.Parallel()
 
+	sharedOwner, _, sharedEmployee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+
 	t.Run("cannot delete pending device", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, _, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
 		created := createDevice(t, owner, orgID, nil)
 
 		_, err := owner.Do(deleteDeviceMutation, map[string]any{
@@ -1087,7 +1094,7 @@ func TestDeviceDelete(t *testing.T) {
 	t.Run("owner can delete revoked device", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, _, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
 		created := createDevice(t, owner, orgID, nil)
 		deviceID := created.CreateDevice.Device.ID
 
@@ -1118,7 +1125,8 @@ func TestDeviceDelete(t *testing.T) {
 	t.Run("cannot delete active device", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
+		employee := sharedEmployee.ForTest(t)
 		enrolled, _ := enrollActivateAndAuthenticateDevice(t, employee, orgID)
 
 		_, err := owner.Do(deleteDeviceMutation, map[string]any{
@@ -1132,7 +1140,8 @@ func TestDeviceDelete(t *testing.T) {
 	t.Run("employee cannot delete device", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
+		employee := sharedEmployee.ForTest(t)
 		created := createDevice(t, owner, orgID, nil)
 		deviceID := created.CreateDevice.Device.ID
 
@@ -1156,9 +1165,7 @@ func TestDeviceDelete(t *testing.T) {
 func TestDeviceEnrollmentPermissionQueryShape(t *testing.T) {
 	t.Parallel()
 
-	owner := testutil.NewClient(t, testutil.RoleOwner)
-	admin := testutil.NewClientInOrg(t, testutil.RoleAdmin, owner)
-	orgID := owner.GetOrganizationID().String()
+	owner, admin, employee, viewer, orgID, _ := setupDeviceEnrollmentClients(t)
 
 	for _, tc := range []struct {
 		name   string
@@ -1170,7 +1177,8 @@ func TestDeviceEnrollmentPermissionQueryShape(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			resp, err := tc.client.Do(devicePermissionQuery, map[string]any{"orgId": orgID})
+			client := tc.client.ForTest(t)
+			resp, err := client.Do(devicePermissionQuery, map[string]any{"orgId": orgID})
 			require.NoError(t, err)
 
 			var result struct {
@@ -1186,8 +1194,6 @@ func TestDeviceEnrollmentPermissionQueryShape(t *testing.T) {
 	t.Run("unassumed session can query enroll permission via connect", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employee, viewer, orgID, _ := setupDeviceEnrollmentClients(t)
-
 		unassumedEmployee := testutil.NewClientWithNewSession(t, employee)
 		unassumedViewer := testutil.NewClientWithNewSession(t, viewer)
 
@@ -1199,10 +1205,13 @@ func TestDeviceEnrollmentPermissionQueryShape(t *testing.T) {
 func TestDevicePostureReports(t *testing.T) {
 	t.Parallel()
 
+	sharedOwner, _, sharedEmployee, sharedViewer, orgID, _ := setupDeviceEnrollmentClients(t)
+
 	t.Run("one agent run becomes one report", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrolled, apiKey := enrollActivateAndAuthenticateDevice(t, employee, orgID)
 		deviceID := enrolled.EnrollDevice.Device.ID
@@ -1260,7 +1269,8 @@ func TestDevicePostureReports(t *testing.T) {
 	t.Run("legacy agent without correlation_id still groups one report", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrolled, apiKey := enrollActivateAndAuthenticateDevice(t, employee, orgID)
 		deviceID := enrolled.EnrollDevice.Device.ID
@@ -1310,7 +1320,8 @@ func TestDevicePostureReports(t *testing.T) {
 	t.Run("each agent run adds a report", func(t *testing.T) {
 		t.Parallel()
 
-		owner, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		owner := sharedOwner.ForTest(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrolled, apiKey := enrollActivateAndAuthenticateDevice(t, employee, orgID)
 		deviceID := enrolled.EnrollDevice.Device.ID
@@ -1372,7 +1383,8 @@ func TestDevicePostureReports(t *testing.T) {
 	t.Run("viewer can read posture reports", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employee, viewer, orgID, _ := setupDeviceEnrollmentClients(t)
+		employee := sharedEmployee.ForTest(t)
+		viewer := sharedViewer.ForTest(t)
 
 		enrolled, apiKey := enrollActivateAndAuthenticateDevice(t, employee, orgID)
 		deviceID := enrolled.EnrollDevice.Device.ID
@@ -1407,7 +1419,7 @@ func TestDevicePostureReports(t *testing.T) {
 	t.Run("another organization cannot read posture reports", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, employee, _, orgID, _ := setupDeviceEnrollmentClients(t)
+		employee := sharedEmployee.ForTest(t)
 
 		enrolled, apiKey := enrollActivateAndAuthenticateDevice(t, employee, orgID)
 		deviceID := enrolled.EnrollDevice.Device.ID

--- a/e2e/console/document_test.go
+++ b/e2e/console/document_test.go
@@ -620,9 +620,6 @@ func TestDocument_Timestamps(t *testing.T) {
 		initialCreatedAt := getResult.Node.CreatedAt
 		initialUpdatedAt := getResult.Node.UpdatedAt
 
-		// Wait long enough for timestamp to change (database may have second precision)
-		time.Sleep(1100 * time.Millisecond)
-
 		updateQuery := `
 			mutation UpdateDocument($input: UpdateDocumentInput!) {
 				updateDocument(input: $input) {

--- a/e2e/console/framework_test.go
+++ b/e2e/console/framework_test.go
@@ -672,9 +672,6 @@ func TestFramework_Timestamps(t *testing.T) {
 		initialCreatedAt := getResult.Node.CreatedAt
 		initialUpdatedAt := getResult.Node.UpdatedAt
 
-		// Wait long enough for timestamp to change (database may have second precision)
-		time.Sleep(1100 * time.Millisecond)
-
 		updateQuery := `
 			mutation UpdateFramework($input: UpdateFrameworkInput!) {
 				updateFramework(input: $input) {

--- a/e2e/console/measure_test.go
+++ b/e2e/console/measure_test.go
@@ -793,9 +793,6 @@ func TestMeasure_Timestamps(t *testing.T) {
 		initialCreatedAt := getResult.Node.CreatedAt
 		initialUpdatedAt := getResult.Node.UpdatedAt
 
-		// Wait long enough for timestamp to change (database may have second precision)
-		time.Sleep(1100 * time.Millisecond)
-
 		updateQuery := `
 			mutation UpdateMeasure($input: UpdateMeasureInput!) {
 				updateMeasure(input: $input) {

--- a/e2e/console/processing_activity_test.go
+++ b/e2e/console/processing_activity_test.go
@@ -564,9 +564,6 @@ func TestProcessingActivity_Timestamps(t *testing.T) {
 		initialCreatedAt := getResult.Node.CreatedAt
 		initialUpdatedAt := getResult.Node.UpdatedAt
 
-		// Wait long enough for timestamp to change (database may have second precision)
-		time.Sleep(1100 * time.Millisecond)
-
 		updateQuery := `
 			mutation UpdateProcessingActivity($input: UpdateProcessingActivityInput!) {
 				updateProcessingActivity(input: $input) {

--- a/e2e/internal/testutil/poll_test.go
+++ b/e2e/internal/testutil/poll_test.go
@@ -22,52 +22,52 @@ package testutil
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPoll(t *testing.T) {
+func TestPoll_SucceedsImmediately(t *testing.T) {
 	t.Parallel()
 
-	t.Run(
-		"returns true when condition succeeds immediately",
-		func(t *testing.T) {
-			t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		calls := 0
 
-			calls := 0
+		ok := Poll(
+			t,
+			time.Hour,
+			time.Second,
+			func() bool {
+				calls++
 
-			ok := Poll(
-				t,
-				time.Second,
-				10*time.Millisecond,
-				func() bool {
-					calls++
+				return true
+			},
+		)
 
-					return true
-				},
-			)
+		assert.True(t, ok)
+		assert.Equal(t, 1, calls)
+	})
+}
 
-			assert.True(t, ok)
-			assert.Equal(t, 1, calls)
-		},
-	)
+func TestPoll_NeverSucceeds(t *testing.T) {
+	t.Parallel()
 
-	t.Run(
-		"returns false when condition never succeeds",
-		func(t *testing.T) {
-			t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		calls := 0
 
-			ok := Poll(
-				t,
-				50*time.Millisecond,
-				10*time.Millisecond,
-				func() bool {
-					return false
-				},
-			)
+		ok := Poll(
+			t,
+			2*time.Second,
+			time.Second,
+			func() bool {
+				calls++
 
-			assert.False(t, ok)
-		},
-	)
+				return false
+			},
+		)
+
+		assert.False(t, ok)
+		assert.Equal(t, 3, calls)
+	})
 }


### PR DESCRIPTION
## Summary
- Device enrollment, cookie-banner, and RBAC cases were spending most of their time on signup. One shared org per suite drops those from tens of seconds to a few hundred milliseconds.
- Timestamp update checks no longer sleep 1.1s. Postgres already stores microseconds.
- In-process `Poll` tests now use `testing/synctest` so they do not wait on real time.

Do not shorten global OAuth token lifetimes. A 1s access token expires other OAuth flows under load.

## Test plan
- [x] `go test ./e2e/internal/testutil/`
- [x] Targeted console e2e: device enrollment/delete/posture, cookie banner versioning, cookie consent RBAC, AI system RBAC, business function RBAC, timestamp suites
- [ ] Full `make test-e2e` on a quiet machine (no local `probod` on :10080)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts e2e runtime in the slowest suites by sharing one org per suite, removing the 1.1s timestamp sleeps (Postgres already stores microseconds), and switching in-process `Poll` tests to `testing/synctest` so they don't wait on real time. Global OAuth token lifetimes stay unchanged — a 1s access token would expire other OAuth flows under load.

### Tests **`+188`** **`-148`**

- Device enrollment, cookie-banner, and RBAC suites share one org instead of signing up per subtest; business-function RBAC subtests now run in parallel too.
- Timestamp update checks no longer sleep 1.1s since Postgres stores microsecond precision.
- `Poll` tests use `testing/synctest` and assert call counts without waiting on real time.

<sup>Written for commit 48ac45a2de6f1fab3bef205e0ab30aedf08df13a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

