### PR TITLE
Accept standard OAuth registration scope

### DIFF
--- a/e2e/console/oauth2_test.go
+++ b/e2e/console/oauth2_test.go
@@ -164,7 +164,7 @@ func TestOAuth2_RegisterClientWithAPIScope(t *testing.T) {
 		"grant_types":                []string{"authorization_code"},
 		"response_types":             []string{"code"},
 		"token_endpoint_auth_method": "client_secret_basic",
-		"scopes":                     "openid v1:document:read",
+		"scope":                      "openid v1:document:read",
 	})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, raw.StatusCode)

--- a/e2e/internal/testutil/oauth2.go
+++ b/e2e/internal/testutil/oauth2.go
@@ -60,7 +60,7 @@ type (
 		GrantTypes              []string `json:"grant_types"`
 		ResponseTypes           []string `json:"response_types"`
 		TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
-		Scopes                  string   `json:"scopes"`
+		Scopes                  string   `json:"scope"`
 	}
 
 	OAuth2IntrospectResponse struct {

--- a/pkg/server/api/connect/v1/types/oauth2.go
+++ b/pkg/server/api/connect/v1/types/oauth2.go
@@ -21,6 +21,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -324,7 +325,7 @@ type (
 		GrantTypes              []coredata.OAuth2GrantType                   `json:"grant_types"`
 		ResponseTypes           []coredata.OAuth2ResponseType                `json:"response_types"`
 		TokenEndpointAuthMethod coredata.OAuth2ClientTokenEndpointAuthMethod `json:"token_endpoint_auth_method"`
-		Scopes                  coredata.OAuth2Scopes                        `json:"scopes"`
+		Scopes                  coredata.OAuth2Scopes                        `json:"scope"`
 	}
 
 	OAuth2ErrorResponse struct {
@@ -332,6 +333,27 @@ type (
 		Description string `json:"error_description,omitempty"`
 	}
 )
+
+func (in *OAuth2RegisterInput) UnmarshalJSON(data []byte) error {
+	type plain OAuth2RegisterInput
+
+	decoded := struct {
+		*plain
+		Scope coredata.OAuth2Scopes `json:"scope"`
+	}{
+		plain: (*plain)(in),
+	}
+
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	if len(decoded.Scope) > 0 {
+		in.Scopes = decoded.Scope
+	}
+
+	return nil
+}
 
 func NewConsent(consent *coredata.OAuth2Consent) *Consent {
 	scopes := make([]string, len(consent.Scopes))

--- a/pkg/server/api/connect/v1/types/oauth2_test.go
+++ b/pkg/server/api/connect/v1/types/oauth2_test.go
@@ -21,11 +21,13 @@
 package types
 
 import (
+	"encoding/json"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/iam/oauth2"
 )
 
@@ -79,4 +81,63 @@ func TestParseResources(t *testing.T) {
 			require.ErrorIs(t, err, oauth2.ErrInvalidTarget)
 		},
 	)
+}
+
+func TestOAuth2RegisterInput_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		body string
+	}{
+		{
+			name: "standard scope field",
+			body: `{"scope":"openid offline_access v1:org"}`,
+		},
+		{
+			name: "legacy scopes field",
+			body: `{"scopes":"openid offline_access v1:org"}`,
+		},
+	} {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				var input OAuth2RegisterInput
+				err := json.Unmarshal([]byte(tt.body), &input)
+				require.NoError(t, err)
+				assert.Equal(
+					t,
+					coredata.OAuth2Scopes{
+						oauth2.ScopeOpenID,
+						oauth2.ScopeOfflineAccess,
+						"v1:org",
+					},
+					input.Scopes,
+				)
+			},
+		)
+	}
+}
+
+func TestOAuth2RegisterResponse_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(
+		OAuth2RegisterResponse{
+			Scopes: coredata.OAuth2Scopes{
+				oauth2.ScopeOpenID,
+				oauth2.ScopeOfflineAccess,
+				"v1:org",
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	var response map[string]any
+	err = json.Unmarshal(data, &response)
+	require.NoError(t, err)
+	assert.Equal(t, "openid offline_access v1:org", response["scope"])
+	assert.NotContains(t, response, "scopes")
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- accept RFC 7591 `scope` during dynamic client registration
- retain compatibility with the existing `scopes` request field
- return registered scopes using the standard response field
- cover standard and legacy registration payloads

## Testing
- `go test ./pkg/server/api/connect/v1/...`
- `PROBO_E2E_BINARY=/workspace/bin/probod PROBO_E2E_TRUST_HTTP_ADDR=:11080 PROBO_E2E_TRUST_HTTPS_ADDR=:18443 PROBOD_ACME_ROOT_CA="$(< compose/step-ca/certs/root_ca.crt)" go test ./e2e/console -run '^TestOAuth2_RegisterClientWithAPIScope$' -count=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cd55349-d578-4c78-8fe8-48dad0433413?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cd55349-d578-4c78-8fe8-48dad0433413&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts the standard OAuth 2.0 registration `scope` field while keeping the legacy `scopes` field working, and returns the registered scope under `scope` in the registration response.

### Tests **`+63`** **`-2`**

- Adds unit tests for standard `scope` and legacy `scopes` payloads, plus response marshaling.
- Updates the e2e registration helper and test to use the standard `scope` field.

### GraphQL API **`+23`** **`-1`**

- Custom unmarshalling reads `scope` and falls back to `scopes` when `scope` is absent.
- Registration responses now serialize the scope under `scope` instead of `scopes`.

<sup>Written for commit 79c344e564b356eb2b2740f1ce9e1c6b290512a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

