### PR TITLE
Preserve calendar months in Duration

### DIFF
--- a/contrib/claude/relay.md
+++ b/contrib/claude/relay.md
@@ -23,7 +23,7 @@ Config lives in `relay.config.json` at the repo root with three projects (`core`
 make relay  # merge split schemas + clean + compile
 ```
 
-Custom scalar mappings: `Datetime → string`, `GID → string`, `CursorKey → string`, `Duration → string`, `BigInt → number`, `EmailAddr → string`.
+Custom scalar mappings: `Datetime → string`, `GID → string`, `CursorKey → string`, `TimeSpan → string`, `BigInt → number`, `EmailAddr → string`.
 
 ## Naming operations and fragments
 

--- a/contrib/claude/validation.md
+++ b/contrib/claude/validation.md
@@ -59,7 +59,7 @@ func (req *CreateThirdPartyRequest) Validate() error {
 ### Time
 - `After(refTime)` — time must be after reference
 - `Before(refTime)` — time must be before reference
-- `RangeDuration(min, max)` — duration between min and max inclusive
+- `RangeDuration(min, max)` — TimeSpan between min and max inclusive (months compared as 30-day units)
 
 ## Pointer handling
 

--- a/e2e/console/task_test.go
+++ b/e2e/console/task_test.go
@@ -905,3 +905,142 @@ func TestTask_OmittableDeadline(t *testing.T) {
 		assert.Nil(t, result.UpdateTask.Task.Deadline)
 	})
 }
+
+func TestTask_TimeEstimate(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	measureID := factory.NewMeasure(owner).
+		WithName("Task Time Estimate Test").
+		Create()
+
+	const createQuery = `
+		mutation CreateTask($input: CreateTaskInput!) {
+			createTask(input: $input) {
+				taskEdge {
+					node {
+						id
+						timeEstimate
+					}
+				}
+			}
+		}
+	`
+
+	var createResult struct {
+		CreateTask struct {
+			TaskEdge struct {
+				Node struct {
+					ID           string  `json:"id"`
+					TimeEstimate *string `json:"timeEstimate"`
+				} `json:"node"`
+			} `json:"taskEdge"`
+		} `json:"createTask"`
+	}
+
+	err := owner.Execute(createQuery, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"measureId":      measureID,
+			"name":           factory.SafeName("Estimate"),
+			"priority":       "MEDIUM",
+			"timeEstimate":   "PT1H",
+		},
+	}, &createResult)
+	require.NoError(t, err)
+	require.NotNil(t, createResult.CreateTask.TaskEdge.Node.TimeEstimate)
+	assert.Equal(t, "PT1H", *createResult.CreateTask.TaskEdge.Node.TimeEstimate)
+
+	taskID := createResult.CreateTask.TaskEdge.Node.ID
+
+	const updateQuery = `
+		mutation UpdateTask($input: UpdateTaskInput!) {
+			updateTask(input: $input) {
+				task {
+					id
+					timeEstimate
+				}
+			}
+		}
+	`
+
+	var updateResult struct {
+		UpdateTask struct {
+			Task struct {
+				ID           string  `json:"id"`
+				TimeEstimate *string `json:"timeEstimate"`
+			} `json:"task"`
+		} `json:"updateTask"`
+	}
+
+	err = owner.Execute(updateQuery, map[string]any{
+		"input": map[string]any{
+			"taskId":       taskID,
+			"timeEstimate": "P1M",
+		},
+	}, &updateResult)
+	require.NoError(t, err)
+	require.NotNil(t, updateResult.UpdateTask.Task.TimeEstimate)
+	assert.Equal(t, "P1M", *updateResult.UpdateTask.Task.TimeEstimate)
+
+	const getQuery = `
+		query GetTask($id: ID!) {
+			node(id: $id) {
+				... on Task {
+					id
+					timeEstimate
+				}
+			}
+		}
+	`
+
+	var getResult struct {
+		Node struct {
+			ID           string  `json:"id"`
+			TimeEstimate *string `json:"timeEstimate"`
+		} `json:"node"`
+	}
+
+	err = owner.Execute(getQuery, map[string]any{"id": taskID}, &getResult)
+	require.NoError(t, err)
+	require.NotNil(t, getResult.Node.TimeEstimate)
+	assert.Equal(t, "P1M", *getResult.Node.TimeEstimate)
+
+	err = owner.Execute(updateQuery, map[string]any{
+		"input": map[string]any{
+			"taskId":       taskID,
+			"timeEstimate": nil,
+		},
+	}, &updateResult)
+	require.NoError(t, err)
+	assert.Nil(t, updateResult.UpdateTask.Task.TimeEstimate)
+
+	t.Run("rejects two calendar months", func(t *testing.T) {
+		t.Parallel()
+
+		err := owner.ExecuteShouldFail(createQuery, map[string]any{
+			"input": map[string]any{
+				"organizationId": owner.GetOrganizationID().String(),
+				"measureId":      measureID,
+				"name":           factory.SafeName("Overlong estimate"),
+				"priority":       "MEDIUM",
+				"timeEstimate":   "P2M",
+			},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("rejects incomplete duration", func(t *testing.T) {
+		t.Parallel()
+
+		err := owner.ExecuteShouldFail(createQuery, map[string]any{
+			"input": map[string]any{
+				"organizationId": owner.GetOrganizationID().String(),
+				"measureId":      measureID,
+				"name":           factory.SafeName("Incomplete estimate"),
+				"priority":       "MEDIUM",
+				"timeEstimate":   "P1YT",
+			},
+		})
+		require.Error(t, err)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/scim2/filter-parser/v2 v2.3.1
 	github.com/sigstore/sigstore-go v1.3.0
+	github.com/sosodev/duration v1.4.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.12.1
 	github.com/tc-hib/winres v0.3.1
@@ -226,7 +227,6 @@ require (
 	github.com/sigstore/sigstore v1.10.9 // indirect
 	github.com/sigstore/timestamp-authority/v2 v2.1.3 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
-	github.com/sosodev/duration v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 // indirect

--- a/pkg/coredata/task.go
+++ b/pkg/coredata/task.go
@@ -33,24 +33,25 @@ import (
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
+	"go.probo.inc/probo/pkg/timespan"
 )
 
 type (
 	Task struct {
-		ID             gid.GID        `db:"id"`
-		OrganizationID gid.GID        `db:"organization_id"`
-		MeasureID      *gid.GID       `db:"measure_id"`
-		Name           string         `db:"name"`
-		Content        string         `db:"content"`
-		State          TaskState      `db:"state"`
-		Priority       TaskPriority   `db:"priority"`
-		ReferenceID    string         `db:"reference_id"`
-		TimeEstimate   *time.Duration `db:"time_estimate"`
-		AssignedToID   *gid.GID       `db:"assigned_to_profile_id"`
-		Deadline       *time.Time     `db:"deadline"`
-		Rank           int            `db:"rank"`
-		CreatedAt      time.Time      `db:"created_at"`
-		UpdatedAt      time.Time      `db:"updated_at"`
+		ID             gid.GID            `db:"id"`
+		OrganizationID gid.GID            `db:"organization_id"`
+		MeasureID      *gid.GID           `db:"measure_id"`
+		Name           string             `db:"name"`
+		Content        string             `db:"content"`
+		State          TaskState          `db:"state"`
+		Priority       TaskPriority       `db:"priority"`
+		ReferenceID    string             `db:"reference_id"`
+		TimeEstimate   *timespan.TimeSpan `db:"time_estimate"`
+		AssignedToID   *gid.GID           `db:"assigned_to_profile_id"`
+		Deadline       *time.Time         `db:"deadline"`
+		Rank           int                `db:"rank"`
+		CreatedAt      time.Time          `db:"created_at"`
+		UpdatedAt      time.Time          `db:"updated_at"`
 
 		// ordering only
 		PriorityRank int `db:"priority_rank"`

--- a/pkg/probo/task_service.go
+++ b/pkg/probo/task_service.go
@@ -32,6 +32,7 @@ import (
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/prosemirror"
+	"go.probo.inc/probo/pkg/timespan"
 	"go.probo.inc/probo/pkg/validator"
 )
 
@@ -49,7 +50,7 @@ type (
 		Content        *string
 		State          *coredata.TaskState
 		Priority       coredata.TaskPriority
-		TimeEstimate   *time.Duration
+		TimeEstimate   *timespan.TimeSpan
 		AssignedToID   *gid.GID
 		Deadline       *time.Time
 	}
@@ -60,7 +61,7 @@ type (
 		Content      **string
 		State        *coredata.TaskState
 		Priority     *coredata.TaskPriority
-		TimeEstimate **time.Duration
+		TimeEstimate **timespan.TimeSpan
 		Deadline     **time.Time
 		AssignedToID **gid.GID
 		MeasureID    **gid.GID

--- a/pkg/server/api/console/v1/gqlgen.yaml
+++ b/pkg/server/api/console/v1/gqlgen.yaml
@@ -32,9 +32,9 @@ models:
   CursorKey:
     model:
       - "go.probo.inc/probo/pkg/server/gqlutils/types/cursor.CursorKeyScalar"
-  Duration:
+  TimeSpan:
     model:
-      - "github.com/99designs/gqlgen/graphql.Duration"
+      - "go.probo.inc/probo/pkg/server/gqlutils/types/timespan.TimeSpanScalar"
   BigInt:
     model:
       - "go.probo.inc/probo/pkg/server/gqlutils/types/bigint.BigIntScalar"

--- a/pkg/server/api/console/v1/graphql/base.graphql
+++ b/pkg/server/api/console/v1/graphql/base.graphql
@@ -14,7 +14,7 @@ directive @goEnum(value: String) on ENUM_VALUE
 scalar CursorKey
 scalar Datetime
 scalar Upload
-scalar Duration
+scalar TimeSpan
 scalar BigInt
 scalar EmailAddr
 

--- a/pkg/server/api/console/v1/graphql/task.graphql
+++ b/pkg/server/api/console/v1/graphql/task.graphql
@@ -48,7 +48,7 @@ type Task implements Node {
     state: TaskState!
     priority: TaskPriority!
     rank: Int!
-    timeEstimate: Duration
+    timeEstimate: TimeSpan
     deadline: Datetime
     assignedTo: Profile @goField(forceResolver: true)
 
@@ -104,7 +104,7 @@ input CreateTaskInput {
     content: String
     state: TaskState
     priority: TaskPriority!
-    timeEstimate: Duration
+    timeEstimate: TimeSpan
     assignedToId: ID
     deadline: Datetime
 }
@@ -116,7 +116,7 @@ input UpdateTaskInput {
     state: TaskState
     priority: TaskPriority
     rank: Int
-    timeEstimate: Duration @goField(omittable: true)
+    timeEstimate: TimeSpan @goField(omittable: true)
     deadline: Datetime @goField(omittable: true)
     assignedToId: ID @goField(omittable: true)
     measureId: ID @goField(omittable: true)

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -10,10 +10,10 @@ components:
       format: string
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/mail.Addr
 
-    Duration:
+    TimeSpan:
       type: string
-      description: A duration
-      go.probo.inc/mcpgen/type: time.Duration
+      description: An ISO-8601 duration
+      go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/timespan.TimeSpan
 
     OrderDirection:
       type: string
@@ -6965,7 +6965,7 @@ components:
           description: Task rank within state
         time_estimate:
           anyOf:
-            - $ref: "#/components/schemas/Duration"
+            - $ref: "#/components/schemas/TimeSpan"
             - type: "null"
               description: No time estimate
           description: Time estimate
@@ -7070,7 +7070,7 @@ components:
           type: string
           description: Task content in markdown format
         time_estimate:
-          $ref: "#/components/schemas/Duration"
+          $ref: "#/components/schemas/TimeSpan"
           description: Time estimate
         deadline:
           type: string
@@ -7134,7 +7134,7 @@ components:
           description: Task rank within state
         time_estimate:
           anyOf:
-            - $ref: "#/components/schemas/Duration"
+            - $ref: "#/components/schemas/TimeSpan"
             - type: "null"
               description: No time estimate
           description: Time estimate

--- a/pkg/server/gqlutils/types/timespan/timespan.go
+++ b/pkg/server/gqlutils/types/timespan/timespan.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package timespan
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/99designs/gqlgen/graphql"
+	"go.probo.inc/probo/pkg/timespan"
+)
+
+type TimeSpanScalar = timespan.TimeSpan
+
+func MarshalTimeSpanScalar(ts timespan.TimeSpan) graphql.Marshaler {
+	return graphql.WriterFunc(
+		func(w io.Writer) {
+			_, _ = w.Write([]byte(strconv.Quote(ts.String())))
+		},
+	)
+}
+
+func UnmarshalTimeSpanScalar(v any) (timespan.TimeSpan, error) {
+	s, ok := v.(string)
+	if !ok {
+		return timespan.Zero, errors.New("must be a string")
+	}
+
+	parsed, err := timespan.Parse(s)
+	if err != nil {
+		return timespan.Zero, fmt.Errorf("cannot parse timespan: %w", err)
+	}
+
+	return parsed, nil
+}

--- a/pkg/timespan/timespan.go
+++ b/pkg/timespan/timespan.go
@@ -1,0 +1,532 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package timespan
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/sosodev/duration"
+)
+
+const (
+	microsecondsPerSecond = 1_000_000
+	microsecondsPerMinute = 60 * microsecondsPerSecond
+	microsecondsPerHour   = 60 * microsecondsPerMinute
+	microsecondsPerDay    = 24 * microsecondsPerHour
+	daysPerMonth          = 30
+	microsecondsPerMonth  = daysPerMonth * microsecondsPerDay
+	monthsPerYear         = 12
+	daysPerWeek           = 7
+)
+
+type TimeSpan struct {
+	Months       int32
+	Days         int32
+	Microseconds int64
+}
+
+var (
+	Zero TimeSpan
+
+	_ pgtype.IntervalValuer  = TimeSpan{}
+	_ pgtype.IntervalScanner = (*TimeSpan)(nil)
+)
+
+func FromDuration(d time.Duration) TimeSpan {
+	return TimeSpan{Microseconds: d.Microseconds()}
+}
+
+func (ts TimeSpan) IsZero() bool {
+	return ts == Zero
+}
+
+func Parse(s string) (TimeSpan, error) {
+	parsed, err := parseISO(s)
+	if err != nil {
+		return Zero, fmt.Errorf("cannot parse timespan %q: %w", s, err)
+	}
+
+	ts, err := fromISO(parsed)
+	if err != nil {
+		return Zero, fmt.Errorf("cannot convert timespan %q: %w", s, err)
+	}
+
+	return ts, nil
+}
+
+func parseISO(s string) (*duration.Duration, error) {
+	const (
+		parsingPeriod = iota
+		parsingTime
+	)
+
+	state := parsingPeriod
+	parsed := &duration.Duration{}
+	num := ""
+	seenComponent := false
+	seenTime := false
+
+	switch {
+	case strings.HasPrefix(s, "P"):
+	case strings.HasPrefix(s, "-P"):
+		parsed.Negative = true
+		s = strings.TrimPrefix(s, "-")
+	default:
+		return nil, fmt.Errorf("cannot parse timespan: unexpected input")
+	}
+
+	var err error
+
+	for _, char := range s {
+		switch char {
+		case 'P':
+			if state != parsingPeriod {
+				return nil, fmt.Errorf("cannot parse timespan: unexpected input")
+			}
+		case 'T':
+			if state == parsingTime {
+				return nil, fmt.Errorf("cannot parse timespan: unexpected input")
+			}
+
+			state = parsingTime
+		case 'Y':
+			if state != parsingPeriod {
+				return nil, fmt.Errorf("cannot parse timespan: unexpected input")
+			}
+
+			parsed.Years, err = strconv.ParseFloat(num, 64)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse years: %w", err)
+			}
+
+			num = ""
+			seenComponent = true
+		case 'M':
+			switch state {
+			case parsingPeriod:
+				parsed.Months, err = strconv.ParseFloat(num, 64)
+				if err != nil {
+					return nil, fmt.Errorf("cannot parse months: %w", err)
+				}
+			case parsingTime:
+				parsed.Minutes, err = strconv.ParseFloat(num, 64)
+				if err != nil {
+					return nil, fmt.Errorf("cannot parse minutes: %w", err)
+				}
+
+				seenTime = true
+			}
+
+			num = ""
+			seenComponent = true
+		case 'W':
+			if state != parsingPeriod {
+				return nil, fmt.Errorf("cannot parse timespan: unexpected input")
+			}
+
+			parsed.Weeks, err = strconv.ParseFloat(num, 64)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse weeks: %w", err)
+			}
+
+			num = ""
+			seenComponent = true
+		case 'D':
+			if state != parsingPeriod {
+				return nil, fmt.Errorf("cannot parse timespan: unexpected input")
+			}
+
+			parsed.Days, err = strconv.ParseFloat(num, 64)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse days: %w", err)
+			}
+
+			num = ""
+			seenComponent = true
+		case 'H':
+			if state != parsingTime {
+				return nil, fmt.Errorf("cannot parse timespan: unexpected input")
+			}
+
+			parsed.Hours, err = strconv.ParseFloat(num, 64)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse hours: %w", err)
+			}
+
+			num = ""
+			seenComponent = true
+			seenTime = true
+		case 'S':
+			if state != parsingTime {
+				return nil, fmt.Errorf("cannot parse timespan: unexpected input")
+			}
+
+			parsed.Seconds, err = strconv.ParseFloat(num, 64)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse seconds: %w", err)
+			}
+
+			num = ""
+			seenComponent = true
+			seenTime = true
+		default:
+			if unicode.IsNumber(char) || char == '.' || (char == '-' && num == "") {
+				num += string(char)
+				continue
+			}
+
+			return nil, fmt.Errorf("cannot parse timespan: unexpected input")
+		}
+	}
+
+	if num != "" || !seenComponent || (state == parsingTime && !seenTime) {
+		return nil, fmt.Errorf("cannot parse timespan: incomplete expression")
+	}
+
+	return parsed, nil
+}
+
+func fromISO(d *duration.Duration) (TimeSpan, error) {
+	months, fracMonths := math.Modf(d.Years*monthsPerYear + d.Months)
+	days, fracDays := math.Modf(d.Weeks*daysPerWeek + d.Days + fracMonths*daysPerMonth)
+	microseconds := math.Round(
+		d.Hours*float64(microsecondsPerHour) +
+			d.Minutes*float64(microsecondsPerMinute) +
+			d.Seconds*float64(microsecondsPerSecond) +
+			fracDays*float64(microsecondsPerDay),
+	)
+
+	if d.Negative {
+		months = -months
+		days = -days
+		microseconds = -microseconds
+	}
+
+	if months < math.MinInt32 || months > math.MaxInt32 {
+		return Zero, fmt.Errorf("cannot parse timespan: months overflow")
+	}
+
+	if days < math.MinInt32 || days > math.MaxInt32 {
+		return Zero, fmt.Errorf("cannot parse timespan: days overflow")
+	}
+
+	if math.IsInf(microseconds, 0) || math.IsNaN(microseconds) ||
+		microseconds < math.MinInt64 || microseconds >= 1<<63 {
+		return Zero, fmt.Errorf("cannot parse timespan: microseconds overflow")
+	}
+
+	return TimeSpan{
+		Months:       int32(months),
+		Days:         int32(days),
+		Microseconds: int64(microseconds),
+	}.normalizeClock(), nil
+}
+
+func (ts TimeSpan) String() string {
+	ts = ts.normalizeClock()
+	if ts.IsZero() {
+		return "PT0S"
+	}
+
+	prefix := "P"
+	months := int64(ts.Months)
+	days := int64(ts.Days)
+	microseconds := absInt64(ts.Microseconds)
+	clockNegative := false
+
+	if ts.Months <= 0 && ts.Days <= 0 && ts.Microseconds <= 0 {
+		prefix = "-P"
+		months = int64(absInt32(ts.Months))
+		days = int64(absInt32(ts.Days))
+	} else if ts.Microseconds < 0 {
+		clockNegative = true
+	}
+
+	var b strings.Builder
+	b.WriteString(prefix)
+
+	years := months / monthsPerYear
+	months = months % monthsPerYear
+
+	if years != 0 {
+		fmt.Fprintf(&b, "%dY", years)
+	}
+
+	if months != 0 {
+		fmt.Fprintf(&b, "%dM", months)
+	}
+
+	if days != 0 {
+		fmt.Fprintf(&b, "%dD", days)
+	}
+
+	if microseconds != 0 {
+		b.WriteByte('T')
+
+		hours := microseconds / microsecondsPerHour
+		microseconds %= microsecondsPerHour
+		minutes := microseconds / microsecondsPerMinute
+		microseconds %= microsecondsPerMinute
+		seconds := microseconds / microsecondsPerSecond
+		frac := microseconds % microsecondsPerSecond
+
+		if hours != 0 {
+			if clockNegative {
+				b.WriteByte('-')
+			}
+
+			fmt.Fprintf(&b, "%dH", hours)
+		}
+
+		if minutes != 0 {
+			if clockNegative {
+				b.WriteByte('-')
+			}
+
+			fmt.Fprintf(&b, "%dM", minutes)
+		}
+
+		if seconds != 0 || frac != 0 {
+			if clockNegative {
+				b.WriteByte('-')
+			}
+
+			if frac == 0 {
+				fmt.Fprintf(&b, "%dS", seconds)
+			} else {
+				fmt.Fprintf(&b, "%d.%sS", seconds, strings.TrimRight(fmt.Sprintf("%06d", frac), "0"))
+			}
+		}
+	}
+
+	if b.String() == "P" || b.String() == "-P" {
+		return "PT0S"
+	}
+
+	return b.String()
+}
+
+func absInt32(v int32) uint64 {
+	if v >= 0 {
+		return uint64(v)
+	}
+
+	if v == math.MinInt32 {
+		return 1 << 31
+	}
+
+	return uint64(-v)
+}
+
+func absInt64(v int64) uint64 {
+	if v >= 0 {
+		return uint64(v)
+	}
+
+	if v == math.MinInt64 {
+		return 1 << 63
+	}
+
+	return uint64(-v)
+}
+
+func (ts TimeSpan) ClockDuration() (time.Duration, bool) {
+	if ts.Months != 0 {
+		return 0, false
+	}
+
+	dayNs, ok := mulInt64(int64(ts.Days), int64(24*time.Hour))
+	if !ok {
+		return 0, false
+	}
+
+	usNs, ok := mulInt64(ts.Microseconds, int64(time.Microsecond))
+	if !ok {
+		return 0, false
+	}
+
+	total, ok := addInt64(dayNs, usNs)
+	if !ok {
+		return 0, false
+	}
+
+	return time.Duration(total), true
+}
+
+func mulInt64(a, b int64) (int64, bool) {
+	if a == 0 || b == 0 {
+		return 0, true
+	}
+
+	if a == math.MinInt64 || b == math.MinInt64 {
+		if a == 1 {
+			return b, true
+		}
+
+		if b == 1 {
+			return a, true
+		}
+
+		return 0, false
+	}
+
+	result := a * b
+	if result/a != b {
+		return 0, false
+	}
+
+	return result, true
+}
+
+func addInt64(a, b int64) (int64, bool) {
+	if b > 0 && a > math.MaxInt64-b {
+		return 0, false
+	}
+
+	if b < 0 && a < math.MinInt64-b {
+		return 0, false
+	}
+
+	return a + b, true
+}
+
+// Compare reports whether ts is less than, equal to, or greater than other.
+// Ordering treats one month as 30 days and one day as 24 hours. That is only
+// an ordering rule; a calendar month is still not a fixed elapsed duration.
+func (ts TimeSpan) Compare(other TimeSpan) int {
+	return ts.linearMicroseconds().Cmp(other.linearMicroseconds())
+}
+
+// CompareDuration reports whether ts is less than, equal to, or greater than d.
+// The span is ordered at microsecond precision against the full nanosecond
+// bound so leftover nanoseconds in d are not discarded.
+func (ts TimeSpan) CompareDuration(d time.Duration) int {
+	return ts.linearNanoseconds().Cmp(big.NewInt(d.Nanoseconds()))
+}
+
+func (ts TimeSpan) linearNanoseconds() *big.Int {
+	ns := ts.linearMicroseconds()
+	ns.Mul(ns, big.NewInt(int64(time.Microsecond)))
+
+	return ns
+}
+
+func (ts TimeSpan) linearMicroseconds() *big.Int {
+	months := new(big.Int).SetInt64(int64(ts.Months))
+	months.Mul(months, big.NewInt(microsecondsPerMonth))
+
+	days := new(big.Int).SetInt64(int64(ts.Days))
+	days.Mul(days, big.NewInt(microsecondsPerDay))
+
+	months.Add(months, days)
+	months.Add(months, new(big.Int).SetInt64(ts.Microseconds))
+
+	return months
+}
+
+func (ts TimeSpan) IntervalValue() (pgtype.Interval, error) {
+	ts = ts.normalizeClock()
+
+	return pgtype.Interval{
+		Months:       ts.Months,
+		Days:         ts.Days,
+		Microseconds: ts.Microseconds,
+		Valid:        true,
+	}, nil
+}
+
+func (ts *TimeSpan) ScanInterval(v pgtype.Interval) error {
+	if !v.Valid {
+		return fmt.Errorf("cannot scan NULL into TimeSpan")
+	}
+
+	*ts = TimeSpan{
+		Months:       v.Months,
+		Days:         v.Days,
+		Microseconds: v.Microseconds,
+	}.normalizeClock()
+
+	return nil
+}
+
+// normalizeClock borrows between days and microseconds so the clock fields
+// share a sign and |microseconds| < 24 hours. Months are left untouched: a
+// calendar month is not a fixed number of days.
+func (ts TimeSpan) normalizeClock() TimeSpan {
+	total := new(big.Int).SetInt64(int64(ts.Days))
+	total.Mul(total, big.NewInt(microsecondsPerDay))
+	total.Add(total, new(big.Int).SetInt64(ts.Microseconds))
+
+	dayUs := big.NewInt(microsecondsPerDay)
+	days, us := new(big.Int).QuoRem(total, dayUs, new(big.Int))
+
+	if !days.IsInt64() || !us.IsInt64() {
+		return ts
+	}
+
+	normalizedDays := days.Int64()
+	if normalizedDays < math.MinInt32 || normalizedDays > math.MaxInt32 {
+		return ts
+	}
+
+	ts.Days = int32(normalizedDays)
+	ts.Microseconds = us.Int64()
+
+	return ts
+}
+
+func (ts TimeSpan) MarshalJSON() ([]byte, error) {
+	data, err := json.Marshal(ts.String())
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal timespan: %w", err)
+	}
+
+	return data, nil
+}
+
+func (ts *TimeSpan) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*ts = Zero
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("cannot unmarshal timespan: %w", err)
+	}
+
+	parsed, err := Parse(s)
+	if err != nil {
+		return fmt.Errorf("cannot parse timespan: %w", err)
+	}
+
+	*ts = parsed
+
+	return nil
+}

--- a/pkg/timespan/timespan_test.go
+++ b/pkg/timespan/timespan_test.go
@@ -1,0 +1,386 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package timespan_test
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/timespan"
+)
+
+func TestParseAndString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		want   timespan.TimeSpan
+		output string
+	}{
+		{
+			name:   "zero seconds",
+			input:  "PT0S",
+			want:   timespan.Zero,
+			output: "PT0S",
+		},
+		{
+			name:   "one hour",
+			input:  "PT1H",
+			want:   timespan.TimeSpan{Microseconds: 3600 * 1_000_000},
+			output: "PT1H",
+		},
+		{
+			name:   "hour and minute",
+			input:  "PT1H30M",
+			want:   timespan.TimeSpan{Microseconds: (3600 + 30*60) * 1_000_000},
+			output: "PT1H30M",
+		},
+		{
+			name:   "one day",
+			input:  "P1D",
+			want:   timespan.TimeSpan{Days: 1},
+			output: "P1D",
+		},
+		{
+			name:   "one month",
+			input:  "P1M",
+			want:   timespan.TimeSpan{Months: 1},
+			output: "P1M",
+		},
+		{
+			name:   "one year",
+			input:  "P1Y",
+			want:   timespan.TimeSpan{Months: 12},
+			output: "P1Y",
+		},
+		{
+			name:   "week becomes days",
+			input:  "P1W",
+			want:   timespan.TimeSpan{Days: 7},
+			output: "P7D",
+		},
+		{
+			name:  "mixed calendar and clock",
+			input: "P1Y2M3DT4H5M6S",
+			want: timespan.TimeSpan{
+				Months:       14,
+				Days:         3,
+				Microseconds: (4*3600 + 5*60 + 6) * 1_000_000,
+			},
+			output: "P1Y2M3DT4H5M6S",
+		},
+		{
+			name:   "fractional seconds",
+			input:  "PT0.5S",
+			want:   timespan.TimeSpan{Microseconds: 500_000},
+			output: "PT0.5S",
+		},
+		{
+			name:   "fractional month becomes days",
+			input:  "P1.5M",
+			want:   timespan.TimeSpan{Months: 1, Days: 15},
+			output: "P1M15D",
+		},
+		{
+			name:   "negative month",
+			input:  "-P1M",
+			want:   timespan.TimeSpan{Months: -1},
+			output: "-P1M",
+		},
+		{
+			name:   "mixed month and negative days",
+			input:  "P1M-5D",
+			want:   timespan.TimeSpan{Months: 1, Days: -5},
+			output: "P1M-5D",
+		},
+		{
+			name:   "day minus one hour normalizes to twenty three hours",
+			input:  "P1DT-1H",
+			want:   timespan.TimeSpan{Microseconds: 23 * 3600 * 1_000_000},
+			output: "PT23H",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				got, err := timespan.Parse(tc.input)
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+				assert.Equal(t, tc.output, got.String())
+			},
+		)
+	}
+}
+
+func TestParseRejectsInvalid(t *testing.T) {
+	t.Parallel()
+
+	for _, input := range []string{
+		"", "1H", "P1H", "PT1D", "P1X", "PT2562047789H",
+		"P", "PT", "-P", "-PT", "P1YT", "P1DT", "-P1YT",
+	} {
+		t.Run(
+			input,
+			func(t *testing.T) {
+				t.Parallel()
+
+				_, err := timespan.Parse(input)
+				assert.Error(t, err)
+			},
+		)
+	}
+}
+
+func TestStringMinIntegerComponents(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		span timespan.TimeSpan
+		want string
+	}{
+		{
+			name: "minimum months",
+			span: timespan.TimeSpan{Months: math.MinInt32},
+			want: "-P178956970Y8M",
+		},
+		{
+			name: "minimum days",
+			span: timespan.TimeSpan{Days: math.MinInt32},
+			want: "-P2147483648D",
+		},
+		{
+			name: "minimum microseconds",
+			span: timespan.TimeSpan{Microseconds: math.MinInt64},
+			want: "-P106751991DT4H54.775808S",
+		},
+		{
+			name: "positive months with minimum microseconds",
+			span: timespan.TimeSpan{Months: 1, Microseconds: math.MinInt64},
+			want: "P1M-106751991DT-4H-54.775808S",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				assert.Equal(t, tc.want, tc.span.String())
+
+				parsed, err := timespan.Parse(tc.want)
+				require.NoError(t, err)
+				assert.Equal(t, 0, tc.span.Compare(parsed))
+			},
+		)
+	}
+}
+
+func TestRoundTripDoesNotFlattenMonths(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := timespan.Parse("P1M")
+	require.NoError(t, err)
+	assert.Equal(t, timespan.TimeSpan{Months: 1}, parsed)
+
+	pgInterval, err := parsed.IntervalValue()
+	require.NoError(t, err)
+	assert.Equal(t, pgtype.Interval{Months: 1, Valid: true}, pgInterval)
+
+	var scanned timespan.TimeSpan
+	require.NoError(t, scanned.ScanInterval(pgInterval))
+	assert.Equal(t, "P1M", scanned.String())
+}
+
+func TestCompare(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		left  timespan.TimeSpan
+		right timespan.TimeSpan
+		want  int
+	}{
+		{
+			name:  "equal clock spans",
+			left:  timespan.FromDuration(time.Hour),
+			right: timespan.FromDuration(time.Hour),
+			want:  0,
+		},
+		{
+			name:  "month equals thirty days",
+			left:  timespan.TimeSpan{Months: 1},
+			right: timespan.TimeSpan{Days: 30},
+			want:  0,
+		},
+		{
+			name:  "month less than one thousand hours",
+			left:  timespan.TimeSpan{Months: 1},
+			right: timespan.FromDuration(1000 * time.Hour),
+			want:  -1,
+		},
+		{
+			name:  "two months greater than one thousand hours",
+			left:  timespan.TimeSpan{Months: 2},
+			right: timespan.FromDuration(1000 * time.Hour),
+			want:  1,
+		},
+		{
+			name:  "day equals twenty four hours",
+			left:  timespan.TimeSpan{Days: 1},
+			right: timespan.FromDuration(24 * time.Hour),
+			want:  0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				assert.Equal(t, tc.want, tc.left.Compare(tc.right))
+				assert.Equal(t, -tc.want, tc.right.Compare(tc.left))
+			},
+		)
+	}
+}
+
+func TestCompareDuration(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"equal microsecond bound",
+		func(t *testing.T) {
+			t.Parallel()
+
+			span := timespan.FromDuration(time.Microsecond)
+			assert.Equal(t, 0, span.CompareDuration(time.Microsecond))
+		},
+	)
+
+	t.Run(
+		"zero below nanosecond bound",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, -1, timespan.Zero.CompareDuration(time.Nanosecond))
+		},
+	)
+
+	t.Run(
+		"microsecond below leftover-nanosecond bound",
+		func(t *testing.T) {
+			t.Parallel()
+
+			span := timespan.FromDuration(time.Microsecond)
+			assert.Equal(t, -1, span.CompareDuration(time.Microsecond+time.Nanosecond))
+		},
+	)
+
+	t.Run(
+		"microsecond above leftover-nanosecond bound",
+		func(t *testing.T) {
+			t.Parallel()
+
+			span := timespan.FromDuration(time.Microsecond)
+			assert.Equal(t, 1, span.CompareDuration(time.Microsecond-time.Nanosecond))
+		},
+	)
+}
+
+func TestFromDurationAndClockDuration(t *testing.T) {
+	t.Parallel()
+
+	clock := timespan.FromDuration(90 * time.Minute)
+	got, ok := clock.ClockDuration()
+	require.True(t, ok)
+	assert.Equal(t, 90*time.Minute, got)
+
+	_, ok = timespan.TimeSpan{Months: 1}.ClockDuration()
+	assert.False(t, ok)
+
+	got, ok = timespan.TimeSpan{Days: 1}.ClockDuration()
+	require.True(t, ok)
+	assert.Equal(t, 24*time.Hour, got)
+
+	_, ok = timespan.TimeSpan{Days: 213504}.ClockDuration()
+	assert.False(t, ok)
+
+	maxDays := int32(int64(math.MaxInt64) / int64(24*time.Hour))
+	got, ok = timespan.TimeSpan{Days: maxDays}.ClockDuration()
+	require.True(t, ok)
+	assert.Equal(t, time.Duration(maxDays)*24*time.Hour, got)
+
+	_, ok = timespan.TimeSpan{Days: maxDays + 1}.ClockDuration()
+	assert.False(t, ok)
+
+	dayNs := int64(maxDays) * int64(24*time.Hour)
+	overflowUs := (math.MaxInt64-dayNs)/int64(time.Microsecond) + 1
+	_, ok = timespan.TimeSpan{Days: maxDays, Microseconds: overflowUs}.ClockDuration()
+	assert.False(t, ok)
+}
+
+func TestJSONRoundTripMixedSigns(t *testing.T) {
+	t.Parallel()
+
+	original := timespan.TimeSpan{Months: 1, Days: -5}
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+	assert.Equal(t, `"P1M-5D"`, string(data))
+
+	var parsed timespan.TimeSpan
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Equal(t, original, parsed)
+
+	var scanned timespan.TimeSpan
+	require.NoError(t, scanned.ScanInterval(pgtype.Interval{Months: 1, Days: -5, Valid: true}))
+	assert.Equal(t, original, scanned)
+
+	data, err = json.Marshal(scanned)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Equal(t, original, parsed)
+}
+
+func TestJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := timespan.TimeSpan{Months: 1, Days: 2, Microseconds: 3_000_000}
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+	assert.Equal(t, `"P1M2DT3S"`, string(data))
+
+	var parsed timespan.TimeSpan
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Equal(t, original, parsed)
+}

--- a/pkg/validator/validator_time.go
+++ b/pkg/validator/validator_time.go
@@ -23,6 +23,8 @@ package validator
 import (
 	"fmt"
 	"time"
+
+	"go.probo.inc/probo/pkg/timespan"
 )
 
 // After validates that a time is after the specified reference time.
@@ -99,7 +101,8 @@ func Before(t any) ValidatorFunc {
 	}
 }
 
-// RangeDuration validates that a duration is within the specified range (inclusive).
+// RangeDuration validates that a TimeSpan is within [min, max] inclusive.
+// Calendar months are ordered as 30-day units.
 func RangeDuration(min, max time.Duration) ValidatorFunc {
 	return func(value any) *ValidationError {
 		actualValue, isNil := dereferenceValue(value)
@@ -107,12 +110,12 @@ func RangeDuration(min, max time.Duration) ValidatorFunc {
 			return nil
 		}
 
-		duration, ok := actualValue.(time.Duration)
+		span, ok := actualValue.(timespan.TimeSpan)
 		if !ok {
-			return newValidationError(ErrorCodeInvalidFormat, "value must be a time.Duration")
+			return newValidationError(ErrorCodeInvalidFormat, "value must be a timespan.TimeSpan")
 		}
 
-		if duration < min || duration > max {
+		if span.CompareDuration(min) < 0 || span.CompareDuration(max) > 0 {
 			return newValidationError(
 				ErrorCodeOutOfRange,
 				fmt.Sprintf("must be between %s and %s", min, max),

--- a/pkg/validator/validator_time_test.go
+++ b/pkg/validator/validator_time_test.go
@@ -23,6 +23,8 @@ package validator
 import (
 	"testing"
 	"time"
+
+	"go.probo.inc/probo/pkg/timespan"
 )
 
 func TestAfter(t *testing.T) {
@@ -106,36 +108,36 @@ func TestRangeDuration(t *testing.T) {
 	maxDuration := 1 * time.Hour
 
 	t.Run("duration within range", func(t *testing.T) {
-		duration := 30 * time.Minute
+		span := timespan.FromDuration(30 * time.Minute)
 
-		err := RangeDuration(minDuration, maxDuration)(&duration)
+		err := RangeDuration(minDuration, maxDuration)(&span)
 		if err != nil {
 			t.Errorf("expected no error, got: %v", err)
 		}
 	})
 
 	t.Run("duration at minimum", func(t *testing.T) {
-		duration := 10 * time.Minute
+		span := timespan.FromDuration(10 * time.Minute)
 
-		err := RangeDuration(minDuration, maxDuration)(&duration)
+		err := RangeDuration(minDuration, maxDuration)(&span)
 		if err != nil {
 			t.Errorf("expected no error, got: %v", err)
 		}
 	})
 
 	t.Run("duration at maximum", func(t *testing.T) {
-		duration := 1 * time.Hour
+		span := timespan.FromDuration(1 * time.Hour)
 
-		err := RangeDuration(minDuration, maxDuration)(&duration)
+		err := RangeDuration(minDuration, maxDuration)(&span)
 		if err != nil {
 			t.Errorf("expected no error, got: %v", err)
 		}
 	})
 
 	t.Run("duration below minimum", func(t *testing.T) {
-		duration := 5 * time.Minute
+		span := timespan.FromDuration(5 * time.Minute)
 
-		err := RangeDuration(minDuration, maxDuration)(&duration)
+		err := RangeDuration(minDuration, maxDuration)(&span)
 		if err == nil {
 			t.Fatal("expected validation error")
 		} else if err.Code != ErrorCodeOutOfRange {
@@ -144,9 +146,9 @@ func TestRangeDuration(t *testing.T) {
 	})
 
 	t.Run("duration above maximum", func(t *testing.T) {
-		duration := 2 * time.Hour
+		span := timespan.FromDuration(2 * time.Hour)
 
-		err := RangeDuration(minDuration, maxDuration)(&duration)
+		err := RangeDuration(minDuration, maxDuration)(&span)
 		if err == nil {
 			t.Fatal("expected validation error")
 		} else if err.Code != ErrorCodeOutOfRange {
@@ -155,11 +157,86 @@ func TestRangeDuration(t *testing.T) {
 	})
 
 	t.Run("nil pointer", func(t *testing.T) {
-		var duration *time.Duration
+		var span *timespan.TimeSpan
 
-		err := RangeDuration(minDuration, maxDuration)(duration)
+		err := RangeDuration(minDuration, maxDuration)(span)
 		if err != nil {
 			t.Errorf("expected no error for nil, got: %v", err)
+		}
+	})
+
+	t.Run("calendar month above maximum", func(t *testing.T) {
+		span := timespan.TimeSpan{Months: 1}
+
+		err := RangeDuration(minDuration, maxDuration)(&span)
+		if err == nil {
+			t.Fatal("expected validation error")
+		} else if err.Code != ErrorCodeOutOfRange {
+			t.Errorf("expected error code %s, got %s", ErrorCodeOutOfRange, err.Code)
+		}
+	})
+
+	t.Run("calendar month within range", func(t *testing.T) {
+		span := timespan.TimeSpan{Months: 1}
+
+		err := RangeDuration(0, 1000*time.Hour)(&span)
+		if err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("two calendar months above maximum", func(t *testing.T) {
+		span := timespan.TimeSpan{Months: 2}
+
+		err := RangeDuration(0, 1000*time.Hour)(&span)
+		if err == nil {
+			t.Fatal("expected validation error")
+		} else if err.Code != ErrorCodeOutOfRange {
+			t.Errorf("expected error code %s, got %s", ErrorCodeOutOfRange, err.Code)
+		}
+	})
+
+	t.Run("overflowing clock days above maximum", func(t *testing.T) {
+		span := timespan.TimeSpan{Days: 213504}
+
+		err := RangeDuration(0, 1000*time.Hour)(&span)
+		if err == nil {
+			t.Fatal("expected validation error")
+		} else if err.Code != ErrorCodeOutOfRange {
+			t.Errorf("expected error code %s, got %s", ErrorCodeOutOfRange, err.Code)
+		}
+	})
+
+	t.Run("zero below nanosecond minimum", func(t *testing.T) {
+		span := timespan.Zero
+
+		err := RangeDuration(time.Nanosecond, time.Hour)(&span)
+		if err == nil {
+			t.Fatal("expected validation error")
+		} else if err.Code != ErrorCodeOutOfRange {
+			t.Errorf("expected error code %s, got %s", ErrorCodeOutOfRange, err.Code)
+		}
+	})
+
+	t.Run("microsecond below leftover-nanosecond minimum", func(t *testing.T) {
+		span := timespan.FromDuration(time.Microsecond)
+
+		err := RangeDuration(time.Microsecond+time.Nanosecond, time.Hour)(&span)
+		if err == nil {
+			t.Fatal("expected validation error")
+		} else if err.Code != ErrorCodeOutOfRange {
+			t.Errorf("expected error code %s, got %s", ErrorCodeOutOfRange, err.Code)
+		}
+	})
+
+	t.Run("microsecond above leftover-nanosecond maximum", func(t *testing.T) {
+		span := timespan.FromDuration(time.Microsecond)
+
+		err := RangeDuration(0, time.Microsecond-time.Nanosecond)(&span)
+		if err == nil {
+			t.Fatal("expected validation error")
+		} else if err.Code != ErrorCodeOutOfRange {
+			t.Errorf("expected error code %s, got %s", ErrorCodeOutOfRange, err.Code)
 		}
 	})
 }

--- a/relay.config.json
+++ b/relay.config.json
@@ -23,7 +23,7 @@
         "Datetime": "string",
         "GID": "string",
         "CursorKey": "string",
-        "Duration": "string",
+        "TimeSpan": "string",
         "BigInt": "number",
         "EmailAddr": "string"
       }
@@ -38,7 +38,7 @@
         "Datetime": "string",
         "GID": "string",
         "CursorKey": "string",
-        "Duration": "string",
+        "TimeSpan": "string",
         "BigInt": "number",
         "EmailAddr": "string",
         "OAuth2Scope": "string",
@@ -65,7 +65,7 @@
         "Datetime": "string",
         "GID": "string",
         "CursorKey": "string",
-        "Duration": "string",
+        "TimeSpan": "string",
         "BigInt": "number",
         "EmailAddr": "string"
       }
@@ -80,7 +80,7 @@
         "Datetime": "string",
         "GID": "string",
         "CursorKey": "string",
-        "Duration": "string",
+        "TimeSpan": "string",
         "BigInt": "number",
         "EmailAddr": "string",
         "OAuth2Scope": "string",


### PR DESCRIPTION
A month is not a fixed amount of time. Go's time.Duration can only
store elapsed nanoseconds, so P1M was flattened to ~30 days and
could not round-trip to PostgreSQL INTERVAL. TimeSpan keeps months,
days, and microseconds. The name avoids time.Duration and the
PostgreSQL-style name "interval", which usually means a start/end
range.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Task time estimates now preserve ISO-8601 calendar months by replacing Go `time.Duration` and the `Duration` API scalar with `TimeSpan`. `P1M` now round-trips across the GraphQL and MCP APIs and PostgreSQL storage; clients must rename the scalar to `TimeSpan`, and range checks compare months as 30-day units.

### **Tests** **`+614`** **`-12`**

Covers parsing, formatting, JSON, PostgreSQL interval conversion, overflow and range boundaries, plus e2e create/update/get and invalid estimate inputs.

### **Coredata** **`+15`** **-14**

Stores `Task.TimeEstimate` as `*timespan.TimeSpan`.

### **GraphQL API** **`+61`** **`-6`**

Adds custom `TimeSpan` scalar parsing and marshaling and updates task fields and inputs from `Duration`.

### **MCP** **`+6`** **`-6`**

Publishes task estimates as ISO-8601 `TimeSpan` values.

### **Service** **`+542`** **`-6`**

Adds `pkg/timespan` with calendar, day, and microsecond components, PostgreSQL interval support, JSON support, comparisons, and clock-duration conversion.

### **Agents** **`+2`** **`-2`**

Updates Relay and validation guidance for the scalar rename and month comparison rule.

### **Other** **`+5`** **`-5`**

Promotes `github.com/sosodev/duration` to a direct dependency and updates Relay scalar mappings.

<sup>Written for commit 376af3ffffb4752eee02212213c622b1360c8972. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



