### PR TITLE
Stamp schema and agent versions on postures

### DIFF
--- a/e2e/console/device_enrollment_test.go
+++ b/e2e/console/device_enrollment_test.go
@@ -437,7 +437,10 @@ func enrollActivateAndAuthenticateDevice(
 func reportPostures(t *testing.T, apiKey string, results []map[string]any) int {
 	t.Helper()
 
-	body, err := json.Marshal(map[string]any{"results": results})
+	body, err := json.Marshal(map[string]any{
+		"agent_version": "1.0.0",
+		"results":       results,
+	})
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(

--- a/packages/n8n-node/nodes/Probo/actions/device/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/device/get.operation.ts
@@ -94,6 +94,8 @@ export async function execute(
 				text
 				number
 			}
+			version
+			agentVersion
 			observedAt
 		}`
 		: '';

--- a/packages/n8n-node/nodes/Probo/actions/device/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/device/getAll.operation.ts
@@ -126,6 +126,8 @@ export async function execute(
 				text
 				number
 			}
+			version
+			agentVersion
 			observedAt
 		}`
 		: '';

--- a/pkg/cmd/device/list/list.go
+++ b/pkg/cmd/device/list/list.go
@@ -95,6 +95,8 @@ query($id: ID!, $first: Int, $after: CursorKey, $orderBy: DeviceOrder) {
                 text
                 number
               }
+              version
+              agentVersion
               observedAt
             }
           }

--- a/pkg/cmd/device/view/view.go
+++ b/pkg/cmd/device/view/view.go
@@ -62,6 +62,8 @@ query($id: ID!) {
           text
           number
         }
+        version
+        agentVersion
         observedAt
       }
     }
@@ -212,11 +214,13 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 					p.CheckKey,
 					p.Status,
 					value,
+					p.Version,
+					p.AgentVersion,
 					cmdutil.FormatTime(p.ObservedAt),
 				})
 			}
 
-			t := cmdutil.NewTable("CHECK", "STATUS", "VALUE", "OBSERVED").Rows(rows...)
+			t := cmdutil.NewTable("CHECK", "STATUS", "VALUE", "VERSION", "AGENT", "OBSERVED").Rows(rows...)
 			_, _ = fmt.Fprintln(out, t)
 
 			return nil

--- a/pkg/coredata/device_orphans_test.go
+++ b/pkg/coredata/device_orphans_test.go
@@ -149,6 +149,8 @@ func TestDevice_DeleteOrphans(t *testing.T) {
 			CorrelationID:  gid.New(tenantID, coredata.DevicePostureReportEntityType),
 			CheckKey:       "DISK_ENCRYPTION",
 			Status:         coredata.DevicePostureStatusPass,
+			Version:        coredata.DevicePostureVersionV1,
+			AgentVersion:   "0.1",
 			ObservedAt:     now,
 			CreatedAt:      now,
 		}

--- a/pkg/coredata/device_posture.go
+++ b/pkg/coredata/device_posture.go
@@ -35,16 +35,18 @@ import (
 
 type (
 	DevicePosture struct {
-		ID             gid.GID             `db:"id"`
-		TenantID       gid.TenantID        `db:"tenant_id"`
-		OrganizationID gid.GID             `db:"organization_id"`
-		DeviceID       gid.GID             `db:"device_id"`
-		CorrelationID  gid.GID             `db:"correlation_id"`
-		CheckKey       string              `db:"check_key"`
-		Status         DevicePostureStatus `db:"status"`
-		Evidence       json.RawMessage     `db:"evidence"`
-		ObservedAt     time.Time           `db:"observed_at"`
-		CreatedAt      time.Time           `db:"created_at"`
+		ID             gid.GID              `db:"id"`
+		TenantID       gid.TenantID         `db:"tenant_id"`
+		OrganizationID gid.GID              `db:"organization_id"`
+		DeviceID       gid.GID              `db:"device_id"`
+		CorrelationID  gid.GID              `db:"correlation_id"`
+		CheckKey       string               `db:"check_key"`
+		Status         DevicePostureStatus  `db:"status"`
+		Evidence       json.RawMessage      `db:"evidence"`
+		Version        DevicePostureVersion `db:"version"`
+		AgentVersion   string               `db:"agent_version"`
+		ObservedAt     time.Time            `db:"observed_at"`
+		CreatedAt      time.Time            `db:"created_at"`
 	}
 
 	DevicePostures []*DevicePosture
@@ -91,6 +93,8 @@ INSERT INTO device_postures (
     check_key,
     status,
     evidence,
+    version,
+    agent_version,
     observed_at,
     created_at
 ) VALUES (
@@ -102,6 +106,8 @@ INSERT INTO device_postures (
     @check_key,
     @status,
     @evidence,
+    @version,
+    @agent_version,
     @observed_at,
     @created_at
 )
@@ -115,6 +121,8 @@ INSERT INTO device_postures (
 		"check_key":       p.CheckKey,
 		"status":          p.Status,
 		"evidence":        evidence,
+		"version":         p.Version,
+		"agent_version":   p.AgentVersion,
 		"observed_at":     observedAt,
 		"created_at":      now,
 	}
@@ -163,6 +171,8 @@ WITH latest AS (
         check_key,
         status,
         evidence,
+        version,
+        agent_version,
         observed_at,
         created_at
     FROM
@@ -218,6 +228,8 @@ SELECT
     check_key,
     status,
     evidence,
+    version,
+    agent_version,
     observed_at,
     created_at
 FROM
@@ -277,6 +289,8 @@ SELECT
     check_key,
     status,
     evidence,
+    version,
+    agent_version,
     observed_at,
     created_at
 FROM

--- a/pkg/coredata/device_posture_report_test.go
+++ b/pkg/coredata/device_posture_report_test.go
@@ -60,6 +60,8 @@ func insertDevicePostureWithEvidence(
 		CheckKey:       checkKey,
 		Status:         status,
 		Evidence:       raw,
+		Version:        coredata.DevicePostureVersionV1,
+		AgentVersion:   "0.1",
 		ObservedAt:     createdAt,
 		CreatedAt:      createdAt,
 	}

--- a/pkg/coredata/device_posture_test.go
+++ b/pkg/coredata/device_posture_test.go
@@ -120,6 +120,8 @@ func insertDevicePosture(
 		CorrelationID:  gid.New(fx.scope.GetTenantID(), coredata.DevicePostureReportEntityType),
 		CheckKey:       checkKey,
 		Status:         status,
+		Version:        coredata.DevicePostureVersionV1,
+		AgentVersion:   "0.1",
 		ObservedAt:     observedAt,
 		CreatedAt:      observedAt,
 	}

--- a/pkg/coredata/device_posture_version.go
+++ b/pkg/coredata/device_posture_version.go
@@ -18,22 +18,55 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package shared
+package coredata
 
-type (
-	PostureValue struct {
-		Kind   string `json:"kind"`
-		Text   string `json:"text"`
-		Number *int   `json:"number"`
-	}
-
-	Posture struct {
-		ID           string       `json:"id"`
-		CheckKey     string       `json:"checkKey"`
-		Status       string       `json:"status"`
-		Value        PostureValue `json:"value"`
-		Version      string       `json:"version"`
-		AgentVersion string       `json:"agentVersion"`
-		ObservedAt   string       `json:"observedAt"`
-	}
+import (
+	"encoding"
+	"fmt"
 )
+
+type DevicePostureVersion string
+
+const (
+	DevicePostureVersionV1 DevicePostureVersion = "v1"
+)
+
+var (
+	_ fmt.Stringer             = DevicePostureVersion("")
+	_ encoding.TextMarshaler   = DevicePostureVersion("")
+	_ encoding.TextUnmarshaler = (*DevicePostureVersion)(nil)
+)
+
+func DevicePostureVersions() []DevicePostureVersion {
+	return []DevicePostureVersion{
+		DevicePostureVersionV1,
+	}
+}
+
+func (v DevicePostureVersion) IsValid() bool {
+	switch v {
+	case DevicePostureVersionV1:
+		return true
+	}
+
+	return false
+}
+
+func (v DevicePostureVersion) String() string {
+	return string(v)
+}
+
+func (v DevicePostureVersion) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+func (v *DevicePostureVersion) UnmarshalText(text []byte) error {
+	val := DevicePostureVersion(text)
+	if !val.IsValid() {
+		return fmt.Errorf("invalid DevicePostureVersion value: %q", string(text))
+	}
+
+	*v = val
+
+	return nil
+}

--- a/pkg/coredata/migrations/20260910T083858Z.sql
+++ b/pkg/coredata/migrations/20260910T083858Z.sql
@@ -1,0 +1,27 @@
+-- Copyright (c) 2026 Probo Inc <hello@probo.com>.
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in
+-- all copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+ALTER TABLE device_postures
+    ADD COLUMN version TEXT NOT NULL DEFAULT 'v1',
+    ADD COLUMN agent_version TEXT NOT NULL DEFAULT '0.1';
+
+ALTER TABLE device_postures
+    ALTER COLUMN version DROP DEFAULT,
+    ALTER COLUMN agent_version DROP DEFAULT;

--- a/pkg/deviceagent/agent.go
+++ b/pkg/deviceagent/agent.go
@@ -516,7 +516,10 @@ func (a *Agent) doPostures(ctx context.Context) {
 		return
 	}
 
-	if err := a.client.PushPostures(ctx, payload); err != nil {
+	if err := a.client.PushPostures(
+		ctx,
+		PosturesRequest{AgentVersion: a.Version, Results: payload},
+	); err != nil {
 		a.Logger.ErrorCtx(ctx, "posture push failed", log.Error(err))
 
 		if IsUnauthorized(err) {
@@ -524,7 +527,12 @@ func (a *Agent) doPostures(ctx context.Context) {
 			return
 		}
 
-		dropped, enqueueErr := enqueuePendingPostureBatch(a.Dir, payload, a.currentTime())
+		dropped, enqueueErr := enqueuePendingPostureBatch(
+			a.Dir,
+			a.Version,
+			payload,
+			a.currentTime(),
+		)
 		if enqueueErr != nil {
 			a.Logger.ErrorCtx(ctx, "cannot queue posture batch after failed push", log.Error(enqueueErr))
 			return
@@ -561,7 +569,10 @@ func (a *Agent) flushQueuedPostures(ctx context.Context) {
 	}
 
 	for i, batch := range batches {
-		if err := a.client.PushPostures(ctx, batch.Results); err != nil {
+		if err := a.client.PushPostures(
+			ctx,
+			PosturesRequest{AgentVersion: batch.AgentVersion, Results: batch.Results},
+		); err != nil {
 			if IsUnauthorized(err) {
 				a.handleUnauthorized()
 				return

--- a/pkg/deviceagent/client.go
+++ b/pkg/deviceagent/client.go
@@ -83,7 +83,8 @@ type (
 	}
 
 	PosturesRequest struct {
-		Results []PostureResultPayload `json:"results"`
+		AgentVersion string                 `json:"agent_version"`
+		Results      []PostureResultPayload `json:"results"`
 	}
 )
 
@@ -105,8 +106,8 @@ func (c *Client) Heartbeat(ctx context.Context, req HeartbeatRequest) (*Heartbea
 }
 
 // PushPostures sends posture check results.
-func (c *Client) PushPostures(ctx context.Context, results []PostureResultPayload) error {
-	if len(results) == 0 {
+func (c *Client) PushPostures(ctx context.Context, req PosturesRequest) error {
+	if len(req.Results) == 0 {
 		return nil
 	}
 
@@ -115,7 +116,7 @@ func (c *Client) PushPostures(ctx context.Context, results []PostureResultPayloa
 		http.MethodPost,
 		"/api/agent/v1/postures",
 		true,
-		PosturesRequest{Results: results},
+		req,
 		nil,
 	)
 }

--- a/pkg/deviceagent/posture_queue.go
+++ b/pkg/deviceagent/posture_queue.go
@@ -35,8 +35,9 @@ const (
 )
 
 type pendingPostureBatch struct {
-	QueuedAt time.Time              `json:"queued_at"`
-	Results  []PostureResultPayload `json:"results"`
+	QueuedAt     time.Time              `json:"queued_at"`
+	AgentVersion string                 `json:"agent_version,omitempty"`
+	Results      []PostureResultPayload `json:"results"`
 }
 
 func pendingPosturesPath(dir string) string {
@@ -111,6 +112,7 @@ func savePendingPostureBatches(dir string, batches []pendingPostureBatch) error 
 
 func enqueuePendingPostureBatch(
 	dir string,
+	agentVersion string,
 	results []PostureResultPayload,
 	queuedAt time.Time,
 ) (int, error) {
@@ -129,8 +131,9 @@ func enqueuePendingPostureBatch(
 	batches = append(
 		batches,
 		pendingPostureBatch{
-			QueuedAt: queuedAt.UTC(),
-			Results:  clonedResults,
+			QueuedAt:     queuedAt.UTC(),
+			AgentVersion: agentVersion,
+			Results:      clonedResults,
 		},
 	)
 

--- a/pkg/deviceagent/posture_queue_test.go
+++ b/pkg/deviceagent/posture_queue_test.go
@@ -22,6 +22,7 @@ package deviceagent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -48,6 +49,7 @@ func TestPendingPostureQueue_EnqueueTrimsOldestBatches(t *testing.T) {
 		}
 		dropped, err := enqueuePendingPostureBatch(
 			dir,
+			"0.1",
 			results,
 			time.Unix(int64(i), 0),
 		)
@@ -79,12 +81,14 @@ func TestAgent_flushQueuedPostures(t *testing.T) {
 			dir := t.TempDir()
 			_, err := enqueuePendingPostureBatch(
 				dir,
+				"0.1",
 				[]PostureResultPayload{{CheckKey: "first", Status: "pass", ObservedAt: time.Now().UTC()}},
 				time.Now().UTC(),
 			)
 			require.NoError(t, err)
 			_, err = enqueuePendingPostureBatch(
 				dir,
+				"0.1",
 				[]PostureResultPayload{{CheckKey: "second", Status: "pass", ObservedAt: time.Now().UTC()}},
 				time.Now().UTC(),
 			)
@@ -118,12 +122,14 @@ func TestAgent_flushQueuedPostures(t *testing.T) {
 			dir := t.TempDir()
 			_, err := enqueuePendingPostureBatch(
 				dir,
+				"0.1",
 				[]PostureResultPayload{{CheckKey: "first", Status: "pass", ObservedAt: time.Now().UTC()}},
 				time.Now().UTC(),
 			)
 			require.NoError(t, err)
 			_, err = enqueuePendingPostureBatch(
 				dir,
+				"0.1",
 				[]PostureResultPayload{{CheckKey: "second", Status: "pass", ObservedAt: time.Now().UTC()}},
 				time.Now().UTC(),
 			)
@@ -164,6 +170,7 @@ func TestAgent_flushQueuedPostures(t *testing.T) {
 			dir := t.TempDir()
 			_, err := enqueuePendingPostureBatch(
 				dir,
+				"0.1",
 				[]PostureResultPayload{{CheckKey: "first", Status: "pass", ObservedAt: time.Now().UTC()}},
 				time.Now().UTC(),
 			)
@@ -209,6 +216,7 @@ func TestAgent_flushQueuedPostures(t *testing.T) {
 			dir := t.TempDir()
 			_, err := enqueuePendingPostureBatch(
 				dir,
+				"0.1",
 				[]PostureResultPayload{{CheckKey: "first", Status: "pass", ObservedAt: time.Now().UTC()}},
 				time.Now().UTC(),
 			)
@@ -250,6 +258,44 @@ func TestAgent_flushQueuedPostures(t *testing.T) {
 			batches, err := loadPendingPostureBatches(dir)
 			require.NoError(t, err)
 			assert.Len(t, batches, 0)
+		},
+	)
+
+	t.Run(
+		"sends empty agent version for legacy queued batches",
+		func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			_, err := enqueuePendingPostureBatch(
+				dir,
+				"",
+				[]PostureResultPayload{{CheckKey: "legacy", Status: "pass", ObservedAt: time.Now().UTC()}},
+				time.Now().UTC(),
+			)
+			require.NoError(t, err)
+
+			var (
+				calls atomic.Int32
+				got   PosturesRequest
+			)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/api/agent/v1/postures", r.URL.Path)
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+				calls.Add(1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			a := New(dir, "2.0.0", nil)
+			a.client = NewClient(srv.URL, "api-key", "test-agent")
+			a.flushQueuedPostures(context.Background())
+
+			require.Equal(t, int32(1), calls.Load())
+			require.Len(t, got.Results, 1)
+			assert.Empty(t, got.AgentVersion)
+			assert.Equal(t, "legacy", got.Results[0].CheckKey)
 		},
 	)
 }

--- a/pkg/itam/service.go
+++ b/pkg/itam/service.go
@@ -955,6 +955,7 @@ func (s *Service) RecordPostures(
 	ctx context.Context,
 	scope coredata.Scoper,
 	deviceID gid.GID,
+	agentVersion string,
 	results []RecordPostureResult,
 ) error {
 	if len(results) == 0 {
@@ -973,6 +974,10 @@ func (s *Service) RecordPostures(
 
 			if device.State != coredata.DeviceStateActive {
 				return ErrDeviceRevoked
+			}
+
+			if agentVersion == "" {
+				agentVersion = *device.AgentVersion
 			}
 
 			for _, r := range results {
@@ -996,6 +1001,8 @@ func (s *Service) RecordPostures(
 					CheckKey:       r.CheckKey,
 					Status:         r.Status,
 					Evidence:       r.Evidence,
+					Version:        coredata.DevicePostureVersionV1,
+					AgentVersion:   agentVersion,
 					ObservedAt:     r.ObservedAt,
 					CreatedAt:      now,
 				}

--- a/pkg/server/api/agent/v1/agent.go
+++ b/pkg/server/api/agent/v1/agent.go
@@ -211,7 +211,7 @@ func (h *Handler) handlePostures(w http.ResponseWriter, r *http.Request) {
 
 	scope := coredata.NewScopeFromObjectID(dev.ID)
 
-	if err := h.itamSvc.RecordPostures(r.Context(), scope, dev.ID, results); err != nil {
+	if err := h.itamSvc.RecordPostures(r.Context(), scope, dev.ID, req.AgentVersion, results); err != nil {
 		if errors.Is(err, itam.ErrDeviceRevoked) {
 			jsonx.RenderUnauthorized(w, errors.New("device revoked"))
 			return

--- a/pkg/server/api/agent/v1/types/models.go
+++ b/pkg/server/api/agent/v1/types/models.go
@@ -60,7 +60,8 @@ type (
 	}
 
 	PostureRequest struct {
-		Results []PostureResultPayload `json:"results"`
+		AgentVersion string                 `json:"agent_version"`
+		Results      []PostureResultPayload `json:"results"`
 	}
 
 	EnrollRequest struct {

--- a/pkg/server/api/console/v1/graphql/device.graphql
+++ b/pkg/server/api/console/v1/graphql/device.graphql
@@ -40,6 +40,13 @@ enum DeviceState
         @goEnum(value: "go.probo.inc/probo/pkg/coredata.DeviceStateRevoked")
 }
 
+enum DevicePostureVersion
+    @goModel(
+        model: "go.probo.inc/probo/pkg/coredata.DevicePostureVersion"
+    ) {
+    V1 @goEnum(value: "go.probo.inc/probo/pkg/coredata.DevicePostureVersionV1")
+}
+
 enum DevicePostureStatus
     @goModel(
         model: "go.probo.inc/probo/pkg/coredata.DevicePostureStatus"
@@ -152,6 +159,8 @@ type DevicePosture implements Node {
     checkKey: String!
     status: DevicePostureStatus!
     value: DevicePostureValue!
+    version: DevicePostureVersion!
+    agentVersion: String!
     observedAt: Datetime!
 }
 

--- a/pkg/server/api/console/v1/types/device.go
+++ b/pkg/server/api/console/v1/types/device.go
@@ -135,12 +135,14 @@ func NewDevicePosture(p *coredata.DevicePosture) *DevicePosture {
 	value := coredata.ParseDevicePostureValue(p.CheckKey, p.Evidence)
 
 	return &DevicePosture{
-		ID:         p.ID,
-		DeviceID:   p.DeviceID,
-		CheckKey:   p.CheckKey,
-		Status:     p.Status,
-		Value:      &value,
-		ObservedAt: p.ObservedAt,
+		ID:           p.ID,
+		DeviceID:     p.DeviceID,
+		CheckKey:     p.CheckKey,
+		Status:       p.Status,
+		Value:        &value,
+		Version:      p.Version,
+		AgentVersion: p.AgentVersion,
+		ObservedAt:   p.ObservedAt,
 	}
 }
 

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -3329,6 +3329,13 @@ components:
         - WINDOWS
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.DevicePlatform
 
+    DevicePostureVersion:
+      type: string
+      description: Server schema version that produced this posture row (v1, v2, ...).
+      enum:
+        - v1
+      go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.DevicePostureVersion
+
     DevicePostureStatus:
       type: string
       description: Posture check verdict. PASS and FAIL are compliance outcomes; UNKNOWN means the agent could not determine a result; NOT_APPLICABLE means the check does not apply on this host or platform (for example no screen-lock tool on a headless Linux host).
@@ -3402,6 +3409,8 @@ components:
         - check_key
         - status
         - value
+        - version
+        - agent_version
         - observed_at
       properties:
         id:
@@ -3419,6 +3428,12 @@ components:
         value:
           $ref: "#/components/schemas/DevicePostureValue"
           description: Observed posture value for this check_key; use value.kind to interpret value.text and value.number.
+        version:
+          $ref: "#/components/schemas/DevicePostureVersion"
+          description: Server schema version that produced this posture row.
+        agent_version:
+          type: string
+          description: Agent version that observed this posture.
         observed_at:
           type: string
           format: date-time

--- a/pkg/server/api/mcp/v1/types/device.go
+++ b/pkg/server/api/mcp/v1/types/device.go
@@ -38,12 +38,14 @@ func NewDevicePosture(p *coredata.DevicePosture) *DevicePosture {
 	value := coredata.ParseDevicePostureValue(p.CheckKey, p.Evidence)
 
 	return &DevicePosture{
-		ID:         p.ID,
-		DeviceID:   p.DeviceID,
-		CheckKey:   p.CheckKey,
-		Status:     p.Status,
-		Value:      NewDevicePostureValue(value),
-		ObservedAt: p.ObservedAt,
+		ID:           p.ID,
+		DeviceID:     p.DeviceID,
+		CheckKey:     p.CheckKey,
+		Status:       p.Status,
+		Value:        NewDevicePostureValue(value),
+		Version:      p.Version,
+		AgentVersion: p.AgentVersion,
+		ObservedAt:   p.ObservedAt,
 	}
 }
 


### PR DESCRIPTION
Existing rows cannot say which server code wrote them or which agent observed them. Persist a v1 schema stamp and the observing agent version on each row. New agents send agent_version with the posture batch; old agents omit it and the server falls back to the last heartbeat so a rolling deploy keeps reporting. Backfill old rows with v1 and 0.1 so every posture has a baseline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Posture rows now carry the server schema version and the observing agent version, flowing from agent batches through storage to GraphQL, MCP, CLI, and n8n. Older agents omit the agent version; the server falls back to the device's last heartbeat, and existing rows are backfilled with v1/0.1.

### Tests **`+56`** **`-1`**

Covers the new agent-version request field, version metadata in posture fixtures, and legacy queued batches sent with an empty version.

### Coredata **`+123`** **`-10`**

Adds a validated `v1` version type, updates posture persistence queries for `version` and `agent_version`, and backfills existing rows via migration.

### GraphQL API **`+20`** **`-8`**

Adds the `DevicePostureVersion` enum and non-null `version` and `agentVersion` fields to the console schema, and the agent endpoint parses `agent_version` from the posture request.

### MCP **`+23`** **`-6`**

Publishes `version` and `agent_version` in the MCP schema and maps them into device posture responses.

### prb (CLI) **`+14`** **`-6`**

Requests the fields for device list and view commands and adds VERSION and AGENT columns to the view table.

### Service **`+33`** **`-11`**

Sends agent version with immediate and queued batches, preserves it across retries, and falls back to the last heartbeat when an older agent omits it.

### Package: `n8n-node` **`+4`** **`-0`**

Requests `version` and `agentVersion` in both device posture operations.

<sup>Written for commit ede045191adef5dec82baeec437c243fb88ff134. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

