### PR TITLE
Add purge of expired deleted files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,11 @@
 # app's .env — same rules as production (including virtual-hosted
 # https://{bucket}.{endpoint}).
 
+# ── Soft-deleted file purge (seconds) ─────────────────────────────────
+# PROBOD_FILE_PURGE_INTERVAL=3600
+# PROBOD_FILE_PURGE_RETENTION=2592000
+# PROBOD_FILE_PURGE_MAX_PER_TICK=1000
+
 # ── Mailer (Mailpit via compose) ──────────────────────────────────────
 # PROBOD_SMTP_ADDR=localhost:1025
 # PROBOD_SMTP_USER=

--- a/contrib/helm/charts/probo/templates/deployment.yaml
+++ b/contrib/helm/charts/probo/templates/deployment.yaml
@@ -262,6 +262,13 @@ spec:
             - name: PROBOD_AWS_USE_PATH_STYLE
               value: "true"
             {{- end }}
+            # Soft-deleted file purge
+            - name: PROBOD_FILE_PURGE_INTERVAL
+              value: {{ .Values.probo.filePurge.interval | quote }}
+            - name: PROBOD_FILE_PURGE_RETENTION
+              value: {{ .Values.probo.filePurge.retention | quote }}
+            - name: PROBOD_FILE_PURGE_MAX_PER_TICK
+              value: {{ .Values.probo.filePurge.maxPerTick | quote }}
             # Email (SMTP)
             - name: PROBOD_MAILER_SENDER_NAME
               value: {{ .Values.probo.mailer.senderName | quote }}

--- a/contrib/helm/charts/probo/values.yaml
+++ b/contrib/helm/charts/probo/values.yaml
@@ -334,6 +334,15 @@ probo:
 #      tlsRequired: false
 #      helloName: ""
 
+  # Soft-deleted file purge (seconds)
+  filePurge:
+    # How often the worker scans for expired soft-deleted files (default: 1 hour)
+    interval: 3600
+    # How long a soft-deleted file is kept before purge (default: 30 days)
+    retention: 2592000
+    # Maximum number of files processed in one run
+    maxPerTick: 1000
+
   # Outbound webhook delivery
   webhook:
     senderInterval: 5

--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -346,6 +346,11 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 					},
 				}
 			}(),
+			FilePurge: probodconfig.FilePurgeConfig{
+				Interval:   b.resolver.getEnvIntOrDefault("PROBOD_FILE_PURGE_INTERVAL", probodconfig.DefaultFilePurgeIntervalSeconds),
+				Retention:  b.resolver.getEnvIntOrDefault("PROBOD_FILE_PURGE_RETENTION", probodconfig.DefaultFilePurgeRetentionSeconds),
+				MaxPerTick: b.resolver.getEnvIntOrDefault("PROBOD_FILE_PURGE_MAX_PER_TICK", probodconfig.DefaultFilePurgeMaxPerTick),
+			},
 			CustomDomains: probodconfig.CustomDomainsConfig{
 				RenewalInterval:   b.resolver.getEnvIntOrDefault("PROBOD_CUSTOM_DOMAINS_RENEWAL_INTERVAL", 3600),
 				ProvisionInterval: b.resolver.getEnvIntOrDefault("PROBOD_CUSTOM_DOMAINS_PROVISION_INTERVAL", 30),

--- a/pkg/bootstrap/builder_test.go
+++ b/pkg/bootstrap/builder_test.go
@@ -388,6 +388,11 @@ func TestBuilder_Build_Defaults(t *testing.T) {
 	assert.Equal(t, 1500, cfg.Probod.ThirdPartyVetting.StaleAfter)
 	assert.Equal(t, 1, cfg.Probod.ThirdPartyVetting.MaxConcurrency)
 
+	// File purge config
+	assert.Equal(t, probodconfig.DefaultFilePurgeIntervalSeconds, cfg.Probod.FilePurge.Interval)
+	assert.Equal(t, probodconfig.DefaultFilePurgeRetentionSeconds, cfg.Probod.FilePurge.Retention)
+	assert.Equal(t, probodconfig.DefaultFilePurgeMaxPerTick, cfg.Probod.FilePurge.MaxPerTick)
+
 	// Custom domains config
 	assert.Equal(t, 3600, cfg.Probod.CustomDomains.RenewalInterval)
 	assert.Equal(t, 30, cfg.Probod.CustomDomains.ProvisionInterval)
@@ -538,6 +543,10 @@ func TestBuilder_Build_CustomValues(t *testing.T) {
 	env["PROBOD_THIRD_PARTY_VETTING_INTERVAL"] = "15"
 	env["PROBOD_THIRD_PARTY_VETTING_STALE_AFTER"] = "1800"
 	env["PROBOD_THIRD_PARTY_VETTING_MAX_CONCURRENCY"] = "2"
+	// File purge
+	env["PROBOD_FILE_PURGE_INTERVAL"] = "1800"
+	env["PROBOD_FILE_PURGE_RETENTION"] = "86400"
+	env["PROBOD_FILE_PURGE_MAX_PER_TICK"] = "50"
 	// Custom domains
 	env["PROBOD_CUSTOM_DOMAINS_RESOLVER_ADDR"] = "1.1.1.1:53"
 	env["PROBOD_ACME_ACCOUNT_KEY"] = testECKeyPEM()
@@ -698,6 +707,10 @@ func TestBuilder_Build_CustomValues(t *testing.T) {
 	// Custom domains
 	assert.Equal(t, "1.1.1.1:53", cfg.Probod.CustomDomains.ResolverAddr)
 	assert.Equal(t, testECKeyPEM(), cfg.Probod.CustomDomains.ACME.AccountKey.PEM())
+	// File purge
+	assert.Equal(t, 1800, cfg.Probod.FilePurge.Interval)
+	assert.Equal(t, 86400, cfg.Probod.FilePurge.Retention)
+	assert.Equal(t, 50, cfg.Probod.FilePurge.MaxPerTick)
 	// SCIM bridge
 	assert.Equal(t, 1800, cfg.Probod.SCIMBridge.SyncInterval)
 	assert.Equal(t, 60, cfg.Probod.SCIMBridge.PollInterval)

--- a/pkg/coredata/file.go
+++ b/pkg/coredata/file.go
@@ -459,3 +459,155 @@ WHERE
 
 	return nil
 }
+
+func (f *Files) LoadDeletedBefore(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	before time.Time,
+	afterID *gid.GID,
+	limit int,
+) error {
+	q := `
+SELECT
+    id,
+    organization_id,
+    bucket_name,
+    mime_type,
+    file_name,
+    file_key,
+    file_size,
+    visibility,
+    created_at,
+    updated_at,
+    deleted_at
+FROM
+    files
+WHERE
+    %s
+    AND deleted_at IS NOT NULL
+    AND deleted_at < @before
+    AND (
+        CASE
+            WHEN @has_after_id THEN id > @after_id
+            ELSE TRUE
+        END
+    )
+ORDER BY
+    id ASC
+LIMIT @limit
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"before":       before,
+		"has_after_id": afterID != nil,
+		"after_id":     gid.Nil,
+		"limit":        limit,
+	}
+	if afterID != nil {
+		args["after_id"] = *afterID
+	}
+
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query deleted files: %w", err)
+	}
+
+	files, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[File])
+	if err != nil {
+		return fmt.Errorf("cannot collect deleted files: %w", err)
+	}
+
+	*f = files
+
+	return nil
+}
+
+func (f *File) LoadDeletedByIDForUpdateSkipLocked(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	fileID gid.GID,
+	before time.Time,
+) error {
+	q := `
+SELECT
+    id,
+    organization_id,
+    bucket_name,
+    mime_type,
+    file_name,
+    file_key,
+    file_size,
+    visibility,
+    created_at,
+    updated_at,
+    deleted_at
+FROM
+    files
+WHERE
+    %s
+    AND id = @file_id
+    AND deleted_at IS NOT NULL
+    AND deleted_at < @before
+FOR UPDATE SKIP LOCKED
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"file_id": fileID, "before": before}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query deleted file: %w", err)
+	}
+
+	file, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[File])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect deleted file: %w", err)
+	}
+
+	*f = file
+
+	return nil
+}
+
+func (f File) Delete(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM files
+WHERE
+    %s
+    AND id = @file_id
+    AND deleted_at IS NOT NULL
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"file_id": f.ID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok &&
+			(pgErr.Code == "23503" || pgErr.Code == "23001") {
+			return fmt.Errorf("cannot delete file from database: file is still referenced: %w", ErrResourceInUse)
+		}
+
+		return fmt.Errorf("cannot delete file from database: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/file_test.go
+++ b/pkg/coredata/file_test.go
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package coredata_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/crypto/uuid"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/internal/test"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+func TestFiles_LoadDeletedBefore_ExcludesRecentAndActive(t *testing.T) {
+	t.Parallel()
+
+	pgClient := test.PGClient(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+	cutoff := now.Add(-30 * 24 * time.Hour)
+
+	expired := insertTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-31*24*time.Hour)))
+	recent := insertTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-2*24*time.Hour)))
+	active := insertTestFile(t, pgClient, scope, organizationID, now, nil)
+
+	var files coredata.Files
+
+	require.NoError(
+		t,
+		pgClient.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				return files.LoadDeletedBefore(
+					ctx,
+					conn,
+					scope,
+					cutoff,
+					nil,
+					100,
+				)
+			},
+		),
+	)
+
+	require.Len(t, files, 1)
+	assert.Equal(t, expired.ID, files[0].ID)
+
+	require.NoError(
+		t,
+		pgClient.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				if err := recent.LoadByID(ctx, conn, scope, recent.ID); err != nil {
+					return err
+				}
+
+				return active.LoadByID(ctx, conn, scope, active.ID)
+			},
+		),
+	)
+}
+
+func TestFiles_LoadDeletedBefore_Paginates(t *testing.T) {
+	t.Parallel()
+
+	pgClient := test.PGClient(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+	cutoff := now.Add(-30 * 24 * time.Hour)
+	deletedAt := now.Add(-31 * 24 * time.Hour)
+
+	first := insertTestFile(t, pgClient, scope, organizationID, now, new(deletedAt))
+	second := insertTestFile(t, pgClient, scope, organizationID, now, new(deletedAt))
+
+	if first.ID.String() > second.ID.String() {
+		first, second = second, first
+	}
+
+	var page coredata.Files
+
+	require.NoError(
+		t,
+		pgClient.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				return page.LoadDeletedBefore(ctx, conn, scope, cutoff, nil, 1)
+			},
+		),
+	)
+	require.Len(t, page, 1)
+	assert.Equal(t, first.ID, page[0].ID)
+
+	require.NoError(
+		t,
+		pgClient.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				return page.LoadDeletedBefore(ctx, conn, scope, cutoff, &page[0].ID, 1)
+			},
+		),
+	)
+	require.Len(t, page, 1)
+	assert.Equal(t, second.ID, page[0].ID)
+}
+
+func TestFile_LoadDeletedByIDForUpdateSkipLocked_RechecksCutoff(t *testing.T) {
+	t.Parallel()
+
+	pgClient := test.PGClient(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+	cutoff := now.Add(-30 * 24 * time.Hour)
+
+	expired := insertTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-31*24*time.Hour)))
+	redeleted := insertTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-31*24*time.Hour)))
+
+	require.NoError(
+		t,
+		pgClient.WithTx(
+			ctx,
+			func(ctx context.Context, tx pg.Tx) error {
+				return redeleted.SoftDelete(ctx, tx, scope)
+			},
+		),
+	)
+
+	require.NoError(
+		t,
+		pgClient.WithTx(
+			ctx,
+			func(ctx context.Context, tx pg.Tx) error {
+				var locked coredata.File
+				if err := locked.LoadDeletedByIDForUpdateSkipLocked(
+					ctx,
+					tx,
+					scope,
+					expired.ID,
+					cutoff,
+				); err != nil {
+					return err
+				}
+
+				assert.Equal(t, expired.ID, locked.ID)
+
+				var skipped coredata.File
+				require.ErrorIs(
+					t,
+					skipped.LoadDeletedByIDForUpdateSkipLocked(
+						ctx,
+						tx,
+						scope,
+						redeleted.ID,
+						cutoff,
+					),
+					coredata.ErrResourceNotFound,
+				)
+
+				return nil
+			},
+		),
+	)
+}
+
+func TestFile_Delete(t *testing.T) {
+	t.Parallel()
+
+	pgClient := test.PGClient(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+
+	deleted := insertTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-31*24*time.Hour)))
+	active := insertTestFile(t, pgClient, scope, organizationID, now, nil)
+
+	require.NoError(
+		t,
+		pgClient.WithTx(
+			ctx,
+			func(ctx context.Context, tx pg.Tx) error {
+				if err := deleted.Delete(ctx, tx, scope); err != nil {
+					return err
+				}
+
+				return active.Delete(ctx, tx, scope)
+			},
+		),
+	)
+
+	require.NoError(
+		t,
+		pgClient.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				var gone coredata.File
+				require.ErrorIs(t, gone.LoadByID(ctx, conn, scope, deleted.ID), coredata.ErrResourceNotFound)
+
+				return active.LoadByID(ctx, conn, scope, active.ID)
+			},
+		),
+	)
+}
+
+func TestFile_Delete_WhenStillReferenced(t *testing.T) {
+	t.Parallel()
+
+	pgClient := test.PGClient(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+	file := insertTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-31*24*time.Hour)))
+
+	require.NoError(
+		t,
+		pgClient.WithTx(
+			ctx,
+			func(ctx context.Context, tx pg.Tx) error {
+				org := &coredata.Organization{
+					ID:         organizationID,
+					TenantID:   tenantID,
+					Name:       "Referenced File Org",
+					LogoFileID: &file.ID,
+					CreatedAt:  now,
+					UpdatedAt:  now,
+				}
+
+				return org.Insert(ctx, tx)
+			},
+		),
+	)
+
+	err := pgClient.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			return file.Delete(ctx, tx, scope)
+		},
+	)
+	require.ErrorIs(t, err, coredata.ErrResourceInUse)
+	assert.ErrorContains(t, err, "file is still referenced")
+
+	require.NoError(
+		t,
+		pgClient.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				return file.LoadByID(ctx, conn, scope, file.ID)
+			},
+		),
+	)
+}
+
+func insertTestFile(
+	t *testing.T,
+	pgClient *pg.Client,
+	scope coredata.Scoper,
+	organizationID gid.GID,
+	now time.Time,
+	deletedAt *time.Time,
+) *coredata.File {
+	t.Helper()
+
+	objectKey, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	file := &coredata.File{
+		ID:             gid.New(organizationID.TenantID(), coredata.FileEntityType),
+		OrganizationID: organizationID,
+		BucketName:     "uploads",
+		MimeType:       "application/pdf",
+		FileName:       "test.pdf",
+		FileKey:        objectKey.String(),
+		FileSize:       1,
+		Visibility:     coredata.FileVisibilityPrivate,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		DeletedAt:      deletedAt,
+	}
+
+	require.NoError(
+		t,
+		pgClient.WithTx(
+			t.Context(),
+			func(ctx context.Context, tx pg.Tx) error {
+				return file.Insert(ctx, tx, scope)
+			},
+		),
+	)
+
+	return file
+}

--- a/pkg/filemanager/file_purge_worker.go
+++ b/pkg/filemanager/file_purge_worker.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package filemanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.gearno.de/kit/worker"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+const (
+	DefaultDeletedFileRetention     = 30 * 24 * time.Hour
+	DefaultDeletedFileCleanupPeriod = time.Hour
+	DefaultDeletedFileCleanupBatch  = 100
+	DefaultDeletedFileMaxPerTick    = 1000
+)
+
+type (
+	DeletedFilePurgeWorker struct {
+		handler  *deletedFilePurgeHandler
+		periodic *worker.PeriodicWorker
+		logger   *log.Logger
+	}
+
+	deletedFilePurgeHandler struct {
+		svc        *Service
+		logger     *log.Logger
+		scope      coredata.Scoper
+		retention  time.Duration
+		batchSize  int
+		maxPerTick int
+		now        func() time.Time
+	}
+)
+
+func NewDeletedFilePurgeWorker(
+	svc *Service,
+	logger *log.Logger,
+	retention time.Duration,
+	maxPerTick int,
+	opts ...worker.Option,
+) *DeletedFilePurgeWorker {
+	if retention <= 0 {
+		retention = DefaultDeletedFileRetention
+	}
+
+	if maxPerTick <= 0 {
+		maxPerTick = DefaultDeletedFileMaxPerTick
+	}
+
+	workerOpts := append(
+		[]worker.Option{worker.WithInterval(DefaultDeletedFileCleanupPeriod)},
+		opts...,
+	)
+
+	handler := &deletedFilePurgeHandler{
+		svc:        svc,
+		logger:     logger,
+		scope:      coredata.NewNoScope(),
+		retention:  retention,
+		batchSize:  DefaultDeletedFileCleanupBatch,
+		maxPerTick: maxPerTick,
+		now:        time.Now,
+	}
+
+	return &DeletedFilePurgeWorker{
+		handler: handler,
+		periodic: worker.NewPeriodic(
+			"file-purge-worker",
+			handler,
+			logger,
+			workerOpts...,
+		),
+		logger: logger,
+	}
+}
+
+func (w *DeletedFilePurgeWorker) Run(ctx context.Context) error {
+	if err := w.handler.Run(context.WithoutCancel(ctx)); err != nil {
+		w.logger.ErrorCtx(
+			ctx,
+			"run failed",
+			log.Error(err),
+		)
+	}
+
+	return w.periodic.Run(ctx)
+}
+
+func (h *deletedFilePurgeHandler) Run(ctx context.Context) error {
+	before := h.now().Add(-h.retention)
+
+	var afterID *gid.GID
+
+	deleted := 0
+	remaining := h.maxPerTick
+
+	var errs []error
+
+	for remaining > 0 {
+		limit := min(h.batchSize, remaining)
+
+		var files coredata.Files
+
+		if err := h.svc.pg.WithConn(
+			ctx,
+			func(ctx context.Context, conn pg.Querier) error {
+				return files.LoadDeletedBefore(
+					ctx,
+					conn,
+					h.scope,
+					before,
+					afterID,
+					limit,
+				)
+			},
+		); err != nil {
+			return fmt.Errorf("cannot load deleted files: %w", err)
+		}
+
+		if len(files) == 0 {
+			break
+		}
+
+		for _, file := range files {
+			id := file.ID
+			afterID = &id
+			remaining--
+
+			if err := h.purge(ctx, file, before); err != nil {
+				h.logger.ErrorCtx(
+					ctx,
+					"cannot purge deleted file",
+					log.String("file_id", file.ID.String()),
+					log.Error(err),
+				)
+				errs = append(errs, err)
+
+				continue
+			}
+
+			deleted++
+		}
+	}
+
+	if deleted > 0 {
+		h.logger.InfoCtx(
+			ctx,
+			"purged soft-deleted files",
+			log.Int("count", deleted),
+		)
+	}
+
+	return errors.Join(errs...)
+}
+
+func (h *deletedFilePurgeHandler) purge(
+	ctx context.Context,
+	file *coredata.File,
+	before time.Time,
+) error {
+	return h.svc.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			var locked coredata.File
+
+			if err := locked.LoadDeletedByIDForUpdateSkipLocked(ctx, tx, h.scope, file.ID, before); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return nil
+				}
+
+				return fmt.Errorf("cannot lock deleted file: %w", err)
+			}
+
+			if err := locked.Delete(ctx, tx, h.scope); err != nil {
+				return fmt.Errorf("cannot delete file from database: %w", err)
+			}
+
+			if err := h.svc.DeleteFile(ctx, &locked); err != nil {
+				return fmt.Errorf("cannot delete file from S3: %w", err)
+			}
+
+			return nil
+		},
+	)
+}

--- a/pkg/filemanager/file_purge_worker_test.go
+++ b/pkg/filemanager/file_purge_worker_test.go
@@ -1,0 +1,393 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package filemanager
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/crypto/uuid"
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.gearno.de/kit/worker"
+	"go.probo.inc/probo/internal/test"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+func TestDeletedFilePurgeHandler_Run_PurgesExpiredFiles(t *testing.T) {
+	t.Parallel()
+
+	pgClient := test.PGClient(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+
+	expired := insertPurgeTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-48*time.Hour)))
+	recent := insertPurgeTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-30*time.Minute)))
+	active := insertPurgeTestFile(t, pgClient, scope, organizationID, now, nil)
+
+	var (
+		mu          sync.Mutex
+		deletedKeys []string
+	)
+
+	svc := newPurgeTestService(
+		t,
+		pgClient,
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodDelete, r.Method)
+
+			mu.Lock()
+
+			deletedKeys = append(deletedKeys, r.URL.Path)
+
+			mu.Unlock()
+
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+
+	h := newPurgeHandler(svc, scope, now, time.Hour, 10, 10)
+	require.NoError(t, h.Run(t.Context()))
+
+	mu.Lock()
+	assert.Contains(t, deletedKeys, "/"+expired.BucketName+"/"+expired.FileKey)
+	assert.NotContains(t, deletedKeys, "/"+recent.BucketName+"/"+recent.FileKey)
+	assert.NotContains(t, deletedKeys, "/"+active.BucketName+"/"+active.FileKey)
+	mu.Unlock()
+
+	require.NoError(
+		t,
+		pgClient.WithConn(
+			t.Context(),
+			func(ctx context.Context, conn pg.Querier) error {
+				var gone coredata.File
+				require.ErrorIs(
+					t,
+					gone.LoadByID(ctx, conn, scope, expired.ID),
+					coredata.ErrResourceNotFound,
+				)
+
+				if err := recent.LoadByID(ctx, conn, scope, recent.ID); err != nil {
+					return err
+				}
+
+				return active.LoadByID(ctx, conn, scope, active.ID)
+			},
+		),
+	)
+}
+
+func TestDeletedFilePurgeHandler_Run_KeepsRowWhenS3DeleteFails(t *testing.T) {
+	t.Parallel()
+
+	pgClient := test.PGClient(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+	expired := insertPurgeTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-48*time.Hour)))
+
+	svc := newPurgeTestService(
+		t,
+		pgClient,
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		},
+	)
+
+	h := newPurgeHandler(svc, scope, now, time.Hour, 10, 10)
+	err := h.Run(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cannot delete file from S3")
+
+	require.NoError(
+		t,
+		pgClient.WithConn(
+			t.Context(),
+			func(ctx context.Context, conn pg.Querier) error {
+				return expired.LoadByID(ctx, conn, scope, expired.ID)
+			},
+		),
+	)
+}
+
+func TestDeletedFilePurgeHandler_Run_SkipsS3WhenFileStillReferenced(t *testing.T) {
+	t.Parallel()
+
+	pgClient := test.PGClient(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+	expired := insertPurgeTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-48*time.Hour)))
+
+	require.NoError(
+		t,
+		pgClient.WithTx(
+			t.Context(),
+			func(ctx context.Context, tx pg.Tx) error {
+				org := &coredata.Organization{
+					ID:         organizationID,
+					TenantID:   tenantID,
+					Name:       "Referenced File Org",
+					LogoFileID: &expired.ID,
+					CreatedAt:  now,
+					UpdatedAt:  now,
+				}
+
+				return org.Insert(ctx, tx)
+			},
+		),
+	)
+
+	var s3Deletes int
+
+	svc := newPurgeTestService(
+		t,
+		pgClient,
+		func(w http.ResponseWriter, _ *http.Request) {
+			s3Deletes++
+
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+
+	h := newPurgeHandler(svc, scope, now, time.Hour, 10, 10)
+	err := h.Run(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cannot delete file from database")
+	assert.ErrorContains(t, err, "file is still referenced")
+	assert.Zero(t, s3Deletes)
+
+	require.NoError(
+		t,
+		pgClient.WithConn(
+			t.Context(),
+			func(ctx context.Context, conn pg.Querier) error {
+				return expired.LoadByID(ctx, conn, scope, expired.ID)
+			},
+		),
+	)
+}
+
+func TestDeletedFilePurgeHandler_Run_StopsAtMaxPerTick(t *testing.T) {
+	t.Parallel()
+
+	pgClient := test.PGClient(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+
+	first := insertPurgeTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-48*time.Hour)))
+	second := insertPurgeTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-48*time.Hour)))
+	third := insertPurgeTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-48*time.Hour)))
+
+	svc := newPurgeTestService(
+		t,
+		pgClient,
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+
+	h := newPurgeHandler(svc, scope, now, time.Hour, 10, 2)
+	require.NoError(t, h.Run(t.Context()))
+
+	remaining := 0
+
+	require.NoError(
+		t,
+		pgClient.WithConn(
+			t.Context(),
+			func(ctx context.Context, conn pg.Querier) error {
+				for _, file := range []*coredata.File{first, second, third} {
+					var loaded coredata.File
+
+					err := loaded.LoadByID(ctx, conn, scope, file.ID)
+					if err == nil {
+						remaining++
+					}
+				}
+
+				return nil
+			},
+		),
+	)
+	assert.Equal(t, 1, remaining)
+}
+
+func TestDeletedFilePurgeWorker_Run_CompletesInitialSweepWhenCanceled(t *testing.T) {
+	t.Parallel()
+
+	pgClient := test.PGClient(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+	expired := insertPurgeTestFile(t, pgClient, scope, organizationID, now, new(now.Add(-48*time.Hour)))
+
+	var s3Deletes int
+
+	svc := newPurgeTestService(
+		t,
+		pgClient,
+		func(w http.ResponseWriter, _ *http.Request) {
+			s3Deletes++
+
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+
+	logger := log.NewLogger(log.WithOutput(io.Discard))
+	handler := newPurgeHandler(svc, scope, now, time.Hour, 10, 10)
+	w := &DeletedFilePurgeWorker{
+		handler: handler,
+		periodic: worker.NewPeriodic(
+			"file-purge-worker-cancel-test",
+			handler,
+			logger,
+			worker.WithInterval(time.Hour),
+		),
+		logger: logger,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := w.Run(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, s3Deletes)
+
+	require.NoError(
+		t,
+		pgClient.WithConn(
+			t.Context(),
+			func(ctx context.Context, conn pg.Querier) error {
+				var gone coredata.File
+
+				require.ErrorIs(
+					t,
+					gone.LoadByID(ctx, conn, scope, expired.ID),
+					coredata.ErrResourceNotFound,
+				)
+
+				return nil
+			},
+		),
+	)
+}
+
+func newPurgeHandler(
+	svc *Service,
+	scope coredata.Scoper,
+	now time.Time,
+	retention time.Duration,
+	batchSize int,
+	maxPerTick int,
+) *deletedFilePurgeHandler {
+	return &deletedFilePurgeHandler{
+		svc:        svc,
+		logger:     log.NewLogger(log.WithOutput(io.Discard)),
+		scope:      scope,
+		retention:  retention,
+		batchSize:  batchSize,
+		maxPerTick: maxPerTick,
+		now:        func() time.Time { return now },
+	}
+}
+
+func newPurgeTestService(
+	t *testing.T,
+	pgClient *pg.Client,
+	handler http.HandlerFunc,
+) *Service {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	s3Client := awss3.NewFromConfig(
+		aws.Config{
+			Region:      "us-east-1",
+			Credentials: credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
+		},
+		func(o *awss3.Options) {
+			o.BaseEndpoint = aws.String(srv.URL)
+			o.UsePathStyle = true
+		},
+	)
+
+	return NewService(pgClient, nil, s3Client, log.NewLogger(log.WithOutput(io.Discard)))
+}
+
+func insertPurgeTestFile(
+	t *testing.T,
+	pgClient *pg.Client,
+	scope coredata.Scoper,
+	organizationID gid.GID,
+	now time.Time,
+	deletedAt *time.Time,
+) *coredata.File {
+	t.Helper()
+
+	objectKey, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	file := &coredata.File{
+		ID:             gid.New(organizationID.TenantID(), coredata.FileEntityType),
+		OrganizationID: organizationID,
+		BucketName:     "uploads",
+		MimeType:       "application/pdf",
+		FileName:       "purge.pdf",
+		FileKey:        objectKey.String(),
+		FileSize:       1,
+		Visibility:     coredata.FileVisibilityPrivate,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		DeletedAt:      deletedAt,
+	}
+
+	require.NoError(
+		t,
+		pgClient.WithTx(
+			t.Context(),
+			func(ctx context.Context, tx pg.Tx) error {
+				return file.Insert(ctx, tx, scope)
+			},
+		),
+	)
+
+	return file
+}

--- a/pkg/filemanager/main_test.go
+++ b/pkg/filemanager/main_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package filemanager
+
+import (
+	"os"
+	"testing"
+
+	internaltest "go.probo.inc/probo/internal/test"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(internaltest.RunGlobalQueuePackage(m))
+}

--- a/pkg/filemanager/s3.go
+++ b/pkg/filemanager/s3.go
@@ -283,6 +283,24 @@ func (s *Service) PutFile(
 	return *headOutput.ContentLength, nil
 }
 
+func (s *Service) DeleteFile(
+	ctx context.Context,
+	file *coredata.File,
+) error {
+	_, err := s.s3Client.DeleteObject(
+		ctx,
+		&s3.DeleteObjectInput{
+			Bucket: new(file.BucketName),
+			Key:    new(file.FileKey),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("cannot delete file from S3: %w", err)
+	}
+
+	return nil
+}
+
 func (s *Service) GeneratePresignedURL(
 	ctx context.Context,
 	file *coredata.File,

--- a/pkg/filemanager/s3_test.go
+++ b/pkg/filemanager/s3_test.go
@@ -77,6 +77,41 @@ func newTestS3Service(
 	return filemanager.NewService(nil, nil, s3Client, log.NewLogger(log.WithOutput(io.Discard)))
 }
 
+func TestDeleteFile_SendsDeleteObject(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu        sync.Mutex
+		gotPath   string
+		gotMethod string
+	)
+
+	svc := newTestS3Service(
+		t,
+		func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			mu.Unlock()
+
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+
+	file := &coredata.File{
+		BucketName: "uploads",
+		FileKey:    "tenant/file",
+	}
+
+	require.NoError(t, svc.DeleteFile(context.Background(), file))
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	assert.Equal(t, http.MethodDelete, gotMethod)
+	assert.Equal(t, "/uploads/tenant/file", gotPath)
+}
+
 func TestOpenFile_StreamsBody(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/probod/aliases.go
+++ b/pkg/probod/aliases.go
@@ -46,6 +46,7 @@ type (
 	PrivateKey                         = probodconfig.PrivateKey
 	RSAPrivateKey                      = probodconfig.RSAPrivateKey
 	AWSConfig                          = probodconfig.AWSConfig
+	FilePurgeConfig                    = probodconfig.FilePurgeConfig
 	ConnectorConfig                    = probodconfig.ConnectorConfig
 	ConnectorConfigOAuth2              = probodconfig.ConnectorConfigOAuth2
 	ConnectorConfigGitHubApp           = probodconfig.ConnectorConfigGitHubApp
@@ -77,6 +78,10 @@ type (
 )
 
 const (
+	DefaultFilePurgeIntervalSeconds  = probodconfig.DefaultFilePurgeIntervalSeconds
+	DefaultFilePurgeRetentionSeconds = probodconfig.DefaultFilePurgeRetentionSeconds
+	DefaultFilePurgeMaxPerTick       = probodconfig.DefaultFilePurgeMaxPerTick
+
 	CompliancePortalTLSModeDirect   = probodconfig.CompliancePortalTLSModeDirect
 	CompliancePortalTLSModeExternal = probodconfig.CompliancePortalTLSModeExternal
 	CookieSameSiteLax               = probodconfig.CookieSameSiteLax

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -176,6 +176,11 @@ func New() *Implm {
 				Region: "us-east-1",
 				Bucket: "probod",
 			},
+			FilePurge: FilePurgeConfig{
+				Interval:   DefaultFilePurgeIntervalSeconds,
+				Retention:  DefaultFilePurgeRetentionSeconds,
+				MaxPerTick: DefaultFilePurgeMaxPerTick,
+			},
 			Notifications: NotificationsConfig{
 				Mailer: MailerConfig{
 					MailerInterval: 60,
@@ -1224,6 +1229,42 @@ func (impl *Implm) Run(
 		},
 	)
 
+	filePurgeInterval := time.Duration(impl.cfg.FilePurge.Interval) * time.Second
+	if filePurgeInterval <= 0 {
+		filePurgeInterval = filemanager.DefaultDeletedFileCleanupPeriod
+	}
+
+	filePurgeRetention := time.Duration(impl.cfg.FilePurge.Retention) * time.Second
+	if filePurgeRetention <= 0 {
+		filePurgeRetention = filemanager.DefaultDeletedFileRetention
+	}
+
+	filePurgeMaxPerTick := impl.cfg.FilePurge.MaxPerTick
+	if filePurgeMaxPerTick <= 0 {
+		filePurgeMaxPerTick = filemanager.DefaultDeletedFileMaxPerTick
+	}
+
+	filePurgeWorker := filemanager.NewDeletedFilePurgeWorker(
+		fileManagerService,
+		l.Named("file-purge-worker"),
+		filePurgeRetention,
+		filePurgeMaxPerTick,
+		worker.WithInterval(filePurgeInterval),
+		worker.WithRegisterer(r),
+		worker.WithTracerProvider(tp),
+	)
+	filePurgeWorkerCtx, stopFilePurgeWorker := context.WithCancel(
+		context.WithoutCancel(ctx),
+	)
+
+	wg.Go(
+		func() {
+			if err := filePurgeWorker.Run(filePurgeWorkerCtx); err != nil {
+				cancel(fmt.Errorf("file purge worker crashed: %w", err))
+			}
+		},
+	)
+
 	webhookWorkerCtx, stopWebhookWorker := context.WithCancel(context.Background())
 	webhookWorker := webhook.NewWebhookWorker(pgClient, l.Named("webhook-sender"), webhook.Config{
 		Interval:       time.Duration(impl.cfg.Notifications.Webhook.SenderInterval) * time.Second,
@@ -1596,6 +1637,7 @@ func (impl *Implm) Run(
 	stopSlackInteractiveCommandWorker()
 	stopSlackDeliveryWorker()
 	stopProbotRetentionWorker()
+	stopFilePurgeWorker()
 
 	wg.Wait()
 

--- a/pkg/probodconfig/config.go
+++ b/pkg/probodconfig/config.go
@@ -64,6 +64,7 @@ type (
 		ITAM               ITAMConfig               `json:"itam"`
 		CompliancePortal   CompliancePortalConfig   `json:"trust-center"`
 		AWS                AWSConfig                `json:"aws"`
+		FilePurge          FilePurgeConfig          `json:"file-purge"`
 		Notifications      NotificationsConfig      `json:"notifications"`
 		Connectors         []ConnectorConfig        `json:"connectors,omitempty"`
 		// ConnectorEndpoints repoints a provider at different hosts (a vendor

--- a/pkg/probodconfig/file_purge_config.go
+++ b/pkg/probodconfig/file_purge_config.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package probodconfig
+
+const (
+	DefaultFilePurgeIntervalSeconds  = 3600
+	DefaultFilePurgeRetentionSeconds = 2592000
+	DefaultFilePurgeMaxPerTick       = 1000
+)
+
+// FilePurgeConfig configures the worker that permanently deletes
+// soft-deleted files from object storage and the database.
+// All durations are in seconds.
+type FilePurgeConfig struct {
+	// Interval is how often the worker scans for expired soft-deleted files.
+	Interval int `json:"interval"`
+	// Retention is how long a soft-deleted file is kept before purge.
+	Retention int `json:"retention"`
+	// MaxPerTick is the maximum number of files processed in one run.
+	MaxPerTick int `json:"max-per-tick"`
+}


### PR DESCRIPTION
Permanently remove S3 objects and database rows for files whose deleted_at is older than the configured retention (default 30 days). Interval, retention, and max files per tick are configurable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a background worker that permanently deletes soft-deleted files from S3 and the database once they're older than the configured retention (default 30 days), instead of keeping them forever. Interval, retention, and max files per tick are configurable via env or Helm.

### Tests **`+798`** **`-0`**

Covers the new coredata queries, `DeleteFile` on S3, and purge worker behavior including S3 failures, still-referenced files, and the per-tick cap.

### Coredata **`+152`** **`-0`**

Adds queries to load soft-deleted files before a cutoff with keyset pagination, lock a deleted file with `FOR UPDATE SKIP LOCKED`, and delete a file row while returning `ErrResourceInUse` when foreign keys still reference it.

### Service **`+321`** **`-0`**

Adds the purge worker and `DeleteFile` on the S3 service, wires worker startup and shutdown into the server, and plumbs purge configuration with defaults.

### Other **`+21`** **`-0`**

Adds `.env.example` entries and Helm chart values plus deployment env vars for the purge settings.

<sup>Written for commit dbc574bdfacec2819400102f00fe4f0338219889. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

