### PR TITLE
Read Windows password policy without ADSI

### DIFF
--- a/pkg/coredata/device_posture_value_checks.go
+++ b/pkg/coredata/device_posture_value_checks.go
@@ -513,6 +513,8 @@ func parsePasswordPolicyValue(ev map[string]any) DevicePostureValue {
 		return minPasswordLengthValue(minLen)
 	}
 
+	// Windows reports the stricter of secedit and MDM DeviceLock as
+	// min_password_length. Older agents sent that key with no backend.
 	if minLen, ok := numberEvidence(ev, "min_password_length"); ok {
 		return minPasswordLengthValue(minLen)
 	}

--- a/pkg/coredata/device_posture_value_test.go
+++ b/pkg/coredata/device_posture_value_test.go
@@ -586,6 +586,26 @@ func TestParseDevicePostureValue_PasswordPolicy(t *testing.T) {
 				wantNumber: new(8),
 			},
 			{
+				name:     "windows secedit and device lock still use min password length",
+				checkKey: "PASSWORD_POLICY",
+				evidence: map[string]any{
+					"backend":             "max",
+					"min_password_length": float64(6),
+					"raw":                 "MinDevicePasswordLength=6;MinimumPasswordLength=0",
+				},
+				wantKind:   coredata.DevicePostureValueKindMinPasswordLength,
+				wantNumber: new(6),
+			},
+			{
+				name:     "windows password policy probe failure is unknown",
+				checkKey: "PASSWORD_POLICY",
+				evidence: map[string]any{
+					"error":  "exit status 1",
+					"stderr": "Exception calling \"InvokeGet\"",
+				},
+				wantKind: coredata.DevicePostureValueKindUnknown,
+			},
+			{
 				name:     "darwin pwpolicy without account policies",
 				checkKey: "PASSWORD_POLICY",
 				evidence: map[string]any{

--- a/pkg/deviceagent/checks/checks_windows.go
+++ b/pkg/deviceagent/checks/checks_windows.go
@@ -22,7 +22,6 @@ package checks
 
 import (
 	"context"
-	"strconv"
 	"strings"
 )
 
@@ -391,31 +390,53 @@ func windowsAutoUpdate(ctx context.Context) Result {
 	return fail(ev)
 }
 
+// ADSI MinPasswordLength is an IADsDomain property; WinNT://$COMPUTERNAME
+// throws DISP_E_UNKNOWNNAME on domain- and Entra-joined hosts.
+const windowsPasswordPolicyScript = `` +
+	`$d = Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\DeviceLock' -ErrorAction SilentlyContinue; ` +
+	`$dir = Join-Path $env:TEMP ('probo-secpol-' + [guid]::NewGuid().Guid); ` +
+	`$sam = ''; ` +
+	`try { ` +
+	`  New-Item -ItemType Directory -Path $dir -Force | Out-Null; ` +
+	`  $cfg = Join-Path $dir 'secpol.inf'; ` +
+	`  secedit /export /cfg $cfg /areas SECURITYPOLICY | Out-Null; ` +
+	`  if (Test-Path -LiteralPath $cfg) { ` +
+	`    $sam = Get-Content -LiteralPath $cfg -Encoding Unicode -Raw ` +
+	`  } ` +
+	`} finally { ` +
+	`  Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue ` +
+	`}; ` +
+	`Write-Output "MinDevicePasswordLength=$($d.MinDevicePasswordLength)"; Write-Output $sam`
+
 func windowsPasswordPolicy(ctx context.Context) Result {
-	out := powershell(
-		ctx,
-		`([ADSI]"WinNT://$env:COMPUTERNAME").InvokeGet('MinPasswordLength')`,
-	)
+	out := powershell(ctx, windowsPasswordPolicyScript)
 	if out.Err != nil {
 		return unknown(
 			map[string]any{
-				"error":  out.Err.Error(),
+				"error":  errString(out.Err),
 				"stderr": out.Stderr,
 			},
 		)
 	}
 
-	minLen, err := strconv.Atoi(strings.TrimSpace(out.Stdout))
-	if err != nil {
-		return unknown(
-			map[string]any{
-				"error": "invalid MinPasswordLength",
-				"raw":   truncate(out.Stdout, 80),
-			},
-		)
+	header, inf, _ := strings.Cut(out.Stdout, "\n")
+	values := parseWindowsJoinedPairs(header)
+	minLen, backend, known := windowsPasswordPolicyOn(
+		inf,
+		values["MinDevicePasswordLength"],
+	)
+
+	ev := map[string]any{
+		"backend": backend,
+		"raw":     strings.TrimSpace(header),
+	}
+	if !known {
+		ev["error"] = "no password length from secedit or DeviceLock"
+
+		return unknown(ev)
 	}
 
-	ev := map[string]any{"min_password_length": minLen}
+	ev["min_password_length"] = minLen
 	if minLen > 0 {
 		return pass(ev)
 	}

--- a/pkg/deviceagent/checks/windows_posture.go
+++ b/pkg/deviceagent/checks/windows_posture.go
@@ -168,6 +168,47 @@ func windowsInt(s string) (int, bool) {
 	return n, true
 }
 
+// parseWindowsSeceditMinPasswordLength reads the first MinimumPasswordLength
+// assignment from a secedit INF export. The key is locale-stable; surrounding
+// whitespace and a missing key must not look like a zero-length policy.
+func parseWindowsSeceditMinPasswordLength(inf string) (int, bool) {
+	for line := range strings.SplitSeq(inf, "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+
+		if !strings.EqualFold(strings.TrimSpace(key), "MinimumPasswordLength") {
+			continue
+		}
+
+		return windowsInt(value)
+	}
+
+	return 0, false
+}
+
+// windowsPasswordPolicyOn picks the stricter of the local SAM policy and the
+// MDM DeviceLock PIN length. Both sources are optional: domain-joined hosts
+// often have only secedit, Entra-joined hosts often have only DeviceLock.
+func windowsPasswordPolicyOn(inf, mdm string) (int, string, bool) {
+	samLen, samOK := parseWindowsSeceditMinPasswordLength(inf)
+	mdmLen, mdmOK := windowsInt(mdm)
+
+	switch {
+	case samOK && mdmOK:
+		length := max(mdmLen, samLen)
+
+		return length, "max", true
+	case samOK:
+		return samLen, "secedit", true
+	case mdmOK:
+		return mdmLen, "mdm_device_lock", true
+	default:
+		return 0, "", false
+	}
+}
+
 func windowsAutoUpdateOn(noAutoUpdate, auOptions, serviceStart string) (bool, bool) {
 	switch strings.TrimSpace(serviceStart) {
 	case "4":

--- a/pkg/deviceagent/checks/windows_posture_test.go
+++ b/pkg/deviceagent/checks/windows_posture_test.go
@@ -286,6 +286,137 @@ func TestWindowsTimeSyncOn(t *testing.T) {
 	)
 }
 
+func TestParseWindowsSeceditMinPasswordLength(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		inf           string
+		expectedLen   int
+		expectedKnown bool
+	}{
+		{
+			name:          "system access assignment",
+			inf:           "[System Access]\nMinimumPasswordLength = 8\nPasswordComplexity = 1\n",
+			expectedLen:   8,
+			expectedKnown: true,
+		},
+		{
+			name:          "zero is a known policy",
+			inf:           "MinimumPasswordLength = 0\n",
+			expectedKnown: true,
+		},
+		{
+			name:          "compact assignment without spaces",
+			inf:           "MinimumPasswordLength=14",
+			expectedLen:   14,
+			expectedKnown: true,
+		},
+		{
+			name: "commented assignment is ignored",
+			inf:  "; MinimumPasswordLength = 8\nPasswordComplexity = 1\n",
+		},
+		{
+			name: "missing key is unknown",
+			inf:  "[System Access]\nPasswordComplexity = 1\n",
+		},
+		{
+			name: "empty export is unknown",
+			inf:  "",
+		},
+		{
+			name: "non-numeric value is unknown",
+			inf:  "MinimumPasswordLength = unset\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				length, known := parseWindowsSeceditMinPasswordLength(tt.inf)
+				assert.Equal(t, tt.expectedLen, length)
+				assert.Equal(t, tt.expectedKnown, known)
+			},
+		)
+	}
+}
+
+func TestWindowsPasswordPolicyOn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		inf             string
+		mdm             string
+		expectedLen     int
+		expectedBackend string
+		expectedKnown   bool
+	}{
+		{
+			name:            "secedit only",
+			inf:             "MinimumPasswordLength = 8\n",
+			expectedLen:     8,
+			expectedBackend: "secedit",
+			expectedKnown:   true,
+		},
+		{
+			name:            "mdm device lock only",
+			mdm:             "6",
+			expectedLen:     6,
+			expectedBackend: "mdm_device_lock",
+			expectedKnown:   true,
+		},
+		{
+			name:            "stricter source wins",
+			inf:             "MinimumPasswordLength = 0\n",
+			mdm:             "6",
+			expectedLen:     6,
+			expectedBackend: "max",
+			expectedKnown:   true,
+		},
+		{
+			name:            "equal sources still report max",
+			inf:             "MinimumPasswordLength = 8\n",
+			mdm:             "8",
+			expectedLen:     8,
+			expectedBackend: "max",
+			expectedKnown:   true,
+		},
+		{
+			name:            "both zero is a known disabled policy",
+			inf:             "MinimumPasswordLength = 0\n",
+			mdm:             "0",
+			expectedBackend: "max",
+			expectedKnown:   true,
+		},
+		{
+			name: "neither source is unknown",
+		},
+		{
+			name: "blank secedit and mdm are unknown",
+			inf:  "",
+			mdm:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				length, backend, known := windowsPasswordPolicyOn(tt.inf, tt.mdm)
+				assert.Equal(t, tt.expectedLen, length)
+				assert.Equal(t, tt.expectedBackend, backend)
+				assert.Equal(t, tt.expectedKnown, known)
+			},
+		)
+	}
+}
+
 func TestWindowsAutoUpdateOn(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
WinNT://$COMPUTERNAME only exposes MinPasswordLength on workgroup hosts. Domain- and Entra-joined machines throw DISP_E_UNKNOWNNAME, so the check reported UNKNOWN.

Read the effective SAM minimum from secedit and the Intune DeviceLock PIN length from the same CSP as screen lock. Keep min_password_length in evidence so the server parser does not change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the ADSI-based Windows password policy probe, which threw DISP_E_UNKNOWNNAME on domain- and Entra-joined hosts, with reads from secedit and the MDM DeviceLock CSP. Evidence keeps `min_password_length` so the server parser is unchanged, and the `backend` field notes where the value came from.

### Coredata **`+2`** **`-0`**

- Documents that Windows reports the stricter of secedit and DeviceLock as `min_password_length`; older agents sent that key with no backend.

### Service **`+77`** **`-15`**

- Replaces the ADSI probe with a PowerShell script that exports secedit to a temp INF and reads `MinimumPasswordLength`, plus `MinDevicePasswordLength` from DeviceLock.
- Picks the stricter of the two sources and reports the backend as `max`, `secedit`, or `mdm_device_lock`.
- Reports UNKNOWN when neither source yields a password length.

### Tests **`+151`** **`-0`**

- Covers secedit INF parsing, source selection, and coredata parsing for the new evidence.

<sup>Written for commit 58be9fdf6492f1be6b6be964b7d5f25f1b9b18e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

