### PR TITLE
Remove the risk analysis updated-at timestamp from the frontend

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -2462,7 +2462,7 @@
     "deleteConfirmation": "This will permanently delete this risk analysis and all its diagrams, nodes, processes, and threats. This action cannot be undone.",
     "actions": { "fork": "Fork", "edit": "Edit", "delete": "Delete", "showMore": "Show more" },
     "details": "Details",
-    "fields": { "period": "Period", "matrixSize": "Matrix size", "createdAt": "Created at", "updatedAt": "Updated at" },
+    "fields": { "period": "Period", "matrixSize": "Matrix size", "createdAt": "Created at" },
     "diagrams": "Diagrams",
     "treatmentPlans": "Risks and Treatment Plans",
     "emptyDiagrams": "No diagrams yet. Create a diagram to start defining nodes, processes, and threats.",

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -4608,8 +4608,7 @@
     "fields": {
       "period": "Période",
       "matrixSize": "Taille de matrice",
-      "createdAt": "Créé le",
-      "updatedAt": "Mis à jour le"
+      "createdAt": "Créé le"
     },
     "diagrams": "Diagrammes",
     "treatmentPlans": "Risques et plans de traitement",

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -4598,8 +4598,7 @@
     "fields": {
       "period": "Periode",
       "matrixSize": "Matrixgrootte",
-      "createdAt": "Aangemaakt op",
-      "updatedAt": "Bijgewerkt op"
+      "createdAt": "Aangemaakt op"
     },
     "diagrams": "Diagrammen",
     "treatmentPlans": "Risico's en behandelplannen",

--- a/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysisDetailLayout.tsx
+++ b/apps/console/src/pages/organizations/risks/risk-analyses/RiskAnalysisDetailLayout.tsx
@@ -59,7 +59,6 @@ export const riskAnalysisDetailLayoutQuery = graphql`
           cols
         }
         createdAt
-        updatedAt
         ...RiskAnalysisActions_riskAnalysis
       }
     }
@@ -117,7 +116,7 @@ export default function RiskAnalysisDetailLayout({ queryRef }: RiskAnalysisDetai
       </PageHeader>
 
       <Card padded>
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
           <div>
             <div className="text-xs text-txt-tertiary font-semibold mb-1">
               {t("riskAnalysisDetailPage.fields.period")}
@@ -140,14 +139,6 @@ export default function RiskAnalysisDetailLayout({ queryRef }: RiskAnalysisDetai
             </div>
             <div className="text-sm text-txt-primary">
               {dateFormat(i18n.language, ra.createdAt)}
-            </div>
-          </div>
-          <div>
-            <div className="text-xs text-txt-tertiary font-semibold mb-1">
-              {t("riskAnalysisDetailPage.fields.updatedAt")}
-            </div>
-            <div className="text-sm text-txt-primary">
-              {dateFormat(i18n.language, ra.updatedAt)}
             </div>
           </div>
         </div>


### PR DESCRIPTION
That field only records edits to the parent RiskAnalysis record itself. It does not follow later changes to diagrams, scenarios, treatment-plan results, or measure status, so showing it as a last-updated date is misleading.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the risk-analysis updated-at timestamp from the console. That field only records edits to the parent RiskAnalysis record and ignores later changes to diagrams, scenarios, treatment-plan results, or measure status, so it showed a misleading last-updated date.

### App: console **`+4`** **`-15`**

- Drops `updatedAt` from the detail layout query and removes the updated-at display card.
- Removes the `updatedAt` translation key from English, French, and Dutch locale files.
- Adjusts the field grid from four columns to three after the removal.

<sup>Written for commit 6e40807e698a991f1ae8fe8755883d244107fc7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

