### PR TITLE
Expose evidence file download URLs

### DIFF
--- a/e2e/mcp/evidence_test.go
+++ b/e2e/mcp/evidence_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package mcp_test
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+func TestMCP_Evidence_GetFileURL(t *testing.T) {
+	t.Parallel()
+
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	mc := testutil.NewMCPClient(t, owner)
+	measureID := factory.NewMeasure(owner).
+		WithName(factory.SafeName("MCP evidence download")).
+		WithCategory("EVIDENCE").
+		Create()
+	fileContent := []byte("%PDF-1.4\nMCP evidence download\n%%EOF")
+
+	var uploadResult struct {
+		UploadMeasureEvidence struct {
+			EvidenceEdge struct {
+				Node struct {
+					ID string `json:"id"`
+				} `json:"node"`
+			} `json:"evidenceEdge"`
+		} `json:"uploadMeasureEvidence"`
+	}
+
+	err := owner.ExecuteWithFile(
+		`
+			mutation UploadMeasureEvidence($input: UploadMeasureEvidenceInput!) {
+				uploadMeasureEvidence(input: $input) {
+					evidenceEdge {
+						node {
+							id
+						}
+					}
+				}
+			}
+		`,
+		map[string]any{
+			"input": map[string]any{
+				"measureId": measureID,
+				"file":      nil,
+			},
+		},
+		"input.file",
+		testutil.UploadFile{
+			Filename:    "mcp-evidence.pdf",
+			ContentType: "application/pdf",
+			Content:     fileContent,
+		},
+		&uploadResult,
+	)
+	require.NoError(t, err)
+	evidenceID := uploadResult.UploadMeasureEvidence.EvidenceEdge.Node.ID
+	require.NotEmpty(t, evidenceID)
+
+	var listResult struct {
+		Evidences []struct {
+			ID string `json:"id"`
+		} `json:"evidences"`
+	}
+	mc.CallToolInto("listMeasureEvidences", map[string]any{
+		"measure_id": measureID,
+	}, &listResult)
+	require.Len(t, listResult.Evidences, 1)
+	assert.Equal(t, evidenceID, listResult.Evidences[0].ID)
+
+	var fileURLResult struct {
+		URL string `json:"url"`
+	}
+	mc.CallToolInto("getEvidenceFileUrl", map[string]any{
+		"id": evidenceID,
+	}, &fileURLResult)
+	require.NotEmpty(t, fileURLResult.URL)
+
+	response, err := owner.HTTPClient().Get(fileURLResult.URL)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+
+	downloaded, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, fileContent, downloaded)
+}

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -9598,3 +9598,36 @@ func (r *Resolver) DeleteTaskCommentTool(ctx context.Context, req *mcp.CallToolR
 		DeletedTaskCommentID: input.ID,
 	}, nil
 }
+
+func (r *Resolver) GetEvidenceFileUrlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetEvidenceFileUrlInput) (*mcp.CallToolResult, types.GetEvidenceFileUrlOutput, error) {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionEvidenceList)
+	if err != nil {
+		return nil, types.GetEvidenceFileUrlOutput{}, err
+	}
+
+	evidence, err := r.proboSvc.Evidences.Get(ctx, scope, input.ID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return nil, types.GetEvidenceFileUrlOutput{}, fmt.Errorf("resource not found")
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot load evidence for file URL", log.Error(err))
+
+		return nil, types.GetEvidenceFileUrlOutput{}, fmt.Errorf("internal server error")
+	}
+
+	if evidence.EvidenceFileId == nil {
+		return nil, types.GetEvidenceFileUrlOutput{}, fmt.Errorf("evidence does not have an attached file")
+	}
+
+	fileURL, err := r.proboSvc.Files.GenerateFileURL(ctx, scope, *evidence.EvidenceFileId, 15*time.Minute)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot generate evidence file URL", log.Error(err))
+
+		return nil, types.GetEvidenceFileUrlOutput{}, fmt.Errorf("internal server error")
+	}
+
+	return nil, types.GetEvidenceFileUrlOutput{
+		URL: fileURL,
+	}, nil
+}

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -2731,6 +2731,24 @@ components:
           items:
             $ref: "#/components/schemas/Evidence"
 
+    GetEvidenceFileUrlInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Evidence ID
+
+    GetEvidenceFileUrlOutput:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+          description: Presigned download URL for the evidence file (valid for 15 minutes)
+
     Evidence:
       type: object
       required:
@@ -16009,6 +16027,18 @@ tools:
       $ref: "#/components/schemas/ListMeasureEvidencesInput"
     outputSchema:
       $ref: "#/components/schemas/ListMeasureEvidencesOutput"
+  - name: getEvidenceFileUrl
+    title: Get Evidence File URL
+    description: Get a presigned download URL for a file-backed evidence. Returns a time-limited URL valid for 15 minutes.
+    hints:
+      readonly: true
+      destructive: false
+      idempotent: true
+      openWorld: false
+    inputSchema:
+      $ref: "#/components/schemas/GetEvidenceFileUrlInput"
+    outputSchema:
+      $ref: "#/components/schemas/GetEvidenceFileUrlOutput"
   - name: deleteEvidence
     title: Delete Evidence
     description: Delete an evidence


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- add an MCP `getEvidenceFileUrl` tool for file-backed evidence
- authorize evidence access and return a 15-minute presigned download URL
- sanitize unexpected resolver failures
- cover listing, URL generation, download, and byte verification end to end

## Testing

- `make go-fmt`
- `go generate ./pkg/server/api/mcp/v1`
- `go test ./pkg/server/api/mcp/v1/... ./pkg/probo/...`
- `TestMCP_Evidence_GetFileURL` end-to-end test
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1719703-4984-4ef9-bf8b-14f541f2d0ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1719703-4984-4ef9-bf8b-14f541f2d0ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an MCP `getEvidenceFileUrl` tool that returns a 15-minute presigned download URL for file-backed evidence, with authorization on the evidence and sanitized errors for unexpected failures.

### Tests **`+112`** **`-0`**

End-to-end test covers evidence listing, URL generation, download, and byte-for-byte content verification.

### MCP **`+63`** **`-0`**

- New `getEvidenceFileUrl` tool returns a presigned URL valid for 15 minutes for evidence with an attached file.
- The tool authorizes evidence access and returns a generic "internal server error" instead of leaking internal failure details.
- Returns a clear error when the evidence has no attached file.

<sup>Written for commit 6713cd081f00d549814adef5cb87f18ac8746ab2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

