### PR TITLE
fix(oauth2): accept a resource that differs only by the root trailing slash

### DIFF
--- a/pkg/iam/oauth2/resource_test.go
+++ b/pkg/iam/oauth2/resource_test.go
@@ -119,6 +119,92 @@ func TestServiceProtectedResource(t *testing.T) {
 	}
 }
 
+func TestServiceProtectedResourceTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	// RFC 3986 section 6.2.3: for http(s) an empty path and "/" denote the same
+	// resource. A client that round-trips the advertised identifier through a
+	// URL library sends the "/" spelling, so both must be accepted whichever
+	// way the issuer itself is configured, and both must resolve to the
+	// configured spelling so downstream comparisons stay consistent.
+	tests := []struct {
+		name    string
+		baseURL uri.URI
+		value   string
+		want    []uri.URI
+	}{
+		{
+			name:    "slashless issuer accepts trailing slash",
+			baseURL: "https://auth.example.com",
+			value:   "https://auth.example.com/",
+			want:    []uri.URI{"https://auth.example.com"},
+		},
+		{
+			name:    "slashless issuer accepts itself",
+			baseURL: "https://auth.example.com",
+			value:   "https://auth.example.com",
+			want:    []uri.URI{"https://auth.example.com"},
+		},
+		{
+			name:    "trailing slash issuer accepts slashless",
+			baseURL: "https://auth.example.com/",
+			value:   "https://auth.example.com",
+			want:    []uri.URI{"https://auth.example.com/"},
+		},
+		{
+			name:    "trailing slash issuer accepts itself",
+			baseURL: "https://auth.example.com/",
+			value:   "https://auth.example.com/",
+			want:    []uri.URI{"https://auth.example.com/"},
+		},
+		{
+			name:    "mcp resource unaffected",
+			baseURL: "https://auth.example.com",
+			value:   "https://auth.example.com/api/mcp/v1",
+			want:    []uri.URI{"https://auth.example.com/api/mcp/v1"},
+		},
+		{
+			name:    "mcp resource unaffected when issuer has trailing slash",
+			baseURL: "https://auth.example.com/",
+			value:   "https://auth.example.com/api/mcp/v1",
+			want:    []uri.URI{"https://auth.example.com/api/mcp/v1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				service := &Service{baseURL: tt.baseURL}
+
+				got, err := service.protectedResources([]string{tt.value})
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			},
+		)
+	}
+}
+
+func TestServiceProtectedResourceNormalizationIsNarrow(t *testing.T) {
+	t.Parallel()
+
+	// Only the root case is equivalent. A trailing slash on a longer path is a
+	// different path, and a different host is still a different resource.
+	service := &Service{baseURL: "https://auth.example.com"}
+
+	for _, value := range []string{
+		"https://auth.example.com/api/mcp/v1/",
+		"https://auth.example.com/api/mcp/",
+		"https://other.example.com/",
+		"https://other.example.com",
+	} {
+		_, err := service.protectedResources([]string{value})
+		require.ErrorIs(t, err, ErrInvalidTarget, "value %q must not be accepted", value)
+	}
+}
+
 func TestResourcesSubset(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/iam/oauth2/service.go
+++ b/pkg/iam/oauth2/service.go
@@ -1867,20 +1867,62 @@ func (s *Service) supportedResources(values []string) ([]uri.URI, error) {
 			)
 		}
 
-		resource := uri.URI(raw)
-		if !slices.Contains(supported, resource) {
+		// RFC 3986 section 6.2.3: for http and https an empty path and "/"
+		// identify the same resource. A client that round-trips the advertised
+		// identifier through a URL library gets the "/" spelling back, so
+		// comparing raw bytes rejects a resource this server itself
+		// advertised. Match on the normalized form, but keep the configured
+		// spelling, so everything stored and compared downstream continues to
+		// use one vocabulary.
+		matched, ok := matchResource(supported, uri.URI(raw))
+		if !ok {
 			return nil, NewError(
 				ErrInvalidTarget,
 				WithDescription("unsupported resource"),
 			)
 		}
 
-		if !slices.Contains(resources, resource) {
-			resources = append(resources, resource)
+		if !slices.Contains(resources, matched) {
+			resources = append(resources, matched)
 		}
 	}
 
 	return resources, nil
+}
+
+// matchResource reports which supported resource the requested one denotes,
+// comparing both under scheme-based normalization. The returned value is the
+// supported entry as configured, not the requested spelling.
+func matchResource(supported []uri.URI, requested uri.URI) (uri.URI, bool) {
+	normalized := normalizeResource(requested)
+
+	for _, entry := range supported {
+		if normalizeResource(entry) == normalized {
+			return entry, true
+		}
+	}
+
+	return "", false
+}
+
+// normalizeResource applies RFC 3986 section 6.2.3 scheme-based normalization
+// to a resource identifier: for an http(s) URI a bare "/" path is equivalent to
+// no path at all. A trailing slash on any longer path is a genuinely different
+// path and is left alone, so this widens nothing beyond the root case. Input
+// that does not parse is returned unchanged, leaving the caller to reject it.
+func normalizeResource(resource uri.URI) uri.URI {
+	parsed, err := url.Parse(resource.String())
+	if err != nil {
+		return resource
+	}
+
+	if parsed.Path != "/" {
+		return resource
+	}
+
+	parsed.Path = ""
+
+	return uri.URI(parsed.String())
 }
 
 func resourcesSubset(requested []uri.URI, allowed []uri.URI) bool {


### PR DESCRIPTION
## What

`supportedResources` compares the requested `resource` against the supported set
with `slices.Contains` — byte equality on the raw string. This changes the
comparison to use RFC 3986 §6.2.3 scheme-based normalization, so an http(s) URI
with an empty path and one with a `/` path are recognised as the same resource.

## Why

RFC 3986 §6.2.3 says that for http and https an empty path and `/` identify the
same resource. Any client that round-trips the advertised identifier through a
URL library gets the `/` spelling back — JavaScript's `new URL()` does exactly
this — and is then rejected with `invalid_target` / `unsupported resource`,
for a value the server itself advertised.

The failure is hard to diagnose from the outside, because nothing in either
metadata document hints at it:

- `PROBOD_BASE_URL=https://host` (no trailing slash)
- `/.well-known/oauth-protected-resource` advertises `resource: "https://host"`
- `/.well-known/oauth-authorization-server` advertises
  `protected_resources: ["https://host"]`
- the client sends `resource=https://host/`
- authorize fails with `invalid_target: unsupported resource`

Reproduced against probod v0.279.0 with an MCP client (Claude Code 2.1.263)
connecting to a self-hosted instance. The client's choice of identifier is
arguably also wrong — the MCP spec points at the protected resource's own
`resource` value, `https://host/api/mcp/v1` — and that is being reported
separately. But a server should not reject a normalized form of an identifier
it published, whatever the client picked.

## How

- `normalizeResource` folds a bare `/` path to an empty path, and only that.
  A trailing slash on any longer path is a genuinely different path and is left
  untouched, so the accepted set widens by exactly the root case and nothing
  else. Input that fails to parse is returned unchanged, so the caller still
  rejects it.
- `matchResource` compares both sides normalized and returns **the supported
  entry as configured**, not the requested spelling. This matters: the returned
  values become the resources recorded on tokens and are later compared against
  `s.baseURL` by `resourcesSubset`. Returning the client's spelling would let
  two spellings of one resource circulate and break those comparisons.

## Tests

`TestServiceProtectedResourceTrailingSlash` asserts both spellings are accepted
in both directions — issuer configured with and without a trailing slash, each
accepting both the slashed and unslashed request — and that each resolves to the
configured spelling. It also covers the MCP resource being unaffected either way.

`TestServiceProtectedResourceNormalizationIsNarrow` asserts the normalization
does not widen anything else: `.../api/mcp/v1/`, `.../api/mcp/`, and a different
host in both spellings are all still rejected.

The existing `TestServiceProtectedResource` cases are unchanged and still pass —
every one of them sends a canonical spelling and expects the same value back.

Verified with `go test ./pkg/iam/oauth2/...` (go1.27.1): `ok` with the change,
and `go vet ./pkg/iam/oauth2/` clean. Reverting only `service.go` to `main` makes
both new trailing-slash cases fail with exactly the production error —
`invalid_target: unsupported resource` — confirming the tests bind to the
behaviour being fixed rather than passing vacuously.

## Related

While tracing this, one nearby thing is worth flagging separately (not changed
here): `pkg/iam/oauth2/metadata.go:127` hardcodes
`ClientIDMetadataDocumentSupported: true` in the discovery document regardless of
whether any CIMD client IDs are allowlisted. An instance with
`PROBOD_OAUTH2_SERVER_CIMD_ALLOWED_CLIENT_IDS` unset advertises CIMD support and
then rejects every CIMD client at authorize time with
`client_id is not allowed for client metadata documents`. Same shape of problem:
metadata promising something the request path declines. Happy to open a separate
issue or PR for it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts OAuth2 resource requests that match a supported resource up to the root trailing slash, per RFC 3986 §6.2.3. Previously, resources were compared byte-for-byte, so a client sending the `/` spelling of an advertised identifier (e.g. `https://host/` for `https://host`) was rejected with `invalid_target: unsupported resource`; now both spellings match, and the configured spelling is what gets recorded on tokens.

### Tests **`+86`** **`-0`**

- `TestServiceProtectedResourceTrailingSlash` covers both spellings in both issuer configurations and confirms each resolves to the configured spelling.
- `TestServiceProtectedResourceNormalizationIsNarrow` confirms longer paths and different hosts are still rejected.

### Service **`+46`** **`-4`**

- `matchResource` compares both sides under normalization but returns the supported entry as configured, so downstream token and `resourcesSubset` comparisons keep a single vocabulary.
- `normalizeResource` folds only a bare `/` path to an empty path; longer paths and unparseable input are left untouched.

<sup>Written for commit 3e32df1240590df88490759ad5cb24dbbc9c935d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

