### PR TITLE
Count Entra SIDs as interactive user hives

### DIFF
--- a/cmd/probo-agent/CHANGELOG.md
+++ b/cmd/probo-agent/CHANGELOG.md
@@ -5,6 +5,12 @@ documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- The Windows screen lock check treats Entra ID users (`S-1-12-1-*`) as
+  interactive hives, so a signed-in cloud account is no longer reported as
+  "no interactive user hives loaded"
+
 ## [0.6.5] - 2026-09-09
 
 ### Fixed

--- a/pkg/deviceagent/checks/checks_windows.go
+++ b/pkg/deviceagent/checks/checks_windows.go
@@ -96,7 +96,7 @@ const windowsScreenLockMachineScript = `` +
 	`ScreenSaveActive=$($c.ScreenSaveActive);ScreenSaveTimeOut=$($c.ScreenSaveTimeOut)"`
 
 const windowsScreenLockUsersScript = `Get-ChildItem 'Registry::HKEY_USERS' | ` +
-	`Where-Object { $_.PSChildName -match '^S-1-5-21-' } | ` +
+	`Where-Object { $_.PSChildName -match '^(S-1-5-21-|S-1-12-1-)' -and $_.PSChildName -notmatch '_Classes$' } | ` +
 	`ForEach-Object { ` +
 	`  $path = "Registry::HKEY_USERS\$($_.PSChildName)\Control Panel\Desktop"; ` +
 	`  $key = Get-ItemProperty $path -ErrorAction SilentlyContinue; ` +
@@ -155,56 +155,6 @@ func windowsScreenLock(ctx context.Context) Result {
 	}
 
 	return fail(ev)
-}
-
-// parseWindowsUserScreenLock parses one "SID=secure:active:timeout" line per
-// user from the registry enumeration and reports whether each user has screen
-// saver locking enforced. A user whose values cannot be read counts as
-// disabled, so one unprotected account fails the host.
-func parseWindowsUserScreenLock(s string) (map[string]string, bool, bool) {
-	users := map[string]string{}
-
-	var anyEnabled, anyDisabled bool
-
-	for line := range strings.SplitSeq(s, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-
-		idx := strings.Index(line, "=")
-		if idx < 0 {
-			continue
-		}
-
-		sid := strings.TrimSpace(line[:idx])
-		value := strings.TrimSpace(line[idx+1:])
-
-		if sid == "" {
-			continue
-		}
-
-		users[sid] = value
-
-		secure, active, timeout := splitWindowsUserScreenLock(value)
-		if on, known := windowsScreenSaverLockOn(secure, active, timeout); known && on {
-			anyEnabled = true
-			continue
-		}
-
-		anyDisabled = true
-	}
-
-	return users, anyDisabled, anyEnabled
-}
-
-func splitWindowsUserScreenLock(value string) (string, string, string) {
-	parts := strings.SplitN(value, ":", 3)
-	for len(parts) < 3 {
-		parts = append(parts, "")
-	}
-
-	return parts[0], parts[1], parts[2]
 }
 
 // windowsFirewallCOMScript reads the effective profile state through

--- a/pkg/deviceagent/checks/windows_posture.go
+++ b/pkg/deviceagent/checks/windows_posture.go
@@ -139,6 +139,73 @@ func windowsScreenLockOn(values map[string]string) (string, bool, bool) {
 	return "", false, false
 }
 
+// windowsInteractiveUserSID reports whether a HKEY_USERS child is a real
+// interactive account. Local and AD users are S-1-5-21-*; Entra users are
+// S-1-12-1-*. The _Classes suffix is a per-user COM hive, not a login.
+func windowsInteractiveUserSID(sid string) bool {
+	sid = strings.TrimSpace(sid)
+	if sid == "" {
+		return false
+	}
+
+	upper := strings.ToUpper(sid)
+	if strings.HasSuffix(upper, "_CLASSES") {
+		return false
+	}
+
+	return strings.HasPrefix(upper, "S-1-5-21-") || strings.HasPrefix(upper, "S-1-12-1-")
+}
+
+// parseWindowsUserScreenLock parses one "SID=secure:active:timeout" line per
+// user from the registry enumeration and reports whether each user has screen
+// saver locking enforced. A user whose values cannot be read counts as
+// disabled, so one unprotected account fails the host.
+func parseWindowsUserScreenLock(s string) (map[string]string, bool, bool) {
+	users := map[string]string{}
+
+	var anyEnabled, anyDisabled bool
+
+	for line := range strings.SplitSeq(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		idx := strings.Index(line, "=")
+		if idx < 0 {
+			continue
+		}
+
+		sid := strings.TrimSpace(line[:idx])
+		value := strings.TrimSpace(line[idx+1:])
+
+		if !windowsInteractiveUserSID(sid) {
+			continue
+		}
+
+		users[sid] = value
+
+		secure, active, timeout := splitWindowsUserScreenLock(value)
+		if on, known := windowsScreenSaverLockOn(secure, active, timeout); known && on {
+			anyEnabled = true
+			continue
+		}
+
+		anyDisabled = true
+	}
+
+	return users, anyDisabled, anyEnabled
+}
+
+func splitWindowsUserScreenLock(value string) (string, string, string) {
+	parts := strings.SplitN(value, ":", 3)
+	for len(parts) < 3 {
+		parts = append(parts, "")
+	}
+
+	return parts[0], parts[1], parts[2]
+}
+
 // windowsScreenSaverLockOn evaluates the screensaver trio shared by the machine
 // policy and the per-user hives. A secure screensaver only locks anything when
 // it is also active with a non-zero timeout.

--- a/pkg/deviceagent/checks/windows_posture_test.go
+++ b/pkg/deviceagent/checks/windows_posture_test.go
@@ -203,6 +203,122 @@ func TestWindowsScreenLockOn(t *testing.T) {
 	}
 }
 
+func TestWindowsInteractiveUserSID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		sid      string
+		expected bool
+	}{
+		{
+			name:     "local account",
+			sid:      "S-1-5-21-1004336348-1177238915-682003330-1001",
+			expected: true,
+		},
+		{
+			name:     "entra account",
+			sid:      "S-1-12-1-123456789-1234567890-123456789-123456789",
+			expected: true,
+		},
+		{
+			name: "per-user classes hive",
+			sid:  "S-1-5-21-1004336348-1177238915-682003330-1001_Classes",
+		},
+		{
+			name: "entra classes hive",
+			sid:  "S-1-12-1-123456789-1234567890-123456789-123456789_Classes",
+		},
+		{
+			name: "local system",
+			sid:  "S-1-5-18",
+		},
+		{
+			name: "local service",
+			sid:  "S-1-5-19",
+		},
+		{
+			name: "network service",
+			sid:  "S-1-5-20",
+		},
+		{
+			name: "default user",
+			sid:  ".DEFAULT",
+		},
+		{
+			name: "empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				assert.Equal(t, tt.expected, windowsInteractiveUserSID(tt.sid))
+			},
+		)
+	}
+}
+
+func TestParseWindowsUserScreenLock(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		raw                 string
+		expectedUsers       map[string]string
+		expectedAnyDisabled bool
+		expectedAnyEnabled  bool
+	}{
+		{
+			name: "entra hive is counted",
+			raw:  "S-1-12-1-123456789-1234567890-123456789-123456789=1:1:600",
+			expectedUsers: map[string]string{
+				"S-1-12-1-123456789-1234567890-123456789-123456789": "1:1:600",
+			},
+			expectedAnyEnabled: true,
+		},
+		{
+			name: "local and entra hives are both counted",
+			raw: "S-1-5-21-1004336348-1177238915-682003330-1001=1:1:600\n" +
+				"S-1-12-1-123456789-1234567890-123456789-123456789=0::",
+			expectedUsers: map[string]string{
+				"S-1-5-21-1004336348-1177238915-682003330-1001":     "1:1:600",
+				"S-1-12-1-123456789-1234567890-123456789-123456789": "0::",
+			},
+			expectedAnyDisabled: true,
+			expectedAnyEnabled:  true,
+		},
+		{
+			name:                "classes and well-known hives are ignored",
+			raw:                 "S-1-5-18=1:1:600\nS-1-5-21-1004336348-1177238915-682003330-1001_Classes=1:1:600\n.DEFAULT=1:1:600",
+			expectedUsers:       map[string]string{},
+			expectedAnyDisabled: false,
+		},
+		{
+			name:          "empty output has no users",
+			raw:           "",
+			expectedUsers: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				users, anyDisabled, anyEnabled := parseWindowsUserScreenLock(tt.raw)
+				assert.Equal(t, tt.expectedUsers, users)
+				assert.Equal(t, tt.expectedAnyDisabled, anyDisabled)
+				assert.Equal(t, tt.expectedAnyEnabled, anyEnabled)
+			},
+		)
+	}
+}
+
 func TestParseWindowsJoinedPairs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The Windows screen-lock fallback only kept S-1-5-21 hives, so a signed-in Entra account looked like nobody was logged on and the check stayed Unknown. Include S-1-12-1 SIDs and drop _Classes plus well-known service hives so a loaded cloud user can decide the result.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Windows screen-lock fallback only kept `S-1-5-21` hives, so a signed-in Entra account looked like nobody was logged on and the check stayed Unknown. It now includes `S-1-12-1` SIDs and drops `_Classes` plus well-known service hives so a loaded cloud user can decide the result.

### Tests **`+116`** **`-0`**

Adds unit tests for `windowsInteractiveUserSID` and `parseWindowsUserScreenLock` covering local, Entra, `_Classes`, service, and empty inputs.

### Service **`+68`** **`-51`**

Adds the `windowsInteractiveUserSID` helper and uses it to filter hives in `parseWindowsUserScreenLock`, which moved from `checks_windows.go` into `windows_posture.go`. The PowerShell filter now matches `^(S-1-5-21-|S-1-12-1-)` and excludes `_Classes$`.

### Other **`+6`** **`-0`**

Adds a changelog entry under Unreleased > Fixed.

<sup>Written for commit c6ef7b70a2dfb2dfe2acabc57a7073c4dbed6d11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

