### PR TITLE
Fix inconsistent Windows posture values

### DIFF
--- a/cmd/probo-agent/CHANGELOG.md
+++ b/cmd/probo-agent/CHANGELOG.md
@@ -5,6 +5,23 @@ documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- The Windows firewall check no longer falls back to parsing localized `netsh`
+  output, which reported a fully enabled firewall as off on non-English
+  systems. It now reads the firewall COM API, which returns booleans and needs
+  no module load, and both probes report the same evidence shape
+- A firewall state that cannot be read reports Unknown instead of Off
+- Posture runs cut short by sleep or shutdown are no longer sent, queued, or
+  replayed as reports. A partial run described the host as it was powering off,
+  and could surface a check as Unknown hours later when the queue drained
+- The Windows screen lock check reads machine-wide policy — the machine
+  inactivity limit, the MDM DeviceLock policy, and the full screensaver policy
+  rather than only whether the screensaver is secure — so a managed host no
+  longer reports Unknown when nobody is signed in
+- `probo-agent collect` no longer truncates its own run on busy hosts, and
+  reports an error rather than silently printing a short list
+
 ## [0.6.4] - 2026-09-09
 
 ### Fixed

--- a/cmd/probo-agent/main.go
+++ b/cmd/probo-agent/main.go
@@ -54,6 +54,11 @@ var version = "dev"
 // "failed" state on a normal self-update.
 const restartExitCode = 75
 
+// collectTimeout bounds the whole check set for a one-shot `collect`. Every
+// check can spend the agent's per-check budget, so this has to clear the full
+// set rather than a single probe.
+const collectTimeout = 5 * time.Minute
+
 // Cobra prints a "this is a command line tool" splash and exits 1 when the
 // parent process is explorer.exe. The shell is what launches the probo://
 // handler and the HKLM Run entry, so the splash would break both browser
@@ -518,21 +523,26 @@ func newCollectCmd() *cobra.Command {
 				fmt.Println(dir)
 			}
 
-			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(cmd.Context(), collectTimeout)
 			defer cancel()
 
 			agent := deviceagent.New(dir, version, newAgentLogger())
-			results := agent.CollectOnce(ctx)
+
+			results, collectErr := agent.CollectOnce(ctx)
 
 			if asJSON {
-				return json.NewEncoder(os.Stdout).Encode(results)
+				if err := json.NewEncoder(os.Stdout).Encode(results); err != nil {
+					return fmt.Errorf("cannot encode results: %w", err)
+				}
+
+				return collectErr
 			}
 
 			for _, r := range results {
 				fmt.Printf("%-20s %-15s %v\n", r.CheckKey, r.Status, r.Evidence)
 			}
 
-			return nil
+			return collectErr
 		},
 	}
 	cmd.Flags().BoolVar(&once, "once", true, "(default true) run the check set once and exit")

--- a/cmd/probod/CHANGELOG.md
+++ b/cmd/probod/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `probod` (the server, including the bundled `@probo/conso
 
 ## Unreleased
 
+### Fixed
+
+- Windows time sync and auto-update postures reported by probo-agent 0.6.4 and
+  later no longer display as Unknown. The agent renamed the evidence it sends
+  for those checks when it moved from transient service state to service
+  configuration, and the reader still expected the old keys
+
 ## [0.283.0] - 2026-09-09
 
 ### Added

--- a/contrib/seed.sh
+++ b/contrib/seed.sh
@@ -878,8 +878,8 @@ posture_evidence() {
       ;;
     WINDOWS:SCREEN_LOCK)
       case "$status" in
-        PASS) jq -nc '{backend:"hkey_users",users:{"S-1-5-21-1004336348-1177238915-682003330-1001":"1"}}' ;;
-        FAIL) jq -nc '{backend:"hkey_users",users:{"S-1-5-21-1004336348-1177238915-682003330-1001":"0"}}' ;;
+        PASS) jq -nc '{backend:"machine_inactivity_limit",screen_lock_enforced:true,policy:{InactivityTimeoutSecs:"900",MaxInactivityTimeDeviceLock:"",ScreenSaverIsSecure:"",ScreenSaveActive:"",ScreenSaveTimeOut:""}}' ;;
+        FAIL) jq -nc '{backend:"hkey_users",screen_lock_enforced:false,users:{"S-1-5-21-1004336348-1177238915-682003330-1001":"0::"}}' ;;
         *) jq -nc '{backend:"hkey_users",users:{},note:"no interactive user hives loaded"}' ;;
       esac
       ;;
@@ -901,7 +901,7 @@ posture_evidence() {
       case "$status" in
         PASS) jq -nc '{backend:"Get-NetFirewallProfile",raw:"Domain=True;Private=True;Public=True",profiles:{Domain:"True",Private:"True",Public:"True"}}' ;;
         FAIL) jq -nc '{backend:"Get-NetFirewallProfile",raw:"Domain=True;Private=True;Public=False",profiles:{Domain:"True",Private:"True",Public:"False"}}' ;;
-        *) jq -nc '{backend:"netsh",state_lines:[]}' ;;
+        *) jq -nc '{backend:"HNetCfg.FwPolicy2",degraded:true,primary_backend:"Get-NetFirewallProfile",primary_error:"command \"powershell.exe\" timed out after 10s: exit status 1",primary_timed_out:true,profiles:{}}' ;;
       esac
       ;;
     DARWIN:TIME_SYNC)
@@ -920,8 +920,8 @@ posture_evidence() {
       ;;
     WINDOWS:TIME_SYNC)
       case "$status" in
-        PASS) jq -nc '{backend:"w32time",w32time_status:"Running",w32time_type:"NTP",ntp_server:"time.windows.com,0x8"}' ;;
-        FAIL) jq -nc '{backend:"w32time",w32time_status:"Stopped",w32time_type:"NTP"}' ;;
+        PASS) jq -nc '{backend:"w32time",w32time_service_start:"3",w32time_type:"NTP",ntp_server:"time.windows.com,0x8"}' ;;
+        FAIL) jq -nc '{backend:"w32time",w32time_service_start:"4",w32time_type:"NTP"}' ;;
         *) jq -nc '{error:"exit status 0x80070426",stderr:""}' ;;
       esac
       ;;
@@ -959,9 +959,9 @@ posture_evidence() {
       ;;
     WINDOWS:AUTO_UPDATE)
       case "$status" in
-        PASS) jq -nc '{no_auto_update:"0",au_options:"4"}' ;;
-        FAIL) jq -nc '{no_auto_update:"",au_options:"2"}' ;;
-        *) jq -nc '{no_auto_update:"",au_options:"",wuauserv:""}' ;;
+        PASS) jq -nc '{no_auto_update:"0",au_options:"4",wuauserv_service_start:"2"}' ;;
+        FAIL) jq -nc '{no_auto_update:"",au_options:"2",wuauserv_service_start:"3"}' ;;
+        *) jq -nc '{no_auto_update:"",au_options:"",wuauserv_service_start:""}' ;;
       esac
       ;;
     DARWIN:PASSWORD_POLICY)

--- a/pkg/coredata/device_posture_value_checks.go
+++ b/pkg/coredata/device_posture_value_checks.go
@@ -116,6 +116,13 @@ func lsblkHasCryptDevice(raw string) bool {
 }
 
 func parseScreenLockValue(ev map[string]any) DevicePostureValue {
+	// Windows resolves a layered policy where the deciding source varies per
+	// host, so the agent states the outcome rather than the server guessing
+	// which key to read. Agents before 0.6.5 set no such key.
+	if enforced, ok := boolEvidence(ev, "screen_lock_enforced"); ok {
+		return onOffValue(enforced)
+	}
+
 	switch backendOf(ev) {
 	case "sysadminctl":
 		return parseDarwinScreenLockModeValue(ev)
@@ -215,9 +222,10 @@ func parseFirewallValue(ev map[string]any) DevicePostureValue {
 		return parseNftablesValue(ev)
 	case "iptables":
 		return parseIptablesValue(ev)
-	case "get-netfirewallprofile":
+	case "get-netfirewallprofile", "hnetcfg.fwpolicy2":
 		return parseWindowsFirewallProfilesValue(ev)
 	case "netsh":
+		// Sent by agents before 0.6.5, which fell back to localized netsh output.
 		return parseNetshFirewallValue(ev)
 	}
 
@@ -343,6 +351,10 @@ func parseNetshFirewallValue(ev map[string]any) DevicePostureValue {
 }
 
 func parseTimeSyncValue(ev map[string]any) DevicePostureValue {
+	if start := stringEvidence(ev, "w32time_service_start"); start != "" {
+		return parseWindowsTimeSyncStartValue(start, stringEvidence(ev, "w32time_type"))
+	}
+
 	if status := stringEvidence(ev, "w32time_status"); status != "" {
 		return parseWindowsTimeSyncValue(status, stringEvidence(ev, "w32time_type"))
 	}
@@ -368,11 +380,29 @@ func parseTimeSyncValue(ev map[string]any) DevicePostureValue {
 	return unknownValue()
 }
 
+// parseWindowsTimeSyncStartValue reads the W32Time service Start value, where 2
+// is automatic and 3 is manual with a start trigger.
+func parseWindowsTimeSyncStartValue(serviceStart, typ string) DevicePostureValue {
+	switch strings.TrimSpace(serviceStart) {
+	case "2", "3":
+	default:
+		return onOffValue(false)
+	}
+
+	return windowsTimeSyncTypeValue(typ)
+}
+
+// parseWindowsTimeSyncValue reads the transient service status sent by agents
+// before 0.6.4, which report the Start value under w32time_service_start.
 func parseWindowsTimeSyncValue(status, typ string) DevicePostureValue {
 	if !strings.EqualFold(status, "Running") {
 		return onOffValue(false)
 	}
 
+	return windowsTimeSyncTypeValue(typ)
+}
+
+func windowsTimeSyncTypeValue(typ string) DevicePostureValue {
 	switch strings.ToUpper(strings.TrimSpace(typ)) {
 	case "NTP", "NT5DS", "ALLSYNC":
 		return onOffValue(true)
@@ -393,7 +423,7 @@ func parseAutoUpdateValue(ev map[string]any) DevicePostureValue {
 	}
 
 	// The Windows Update policy read sets no backend key.
-	if hasAnyKey(ev, "no_auto_update", "au_options", "wuauserv") {
+	if hasAnyKey(ev, "no_auto_update", "au_options", "wuauserv", "wuauserv_service_start") {
 		return parseWindowsAutoUpdateValue(ev)
 	}
 
@@ -415,6 +445,10 @@ func parseDarwinSoftwareUpdateValue(ev map[string]any) DevicePostureValue {
 }
 
 func parseWindowsAutoUpdateValue(ev map[string]any) DevicePostureValue {
+	if start := stringEvidence(ev, "wuauserv_service_start"); start != "" {
+		return parseWindowsAutoUpdateStartValue(ev, start)
+	}
+
 	if stringEvidence(ev, "no_auto_update") == "1" {
 		return onOffValue(false)
 	}
@@ -428,12 +462,41 @@ func parseWindowsAutoUpdateValue(ev map[string]any) DevicePostureValue {
 		return onOffValue(false)
 	}
 
-	// With no managed policy the value is whether the Windows Update service is
-	// running to apply the OS default.
+	// Agents before 0.6.4 reported whether the Windows Update service happened
+	// to be running rather than its Start configuration.
 	switch stringEvidence(ev, "wuauserv") {
 	case "running":
 		return onOffValue(true)
 	case "stopped":
+		return onOffValue(false)
+	}
+
+	return unknownValue()
+}
+
+// parseWindowsAutoUpdateStartValue mirrors the agent ordering: a disabled
+// wuauserv (Start 4) beats any policy, then NoAutoUpdate, then AUOptions, where
+// an unset AUOptions leaves the OS default of automatic install in place.
+func parseWindowsAutoUpdateStartValue(
+	ev map[string]any,
+	serviceStart string,
+) DevicePostureValue {
+	switch strings.TrimSpace(serviceStart) {
+	case "4":
+		return onOffValue(false)
+	case "2", "3":
+	default:
+		return unknownValue()
+	}
+
+	if stringEvidence(ev, "no_auto_update") == "1" {
+		return onOffValue(false)
+	}
+
+	switch stringEvidence(ev, "au_options") {
+	case "", "3", "4", "5":
+		return onOffValue(true)
+	case "2":
 		return onOffValue(false)
 	}
 

--- a/pkg/coredata/device_posture_value_test.go
+++ b/pkg/coredata/device_posture_value_test.go
@@ -247,6 +247,38 @@ func TestParseDevicePostureValue_ScreenLock(t *testing.T) {
 				},
 				wantKind: coredata.DevicePostureValueKindUnknown,
 			},
+			{
+				name:     "windows machine inactivity limit enforces lock",
+				checkKey: "SCREEN_LOCK",
+				evidence: map[string]any{
+					"backend":              "machine_inactivity_limit",
+					"screen_lock_enforced": true,
+					"policy":               map[string]any{"InactivityTimeoutSecs": "900"},
+				},
+				wantKind: coredata.DevicePostureValueKindOn,
+			},
+			{
+				name:     "windows machine policy leaves the screensaver insecure",
+				checkKey: "SCREEN_LOCK",
+				evidence: map[string]any{
+					"backend":              "machine_policy",
+					"screen_lock_enforced": false,
+					"policy":               map[string]any{"ScreenSaverIsSecure": "0"},
+				},
+				wantKind: coredata.DevicePostureValueKindOff,
+			},
+			{
+				name:     "windows per-user hives resolved by the agent",
+				checkKey: "SCREEN_LOCK",
+				evidence: map[string]any{
+					"backend":              "hkey_users",
+					"screen_lock_enforced": true,
+					"users": map[string]any{
+						"S-1-5-21-1004336348-1177238915-682003330-1001": "1:1:600",
+					},
+				},
+				wantKind: coredata.DevicePostureValueKindOn,
+			},
 		},
 	)
 }
@@ -273,6 +305,16 @@ func TestParseDevicePostureValue_Firewall(t *testing.T) {
 				evidence: map[string]any{
 					"backend":     "netsh",
 					"state_lines": []any{},
+				},
+				wantKind: coredata.DevicePostureValueKindUnknown,
+			},
+			{
+				name:     "windows firewall COM fallback without profiles is unknown",
+				checkKey: "FIREWALL_ENABLED",
+				evidence: map[string]any{
+					"backend":  "HNetCfg.FwPolicy2",
+					"degraded": true,
+					"profiles": map[string]any{},
 				},
 				wantKind: coredata.DevicePostureValueKindUnknown,
 			},
@@ -342,6 +384,37 @@ func TestParseDevicePostureValue_TimeSync(t *testing.T) {
 					"backend":        "w32time",
 					"w32time_status": "Running",
 					"w32time_type":   "NoSync",
+				},
+				wantKind: coredata.DevicePostureValueKindOff,
+			},
+			{
+				name:     "windows w32time trigger-start service with NTP is on",
+				checkKey: "TIME_SYNC",
+				evidence: map[string]any{
+					"backend":               "w32time",
+					"w32time_service_start": "3",
+					"w32time_type":          "NTP",
+					"ntp_server":            "time.windows.com,0x9",
+				},
+				wantKind: coredata.DevicePostureValueKindOn,
+			},
+			{
+				name:     "windows w32time disabled service is off",
+				checkKey: "TIME_SYNC",
+				evidence: map[string]any{
+					"backend":               "w32time",
+					"w32time_service_start": "4",
+					"w32time_type":          "NTP",
+				},
+				wantKind: coredata.DevicePostureValueKindOff,
+			},
+			{
+				name:     "windows w32time automatic service with NoSync is off",
+				checkKey: "TIME_SYNC",
+				evidence: map[string]any{
+					"backend":               "w32time",
+					"w32time_service_start": "2",
+					"w32time_type":          "NoSync",
 				},
 				wantKind: coredata.DevicePostureValueKindOff,
 			},
@@ -654,11 +727,14 @@ type devicePostureAgreementCase struct {
 
 // passingKindByCheckKey is the state a passing check observed. Remote login is
 // the inverted one: a reachable SSH server is the finding, so PASS means OFF.
+// SCREEN_LOCK is absent on purpose: a passing macOS host reports a delay rather
+// than ON, so its value has no single passing kind to compare against.
 var passingKindByCheckKey = map[string]coredata.DevicePostureValueKind{
 	"FIREWALL_ENABLED":   coredata.DevicePostureValueKindOn,
 	"DISK_ENCRYPTION":    coredata.DevicePostureValueKindOn,
 	"TIME_SYNC":          coredata.DevicePostureValueKindOn,
 	"MALWARE_PROTECTION": coredata.DevicePostureValueKindOn,
+	"AUTO_UPDATE":        coredata.DevicePostureValueKindOn,
 	"REMOTE_LOGIN":       coredata.DevicePostureValueKindOff,
 }
 
@@ -894,6 +970,60 @@ func TestParseDevicePostureValue_AgreesWithAgentStatus(t *testing.T) {
 				"w32time_type":   "NTP",
 			},
 			agentStatus: coredata.DevicePostureStatusFail,
+		},
+		{
+			name:     "windows w32time trigger-start service",
+			checkKey: "TIME_SYNC",
+			evidence: map[string]any{
+				"backend":               "w32time",
+				"w32time_service_start": "3",
+				"w32time_type":          "NTP",
+			},
+			agentStatus: coredata.DevicePostureStatusPass,
+		},
+		{
+			name:     "windows w32time disabled service",
+			checkKey: "TIME_SYNC",
+			evidence: map[string]any{
+				"backend":               "w32time",
+				"w32time_service_start": "4",
+				"w32time_type":          "NTP",
+			},
+			agentStatus: coredata.DevicePostureStatusFail,
+		},
+		{
+			name:     "windows auto-update with no policy and a trigger-start service",
+			checkKey: "AUTO_UPDATE",
+			evidence: map[string]any{
+				"no_auto_update":         "",
+				"au_options":             "",
+				"wuauserv_service_start": "3",
+			},
+			agentStatus: coredata.DevicePostureStatusPass,
+		},
+		{
+			name:     "windows auto-update with a disabled service",
+			checkKey: "AUTO_UPDATE",
+			evidence: map[string]any{
+				"no_auto_update":         "",
+				"au_options":             "",
+				"wuauserv_service_start": "4",
+			},
+			agentStatus: coredata.DevicePostureStatusFail,
+		},
+		{
+			name:     "windows firewall through the COM fallback",
+			checkKey: "FIREWALL_ENABLED",
+			evidence: map[string]any{
+				"backend":  "HNetCfg.FwPolicy2",
+				"degraded": true,
+				"profiles": map[string]any{
+					"Domain":  "True",
+					"Private": "True",
+					"Public":  "True",
+				},
+			},
+			agentStatus: coredata.DevicePostureStatusPass,
 		},
 		{
 			name:        "darwin network time on",

--- a/pkg/deviceagent/agent.go
+++ b/pkg/deviceagent/agent.go
@@ -65,6 +65,7 @@ type Agent struct {
 	revoked bool
 
 	collectHostInfo     func() HostInfo
+	checkSet            func() []checks.Check
 	hostInfo            HostInfo
 	hostInfoCollectedAt time.Time
 
@@ -89,7 +90,8 @@ func New(dir, version string, logger *log.Logger) *Agent {
 		collectHostInfo: func() HostInfo {
 			return CollectHostInfo()
 		},
-		now: time.Now,
+		checkSet: checks.All,
+		now:      time.Now,
 		randInt63n: func(n int64) int64 {
 			return rand.Int63n(n)
 		},
@@ -302,15 +304,19 @@ func (a *Agent) tryAutoUpdate(parent context.Context) bool {
 	return true
 }
 
-// CollectOnce executes checks without pushing results to the server.
-func (a *Agent) CollectOnce(ctx context.Context) []checks.Result {
+// CollectOnce executes checks without pushing results to the server. A
+// non-nil error means the run was cut short: the set may be incomplete, and a
+// check caught by the cancellation reports a failure of the shutdown rather
+// than of the host, so callers must not persist the results as a report.
+func (a *Agent) CollectOnce(ctx context.Context) ([]checks.Result, error) {
 	now := time.Now()
-	results := make([]checks.Result, 0)
+	all := a.checks()
+	results := make([]checks.Result, 0, len(all))
 
-	for _, c := range checks.All() {
+	for _, c := range all {
 		select {
 		case <-ctx.Done():
-			return results
+			return results, fmt.Errorf("cannot complete posture collection: %w", ctx.Err())
 		default:
 		}
 
@@ -330,7 +336,22 @@ func (a *Agent) CollectOnce(ctx context.Context) []checks.Result {
 		results = append(results, r)
 	}
 
-	return results
+	// A check already running when the context ends still returns, so the loop
+	// can finish on its own with only that last result poisoned by the
+	// shutdown. Counting the results cannot catch it; the context can.
+	if err := ctx.Err(); err != nil {
+		return results, fmt.Errorf("cannot complete posture collection: %w", err)
+	}
+
+	return results, nil
+}
+
+func (a *Agent) checks() []checks.Check {
+	if a.checkSet == nil {
+		return checks.All()
+	}
+
+	return a.checkSet()
 }
 
 // Unenroll asks the server to revoke this device. Local wipe is left to
@@ -415,7 +436,19 @@ func (a *Agent) doPostures(ctx context.Context) {
 
 	start := time.Now()
 
-	results := a.CollectOnce(ctx)
+	results, err := a.CollectOnce(ctx)
+	if err != nil {
+		a.Logger.WarnCtx(
+			ctx,
+			"discarding truncated posture run",
+			log.Error(err),
+			log.Int("collected_checks", len(results)),
+			log.Int("expected_checks", len(a.checks())),
+		)
+
+		return
+	}
+
 	if len(results) == 0 {
 		return
 	}

--- a/pkg/deviceagent/checks/checks_windows.go
+++ b/pkg/deviceagent/checks/checks_windows.go
@@ -84,23 +84,39 @@ func windowsDiskEncryption(ctx context.Context) Result {
 	return fail(ev)
 }
 
+// windowsScreenLockMachineScript reads every machine-wide lock source in one
+// invocation. Three separate calls would cost up to 30s against a 25s
+// per-check budget. Each source applies to all users and needs no loaded user
+// hive.
+const windowsScreenLockMachineScript = `` +
+	`$s = Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' -ErrorAction SilentlyContinue; ` +
+	`$d = Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\DeviceLock' -ErrorAction SilentlyContinue; ` +
+	`$c = Get-ItemProperty 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Control Panel\Desktop' -ErrorAction SilentlyContinue; ` +
+	`"InactivityTimeoutSecs=$($s.InactivityTimeoutSecs);` +
+	`MaxInactivityTimeDeviceLock=$($d.MaxInactivityTimeDeviceLock);ScreenSaverIsSecure=$($c.ScreenSaverIsSecure);` +
+	`ScreenSaveActive=$($c.ScreenSaveActive);ScreenSaveTimeOut=$($c.ScreenSaveTimeOut)"`
+
+const windowsScreenLockUsersScript = `Get-ChildItem 'Registry::HKEY_USERS' | ` +
+	`Where-Object { $_.PSChildName -match '^S-1-5-21-' } | ` +
+	`ForEach-Object { ` +
+	`  $path = "Registry::HKEY_USERS\$($_.PSChildName)\Control Panel\Desktop"; ` +
+	`  $key = Get-ItemProperty $path -ErrorAction SilentlyContinue; ` +
+	`  "$($_.PSChildName)=$($key.ScreenSaverIsSecure):$($key.ScreenSaveActive):$($key.ScreenSaveTimeOut)" ` +
+	`}`
+
 func windowsScreenLock(ctx context.Context) Result {
-	// HKCU resolves to the SYSTEM hive when the agent runs as LocalSystem,
-	// so we first look for a machine-wide policy and then enumerate every
-	// loaded interactive user hive under HKU.
-	machine := powershell(
-		ctx,
-		`(Get-ItemProperty 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Control Panel\Desktop' `+
-			`-ErrorAction SilentlyContinue).ScreenSaverIsSecure`,
-	)
+	// HKCU resolves to the SYSTEM hive when the agent runs as LocalSystem, so we
+	// exhaust machine-wide policy before enumerating loaded interactive hives.
+	machine := powershell(ctx, windowsScreenLockMachineScript)
 	if machine.Err == nil {
-		v := strings.TrimSpace(machine.Stdout)
-		if v != "" {
+		policy := parseWindowsJoinedPairs(machine.Stdout)
+		if source, on, known := windowsScreenLockOn(policy); known {
 			ev := map[string]any{
-				"backend":                "machine_policy",
-				"screen_saver_is_secure": v,
+				"backend":              source,
+				"policy":               policy,
+				"screen_lock_enforced": on,
 			}
-			if v == "1" {
+			if on {
 				return pass(ev)
 			}
 
@@ -108,21 +124,12 @@ func windowsScreenLock(ctx context.Context) Result {
 		}
 	}
 
-	users := powershell(
-		ctx,
-		`Get-ChildItem 'Registry::HKEY_USERS' | `+
-			`Where-Object { $_.PSChildName -match '^S-1-5-21-' } | `+
-			`ForEach-Object { `+
-			`  $path = "Registry::HKEY_USERS\$($_.PSChildName)\Control Panel\Desktop"; `+
-			`  $key = Get-ItemProperty $path -ErrorAction SilentlyContinue; `+
-			`  "$($_.PSChildName)=$($key.ScreenSaverIsSecure)" `+
-			`}`,
-	)
+	users := powershell(ctx, windowsScreenLockUsersScript)
 	if users.Err != nil {
 		return unknown(
 			map[string]any{
 				"backend":              "hkey_users",
-				"error":                users.Err.Error(),
+				"error":                errString(users.Err),
 				"stderr":               users.Stderr,
 				"machine_policy_error": errString(machine.Err),
 			},
@@ -133,24 +140,28 @@ func windowsScreenLock(ctx context.Context) Result {
 		"backend": "hkey_users",
 		"raw":     truncate(users.Stdout, 400),
 	}
-	users_, anyDisabled, anyEnabled := parseWindowsUserScreenLock(users.Stdout)
+	perUser, anyDisabled, anyEnabled := parseWindowsUserScreenLock(users.Stdout)
 
-	ev["users"] = users_
-	if len(users_) == 0 {
+	ev["users"] = perUser
+	if len(perUser) == 0 {
 		ev["note"] = "no interactive user hives loaded"
 		return unknown(ev)
 	}
 
-	if anyEnabled && !anyDisabled {
+	enforced := anyEnabled && !anyDisabled
+	ev["screen_lock_enforced"] = enforced
+
+	if enforced {
 		return pass(ev)
 	}
 
 	return fail(ev)
 }
 
-// parseWindowsUserScreenLock parses one "SID=<value>" line per user from
-// the registry enumeration and reports whether each user has screen
-// saver locking enabled.
+// parseWindowsUserScreenLock parses one "SID=secure:active:timeout" line per
+// user from the registry enumeration and reports whether each user has screen
+// saver locking enforced. A user whose values cannot be read counts as
+// disabled, so one unprotected account fails the host.
 func parseWindowsUserScreenLock(s string) (map[string]string, bool, bool) {
 	users := map[string]string{}
 
@@ -162,7 +173,7 @@ func parseWindowsUserScreenLock(s string) (map[string]string, bool, bool) {
 			continue
 		}
 
-		idx := strings.LastIndex(line, "=")
+		idx := strings.Index(line, "=")
 		if idx < 0 {
 			continue
 		}
@@ -175,16 +186,35 @@ func parseWindowsUserScreenLock(s string) (map[string]string, bool, bool) {
 		}
 
 		users[sid] = value
-		switch value {
-		case "1":
+
+		secure, active, timeout := splitWindowsUserScreenLock(value)
+		if on, known := windowsScreenSaverLockOn(secure, active, timeout); known && on {
 			anyEnabled = true
-		default:
-			anyDisabled = true
+			continue
 		}
+
+		anyDisabled = true
 	}
 
 	return users, anyDisabled, anyEnabled
 }
+
+func splitWindowsUserScreenLock(value string) (string, string, string) {
+	parts := strings.SplitN(value, ":", 3)
+	for len(parts) < 3 {
+		parts = append(parts, "")
+	}
+
+	return parts[0], parts[1], parts[2]
+}
+
+// windowsFirewallCOMScript reads the effective profile state through
+// INetFwPolicy2, whose profile constants are 1 domain, 2 private and 4 public.
+// It needs no NetSecurity module load and returns booleans rather than the
+// localized prose that `netsh advfirewall` prints.
+const windowsFirewallCOMScript = `$ErrorActionPreference = 'Stop'; ` +
+	`$fw = New-Object -ComObject HNetCfg.FwPolicy2; ` +
+	`"Domain=$($fw.FirewallEnabled(1));Private=$($fw.FirewallEnabled(2));Public=$($fw.FirewallEnabled(4))"`
 
 func windowsFirewall(ctx context.Context) Result {
 	primary := powershell(
@@ -194,75 +224,56 @@ func windowsFirewall(ctx context.Context) Result {
 			`ForEach-Object { "$($_.Name)=$($_.Enabled)" }) -join ";"`,
 	)
 	if primary.Err == nil && strings.TrimSpace(primary.Stdout) != "" {
-		ev := map[string]any{
-			"backend": "Get-NetFirewallProfile",
-			"raw":     primary.Stdout,
-		}
-		profiles, allEnabled := parseWindowsFirewallProfiles(primary.Stdout)
-
-		ev["profiles"] = profiles
-		if allEnabled {
-			return pass(ev)
-		}
-
-		return fail(ev)
-	}
-
-	fallback := RunCommand(ctx, "netsh", "advfirewall", "show", "allprofiles", "state")
-	if fallback.Err != nil {
-		return unknown(
+		return windowsFirewallResult(
 			map[string]any{
-				"error":            errString(fallback.Err),
-				"stderr":           fallback.Stderr,
-				"powershell_error": errString(primary.Err),
+				"backend": "Get-NetFirewallProfile",
+				"raw":     primary.Stdout,
 			},
+			primary.Stdout,
 		)
 	}
 
 	ev := map[string]any{
-		"backend": "netsh",
-		"raw":     truncate(fallback.Stdout, 600),
+		"backend":         "HNetCfg.FwPolicy2",
+		"degraded":        true,
+		"primary_backend": "Get-NetFirewallProfile",
+		"primary_error":   errString(primary.Err),
 	}
-	stateLines, anyOff := parseNetshFirewallStates(fallback.Stdout)
+	if primary.TimedOut {
+		ev["primary_timed_out"] = true
+	}
 
-	ev["state_lines"] = stateLines
-	if len(stateLines) > 0 && !anyOff {
+	fallback := powershell(ctx, windowsFirewallCOMScript)
+	if fallback.Err != nil {
+		ev["error"] = errString(fallback.Err)
+		ev["stderr"] = fallback.Stderr
+
+		if fallback.TimedOut {
+			ev["timed_out"] = true
+		}
+
+		return unknown(ev)
+	}
+
+	ev["raw"] = fallback.Stdout
+
+	return windowsFirewallResult(ev, fallback.Stdout)
+}
+
+func windowsFirewallResult(ev map[string]any, raw string) Result {
+	profiles := parseWindowsJoinedPairs(raw)
+	ev["profiles"] = profiles
+
+	on, known := windowsFirewallOn(profiles)
+	if !known {
+		return unknown(ev)
+	}
+
+	if on {
 		return pass(ev)
 	}
 
 	return fail(ev)
-}
-
-// parseNetshFirewallStates extracts per-profile "State <ON|OFF>" lines
-// from `netsh advfirewall show allprofiles state`. It is whitespace- and
-// case-insensitive.
-func parseNetshFirewallStates(s string) ([]string, bool) {
-	var states []string
-
-	anyOff := false
-
-	for line := range strings.SplitSeq(s, "\n") {
-		trimmed := strings.TrimSpace(line)
-
-		lower := strings.ToLower(trimmed)
-		if !strings.HasPrefix(lower, "state") {
-			continue
-		}
-
-		fields := strings.Fields(lower)
-		if len(fields) < 2 {
-			continue
-		}
-
-		value := fields[len(fields)-1]
-
-		states = append(states, value)
-		if value != "on" {
-			anyOff = true
-		}
-	}
-
-	return states, anyOff
 }
 
 func windowsTimeSync(ctx context.Context) Result {

--- a/pkg/deviceagent/checks/runcmd.go
+++ b/pkg/deviceagent/checks/runcmd.go
@@ -23,6 +23,7 @@ package checks
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -39,9 +40,11 @@ var commandExistsCache sync.Map
 
 // CmdResult captures the basic outcome of an OS subcommand.
 type CmdResult struct {
-	Stdout string
-	Stderr string
-	Err    error
+	Stdout   string
+	Stderr   string
+	Err      error
+	TimedOut bool
+	Canceled bool
 }
 
 // RunCommand executes a command and returns trimmed stdout/stderr.
@@ -64,11 +67,35 @@ func RunCommand(ctx context.Context, name string, args ...string) CmdResult {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 
-	return CmdResult{
+	result := CmdResult{
 		Stdout: strings.TrimSpace(stdout.String()),
 		Stderr: strings.TrimSpace(stderr.String()),
 		Err:    err,
 	}
+	if err == nil {
+		return result
+	}
+
+	// A killed process only reports a non-zero exit status, so the context is
+	// the sole witness to whether we stopped it and why.
+	switch {
+	case errors.Is(ctx.Err(), context.Canceled):
+		result.Canceled = true
+		result.Err = fmt.Errorf("command %q canceled: %w", name, err)
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		result.TimedOut = true
+		result.Err = fmt.Errorf("command %q stopped by the check deadline: %w", name, err)
+	case errors.Is(cmdCtx.Err(), context.DeadlineExceeded):
+		result.TimedOut = true
+		result.Err = fmt.Errorf(
+			"command %q timed out after %s: %w",
+			name,
+			defaultCommandTimeout,
+			err,
+		)
+	}
+
+	return result
 }
 
 // CommandExists reports whether `cmd` exists at expected absolute path(s).

--- a/pkg/deviceagent/checks/runcmd_paths_windows.go
+++ b/pkg/deviceagent/checks/runcmd_paths_windows.go
@@ -27,7 +27,6 @@ import (
 )
 
 var windowsCommandPaths = map[string][]string{
-	"netsh":      {`%s\System32\netsh.exe`},
 	"powershell": {`%s\System32\WindowsPowerShell\v1.0\powershell.exe`},
 	"sc":         {`%s\System32\sc.exe`},
 }

--- a/pkg/deviceagent/checks/runcmd_test.go
+++ b/pkg/deviceagent/checks/runcmd_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package checks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSleepBinary = "/bin/sleep"
+
+func TestRunCommandTermination(t *testing.T) {
+	t.Parallel()
+
+	if !isExecutableFile(testSleepBinary) {
+		t.Skipf("%s is not available", testSleepBinary)
+	}
+
+	t.Run(
+		"an expired deadline reports a timeout",
+		func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+
+			out := RunCommand(ctx, testSleepBinary, "30")
+			require.Error(t, out.Err)
+			assert.True(t, out.TimedOut)
+			assert.False(t, out.Canceled)
+		},
+	)
+
+	t.Run(
+		"a cancelled context reports a cancellation",
+		func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				cancel()
+			}()
+
+			out := RunCommand(ctx, testSleepBinary, "30")
+			require.Error(t, out.Err)
+			assert.True(t, out.Canceled)
+			assert.False(t, out.TimedOut)
+		},
+	)
+
+	t.Run(
+		"a command that completes reports neither",
+		func(t *testing.T) {
+			t.Parallel()
+
+			out := RunCommand(context.Background(), testSleepBinary, "0")
+			require.NoError(t, out.Err)
+			assert.False(t, out.TimedOut)
+			assert.False(t, out.Canceled)
+		},
+	)
+}

--- a/pkg/deviceagent/checks/windows_posture.go
+++ b/pkg/deviceagent/checks/windows_posture.go
@@ -20,7 +20,10 @@
 
 package checks
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // parseWindowsJoinedPairs parses "K=V;K2=V2" produced by PowerShell
 // `-join ";"`. Malformed segments and empty keys are skipped. SplitN
@@ -70,13 +73,27 @@ func parseWindowsBitLockerVolumes(s string) (map[string]string, bool) {
 	return volumes, windowsAllValuesEqualFold(volumes, "on")
 }
 
-// parseWindowsFirewallProfiles parses "Domain=True;Private=True;Public=True"
-// from Get-NetFirewallProfile output, returning per-profile state and
-// whether every profile is enabled.
-func parseWindowsFirewallProfiles(s string) (map[string]string, bool) {
-	profiles := parseWindowsJoinedPairs(s)
+// windowsFirewallOn reports whether every firewall profile is enabled, and
+// whether the values could be read at all. A profile set that is empty or holds
+// anything other than a boolean must not be reported as a disabled firewall.
+func windowsFirewallOn(profiles map[string]string) (bool, bool) {
+	if len(profiles) == 0 {
+		return false, false
+	}
 
-	return profiles, windowsAllValuesEqualFold(profiles, "true")
+	on := true
+
+	for _, value := range profiles {
+		switch strings.ToLower(strings.TrimSpace(value)) {
+		case "true", "1":
+		case "false", "0":
+			on = false
+		default:
+			return false, false
+		}
+	}
+
+	return on, true
 }
 
 func windowsTimeSyncOn(serviceStart, typ string) bool {
@@ -92,6 +109,63 @@ func windowsTimeSyncOn(serviceStart, typ string) bool {
 	}
 
 	return false
+}
+
+// windowsScreenLockOn resolves screen lock from machine-wide policy, which
+// applies to every user and is readable without a loaded user hive. It names
+// the source that decided so a change of source is not mistaken for a change of
+// state, and reports whether any source answered at all.
+// Nothing here reads "Do not display the lock screen": it replaces the glance
+// screen with the credential prompt and does not stop the host locking, so it
+// cannot answer this check either way.
+func windowsScreenLockOn(values map[string]string) (string, bool, bool) {
+	if seconds, ok := windowsInt(values["InactivityTimeoutSecs"]); ok && seconds > 0 {
+		return "machine_inactivity_limit", true, true
+	}
+
+	if minutes, ok := windowsInt(values["MaxInactivityTimeDeviceLock"]); ok && minutes > 0 {
+		return "mdm_device_lock", true, true
+	}
+
+	on, known := windowsScreenSaverLockOn(
+		values["ScreenSaverIsSecure"],
+		values["ScreenSaveActive"],
+		values["ScreenSaveTimeOut"],
+	)
+	if known {
+		return "machine_policy", on, true
+	}
+
+	return "", false, false
+}
+
+// windowsScreenSaverLockOn evaluates the screensaver trio shared by the machine
+// policy and the per-user hives. A secure screensaver only locks anything when
+// it is also active with a non-zero timeout.
+func windowsScreenSaverLockOn(secure, active, timeout string) (bool, bool) {
+	switch strings.TrimSpace(secure) {
+	case "0":
+		return false, true
+	case "1":
+		if strings.TrimSpace(active) != "1" {
+			return false, true
+		}
+
+		seconds, ok := windowsInt(timeout)
+
+		return ok && seconds > 0, true
+	}
+
+	return false, false
+}
+
+func windowsInt(s string) (int, bool) {
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return 0, false
+	}
+
+	return n, true
 }
 
 func windowsAutoUpdateOn(noAutoUpdate, auOptions, serviceStart string) (bool, bool) {

--- a/pkg/deviceagent/checks/windows_posture_test.go
+++ b/pkg/deviceagent/checks/windows_posture_test.go
@@ -64,61 +64,143 @@ func TestParseWindowsBitLockerVolumes(t *testing.T) {
 	)
 }
 
-func TestParseWindowsFirewallProfiles(t *testing.T) {
+func TestWindowsFirewallOn(t *testing.T) {
 	t.Parallel()
 
-	t.Run(
-		"all profiles enabled",
-		func(t *testing.T) {
-			t.Parallel()
-
-			profiles, allEnabled := parseWindowsFirewallProfiles(
-				"Domain=True;Private=True;Public=True",
-			)
-			require.Equal(
-				t,
-				map[string]string{
-					"Domain":  "True",
-					"Private": "True",
-					"Public":  "True",
-				},
-				profiles,
-			)
-			assert.True(t, allEnabled)
+	tests := []struct {
+		name          string
+		raw           string
+		expectedOn    bool
+		expectedKnown bool
+	}{
+		{
+			name:          "all profiles enabled",
+			raw:           "Domain=True;Private=True;Public=True",
+			expectedOn:    true,
+			expectedKnown: true,
 		},
-	)
-
-	t.Run(
-		"one profile disabled",
-		func(t *testing.T) {
-			t.Parallel()
-
-			profiles, allEnabled := parseWindowsFirewallProfiles(
-				"Domain=True;Private=False;Public=True",
-			)
-			require.Equal(
-				t,
-				map[string]string{
-					"Domain":  "True",
-					"Private": "False",
-					"Public":  "True",
-				},
-				profiles,
-			)
-			assert.False(t, allEnabled)
+		{
+			name:          "one profile disabled",
+			raw:           "Domain=True;Private=False;Public=True",
+			expectedKnown: true,
 		},
-	)
-
-	t.Run(
-		"empty output is not enabled",
-		func(t *testing.T) {
-			t.Parallel()
-
-			profiles, allEnabled := parseWindowsFirewallProfiles("")
-			require.Empty(t, profiles)
-			assert.False(t, allEnabled)
+		{
+			name: "empty output is unknown",
+			raw:  "",
 		},
-	)
+		{
+			name: "localized output is unknown, not disabled",
+			raw:  "Domaine=Actif;Privé=Actif;Public=Actif",
+		},
+		{
+			name: "null COM properties are unknown, not disabled",
+			raw:  "Domain=;Private=;Public=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				on, known := windowsFirewallOn(parseWindowsJoinedPairs(tt.raw))
+				assert.Equal(t, tt.expectedOn, on)
+				assert.Equal(t, tt.expectedKnown, known)
+			},
+		)
+	}
+}
+
+func TestWindowsScreenLockOn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		values         map[string]string
+		expectedSource string
+		expectedOn     bool
+		expectedKnown  bool
+	}{
+		{
+			// "Do not display the lock screen" swaps the glance screen for the
+			// credential prompt; it must not veto a host that does lock.
+			name:           "a hidden lock screen does not override the inactivity limit",
+			values:         map[string]string{"NoLockScreen": "1", "InactivityTimeoutSecs": "900"},
+			expectedSource: "machine_inactivity_limit",
+			expectedOn:     true,
+			expectedKnown:  true,
+		},
+		{
+			name:           "machine inactivity limit enforces lock",
+			values:         map[string]string{"InactivityTimeoutSecs": "900"},
+			expectedSource: "machine_inactivity_limit",
+			expectedOn:     true,
+			expectedKnown:  true,
+		},
+		{
+			name:           "mdm device lock enforces lock",
+			values:         map[string]string{"MaxInactivityTimeDeviceLock": "15"},
+			expectedSource: "mdm_device_lock",
+			expectedOn:     true,
+			expectedKnown:  true,
+		},
+		{
+			name: "secure and active screensaver with timeout enforces lock",
+			values: map[string]string{
+				"ScreenSaverIsSecure": "1",
+				"ScreenSaveActive":    "1",
+				"ScreenSaveTimeOut":   "600",
+			},
+			expectedSource: "machine_policy",
+			expectedOn:     true,
+			expectedKnown:  true,
+		},
+		{
+			name: "secure but inactive screensaver does not enforce lock",
+			values: map[string]string{
+				"ScreenSaverIsSecure": "1",
+				"ScreenSaveActive":    "0",
+				"ScreenSaveTimeOut":   "600",
+			},
+			expectedSource: "machine_policy",
+			expectedKnown:  true,
+		},
+		{
+			name: "secure and active screensaver without timeout does not enforce lock",
+			values: map[string]string{
+				"ScreenSaverIsSecure": "1",
+				"ScreenSaveActive":    "1",
+				"ScreenSaveTimeOut":   "0",
+			},
+			expectedSource: "machine_policy",
+			expectedKnown:  true,
+		},
+		{
+			name:           "zero inactivity limit falls through to the screensaver policy",
+			values:         map[string]string{"InactivityTimeoutSecs": "0", "ScreenSaverIsSecure": "0"},
+			expectedSource: "machine_policy",
+			expectedKnown:  true,
+		},
+		{
+			name:   "no machine policy is unknown",
+			values: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				source, on, known := windowsScreenLockOn(tt.values)
+				assert.Equal(t, tt.expectedSource, source)
+				assert.Equal(t, tt.expectedOn, on)
+				assert.Equal(t, tt.expectedKnown, known)
+			},
+		)
+	}
 }
 
 func TestParseWindowsJoinedPairs(t *testing.T) {

--- a/pkg/deviceagent/posture_collect_test.go
+++ b/pkg/deviceagent/posture_collect_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package deviceagent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/deviceagent/checks"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+// stubCheck runs an arbitrary function so a test can end the run mid-set.
+type stubCheck struct {
+	key string
+	run func(ctx context.Context) checks.Result
+}
+
+func (c stubCheck) Key() string { return c.key }
+
+func (c stubCheck) Run(ctx context.Context) checks.Result {
+	r := c.run(ctx)
+	if r.CheckKey == "" {
+		r.CheckKey = c.key
+	}
+
+	return r
+}
+
+func passingCheck(key string) stubCheck {
+	return stubCheck{
+		key: key,
+		run: func(context.Context) checks.Result {
+			return checks.Result{Status: checks.StatusPass}
+		},
+	}
+}
+
+func TestAgent_CollectOnce(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"a complete run returns every check and no error",
+		func(t *testing.T) {
+			t.Parallel()
+
+			a := New(t.TempDir(), "test", nil)
+			a.checkSet = func() []checks.Check {
+				return []checks.Check{passingCheck("FIRST"), passingCheck("SECOND")}
+			}
+
+			results, err := a.CollectOnce(context.Background())
+			require.NoError(t, err)
+			require.Len(t, results, 2)
+			assert.Equal(t, "FIRST", results[0].CheckKey)
+			assert.False(t, results[0].ObservedAt.IsZero())
+		},
+	)
+
+	t.Run(
+		"a run cut short returns the partial results and an error",
+		func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			a := New(t.TempDir(), "test", nil)
+			a.checkSet = func() []checks.Check {
+				return []checks.Check{
+					passingCheck("FIRST"),
+					stubCheck{
+						key: "SECOND",
+						run: func(context.Context) checks.Result {
+							cancel()
+
+							return checks.Result{Status: checks.StatusPass}
+						},
+					},
+					passingCheck("THIRD"),
+				}
+			}
+
+			results, err := a.CollectOnce(ctx)
+			require.ErrorIs(t, err, context.Canceled)
+			require.Len(t, results, 2)
+			assert.Equal(t, "SECOND", results[1].CheckKey)
+		},
+	)
+}
+
+func TestAgent_doPosturesDropsTruncatedRun(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	var pushes atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pushes.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	deviceID := gid.New(gid.NewTenantID(), coredata.DeviceEntityType)
+
+	a := New(dir, "test", nil)
+	a.cfg = &Config{ServerURL: srv.URL, DeviceID: deviceID.String()}
+	a.client = NewClient(srv.URL, "api-key", "test-agent")
+	a.checkSet = func() []checks.Check {
+		return []checks.Check{
+			passingCheck("FIRST"),
+			stubCheck{
+				key: "SECOND",
+				run: func(context.Context) checks.Result {
+					cancel()
+
+					return checks.Result{Status: checks.StatusPass}
+				},
+			},
+			passingCheck("THIRD"),
+		}
+	}
+
+	a.doPostures(ctx)
+
+	assert.Equal(t, int32(0), pushes.Load(), "a truncated run must not be pushed")
+
+	batches, err := loadPendingPostureBatches(dir)
+	require.NoError(t, err)
+	assert.Empty(t, batches, "a truncated run must not be queued for replay")
+}
+
+func TestAgent_doPosturesPushesCompleteRun(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	var pushes atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pushes.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	deviceID := gid.New(gid.NewTenantID(), coredata.DeviceEntityType)
+
+	a := New(dir, "test", nil)
+	a.cfg = &Config{ServerURL: srv.URL, DeviceID: deviceID.String()}
+	a.client = NewClient(srv.URL, "api-key", "test-agent")
+	a.checkSet = func() []checks.Check {
+		return []checks.Check{passingCheck("FIRST"), passingCheck("SECOND")}
+	}
+
+	a.doPostures(context.Background())
+
+	assert.Equal(t, int32(1), pushes.Load())
+
+	batches, err := loadPendingPostureBatches(dir)
+	require.NoError(t, err)
+	assert.Empty(t, batches)
+}


### PR DESCRIPTION
An unchanged host reported different results run to run. The firewall check silently fell back to localized netsh output whenever the PowerShell probe timed out, which reported an enabled firewall as off on non-English systems; it now uses the firewall COM API, which returns booleans and emits the same evidence shape as the primary probe. Runs cut short by sleep or shutdown were queued and replayed as reports hours later, so they are now discarded instead. Screen lock consulted only per-user hives, which exist only while someone is signed in, and now reads machine-wide policy first.

Agent 0.6.4 also renamed the time sync and auto-update evidence keys without updating the server-side value readers, so those checks display Unknown against a PASS status. The readers accept both key sets, since old rows keep the old shape forever.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Windows posture collection and server-side interpretation so repeated checks produce stable results across hosts and agent versions. Incomplete collections are no longer treated as posture reports.

### Tests <span style="color:green">**`+536`**</span> <span style="color:red">**`-47`**</span>

- Covers firewall fallback and unknown states, layered screen-lock policy, renamed evidence keys, and truncated collections.

### Coredata <span style="color:green">**`+67`**</span> <span style="color:red">**`-4`**</span>

- Reads the agent-resolved screen-lock result and accepts legacy and renamed time sync, auto-update, and firewall evidence shapes.

### Service <span style="color:green">**`+251`**</span> <span style="color:red">**`-107`**</span>

- Uses the boolean `HNetCfg.FwPolicy2` API instead of localized `netsh` output, checks machine-wide screen-lock policy before user hives, and identifies canceled or timed-out runs.

### Other <span style="color:green">**`+46`**</span> <span style="color:red">**`-12`**</span>

- `probo-agent collect` now allows five minutes and returns errors for partial results, while changelogs and seed data reflect the updated evidence.

<sup>Written for commit e0e21daa8118957611fdfe22c0f6c878f73ca09a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

