### PR TITLE
Show audit date ranges in list

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -2113,9 +2113,20 @@
     },
     "dropzoneOverlay": "Drop a PDF to create an audit with a report",
     "actions": { "addAudit": "Add audit", "delete": "Delete" },
-    "columns": { "name": "Name", "framework": "Framework", "state": "State", "validFrom": "Valid From", "validUntil": "Valid Until", "report": "Report" },
+    "columns": { "name": "Name", "framework": "Framework", "state": "State", "auditPeriod": "Audit period", "validityPeriod": "Validity period", "report": "Report" },
     "states": { "to_book": "To book", "audit_booked": "Audit booked", "not_started": "Not Started", "in_progress": "In Progress", "completed": "Completed", "rejected": "Rejected", "outdated": "Outdated" },
-    "row": { "untitled": "Untitled", "unknownFramework": "Unknown Framework", "notSet": "Not set", "uploaded": "Uploaded", "notUploaded": "Not uploaded" }
+    "row": {
+      "untitled": "Untitled",
+      "unknownFramework": "Unknown Framework",
+      "notSet": "Not set",
+      "uploaded": "Uploaded",
+      "notUploaded": "Not uploaded",
+      "period": {
+        "range": "{{start}} – {{end}}",
+        "from": "From {{date}}",
+        "until": "Until {{date}}"
+      }
+    }
   },
   "createAuditDialog": {
     "breadcrumb": { "audits": "Audits", "newAudit": "New Audit" },

--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -2122,7 +2122,6 @@
       "uploaded": "Uploaded",
       "notUploaded": "Not uploaded",
       "period": {
-        "range": "{{start}} – {{end}}",
         "from": "From {{date}}",
         "until": "Until {{date}}"
       }

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -3538,8 +3538,8 @@
       "name": "Nom",
       "framework": "Référentiel",
       "state": "État",
-      "validFrom": "Valide à partir de",
-      "validUntil": "Valide jusqu’au",
+      "auditPeriod": "Période d’audit",
+      "validityPeriod": "Période de validité",
       "report": "Rapport"
     },
     "states": {
@@ -3556,7 +3556,12 @@
       "unknownFramework": "Référentiel inconnu",
       "notSet": "Non défini",
       "uploaded": "Téléversé",
-      "notUploaded": "Non téléversé"
+      "notUploaded": "Non téléversé",
+      "period": {
+        "range": "{{start}} – {{end}}",
+        "from": "À partir du {{date}}",
+        "until": "Jusqu’au {{date}}"
+      }
     }
   },
   "createAuditDialog": {

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -3558,7 +3558,6 @@
       "uploaded": "Téléversé",
       "notUploaded": "Non téléversé",
       "period": {
-        "range": "{{start}} – {{end}}",
         "from": "À partir du {{date}}",
         "until": "Jusqu’au {{date}}"
       }

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -3538,8 +3538,8 @@
       "name": "Naam",
       "framework": "Framework",
       "state": "Status",
-      "validFrom": "Geldig vanaf",
-      "validUntil": "Geldig tot",
+      "auditPeriod": "Auditperiode",
+      "validityPeriod": "Geldigheidsperiode",
       "report": "Rapport"
     },
     "states": {
@@ -3556,7 +3556,12 @@
       "unknownFramework": "Onbekend framework",
       "notSet": "Niet ingesteld",
       "uploaded": "Geüpload",
-      "notUploaded": "Niet geüpload"
+      "notUploaded": "Niet geüpload",
+      "period": {
+        "range": "{{start}} – {{end}}",
+        "from": "Vanaf {{date}}",
+        "until": "Tot {{date}}"
+      }
     }
   },
   "createAuditDialog": {

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -3558,7 +3558,6 @@
       "uploaded": "Geüpload",
       "notUploaded": "Niet geüpload",
       "period": {
-        "range": "{{start}} – {{end}}",
         "from": "Vanaf {{date}}",
         "until": "Tot {{date}}"
       }

--- a/apps/console/src/pages/organizations/audits/AuditsPage.tsx
+++ b/apps/console/src/pages/organizations/audits/AuditsPage.tsx
@@ -18,22 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import {
-  getAuditStateVariant,
-} from "@probo/helpers";
 import { usePageTitle } from "@probo/hooks";
-import { dateFormat } from "@probo/i18n";
 import {
-  ActionDropdown,
-  Badge,
   Button,
-  DropdownItem,
   IconPlusLarge,
-  IconTrashCan,
   IconUpload,
   PageHeader,
   Tbody,
-  Td,
   Th,
   Thead,
   Tr,
@@ -52,15 +43,14 @@ import {
 
 import type { AuditGraphListQuery } from "#/__generated__/core/AuditGraphListQuery.graphql";
 import type {
-  AuditsPageFragment$data,
   AuditsPageFragment$key,
 } from "#/__generated__/core/AuditsPageFragment.graphql";
 import { SortableTable } from "#/components/SortableTable";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
-import type { NodeOf } from "#/types";
 
-import { auditsQuery, useDeleteAudit } from "../../../hooks/graph/AuditGraph";
+import { auditsQuery } from "../../../hooks/graph/AuditGraph";
 
+import { AuditListItem } from "./_components/AuditListItem";
 import { CreateAuditDialog } from "./dialogs/CreateAuditDialog";
 
 const paginatedAuditsFragment = graphql`
@@ -84,28 +74,14 @@ const paginatedAuditsFragment = graphql`
       edges {
         node {
           id
-          name
-          validity {
-            start
-            end
-          }
-          reportFile {
-            id
-          }
-          state
-          framework {
-            id
-            name
-          }
           canUpdate: permission(action: "core:audit:update")
           canDelete: permission(action: "core:audit:delete")
+          ...AuditListItem_audit
         }
       }
     }
   }
 `;
-
-type AuditEntry = NodeOf<AuditsPageFragment$data["audits"]>;
 
 type Props = {
   queryRef: PreloadedQuery<AuditGraphListQuery>;
@@ -245,17 +221,17 @@ export default function AuditsPage(props: Props) {
             <Th>{t("auditsPage.columns.name")}</Th>
             <Th>{t("auditsPage.columns.framework")}</Th>
             <Th>{t("auditsPage.columns.state")}</Th>
-            <Th>{t("auditsPage.columns.validFrom")}</Th>
-            <Th>{t("auditsPage.columns.validUntil")}</Th>
+            <Th>{t("auditsPage.columns.auditPeriod")}</Th>
+            <Th>{t("auditsPage.columns.validityPeriod")}</Th>
             <Th>{t("auditsPage.columns.report")}</Th>
             {hasAnyAction && <Th></Th>}
           </Tr>
         </Thead>
         <Tbody>
           {audits.map(entry => (
-            <AuditRow
+            <AuditListItem
               key={entry.id}
-              entry={entry}
+              auditKey={entry}
               connectionId={connectionId}
               hasAnyAction={hasAnyAction}
             />
@@ -272,69 +248,5 @@ export default function AuditsPage(props: Props) {
         />
       )}
     </div>
-  );
-}
-
-function AuditRow({
-  entry,
-  connectionId,
-  hasAnyAction,
-}: {
-  entry: AuditEntry;
-  connectionId: string;
-  hasAnyAction: boolean;
-}) {
-  const organizationId = useOrganizationId();
-  const { i18n, t } = useTranslation();
-  const deleteAudit = useDeleteAudit(entry, connectionId);
-
-  return (
-    <Tr to={`/organizations/${organizationId}/governance/audits/${entry.id}`}>
-      <Td>{entry.name || t("auditsPage.row.untitled")}</Td>
-      <Td>{entry.framework?.name ?? t("auditsPage.row.unknownFramework")}</Td>
-      <Td>
-        <Badge variant={getAuditStateVariant(entry.state)}>
-          {t(`auditsPage.states.${entry.state.toLowerCase()}`)}
-        </Badge>
-      </Td>
-      <Td>
-        {dateFormat(i18n.language, entry.validity?.start)
-          || t("auditsPage.row.notSet")}
-      </Td>
-      <Td>
-        {dateFormat(i18n.language, entry.validity?.end)
-          || t("auditsPage.row.notSet")}
-      </Td>
-      <Td>
-        {entry.reportFile
-          ? (
-              <div className="flex flex-col">
-                <Badge variant="success">
-                  {t("auditsPage.row.uploaded")}
-                </Badge>
-              </div>
-            )
-          : (
-              <Badge variant="neutral">
-                {t("auditsPage.row.notUploaded")}
-              </Badge>
-            )}
-      </Td>
-      {hasAnyAction && (
-        <Td noLink width={50} className="text-end">
-          <ActionDropdown>
-            {entry.canDelete && (
-              <DropdownItem
-                onClick={deleteAudit}
-                variant="danger"
-                icon={IconTrashCan}
-              >
-                {t("auditsPage.actions.delete")}
-              </DropdownItem>
-            )}
-          </ActionDropdown>
-        </Td>
-      )}
-    </Tr>
   );
 }

--- a/apps/console/src/pages/organizations/audits/_components/AuditListItem.tsx
+++ b/apps/console/src/pages/organizations/audits/_components/AuditListItem.tsx
@@ -18,8 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { getAuditStateVariant, parseDate } from "@probo/helpers";
-import { dateFormat } from "@probo/i18n";
+import { getAuditStateVariant } from "@probo/helpers";
 import {
   ActionDropdown,
   Badge,
@@ -32,8 +31,10 @@ import { useTranslation } from "react-i18next";
 import { graphql, useFragment } from "react-relay";
 
 import type { AuditListItem_audit$key } from "#/__generated__/core/AuditListItem_audit.graphql";
-import { useOrganizationId } from "#/hooks/useOrganizationId";
 import { useDeleteAudit } from "#/hooks/graph/AuditGraph";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+
+import { formatAuditPeriod } from "../_lib/formatAuditPeriod";
 
 const auditListItemFragment = graphql`
   fragment AuditListItem_audit on Audit {
@@ -79,29 +80,14 @@ export function AuditListItem({
     start: string | null | undefined,
     end: string | null | undefined,
   ) {
-    const compactDateOptions: Intl.DateTimeFormatOptions = {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    };
-
-    if (start && end) {
-      return new Intl.DateTimeFormat(
-        i18n.language,
-        compactDateOptions,
-      ).formatRange(parseDate(start), parseDate(end));
-    }
-    if (start) {
-      return t("auditsPage.row.period.from", {
-        date: dateFormat(i18n.language, start, compactDateOptions),
-      });
-    }
-    if (end) {
-      return t("auditsPage.row.period.until", {
-        date: dateFormat(i18n.language, end, compactDateOptions),
-      });
-    }
-    return t("auditsPage.row.notSet");
+    return formatAuditPeriod({
+      language: i18n.language,
+      start,
+      end,
+      from: date => t("auditsPage.row.period.from", { date }),
+      until: date => t("auditsPage.row.period.until", { date }),
+      notSet: t("auditsPage.row.notSet"),
+    });
   }
 
   return (

--- a/apps/console/src/pages/organizations/audits/_components/AuditListItem.tsx
+++ b/apps/console/src/pages/organizations/audits/_components/AuditListItem.tsx
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { getAuditStateVariant } from "@probo/helpers";
+import { getAuditStateVariant, parseDate } from "@probo/helpers";
 import { dateFormat } from "@probo/i18n";
 import {
   ActionDropdown,
@@ -79,20 +79,26 @@ export function AuditListItem({
     start: string | null | undefined,
     end: string | null | undefined,
   ) {
+    const compactDateOptions: Intl.DateTimeFormatOptions = {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    };
+
     if (start && end) {
-      return t("auditsPage.row.period.range", {
-        start: dateFormat(i18n.language, start),
-        end: dateFormat(i18n.language, end),
-      });
+      return new Intl.DateTimeFormat(
+        i18n.language,
+        compactDateOptions,
+      ).formatRange(parseDate(start), parseDate(end));
     }
     if (start) {
       return t("auditsPage.row.period.from", {
-        date: dateFormat(i18n.language, start),
+        date: dateFormat(i18n.language, start, compactDateOptions),
       });
     }
     if (end) {
       return t("auditsPage.row.period.until", {
-        date: dateFormat(i18n.language, end),
+        date: dateFormat(i18n.language, end, compactDateOptions),
       });
     }
     return t("auditsPage.row.notSet");

--- a/apps/console/src/pages/organizations/audits/_components/AuditListItem.tsx
+++ b/apps/console/src/pages/organizations/audits/_components/AuditListItem.tsx
@@ -1,0 +1,150 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { getAuditStateVariant } from "@probo/helpers";
+import { dateFormat } from "@probo/i18n";
+import {
+  ActionDropdown,
+  Badge,
+  DropdownItem,
+  IconTrashCan,
+  Td,
+  Tr,
+} from "@probo/ui";
+import { useTranslation } from "react-i18next";
+import { graphql, useFragment } from "react-relay";
+
+import type { AuditListItem_audit$key } from "#/__generated__/core/AuditListItem_audit.graphql";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { useDeleteAudit } from "#/hooks/graph/AuditGraph";
+
+const auditListItemFragment = graphql`
+  fragment AuditListItem_audit on Audit {
+    id
+    name
+    validity {
+      start
+      end
+    }
+    auditDates {
+      start
+      end
+    }
+    reportFile {
+      id
+    }
+    state
+    framework {
+      id
+      name
+    }
+    canDelete: permission(action: "core:audit:delete")
+  }
+`;
+
+interface AuditListItemProps {
+  auditKey: AuditListItem_audit$key;
+  connectionId: string;
+  hasAnyAction: boolean;
+}
+
+export function AuditListItem({
+  auditKey,
+  connectionId,
+  hasAnyAction,
+}: AuditListItemProps) {
+  const audit = useFragment(auditListItemFragment, auditKey);
+  const organizationId = useOrganizationId();
+  const { i18n, t } = useTranslation();
+  const deleteAudit = useDeleteAudit(audit, connectionId);
+
+  function formatPeriod(
+    start: string | null | undefined,
+    end: string | null | undefined,
+  ) {
+    if (start && end) {
+      return t("auditsPage.row.period.range", {
+        start: dateFormat(i18n.language, start),
+        end: dateFormat(i18n.language, end),
+      });
+    }
+    if (start) {
+      return t("auditsPage.row.period.from", {
+        date: dateFormat(i18n.language, start),
+      });
+    }
+    if (end) {
+      return t("auditsPage.row.period.until", {
+        date: dateFormat(i18n.language, end),
+      });
+    }
+    return t("auditsPage.row.notSet");
+  }
+
+  return (
+    <Tr to={`/organizations/${organizationId}/governance/audits/${audit.id}`}>
+      <Td>{audit.name || t("auditsPage.row.untitled")}</Td>
+      <Td>
+        {audit.framework?.name ?? t("auditsPage.row.unknownFramework")}
+      </Td>
+      <Td>
+        <Badge variant={getAuditStateVariant(audit.state)}>
+          {t(`auditsPage.states.${audit.state.toLowerCase()}`)}
+        </Badge>
+      </Td>
+      <Td className="whitespace-nowrap">
+        {formatPeriod(audit.auditDates?.start, audit.auditDates?.end)}
+      </Td>
+      <Td className="whitespace-nowrap">
+        {formatPeriod(audit.validity?.start, audit.validity?.end)}
+      </Td>
+      <Td>
+        {audit.reportFile
+          ? (
+              <div className="flex flex-col">
+                <Badge variant="success">
+                  {t("auditsPage.row.uploaded")}
+                </Badge>
+              </div>
+            )
+          : (
+              <Badge variant="neutral">
+                {t("auditsPage.row.notUploaded")}
+              </Badge>
+            )}
+      </Td>
+      {hasAnyAction && (
+        <Td noLink width={50} className="text-end">
+          <ActionDropdown>
+            {audit.canDelete && (
+              <DropdownItem
+                onClick={deleteAudit}
+                variant="danger"
+                icon={IconTrashCan}
+              >
+                {t("auditsPage.actions.delete")}
+              </DropdownItem>
+            )}
+          </ActionDropdown>
+        </Td>
+      )}
+    </Tr>
+  );
+}

--- a/apps/console/src/pages/organizations/audits/_lib/formatAuditPeriod.ts
+++ b/apps/console/src/pages/organizations/audits/_lib/formatAuditPeriod.ts
@@ -33,9 +33,12 @@ const compactDateOptions: Intl.DateTimeFormatOptions = {
   day: "numeric",
 };
 
+const datetimeSuffixPattern
+  = /^T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
+
 function parsePeriodDate(value?: string | null): Date | null {
-  const match = value?.match(/^(\d{4})-(\d{2})-(\d{2})(?:T.*)?$/);
-  if (!match) {
+  const match = value?.match(/^(\d{4})-(\d{2})-(\d{2})(.*)$/);
+  if (!match || (match[4] && !datetimeSuffixPattern.test(match[4]))) {
     return null;
   }
 

--- a/apps/console/src/pages/organizations/audits/_lib/formatAuditPeriod.ts
+++ b/apps/console/src/pages/organizations/audits/_lib/formatAuditPeriod.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+interface FormatAuditPeriodOptions {
+  language: string;
+  start?: string | null;
+  end?: string | null;
+  from: (date: string) => string;
+  until: (date: string) => string;
+  notSet: string;
+}
+
+const compactDateOptions: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+};
+
+function parsePeriodDate(value?: string | null): Date | null {
+  const match = value?.match(/^(\d{4})-(\d{2})-(\d{2})(?:T.*)?$/);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+
+  if (
+    date.getFullYear() !== year
+    || date.getMonth() !== month - 1
+    || date.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+}
+
+export function formatAuditPeriod({
+  language,
+  start,
+  end,
+  from,
+  until,
+  notSet,
+}: FormatAuditPeriodOptions): string {
+  const startDate = parsePeriodDate(start);
+  const endDate = parsePeriodDate(end);
+  const formatter = new Intl.DateTimeFormat(language, compactDateOptions);
+
+  if (startDate && endDate) {
+    if (startDate < endDate) {
+      return formatter.formatRange(startDate, endDate);
+    }
+
+    if (startDate.getTime() === endDate.getTime()) {
+      return formatter.format(startDate);
+    }
+
+    return `${formatter.format(startDate)} – ${formatter.format(endDate)}`;
+  }
+  if (startDate) {
+    return from(formatter.format(startDate));
+  }
+  if (endDate) {
+    return until(formatter.format(endDate));
+  }
+  return notSet;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- show audit start/end and validity start/end dates in two compact period columns
- normalize persisted datetime values to calendar dates before display
- accept only date-only or RFC 3339-shaped period endpoints, rejecting malformed suffixes
- avoid `formatRange` for equal, reversed, or malformed data
- retain localized compact, open-ended, and unset period formatting

## Validation
- assertions cover date-only, UTC, fractional-second, and offset timestamps
- malformed suffix, missing timezone, invalid time component, timezone-shift, equal, and reversed cases
- `npm -w @probo/console run check`
- ESLint on the changed helper with TypeScript config loading enabled
- manual browser reload confirms valid audit periods still render without errors

[safe_audit_period_rendering.mp4](https://cursor.com/agents/bc-65fbbfad-8caa-4ca1-8b64-9f3bff081369/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsafe_audit_period_rendering.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65fbbfad-8caa-4ca1-8b64-9f3bff081369?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65fbbfad-8caa-4ca1-8b64-9f3bff081369&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The audit list now shows audit and validity dates as two compact period columns instead of four separate date columns. Persisted values are treated as calendar dates so timezone conversion can't shift them, and malformed datetimes are rejected before display.

### App: console **`+266`** **`-103`**

- Extracts row rendering into `AuditListItem` with its own Relay fragment, adding the `auditDates` field.
- Adds `formatAuditPeriod`, which accepts only date-only values or RFC 3339-shaped datetimes, order-checks both endpoints, and falls back to single-date or dash-separated formatting for equal or reversed ranges.
- Replaces `Valid From` / `Valid Until` columns with `Audit period` and `Validity period`.
- Adds EN, FR, and NL translations for range, "from", and "until" labels.

<sup>Written for commit 75c3044984999648dd04891648498a5f90e21b12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

