### PR TITLE
Link findings to audits

### DIFF
--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -321,7 +321,7 @@
     "fields": { "description": "Description", "source": "Source", "owner": "Owner", "status": "Status", "priority": "Priority", "acceptedRisk": "Accepted risk", "dateIdentified": "Date identified", "dueDate": "Due date", "rootCause": "Root cause", "correctiveAction": "Corrective action", "effectivenessCheck": "Effectiveness check" },
     "placeholders": { "description": "Enter description", "source": "Enter source", "rootCause": "Enter root cause", "correctiveAction": "Enter corrective action", "effectivenessCheck": "Enter effectiveness check details" },
     "actions": { "delete": "Delete", "updating": "Updating...", "update": "Update" },
-    "audits": { "title": "Linked audits", "referenceId": "Audit reference", "link": "Link audit", "empty": "No audits linked" }
+    "audits": { "title": "Linked audits", "referenceId": "Audit reference", "link": "Link audit", "empty": "No audits linked", "loadMore": "Load more audits", "loading": "Loading..." }
   },
   "findingsPage": {
     "pageTitle": "Findings",

--- a/apps/console/src/_locales/en-US.json
+++ b/apps/console/src/_locales/en-US.json
@@ -316,11 +316,12 @@
     "status": { "open": "Open", "in_progress": "In progress", "closed": "Closed", "risk_accepted": "Risk accepted", "mitigated": "Mitigated", "false_positive": "False positive" },
     "priority": { "low": "Low", "medium": "Medium", "high": "High" },
     "messages": { "successTitle": "Success", "deleted": "Finding deleted successfully", "updated": "Finding updated successfully" },
-    "errors": { "title": "Error", "delete": "Failed to delete finding", "update": "Failed to update finding" },
+    "errors": { "title": "Error", "delete": "Failed to delete finding", "update": "Failed to update finding", "linkAudit": "Failed to link audit", "unlinkAudit": "Failed to unlink audit" },
     "deleteConfirmation": "This will permanently delete the finding {{referenceId}}. This action cannot be undone.",
     "fields": { "description": "Description", "source": "Source", "owner": "Owner", "status": "Status", "priority": "Priority", "acceptedRisk": "Accepted risk", "dateIdentified": "Date identified", "dueDate": "Due date", "rootCause": "Root cause", "correctiveAction": "Corrective action", "effectivenessCheck": "Effectiveness check" },
     "placeholders": { "description": "Enter description", "source": "Enter source", "rootCause": "Enter root cause", "correctiveAction": "Enter corrective action", "effectivenessCheck": "Enter effectiveness check details" },
-    "actions": { "delete": "Delete", "updating": "Updating...", "update": "Update" }
+    "actions": { "delete": "Delete", "updating": "Updating...", "update": "Update" },
+    "audits": { "title": "Linked audits", "referenceId": "Audit reference", "link": "Link audit", "empty": "No audits linked" }
   },
   "findingsPage": {
     "pageTitle": "Findings",
@@ -444,8 +445,14 @@
   "linkedAuditsDialog": {
     "title": "Link audits",
     "searchPlaceholder": "Search audits...",
+    "referenceIdLabel": "Audit reference",
+    "referenceIdDescription": "Enter the reference used for this finding in the audit report.",
+    "referenceIdPlaceholder": "Enter the report reference",
+    "empty": "No audits match your search.",
     "actions": {
+      "back": "Back",
       "close": "Close",
+      "confirmLink": "Link audit",
       "link": "Link",
       "unlink": "Unlink"
     }

--- a/apps/console/src/_locales/fr-FR.json
+++ b/apps/console/src/_locales/fr-FR.json
@@ -574,7 +574,9 @@
     "errors": {
       "title": "Erreur",
       "delete": "Échec de la suppression du constat",
-      "update": "Échec de la mise à jour du constat"
+      "update": "Échec de la mise à jour du constat",
+      "linkAudit": "Échec de l’association de l’audit",
+      "unlinkAudit": "Échec de la dissociation de l’audit"
     },
     "deleteConfirmation": "Cette action supprimera définitivement le constat {{referenceId}}. Cette action est irréversible.",
     "fields": {
@@ -601,6 +603,14 @@
       "delete": "Supprimer",
       "updating": "Mise à jour...",
       "update": "Mettre à jour"
+    },
+    "audits": {
+      "title": "Audits associés",
+      "referenceId": "Référence de l’audit",
+      "link": "Associer un audit",
+      "empty": "Aucun audit associé",
+      "loadMore": "Charger plus d’audits",
+      "loading": "Chargement..."
     }
   },
   "findingsPage": {
@@ -821,8 +831,14 @@
   "linkedAuditsDialog": {
     "title": "Associer des audits",
     "searchPlaceholder": "Rechercher des audits...",
+    "referenceIdLabel": "Référence de l’audit",
+    "referenceIdDescription": "Saisissez la référence utilisée pour ce constat dans le rapport d’audit.",
+    "referenceIdPlaceholder": "Saisir la référence du rapport",
+    "empty": "Aucun audit ne correspond à votre recherche.",
     "actions": {
+      "back": "Retour",
       "close": "Fermer",
+      "confirmLink": "Associer l’audit",
       "link": "Associer",
       "unlink": "Dissocier"
     }

--- a/apps/console/src/_locales/nl-NL.json
+++ b/apps/console/src/_locales/nl-NL.json
@@ -574,7 +574,9 @@
     "errors": {
       "title": "Fout",
       "delete": "Verwijderen van bevinding mislukt",
-      "update": "Bijwerken van bevinding mislukt"
+      "update": "Bijwerken van bevinding mislukt",
+      "linkAudit": "Koppelen van audit mislukt",
+      "unlinkAudit": "Ontkoppelen van audit mislukt"
     },
     "deleteConfirmation": "Hiermee wordt de bevinding {{referenceId}} permanent verwijderd. Deze actie kan niet ongedaan worden gemaakt.",
     "fields": {
@@ -601,6 +603,14 @@
       "delete": "Verwijderen",
       "updating": "Bijwerken...",
       "update": "Bijwerken"
+    },
+    "audits": {
+      "title": "Gekoppelde audits",
+      "referenceId": "Auditreferentie",
+      "link": "Audit koppelen",
+      "empty": "Geen audits gekoppeld",
+      "loadMore": "Meer audits laden",
+      "loading": "Laden..."
     }
   },
   "findingsPage": {
@@ -821,8 +831,14 @@
   "linkedAuditsDialog": {
     "title": "Audits koppelen",
     "searchPlaceholder": "Audits zoeken...",
+    "referenceIdLabel": "Auditreferentie",
+    "referenceIdDescription": "Voer de referentie in die voor deze bevinding in het auditrapport wordt gebruikt.",
+    "referenceIdPlaceholder": "Voer de rapportreferentie in",
+    "empty": "Geen audits gevonden voor uw zoekopdracht.",
     "actions": {
+      "back": "Terug",
       "close": "Sluiten",
+      "confirmLink": "Audit koppelen",
       "link": "Koppelen",
       "unlink": "Ontkoppelen"
     }

--- a/apps/console/src/components/audits/LinkedAuditsDialog.tsx
+++ b/apps/console/src/components/audits/LinkedAuditsDialog.tsx
@@ -150,6 +150,7 @@ function LinkedAuditsDialogContent(props: Omit<Props, "children">) {
 
   function onSelectAudit(auditId: string) {
     if (props.referenceIdRequired) {
+      setReferenceId("");
       setSelectedAuditId(auditId);
       return;
     }
@@ -201,7 +202,10 @@ function LinkedAuditsDialogContent(props: Omit<Props, "children">) {
         <div className="flex justify-end gap-2">
           <Button
             variant="secondary"
-            onClick={() => setSelectedAuditId(null)}
+            onClick={() => {
+              setReferenceId("");
+              setSelectedAuditId(null);
+            }}
           >
             {t("linkedAuditsDialog.actions.back")}
           </Button>
@@ -273,7 +277,7 @@ function AuditRow(props: RowProps) {
 
   return (
     <div
-      className="py-4 flex items-center gap-4 hover:bg-subtle cursor-pointer px-6 w-full h-[100px]"
+      className="py-4 flex items-center gap-4 px-6 w-full h-[100px]"
     >
       <div className="flex flex-col items-start gap-1">
         <div className="font-medium">{props.audit.framework?.name}</div>

--- a/apps/console/src/components/audits/LinkedAuditsDialog.tsx
+++ b/apps/console/src/components/audits/LinkedAuditsDialog.tsx
@@ -25,6 +25,7 @@ import {
   Dialog,
   DialogContent,
   DialogFooter,
+  Field,
   IconMagnifyingGlass,
   IconPlusLarge,
   IconTrashCan,
@@ -93,8 +94,9 @@ type Props = {
   children: ReactNode;
   disabled?: boolean;
   linkedAudits?: { id: string }[];
-  onLink: (auditId: string) => void;
-  onUnlink: (auditId: string) => void;
+  referenceIdRequired?: boolean;
+  onLink: (auditId: string, referenceId?: string) => void;
+  onUnlink?: (auditId: string) => void;
 };
 
 export function LinkedAuditsDialog({ children, ...props }: Props) {
@@ -124,6 +126,8 @@ function LinkedAuditsDialogContent(props: Omit<Props, "children">) {
     );
   const { t } = useTranslation();
   const [search, setSearch] = useState("");
+  const [referenceId, setReferenceId] = useState("");
+  const [selectedAuditId, setSelectedAuditId] = useState<string | null>(null);
   const audits = useMemo(
     () => data.audits?.edges?.map(edge => edge.node) ?? [],
     [data.audits],
@@ -133,10 +137,85 @@ function LinkedAuditsDialogContent(props: Omit<Props, "children">) {
   }, [props.linkedAudits]);
 
   const filteredAudits = useMemo(() => {
-    return audits.filter(audit =>
-      (audit.name || "").toLowerCase().includes(search.toLowerCase()),
-    );
+    const normalizedSearch = search.toLowerCase();
+
+    return audits.filter((audit) => {
+      return (audit.name || "").toLowerCase().includes(normalizedSearch)
+        || (audit.framework?.name || "")
+          .toLowerCase()
+          .includes(normalizedSearch);
+    });
   }, [audits, search]);
+  const selectedAudit = audits.find(audit => audit.id === selectedAuditId);
+
+  function onSelectAudit(auditId: string) {
+    if (props.referenceIdRequired) {
+      setSelectedAuditId(auditId);
+      return;
+    }
+
+    props.onLink(auditId);
+  }
+
+  function onLink() {
+    if (!selectedAudit) {
+      return;
+    }
+
+    props.onLink(selectedAudit.id, referenceId.trim());
+    setReferenceId("");
+    setSelectedAuditId(null);
+  }
+
+  if (selectedAudit && props.referenceIdRequired) {
+    return (
+      <div className="space-y-5 px-6 py-5">
+        <div className="flex items-center gap-4 rounded-lg border border-border-low bg-subtle p-4">
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="font-medium">{selectedAudit.framework?.name}</div>
+            {selectedAudit.name && (
+              <div className="text-sm text-txt-secondary">
+                {selectedAudit.name}
+              </div>
+            )}
+          </div>
+          <Badge color={getAuditStateVariant(selectedAudit.state)}>
+            {selectedAudit.state.replace(/_/g, " ")}
+          </Badge>
+        </div>
+        <Field
+          label={t("linkedAuditsDialog.referenceIdLabel")}
+          help={t("linkedAuditsDialog.referenceIdDescription")}
+          name="auditReference"
+        >
+          <Input
+            autoFocus
+            id="auditReference"
+            name="auditReference"
+            required
+            value={referenceId}
+            placeholder={t("linkedAuditsDialog.referenceIdPlaceholder")}
+            onValueChange={setReferenceId}
+          />
+        </Field>
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="secondary"
+            onClick={() => setSelectedAuditId(null)}
+          >
+            {t("linkedAuditsDialog.actions.back")}
+          </Button>
+          <Button
+            disabled={props.disabled || !referenceId.trim()}
+            icon={IconPlusLarge}
+            onClick={onLink}
+          >
+            {t("linkedAuditsDialog.actions.confirmLink")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>
@@ -148,12 +227,17 @@ function LinkedAuditsDialogContent(props: Omit<Props, "children">) {
         />
       </div>
       <div className="divide-y divide-border-low">
+        {filteredAudits.length === 0 && (
+          <div className="px-6 py-10 text-center text-sm text-txt-secondary">
+            {t("linkedAuditsDialog.empty")}
+          </div>
+        )}
         {filteredAudits.map(audit => (
           <AuditRow
             key={audit.id}
             audit={audit}
             linkedAudits={linkedIds}
-            onLink={props.onLink}
+            onLink={onSelectAudit}
             onUnlink={props.onUnlink}
             disabled={props.disabled}
           />
@@ -176,7 +260,7 @@ type RowProps = {
   linkedAudits: Set<string>;
   disabled?: boolean;
   onLink: (auditId: string) => void;
-  onUnlink: (auditId: string) => void;
+  onUnlink?: (auditId: string) => void;
 };
 
 function AuditRow(props: RowProps) {
@@ -185,11 +269,11 @@ function AuditRow(props: RowProps) {
   const isLinked = props.linkedAudits.has(props.audit.id);
   const onClick = isLinked ? props.onUnlink : props.onLink;
   const IconComponent = isLinked ? IconTrashCan : IconPlusLarge;
+  const disabled = props.disabled || (isLinked && !props.onUnlink);
 
   return (
-    <button
+    <div
       className="py-4 flex items-center gap-4 hover:bg-subtle cursor-pointer px-6 w-full h-[100px]"
-      onClick={() => onClick(props.audit.id)}
     >
       <div className="flex flex-col items-start gap-1">
         <div className="font-medium">{props.audit.framework?.name}</div>
@@ -201,19 +285,16 @@ function AuditRow(props: RowProps) {
         {props.audit.state.replace(/_/g, " ")}
       </Badge>
       <Button
-        disabled={props.disabled}
+        disabled={disabled}
         className="ml-auto"
         variant={isLinked ? "secondary" : "primary"}
-        asChild
+        icon={IconComponent}
+        onClick={() => onClick?.(props.audit.id)}
       >
-        <span>
-          <IconComponent size={16} />
-          {" "}
-          {isLinked
-            ? t("linkedAuditsDialog.actions.unlink")
-            : t("linkedAuditsDialog.actions.link")}
-        </span>
+        {isLinked
+          ? t("linkedAuditsDialog.actions.unlink")
+          : t("linkedAuditsDialog.actions.link")}
       </Button>
-    </button>
+    </div>
   );
 }

--- a/apps/console/src/pages/organizations/findings/FindingDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/findings/FindingDetailsPage.tsx
@@ -60,6 +60,7 @@ import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 import { z } from "#/lib/zod";
 
+import { FindingAuditsCard } from "./_components/FindingAuditsCard";
 import { FindingsConnectionKey } from "./FindingsPage";
 
 export const findingDetailsPageQuery = graphql`
@@ -87,6 +88,7 @@ export const findingDetailsPageQuery = graphql`
         }
         canUpdate: permission(action: "core:finding:update")
         canDelete: permission(action: "core:finding:delete")
+        ...FindingAuditsCard_finding
       }
     }
   }
@@ -373,6 +375,9 @@ export default function FindingDetailsPage(props: Props) {
       </div>
 
       <div className="max-w-4xl">
+        <div className="mb-6">
+          <FindingAuditsCard findingKey={finding} />
+        </div>
         <Card padded>
           <form onSubmit={e => void onSubmit(e)} className="space-y-6">
             <Field label={t("findingDetails.fields.description")}>

--- a/apps/console/src/pages/organizations/findings/FindingDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/findings/FindingDetailsPage.tsx
@@ -88,7 +88,7 @@ export const findingDetailsPageQuery = graphql`
         }
         canUpdate: permission(action: "core:finding:update")
         canDelete: permission(action: "core:finding:delete")
-        ...FindingAuditsCard_finding
+        canListAudits: permission(action: "core:audit:list")
       }
     }
   }
@@ -375,9 +375,11 @@ export default function FindingDetailsPage(props: Props) {
       </div>
 
       <div className="max-w-4xl">
-        <div className="mb-6">
-          <FindingAuditsCard findingKey={finding} />
-        </div>
+        {finding.canListAudits && (
+          <div className="mb-6">
+            <FindingAuditsCard />
+          </div>
+        )}
         <Card padded>
           <form onSubmit={e => void onSubmit(e)} className="space-y-6">
             <Field label={t("findingDetails.fields.description")}>

--- a/apps/console/src/pages/organizations/findings/_components/FindingAuditListItem.tsx
+++ b/apps/console/src/pages/organizations/findings/_components/FindingAuditListItem.tsx
@@ -49,12 +49,14 @@ const findingAuditListItemFragment = graphql`
 interface FindingAuditListItemProps {
   auditEdgeKey: FindingAuditListItem_auditEdge$key;
   canUnlink: boolean;
+  disabled?: boolean;
   onUnlink: (auditId: string) => void;
 }
 
 export function FindingAuditListItem({
   auditEdgeKey,
   canUnlink,
+  disabled,
   onUnlink,
 }: FindingAuditListItemProps) {
   const auditEdge = useFragment(findingAuditListItemFragment, auditEdgeKey);
@@ -83,6 +85,7 @@ export function FindingAuditListItem({
           <Button
             variant="secondary"
             icon={IconTrashCan}
+            disabled={disabled}
             onClick={() => onUnlink(audit.id)}
           >
             {t("linkedAuditsCard.actions.unlink")}

--- a/apps/console/src/pages/organizations/findings/_components/FindingAuditListItem.tsx
+++ b/apps/console/src/pages/organizations/findings/_components/FindingAuditListItem.tsx
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { getAuditStateVariant } from "@probo/helpers";
+import {
+  Badge,
+  Button,
+  IconTrashCan,
+  Td,
+  Tr,
+} from "@probo/ui";
+import { useTranslation } from "react-i18next";
+import { graphql, useFragment } from "react-relay";
+
+import type { FindingAuditListItem_auditEdge$key } from "#/__generated__/core/FindingAuditListItem_auditEdge.graphql";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+
+const findingAuditListItemFragment = graphql`
+  fragment FindingAuditListItem_auditEdge on AuditEdge {
+    referenceId
+    node {
+      id
+      name
+      state
+      framework {
+        name
+      }
+    }
+  }
+`;
+
+interface FindingAuditListItemProps {
+  auditEdgeKey: FindingAuditListItem_auditEdge$key;
+  canUnlink: boolean;
+  onUnlink: (auditId: string) => void;
+}
+
+export function FindingAuditListItem({
+  auditEdgeKey,
+  canUnlink,
+  onUnlink,
+}: FindingAuditListItemProps) {
+  const auditEdge = useFragment(findingAuditListItemFragment, auditEdgeKey);
+  const organizationId = useOrganizationId();
+  const { t } = useTranslation();
+  const audit = auditEdge.node;
+
+  return (
+    <Tr to={`/organizations/${organizationId}/governance/audits/${audit.id}`}>
+      <Td>
+        <div className="flex flex-col">
+          <div className="font-medium">{audit.framework?.name}</div>
+          {audit.name && (
+            <div className="text-sm text-txt-secondary">{audit.name}</div>
+          )}
+        </div>
+      </Td>
+      <Td>{auditEdge.referenceId}</Td>
+      <Td>
+        <Badge color={getAuditStateVariant(audit.state)}>
+          {audit.state.replace(/_/g, " ")}
+        </Badge>
+      </Td>
+      {canUnlink && (
+        <Td noLink width={50} className="text-end">
+          <Button
+            variant="secondary"
+            icon={IconTrashCan}
+            onClick={() => onUnlink(audit.id)}
+          >
+            {t("linkedAuditsCard.actions.unlink")}
+          </Button>
+        </Td>
+      )}
+    </Tr>
+  );
+}

--- a/apps/console/src/pages/organizations/findings/_components/FindingAuditsCard.tsx
+++ b/apps/console/src/pages/organizations/findings/_components/FindingAuditsCard.tsx
@@ -146,7 +146,7 @@ function FindingAuditsCardQueryLoader() {
     }
   }, [findingId, loadQuery]);
 
-  if (!queryRef) {
+  if (!queryRef || queryRef.variables.findingId !== findingId) {
     return (
       <Card padded>
         <Spinner centered />

--- a/apps/console/src/pages/organizations/findings/_components/FindingAuditsCard.tsx
+++ b/apps/console/src/pages/organizations/findings/_components/FindingAuditsCard.tsx
@@ -22,7 +22,9 @@ import { formatError } from "@probo/helpers";
 import {
   Button,
   Card,
+  IconChevronDown,
   IconPlusLarge,
+  Spinner,
   Table,
   Tbody,
   Td,
@@ -31,23 +33,52 @@ import {
   Tr,
   useToast,
 } from "@probo/ui";
+import { Suspense, useEffect, useTransition } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import { useTranslation } from "react-i18next";
-import { graphql, useFragment, useMutation } from "react-relay";
+import {
+  graphql,
+  type PreloadedQuery,
+  useMutation,
+  usePaginationFragment,
+  usePreloadedQuery,
+  useQueryLoader,
+} from "react-relay";
+import { useParams } from "react-router";
 
 import type { FindingAuditsCard_finding$key } from "#/__generated__/core/FindingAuditsCard_finding.graphql";
 import type { FindingAuditsCardLinkMutation } from "#/__generated__/core/FindingAuditsCardLinkMutation.graphql";
+import type { FindingAuditsCardPaginationQuery } from "#/__generated__/core/FindingAuditsCardPaginationQuery.graphql";
+import type { FindingAuditsCardQuery } from "#/__generated__/core/FindingAuditsCardQuery.graphql";
 import type { FindingAuditsCardUnlinkMutation } from "#/__generated__/core/FindingAuditsCardUnlinkMutation.graphql";
 import { LinkedAuditsDialog } from "#/components/audits/LinkedAuditsDialog";
 
 import { FindingAuditListItem } from "./FindingAuditListItem";
 
+const findingAuditsCardQuery = graphql`
+  query FindingAuditsCardQuery($findingId: ID!) {
+    node(id: $findingId) {
+      __typename
+      ... on Finding {
+        ...FindingAuditsCard_finding
+      }
+    }
+  }
+`;
+
 const findingAuditsCardFragment = graphql`
-  fragment FindingAuditsCard_finding on Finding {
+  fragment FindingAuditsCard_finding on Finding
+  @refetchable(queryName: "FindingAuditsCardPaginationQuery")
+  @argumentDefinitions(
+    first: { type: "Int", defaultValue: 100 }
+    after: { type: "CursorKey", defaultValue: null }
+  ) {
     id
     canLinkAudit: permission(action: "core:finding:create-audit-mapping")
     canUnlinkAudit: permission(action: "core:finding:delete-audit-mapping")
     audits(
-      first: 100
+      first: $first
+      after: $after
       orderBy: { field: CREATED_AT, direction: DESC }
     )
     @connection(key: "FindingAuditsCard_audits", filters: [])
@@ -64,12 +95,9 @@ const findingAuditsCardFragment = graphql`
 `;
 
 const linkAuditMutation = graphql`
-  mutation FindingAuditsCardLinkMutation(
-    $input: CreateFindingAuditMappingInput!
-    $connections: [ID!]!
-  ) {
+  mutation FindingAuditsCardLinkMutation($input: CreateFindingAuditMappingInput!) {
     createFindingAuditMapping(input: $input) {
-      auditEdge @prependEdge(connections: $connections) {
+      auditEdge {
         node {
           id
         }
@@ -90,20 +118,92 @@ const unlinkAuditMutation = graphql`
   }
 `;
 
-interface FindingAuditsCardProps {
+interface FindingAuditsCardContentProps {
+  queryRef: PreloadedQuery<FindingAuditsCardQuery>;
+}
+
+interface FindingAuditsCardDataProps {
   findingKey: FindingAuditsCard_finding$key;
 }
 
-export function FindingAuditsCard({ findingKey }: FindingAuditsCardProps) {
-  const finding = useFragment(findingAuditsCardFragment, findingKey);
+export function FindingAuditsCard() {
+  return (
+    <ErrorBoundary fallback={null}>
+      <FindingAuditsCardQueryLoader />
+    </ErrorBoundary>
+  );
+}
+
+function FindingAuditsCardQueryLoader() {
+  const { findingId } = useParams<{ findingId: string }>();
+  const [queryRef, loadQuery] = useQueryLoader<FindingAuditsCardQuery>(
+    findingAuditsCardQuery,
+  );
+
+  useEffect(() => {
+    if (findingId) {
+      loadQuery({ findingId });
+    }
+  }, [findingId, loadQuery]);
+
+  if (!queryRef) {
+    return (
+      <Card padded>
+        <Spinner centered />
+      </Card>
+    );
+  }
+
+  return (
+    <Suspense
+      fallback={(
+        <Card padded>
+          <Spinner centered />
+        </Card>
+      )}
+    >
+      <FindingAuditsCardContent queryRef={queryRef} />
+    </Suspense>
+  );
+}
+
+function FindingAuditsCardContent({
+  queryRef,
+}: FindingAuditsCardContentProps) {
+  const query = usePreloadedQuery<FindingAuditsCardQuery>(
+    findingAuditsCardQuery,
+    queryRef,
+  );
+  if (query.node?.__typename !== "Finding") {
+    return null;
+  }
+
+  return <FindingAuditsCardData findingKey={query.node} />;
+}
+
+function FindingAuditsCardData({
+  findingKey,
+}: FindingAuditsCardDataProps) {
+  const {
+    data: finding,
+    hasNext,
+    isLoadingNext,
+    loadNext,
+    refetch,
+  } = usePaginationFragment<
+    FindingAuditsCardPaginationQuery,
+    FindingAuditsCard_finding$key
+  >(findingAuditsCardFragment, findingKey);
   const [linkAudit, isLinking] = useMutation<FindingAuditsCardLinkMutation>(
     linkAuditMutation,
   );
   const [unlinkAudit, isUnlinking] = useMutation<FindingAuditsCardUnlinkMutation>(
     unlinkAuditMutation,
   );
+  const [isRefreshing, startTransition] = useTransition();
   const { t } = useTranslation();
   const { toast } = useToast();
+
   const connectionId = finding.audits.__id;
   const auditEdges = finding.audits.edges;
   const linkedAudits = auditEdges.map(edge => edge.node);
@@ -120,7 +220,11 @@ export function FindingAuditsCard({ findingKey }: FindingAuditsCardProps) {
           auditId,
           referenceId,
         },
-        connections: [connectionId],
+      },
+      onCompleted() {
+        startTransition(() => {
+          refetch({}, { fetchPolicy: "network-only" });
+        });
       },
       onError(error) {
         toast({
@@ -158,6 +262,7 @@ export function FindingAuditsCard({ findingKey }: FindingAuditsCardProps) {
   }
 
   const columnCount = finding.canUnlinkAudit ? 4 : 3;
+  const isMutating = isLinking || isUnlinking || isRefreshing;
 
   return (
     <Card padded className="space-y-[10px]">
@@ -167,13 +272,17 @@ export function FindingAuditsCard({ findingKey }: FindingAuditsCardProps) {
         </div>
         {finding.canLinkAudit && (
           <LinkedAuditsDialog
-            disabled={isLinking || isUnlinking}
+            disabled={isMutating}
             linkedAudits={linkedAudits}
             referenceIdRequired
             onLink={onLink}
             onUnlink={finding.canUnlinkAudit ? onUnlink : undefined}
           >
-            <Button variant="tertiary" icon={IconPlusLarge}>
+            <Button
+              variant="tertiary"
+              icon={IconPlusLarge}
+              disabled={hasNext || isLoadingNext}
+            >
               {t("findingDetails.audits.link")}
             </Button>
           </LinkedAuditsDialog>
@@ -204,11 +313,25 @@ export function FindingAuditsCard({ findingKey }: FindingAuditsCardProps) {
               key={edge.node.id}
               auditEdgeKey={edge}
               canUnlink={finding.canUnlinkAudit}
+              disabled={isMutating}
               onUnlink={onUnlink}
             />
           ))}
         </Tbody>
       </Table>
+      {hasNext && (
+        <Button
+          className="mx-auto"
+          variant="tertiary"
+          icon={IconChevronDown}
+          disabled={isLoadingNext}
+          onClick={() => loadNext(100)}
+        >
+          {isLoadingNext
+            ? t("findingDetails.audits.loading")
+            : t("findingDetails.audits.loadMore")}
+        </Button>
+      )}
     </Card>
   );
 }

--- a/apps/console/src/pages/organizations/findings/_components/FindingAuditsCard.tsx
+++ b/apps/console/src/pages/organizations/findings/_components/FindingAuditsCard.tsx
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { formatError } from "@probo/helpers";
+import {
+  Button,
+  Card,
+  IconPlusLarge,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  useToast,
+} from "@probo/ui";
+import { useTranslation } from "react-i18next";
+import { graphql, useFragment, useMutation } from "react-relay";
+
+import type { FindingAuditsCard_finding$key } from "#/__generated__/core/FindingAuditsCard_finding.graphql";
+import type { FindingAuditsCardLinkMutation } from "#/__generated__/core/FindingAuditsCardLinkMutation.graphql";
+import type { FindingAuditsCardUnlinkMutation } from "#/__generated__/core/FindingAuditsCardUnlinkMutation.graphql";
+import { LinkedAuditsDialog } from "#/components/audits/LinkedAuditsDialog";
+
+import { FindingAuditListItem } from "./FindingAuditListItem";
+
+const findingAuditsCardFragment = graphql`
+  fragment FindingAuditsCard_finding on Finding {
+    id
+    canLinkAudit: permission(action: "core:finding:create-audit-mapping")
+    canUnlinkAudit: permission(action: "core:finding:delete-audit-mapping")
+    audits(
+      first: 100
+      orderBy: { field: CREATED_AT, direction: DESC }
+    )
+    @connection(key: "FindingAuditsCard_audits", filters: [])
+    @required(action: THROW) {
+      __id
+      edges {
+        node {
+          id
+        }
+        ...FindingAuditListItem_auditEdge
+      }
+    }
+  }
+`;
+
+const linkAuditMutation = graphql`
+  mutation FindingAuditsCardLinkMutation(
+    $input: CreateFindingAuditMappingInput!
+    $connections: [ID!]!
+  ) {
+    createFindingAuditMapping(input: $input) {
+      auditEdge @prependEdge(connections: $connections) {
+        node {
+          id
+        }
+        ...FindingAuditListItem_auditEdge
+      }
+    }
+  }
+`;
+
+const unlinkAuditMutation = graphql`
+  mutation FindingAuditsCardUnlinkMutation(
+    $input: DeleteFindingAuditMappingInput!
+    $connections: [ID!]!
+  ) {
+    deleteFindingAuditMapping(input: $input) {
+      deletedAuditId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+interface FindingAuditsCardProps {
+  findingKey: FindingAuditsCard_finding$key;
+}
+
+export function FindingAuditsCard({ findingKey }: FindingAuditsCardProps) {
+  const finding = useFragment(findingAuditsCardFragment, findingKey);
+  const [linkAudit, isLinking] = useMutation<FindingAuditsCardLinkMutation>(
+    linkAuditMutation,
+  );
+  const [unlinkAudit, isUnlinking] = useMutation<FindingAuditsCardUnlinkMutation>(
+    unlinkAuditMutation,
+  );
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const connectionId = finding.audits.__id;
+  const auditEdges = finding.audits.edges;
+  const linkedAudits = auditEdges.map(edge => edge.node);
+
+  function onLink(auditId: string, referenceId?: string) {
+    if (!referenceId) {
+      return;
+    }
+
+    linkAudit({
+      variables: {
+        input: {
+          findingId: finding.id,
+          auditId,
+          referenceId,
+        },
+        connections: [connectionId],
+      },
+      onError(error) {
+        toast({
+          title: t("findingDetails.errors.title"),
+          description: formatError(
+            t("findingDetails.errors.linkAudit"),
+            error,
+          ),
+          variant: "error",
+        });
+      },
+    });
+  }
+
+  function onUnlink(auditId: string) {
+    unlinkAudit({
+      variables: {
+        input: {
+          findingId: finding.id,
+          auditId,
+        },
+        connections: [connectionId],
+      },
+      onError(error) {
+        toast({
+          title: t("findingDetails.errors.title"),
+          description: formatError(
+            t("findingDetails.errors.unlinkAudit"),
+            error,
+          ),
+          variant: "error",
+        });
+      },
+    });
+  }
+
+  const columnCount = finding.canUnlinkAudit ? 4 : 3;
+
+  return (
+    <Card padded className="space-y-[10px]">
+      <div className="flex justify-between">
+        <div className="text-lg font-semibold">
+          {t("findingDetails.audits.title")}
+        </div>
+        {finding.canLinkAudit && (
+          <LinkedAuditsDialog
+            disabled={isLinking || isUnlinking}
+            linkedAudits={linkedAudits}
+            referenceIdRequired
+            onLink={onLink}
+            onUnlink={finding.canUnlinkAudit ? onUnlink : undefined}
+          >
+            <Button variant="tertiary" icon={IconPlusLarge}>
+              {t("findingDetails.audits.link")}
+            </Button>
+          </LinkedAuditsDialog>
+        )}
+      </div>
+      <Table className="bg-invert">
+        <Thead>
+          <Tr>
+            <Th>{t("linkedAuditsCard.columns.name")}</Th>
+            <Th>{t("findingDetails.audits.referenceId")}</Th>
+            <Th>{t("linkedAuditsCard.columns.state")}</Th>
+            {finding.canUnlinkAudit && <Th></Th>}
+          </Tr>
+        </Thead>
+        <Tbody>
+          {auditEdges.length === 0 && (
+            <Tr>
+              <Td
+                colSpan={columnCount}
+                className="text-center text-txt-secondary"
+              >
+                {t("findingDetails.audits.empty")}
+              </Td>
+            </Tr>
+          )}
+          {auditEdges.map(edge => (
+            <FindingAuditListItem
+              key={edge.node.id}
+              auditEdgeKey={edge}
+              canUnlink={finding.canUnlinkAudit}
+              onUnlink={onUnlink}
+            />
+          ))}
+        </Tbody>
+      </Table>
+    </Card>
+  );
+}

--- a/e2e/console/finding_test.go
+++ b/e2e/console/finding_test.go
@@ -572,6 +572,7 @@ func TestFinding_CreateAuditMapping(t *testing.T) {
 				... on Finding {
 					audits(first: 10) {
 						edges {
+							referenceId
 							node {
 								id
 							}
@@ -587,7 +588,8 @@ func TestFinding_CreateAuditMapping(t *testing.T) {
 		Node struct {
 			Audits struct {
 				Edges []struct {
-					Node struct {
+					ReferenceID string `json:"referenceId"`
+					Node        struct {
 						ID string `json:"id"`
 					} `json:"node"`
 				} `json:"edges"`
@@ -602,6 +604,7 @@ func TestFinding_CreateAuditMapping(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, auditsResult.Node.Audits.TotalCount)
 	assert.Equal(t, auditID, auditsResult.Node.Audits.Edges[0].Node.ID)
+	assert.Equal(t, "MinNC/001", auditsResult.Node.Audits.Edges[0].ReferenceID)
 }
 
 func TestFinding_DeleteAuditMapping(t *testing.T) {

--- a/e2e/console/finding_test.go
+++ b/e2e/console/finding_test.go
@@ -531,6 +531,7 @@ func TestFinding_CreateAuditMapping(t *testing.T) {
 					}
 				}
 				auditEdge {
+					referenceId
 					node {
 						id
 					}
@@ -547,7 +548,8 @@ func TestFinding_CreateAuditMapping(t *testing.T) {
 				} `json:"node"`
 			} `json:"findingEdge"`
 			AuditEdge struct {
-				Node struct {
+				ReferenceID string `json:"referenceId"`
+				Node        struct {
 					ID string `json:"id"`
 				} `json:"node"`
 			} `json:"auditEdge"`
@@ -564,6 +566,17 @@ func TestFinding_CreateAuditMapping(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, findingID, linkResult.CreateFindingAuditMapping.FindingEdge.Node.ID)
 	assert.Equal(t, auditID, linkResult.CreateFindingAuditMapping.AuditEdge.Node.ID)
+	assert.Equal(t, "MinNC/001", linkResult.CreateFindingAuditMapping.AuditEdge.ReferenceID)
+
+	err = owner.Execute(linkQuery, map[string]any{
+		"input": map[string]any{
+			"findingId":   findingID,
+			"auditId":     auditID,
+			"referenceId": "MinNC/002",
+		},
+	}, &linkResult)
+	require.NoError(t, err)
+	assert.Equal(t, "MinNC/002", linkResult.CreateFindingAuditMapping.AuditEdge.ReferenceID)
 
 	// Verify audits appear on finding
 	auditsQuery := `
@@ -604,7 +617,7 @@ func TestFinding_CreateAuditMapping(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, auditsResult.Node.Audits.TotalCount)
 	assert.Equal(t, auditID, auditsResult.Node.Audits.Edges[0].Node.ID)
-	assert.Equal(t, "MinNC/001", auditsResult.Node.Audits.Edges[0].ReferenceID)
+	assert.Equal(t, "MinNC/002", auditsResult.Node.Audits.Edges[0].ReferenceID)
 }
 
 func TestFinding_DeleteAuditMapping(t *testing.T) {

--- a/pkg/coredata/finding_audit.go
+++ b/pkg/coredata/finding_audit.go
@@ -88,6 +88,7 @@ WHERE
 	}
 
 	*fas = findingAudits
+
 	return nil
 }
 
@@ -145,6 +146,7 @@ RETURNING
 	}
 
 	*fa = findingAudit
+
 	return nil
 }
 

--- a/pkg/coredata/finding_audit.go
+++ b/pkg/coredata/finding_audit.go
@@ -43,6 +43,54 @@ type (
 	FindingAudits []*FindingAudit
 )
 
+func (fas *FindingAudits) LoadByFindingIDAndAuditIDs(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	findingID gid.GID,
+	auditIDs []gid.GID,
+) error {
+	if len(auditIDs) == 0 {
+		*fas = FindingAudits{}
+		return nil
+	}
+
+	q := `
+SELECT
+    finding_id,
+    audit_id,
+    reference_id,
+    organization_id,
+    created_at
+FROM
+    findings_audits
+WHERE
+    %s
+    AND finding_id = @finding_id
+    AND audit_id = ANY(@audit_ids);
+`
+
+	args := pgx.StrictNamedArgs{
+		"finding_id": findingID,
+		"audit_ids":  auditIDs,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query finding audits: %w", err)
+	}
+
+	findingAudits, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[FindingAudit])
+	if err != nil {
+		return fmt.Errorf("cannot collect finding audits: %w", err)
+	}
+
+	*fas = findingAudits
+	return nil
+}
+
 func (fa FindingAudit) Upsert(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/coredata/finding_audit.go
+++ b/pkg/coredata/finding_audit.go
@@ -91,9 +91,9 @@ WHERE
 	return nil
 }
 
-func (fa FindingAudit) Upsert(
+func (fa *FindingAudit) Upsert(
 	ctx context.Context,
-	conn pg.Querier,
+	conn pg.Tx,
 	scope Scoper,
 ) error {
 	q := `
@@ -114,7 +114,15 @@ VALUES (
     @tenant_id,
     @created_at
 )
-ON CONFLICT (finding_id, audit_id) DO NOTHING;
+ON CONFLICT (finding_id, audit_id) DO UPDATE
+SET
+    reference_id = EXCLUDED.reference_id
+RETURNING
+    finding_id,
+    audit_id,
+    reference_id,
+    organization_id,
+    created_at;
 `
 
 	args := pgx.StrictNamedArgs{
@@ -126,11 +134,17 @@ ON CONFLICT (finding_id, audit_id) DO NOTHING;
 		"created_at":      fa.CreatedAt,
 	}
 
-	_, err := conn.Exec(ctx, q, args)
+	rows, err := conn.Query(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot upsert finding audit: %w", err)
 	}
 
+	findingAudit, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[FindingAudit])
+	if err != nil {
+		return fmt.Errorf("cannot collect finding audit: %w", err)
+	}
+
+	*fa = findingAudit
 	return nil
 }
 

--- a/pkg/probo/finding_service.go
+++ b/pkg/probo/finding_service.go
@@ -445,6 +445,37 @@ func (s FindingService) DeleteAuditMapping(
 	return finding, audit, nil
 }
 
+func (s FindingService) ListAuditMappings(
+	ctx context.Context,
+	scope coredata.Scoper,
+	findingID gid.GID,
+	auditIDs []gid.GID,
+) (coredata.FindingAudits, error) {
+	var findingAudits coredata.FindingAudits
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := findingAudits.LoadByFindingIDAndAuditIDs(
+				ctx,
+				conn,
+				scope,
+				findingID,
+				auditIDs,
+			); err != nil {
+				return fmt.Errorf("cannot load finding audit mappings: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list finding audit mappings: %w", err)
+	}
+
+	return findingAudits, nil
+}
+
 func (s FindingService) ListForAuditID(
 	ctx context.Context, scope coredata.Scoper,
 	auditID gid.GID,

--- a/pkg/probo/finding_service.go
+++ b/pkg/probo/finding_service.go
@@ -370,18 +370,24 @@ func (s FindingService) CreateAuditMapping(
 	findingID gid.GID,
 	auditID gid.GID,
 	referenceID string,
-) (*coredata.Finding, *coredata.Audit, error) {
+) (*coredata.Finding, *coredata.Audit, *coredata.FindingAudit, error) {
 	finding := &coredata.Finding{}
 	audit := &coredata.Audit{}
+	findingAudit := &coredata.FindingAudit{
+		FindingID:   findingID,
+		AuditID:     auditID,
+		ReferenceID: referenceID,
+		CreatedAt:   time.Now(),
+	}
 
-	err := s.svc.pg.WithConn(
+	err := s.svc.pg.WithTx(
 		ctx,
-		func(ctx context.Context, conn pg.Querier) error {
-			if err := finding.LoadByID(ctx, conn, scope, findingID); err != nil {
+		func(ctx context.Context, tx pg.Tx) error {
+			if err := finding.LoadByID(ctx, tx, scope, findingID); err != nil {
 				return fmt.Errorf("cannot load finding: %w", err)
 			}
 
-			if err := audit.LoadByID(ctx, conn, scope, auditID); err != nil {
+			if err := audit.LoadByID(ctx, tx, scope, auditID); err != nil {
 				return fmt.Errorf("cannot load audit: %w", err)
 			}
 
@@ -389,15 +395,9 @@ func (s FindingService) CreateAuditMapping(
 				return fmt.Errorf("cannot create finding audit mapping: finding and audit belong to different organizations")
 			}
 
-			findingAudit := &coredata.FindingAudit{
-				FindingID:      findingID,
-				AuditID:        auditID,
-				ReferenceID:    referenceID,
-				OrganizationID: finding.OrganizationID,
-				CreatedAt:      time.Now(),
-			}
+			findingAudit.OrganizationID = finding.OrganizationID
 
-			if err := findingAudit.Upsert(ctx, conn, scope); err != nil {
+			if err := findingAudit.Upsert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot create finding audit mapping: %w", err)
 			}
 
@@ -405,10 +405,10 @@ func (s FindingService) CreateAuditMapping(
 		},
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return finding, audit, nil
+	return finding, audit, findingAudit, nil
 }
 
 func (s FindingService) DeleteAuditMapping(

--- a/pkg/server/api/console/v1/audit_resolvers.go
+++ b/pkg/server/api/console/v1/audit_resolvers.go
@@ -705,7 +705,13 @@ func (r *mutationResolver) CreateFindingAuditMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	finding, audit, err := r.probo.Findings.CreateAuditMapping(ctx, scope, input.FindingID, input.AuditID, input.ReferenceID)
+	finding, audit, findingAudit, err := r.probo.Findings.CreateAuditMapping(
+		ctx,
+		scope,
+		input.FindingID,
+		input.AuditID,
+		input.ReferenceID,
+	)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create finding audit mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -716,7 +722,7 @@ func (r *mutationResolver) CreateFindingAuditMapping(ctx context.Context, input 
 		AuditEdge: types.NewFindingAuditEdge(
 			audit,
 			coredata.AuditOrderFieldCreatedAt,
-			input.ReferenceID,
+			&findingAudit.ReferenceID,
 		),
 	}, nil
 }

--- a/pkg/server/api/console/v1/audit_resolvers.go
+++ b/pkg/server/api/console/v1/audit_resolvers.go
@@ -326,7 +326,23 @@ func (r *findingResolver) Audits(ctx context.Context, obj *types.Finding, first 
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	return types.NewAuditConnection(p, r, obj.ID), nil
+	auditIDs := make([]gid.GID, len(p.Data))
+	for i, audit := range p.Data {
+		auditIDs[i] = audit.ID
+	}
+
+	findingAudits, err := r.probo.Findings.ListAuditMappings(
+		ctx,
+		scope,
+		obj.ID,
+		auditIDs,
+	)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot list finding audit mappings", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewFindingAuditConnection(p, findingAudits, r, obj.ID), nil
 }
 
 // Owner is the resolver for the owner field.
@@ -697,7 +713,11 @@ func (r *mutationResolver) CreateFindingAuditMapping(ctx context.Context, input 
 
 	return &types.CreateFindingAuditMappingPayload{
 		FindingEdge: types.NewFindingEdge(finding, coredata.FindingOrderFieldCreatedAt),
-		AuditEdge:   types.NewAuditEdge(audit, coredata.AuditOrderFieldCreatedAt),
+		AuditEdge: types.NewFindingAuditEdge(
+			audit,
+			coredata.AuditOrderFieldCreatedAt,
+			input.ReferenceID,
+		),
 	}, nil
 }
 

--- a/pkg/server/api/console/v1/graphql/audit.graphql
+++ b/pkg/server/api/console/v1/graphql/audit.graphql
@@ -234,8 +234,12 @@ type AuditConnection
     pageInfo: PageInfo!
 }
 
-type AuditEdge {
+type AuditEdge
+    @goModel(
+        model: "go.probo.inc/probo/pkg/server/api/console/v1/types.AuditEdge"
+    ) {
     cursor: CursorKey!
+    referenceId: String
     node: Audit!
 }
 

--- a/pkg/server/api/console/v1/types/audit.go
+++ b/pkg/server/api/console/v1/types/audit.go
@@ -58,10 +58,15 @@ func NewFindingAuditConnection(
 
 	edges := make([]*AuditEdge, len(p.Data))
 	for i, audit := range p.Data {
+		var referenceID *string
+		if value, ok := referenceIDs[audit.ID]; ok {
+			referenceID = &value
+		}
+
 		edges[i] = NewFindingAuditEdge(
 			audit,
 			p.Cursor.OrderBy.Field,
-			referenceIDs[audit.ID],
+			referenceID,
 		)
 	}
 
@@ -96,12 +101,12 @@ func NewAuditConnection(
 func NewFindingAuditEdge(
 	a *coredata.Audit,
 	orderField coredata.AuditOrderField,
-	referenceID string,
+	referenceID *string,
 ) *AuditEdge {
 	return &AuditEdge{
 		Node:        NewAudit(a),
 		Cursor:      a.CursorKey(orderField),
-		ReferenceID: &referenceID,
+		ReferenceID: referenceID,
 	}
 }
 

--- a/pkg/server/api/console/v1/types/audit.go
+++ b/pkg/server/api/console/v1/types/audit.go
@@ -29,6 +29,12 @@ import (
 type (
 	AuditOrderBy OrderBy[coredata.AuditOrderField]
 
+	AuditEdge struct {
+		Cursor      page.CursorKey
+		ReferenceID *string
+		Node        *Audit
+	}
+
 	AuditConnection struct {
 		TotalCount int
 		Edges      []*AuditEdge
@@ -38,6 +44,35 @@ type (
 		ParentID gid.GID
 	}
 )
+
+func NewFindingAuditConnection(
+	p *page.Page[*coredata.Audit, coredata.AuditOrderField],
+	findingAudits coredata.FindingAudits,
+	parentType any,
+	parentID gid.GID,
+) *AuditConnection {
+	referenceIDs := make(map[gid.GID]string, len(findingAudits))
+	for _, findingAudit := range findingAudits {
+		referenceIDs[findingAudit.AuditID] = findingAudit.ReferenceID
+	}
+
+	edges := make([]*AuditEdge, len(p.Data))
+	for i, audit := range p.Data {
+		edges[i] = NewFindingAuditEdge(
+			audit,
+			p.Cursor.OrderBy.Field,
+			referenceIDs[audit.ID],
+		)
+	}
+
+	return &AuditConnection{
+		Edges:    edges,
+		PageInfo: *NewPageInfo(p),
+
+		Resolver: parentType,
+		ParentID: parentID,
+	}
+}
 
 func NewAuditConnection(
 	p *page.Page[*coredata.Audit, coredata.AuditOrderField],
@@ -55,6 +90,18 @@ func NewAuditConnection(
 
 		Resolver: parentType,
 		ParentID: parentID,
+	}
+}
+
+func NewFindingAuditEdge(
+	a *coredata.Audit,
+	orderField coredata.AuditOrderField,
+	referenceID string,
+) *AuditEdge {
+	return &AuditEdge{
+		Node:        NewAudit(a),
+		Cursor:      a.CursorKey(orderField),
+		ReferenceID: &referenceID,
 	}
 }
 

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -3444,7 +3444,13 @@ func (r *Resolver) LinkFindingAuditTool(ctx context.Context, req *mcp.CallToolRe
 
 	svc := r.proboSvc
 
-	finding, audit, err := svc.Findings.CreateAuditMapping(ctx, scope, input.FindingID, input.AuditID, input.ReferenceID)
+	finding, audit, _, err := svc.Findings.CreateAuditMapping(
+		ctx,
+		scope,
+		input.FindingID,
+		input.AuditID,
+		input.ReferenceID,
+	)
 	if err != nil {
 		return nil, types.LinkFindingAuditOutput{}, fmt.Errorf("cannot link finding to audit: %w", err)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- expose audit-specific finding references through the console GraphQL API
- add linked audits to finding details with navigation and unlinking
- use a two-step modal to select an audit before entering its report reference
- verify reference IDs round-trip in the finding audit mapping test

## Testing
- `npm -w @probo/console run check`
- changed-file ESLint
- `go test ./pkg/coredata ./pkg/probo ./pkg/server/api/console/v1`
- manual link, display, unlink, and relink walkthrough

## Demo
[improved_finding_audit_modal.mp4](https://cursor.com/agents/bc-a1e4878d-111b-42d7-9aaf-f6665fbb0474/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimproved_finding_audit_modal.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1e4878d-111b-42d7-9aaf-f6665fbb0474?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1e4878d-111b-42d7-9aaf-f6665fbb0474&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Links findings to audits so each linked audit carries the report reference used for the finding. The finding details page now lists linked audits with their references and state, navigates to each audit, and supports linking and unlinking in place; relinking now updates the stored reference instead of keeping the old one.

### Tests **`+18`** **`-2`**

The e2e test asserts the linked edge returns the reference that was sent, including after a relink.

### Coredata **`+67`** **`-3`**

- Adds a loader that fetches finding-audit mappings for a finding and a set of audit IDs.
- Upsert now overwrites the reference on relink and returns the saved row.

### GraphQL API **`+86`** **`-4`**

`AuditEdge.referenceId` is exposed on a finding's audits connection and on the create-mapping mutation edge.

### MCP **`+7`** **`-1`**

Adapts the link-finding-audit tool to the new service signature.

### Service **`+46`** **`-15`**

- `CreateAuditMapping` runs in a transaction and returns the saved mapping.
- Adds `ListAuditMappings` so resolvers can attach reference IDs to linked audits.

### App: console **`+589`** **`-24`**

- The finding details page shows a linked-audits card with reference, state, and unlink actions, gated by permissions.
- Linking uses a two-step dialog: choose the audit first, then enter its report reference; actions are disabled while a mutation is in flight.
- The card discards data for a previous finding while a new route's query loads.
- The card renders nothing on authorization errors so the rest of the finding page still works.
- Adds English, French, and Dutch translations for the new flows.

<sup>Written for commit 133ffad700f0e2395d3a838250cd63b1f723cffa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

