### PR TITLE
Stabilize Windows posture collection

### DIFF
--- a/cmd/probo-agent/CHANGELOG.md
+++ b/cmd/probo-agent/CHANGELOG.md
@@ -5,6 +5,12 @@ documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Windows auto-update and time-sync checks now inspect stable service
+  configuration instead of transient running state, and posture commands have
+  more time to complete on busy systems.
+
 ## [0.6.3] - 2026-08-18
 
 ### Fixed

--- a/pkg/deviceagent/agent.go
+++ b/pkg/deviceagent/agent.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	hostInfoRefreshInterval = 6 * time.Hour
-	perCheckTimeout         = 15 * time.Second
+	perCheckTimeout         = 25 * time.Second
 
 	pendingFlushBackoffMin = 15 * time.Second
 	pendingFlushBackoffMax = 30 * time.Minute

--- a/pkg/deviceagent/checks/checks_windows.go
+++ b/pkg/deviceagent/checks/checks_windows.go
@@ -268,9 +268,9 @@ func parseNetshFirewallStates(s string) ([]string, bool) {
 func windowsTimeSync(ctx context.Context) Result {
 	out := powershell(
 		ctx,
-		`$s = Get-Service w32time; `+
+		`$s = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\W32Time'; `+
 			`$p = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Parameters'; `+
-			`"$($s.Status);$($p.Type);$($p.NtpServer)"`,
+			`"$($s.Start);$($p.Type);$($p.NtpServer)"`,
 	)
 	if out.Err != nil {
 		return unknown(
@@ -283,9 +283,9 @@ func windowsTimeSync(ctx context.Context) Result {
 
 	parts := strings.SplitN(strings.TrimSpace(out.Stdout), ";", 3)
 
-	var status, typ, ntpServer string
+	var serviceStart, typ, ntpServer string
 	if len(parts) >= 1 {
-		status = strings.TrimSpace(parts[0])
+		serviceStart = strings.TrimSpace(parts[0])
 	}
 
 	if len(parts) >= 2 {
@@ -297,19 +297,19 @@ func windowsTimeSync(ctx context.Context) Result {
 	}
 
 	ev := map[string]any{
-		"backend":        "w32time",
-		"w32time_status": status,
-		"w32time_type":   typ,
+		"backend":               "w32time",
+		"w32time_service_start": serviceStart,
+		"w32time_type":          typ,
 	}
 	if ntpServer != "" {
 		ev["ntp_server"] = ntpServer
 	}
 
-	if windowsTimeSyncOn(status, typ) {
+	if windowsTimeSyncOn(serviceStart, typ) {
 		return pass(ev)
 	}
 
-	if status == "" {
+	if serviceStart == "" {
 		return unknown(ev)
 	}
 
@@ -337,7 +337,8 @@ func windowsAutoUpdate(ctx context.Context) Result {
 		ctx,
 		`$au = Get-ItemProperty 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU' `+
 			`-ErrorAction SilentlyContinue; `+
-			`"$($au.NoAutoUpdate);$($au.AUOptions)"`,
+			`$svc = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\wuauserv'; `+
+			`"$($au.NoAutoUpdate);$($au.AUOptions);$($svc.Start)"`,
 	)
 
 	ev := map[string]any{}
@@ -348,9 +349,9 @@ func windowsAutoUpdate(ctx context.Context) Result {
 		return unknown(ev)
 	}
 
-	parts := strings.SplitN(strings.TrimSpace(out.Stdout), ";", 2)
+	parts := strings.SplitN(strings.TrimSpace(out.Stdout), ";", 3)
 
-	var noAutoUpdate, auOptions string
+	var noAutoUpdate, auOptions, serviceStart string
 	if len(parts) >= 1 {
 		noAutoUpdate = strings.TrimSpace(parts[0])
 	}
@@ -359,40 +360,22 @@ func windowsAutoUpdate(ctx context.Context) Result {
 		auOptions = strings.TrimSpace(parts[1])
 	}
 
+	if len(parts) >= 3 {
+		serviceStart = strings.TrimSpace(parts[2])
+	}
+
 	ev["no_auto_update"] = noAutoUpdate
 	ev["au_options"] = auOptions
+	ev["wuauserv_service_start"] = serviceStart
 
-	// NoAutoUpdate=1 explicitly disables automatic updates via policy.
-	if noAutoUpdate == "1" {
-		return fail(ev)
-	}
-
-	// AUOptions semantics:
-	//   2 — notify before download (no auto-install)
-	//   3 — auto download, prompt to install
-	//   4 — auto download + auto install (target SOC posture)
-	//   5 — managed by local administrators
-	switch auOptions {
-	case "3", "4", "5":
-		return pass(ev)
-	case "2":
-		return fail(ev)
-	}
-
-	// No managed policy. The Windows Update service must at least be
-	// running for the OS default of auto-install to take effect.
-	svc := RunCommand(ctx, "sc.exe", "query", "wuauserv")
-	if svc.Err != nil {
-		ev["wuauserv_error"] = svc.Err.Error()
+	on, known := windowsAutoUpdateOn(noAutoUpdate, auOptions, serviceStart)
+	if !known {
 		return unknown(ev)
 	}
 
-	if strings.Contains(svc.Stdout, "RUNNING") {
-		ev["wuauserv"] = "running"
+	if on {
 		return pass(ev)
 	}
-
-	ev["wuauserv"] = "stopped"
 
 	return fail(ev)
 }

--- a/pkg/deviceagent/checks/runcmd.go
+++ b/pkg/deviceagent/checks/runcmd.go
@@ -33,7 +33,7 @@ import (
 	"time"
 )
 
-const defaultCommandTimeout = 5 * time.Second
+const defaultCommandTimeout = 10 * time.Second
 
 var commandExistsCache sync.Map
 

--- a/pkg/deviceagent/checks/windows_posture.go
+++ b/pkg/deviceagent/checks/windows_posture.go
@@ -79,8 +79,10 @@ func parseWindowsFirewallProfiles(s string) (map[string]string, bool) {
 	return profiles, windowsAllValuesEqualFold(profiles, "true")
 }
 
-func windowsTimeSyncOn(status, typ string) bool {
-	if !strings.EqualFold(strings.TrimSpace(status), "Running") {
+func windowsTimeSyncOn(serviceStart, typ string) bool {
+	switch strings.TrimSpace(serviceStart) {
+	case "2", "3":
+	default:
 		return false
 	}
 
@@ -90,4 +92,27 @@ func windowsTimeSyncOn(status, typ string) bool {
 	}
 
 	return false
+}
+
+func windowsAutoUpdateOn(noAutoUpdate, auOptions, serviceStart string) (bool, bool) {
+	switch strings.TrimSpace(serviceStart) {
+	case "4":
+		return false, true
+	case "2", "3":
+	default:
+		return false, false
+	}
+
+	if strings.TrimSpace(noAutoUpdate) == "1" {
+		return false, true
+	}
+
+	switch strings.TrimSpace(auOptions) {
+	case "", "3", "4", "5":
+		return true, true
+	case "2":
+		return false, true
+	default:
+		return false, false
+	}
 }

--- a/pkg/deviceagent/checks/windows_posture_test.go
+++ b/pkg/deviceagent/checks/windows_posture_test.go
@@ -168,38 +168,105 @@ func TestWindowsTimeSyncOn(t *testing.T) {
 	t.Parallel()
 
 	t.Run(
-		"running NTP is on",
+		"manual NTP service is on",
 		func(t *testing.T) {
 			t.Parallel()
 
-			assert.True(t, windowsTimeSyncOn("Running", "NTP"))
+			assert.True(t, windowsTimeSyncOn("3", "NTP"))
 		},
 	)
 
 	t.Run(
-		"stopped service is off",
+		"disabled service is off",
 		func(t *testing.T) {
 			t.Parallel()
 
-			assert.False(t, windowsTimeSyncOn("Stopped", "NTP"))
+			assert.False(t, windowsTimeSyncOn("4", "NTP"))
 		},
 	)
 
 	t.Run(
-		"running NoSync is off",
+		"manual NoSync service is off",
 		func(t *testing.T) {
 			t.Parallel()
 
-			assert.False(t, windowsTimeSyncOn("Running", "NoSync"))
+			assert.False(t, windowsTimeSyncOn("3", "NoSync"))
 		},
 	)
 
 	t.Run(
-		"running NT5DS is on",
+		"automatic NT5DS service is on",
 		func(t *testing.T) {
 			t.Parallel()
 
-			assert.True(t, windowsTimeSyncOn("Running", "NT5DS"))
+			assert.True(t, windowsTimeSyncOn("2", "NT5DS"))
 		},
 	)
+}
+
+func TestWindowsAutoUpdateOn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		noAutoUpdate  string
+		auOptions     string
+		serviceStart  string
+		expectedOn    bool
+		expectedKnown bool
+	}{
+		{
+			name:          "default trigger-start service is on",
+			serviceStart:  "3",
+			expectedOn:    true,
+			expectedKnown: true,
+		},
+		{
+			name:          "automatic service and install policy are on",
+			auOptions:     "4",
+			serviceStart:  "2",
+			expectedOn:    true,
+			expectedKnown: true,
+		},
+		{
+			name:          "disabled by policy is off",
+			noAutoUpdate:  "1",
+			serviceStart:  "3",
+			expectedKnown: true,
+		},
+		{
+			name:          "notify-only policy is off",
+			auOptions:     "2",
+			serviceStart:  "3",
+			expectedKnown: true,
+		},
+		{
+			name:          "disabled service is off",
+			auOptions:     "4",
+			serviceStart:  "4",
+			expectedKnown: true,
+		},
+		{
+			name:          "missing service state is unknown",
+			expectedOn:    false,
+			expectedKnown: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				on, known := windowsAutoUpdateOn(
+					tt.noAutoUpdate,
+					tt.auOptions,
+					tt.serviceStart,
+				)
+				assert.Equal(t, tt.expectedOn, on)
+				assert.Equal(t, tt.expectedKnown, known)
+			},
+		)
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- evaluate Windows Update and W32Time using persistent service configuration
- preserve policy-aware pass, fail, and unknown outcomes
- allow slower Windows posture probes to complete on busy hosts
- add coverage for stable auto-update and time-sync classification

## Testing

- `go test ./pkg/deviceagent/checks ./pkg/deviceagent`
- `go test -race ./pkg/deviceagent/checks ./pkg/deviceagent`
- cross-compiled both package test binaries with `GOOS=windows GOARCH=amd64`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f79271c8-aad9-44ed-aff0-fb176af03133?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f79271c8-aad9-44ed-aff0-fb176af03133&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Windows auto-update and time-sync posture checks by reading persistent service configuration instead of transient running state, and gives posture probes more time to complete on busy hosts.

### Tests **`+75`** **`-8`**

- Adds table-driven coverage for auto-update classification and updates time-sync tests for the new service-start values.

### Service **`+50`** **`-42`**

- Reads the `Start` value for `wuauserv` and `W32Time` from the registry instead of querying live service state.
- Raises the per-check timeout from 15s to 25s and the default command timeout from 5s to 10s.

### Other **`+6`** **`-0`**

- Documents the fix in the `probo-agent` changelog.

<sup>Written for commit ab5aee97fff55dd3dba22525a04e51156f595449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

