### PR TITLE
Keep last screen lock after Windows sign-out

### DIFF
--- a/cmd/probo-agent/CHANGELOG.md
+++ b/cmd/probo-agent/CHANGELOG.md
@@ -7,6 +7,9 @@ documented in this file.
 
 ### Fixed
 
+- The Windows screen lock check keeps the last PASS or FAIL when no
+  interactive user hives are loaded, so a signed-out host no longer flaps
+  to UNKNOWN after a user was once observed
 - The Windows screen lock check treats Entra ID users (`S-1-12-1-*`) as
   interactive hives, so a signed-in cloud account is no longer reported as
   "no interactive user hives loaded"

--- a/pkg/coredata/device_posture_value_test.go
+++ b/pkg/coredata/device_posture_value_test.go
@@ -248,6 +248,19 @@ func TestParseDevicePostureValue_ScreenLock(t *testing.T) {
 				wantKind: coredata.DevicePostureValueKindUnknown,
 			},
 			{
+				name:     "windows remembered screen lock after no user hives",
+				checkKey: "SCREEN_LOCK",
+				evidence: map[string]any{
+					"backend":                "hkey_users",
+					"users":                  map[string]any{},
+					"note":                   "no interactive user hives loaded",
+					"screen_lock_enforced":   true,
+					"remembered":             true,
+					"remembered_observed_at": "2026-09-09T12:00:00Z",
+				},
+				wantKind: coredata.DevicePostureValueKindOn,
+			},
+			{
 				name:     "windows machine inactivity limit enforces lock",
 				checkKey: "SCREEN_LOCK",
 				evidence: map[string]any{

--- a/pkg/deviceagent/agent.go
+++ b/pkg/deviceagent/agent.go
@@ -343,7 +343,25 @@ func (a *Agent) CollectOnce(ctx context.Context) ([]checks.Result, error) {
 		return results, fmt.Errorf("cannot complete posture collection: %w", err)
 	}
 
-	return results, nil
+	return a.rememberChecks(ctx, results), nil
+}
+
+func (a *Agent) rememberChecks(ctx context.Context, results []checks.Result) []checks.Result {
+	memory, err := loadCheckMemory(a.Dir)
+	if err != nil {
+		a.Logger.WarnCtx(ctx, "cannot load check memory", log.Error(err))
+
+		// An unreadable file must not be replaced with a partial map.
+		return results
+	}
+
+	if applyCheckMemory(results, memory) {
+		if err := saveCheckMemory(a.Dir, memory); err != nil {
+			a.Logger.WarnCtx(ctx, "cannot persist check memory", log.Error(err))
+		}
+	}
+
+	return results
 }
 
 func (a *Agent) checks() []checks.Check {

--- a/pkg/deviceagent/check_memory.go
+++ b/pkg/deviceagent/check_memory.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package deviceagent
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.probo.inc/probo/pkg/deviceagent/checks"
+)
+
+const checkMemoryFileName = "check-memory.json"
+
+// checkMemory is the last PASS or FAIL per check key.
+type checkMemory map[string]checks.Status
+
+func checkMemoryPath(dir string) string {
+	if dir == "" {
+		dir = DefaultConfigDir()
+	}
+
+	return filepath.Join(dir, checkMemoryFileName)
+}
+
+func loadCheckMemory(dir string) (checkMemory, error) {
+	data, err := os.ReadFile(checkMemoryPath(dir))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return checkMemory{}, nil
+		}
+
+		return nil, fmt.Errorf("cannot read check memory: %w", err)
+	}
+
+	var memory checkMemory
+	if err := json.Unmarshal(data, &memory); err != nil {
+		return nil, fmt.Errorf("cannot decode check memory: %w", err)
+	}
+
+	if memory == nil {
+		return checkMemory{}, nil
+	}
+
+	return memory, nil
+}
+
+func saveCheckMemory(dir string, memory checkMemory) error {
+	path := checkMemoryPath(dir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("cannot create check memory dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(memory, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot encode check memory: %w", err)
+	}
+
+	if err := replaceRegularFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("cannot replace check memory: %w", err)
+	}
+
+	return nil
+}
+
+func applyCheckMemory(results []checks.Result, memory checkMemory) bool {
+	dirty := false
+
+	for i := range results {
+		result := &results[i]
+
+		switch result.Status {
+		case checks.StatusPass, checks.StatusFail:
+			if memory[result.CheckKey] != result.Status {
+				memory[result.CheckKey] = result.Status
+				dirty = true
+			}
+		case checks.StatusUnknown:
+			if !result.Rememberable {
+				continue
+			}
+
+			last, ok := memory[result.CheckKey]
+			if !ok || (last != checks.StatusPass && last != checks.StatusFail) {
+				continue
+			}
+
+			result.Status = last
+			if result.Evidence == nil {
+				result.Evidence = map[string]any{}
+			}
+
+			result.Evidence["remembered"] = true
+			if result.CheckKey == checks.KeyScreenLock {
+				result.Evidence["screen_lock_enforced"] = last == checks.StatusPass
+			}
+		}
+	}
+
+	return dirty
+}

--- a/pkg/deviceagent/check_memory_test.go
+++ b/pkg/deviceagent/check_memory_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package deviceagent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/deviceagent/checks"
+)
+
+func TestLoadCheckMemory_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	memory, err := loadCheckMemory(t.TempDir())
+	require.NoError(t, err)
+	assert.Empty(t, memory)
+}
+
+func TestLoadCheckMemory_CorruptFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(dir, checkMemoryFileName),
+			[]byte("{"),
+			0o600,
+		),
+	)
+
+	_, err := loadCheckMemory(dir)
+	require.Error(t, err)
+}
+
+func TestRememberChecks_UnreadableMemoryIsNotReplaced(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, checkMemoryFileName)
+	require.NoError(t, os.WriteFile(path, []byte("{"), 0o600))
+
+	a := New(dir, "test", nil)
+	results := a.rememberChecks(
+		context.Background(),
+		[]checks.Result{
+			{CheckKey: "FIREWALL", Status: checks.StatusPass},
+		},
+	)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("{"), data)
+	assert.Equal(t, checks.StatusPass, results[0].Status)
+}
+
+func TestSaveAndLoadCheckMemory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(
+		t,
+		saveCheckMemory(dir, checkMemory{"SCREEN_LOCK": checks.StatusFail}),
+	)
+
+	memory, err := loadCheckMemory(dir)
+	require.NoError(t, err)
+	assert.Equal(t, checks.StatusFail, memory["SCREEN_LOCK"])
+}
+
+func TestApplyCheckMemory(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"stores pass and fail",
+		func(t *testing.T) {
+			t.Parallel()
+
+			memory := checkMemory{}
+			results := []checks.Result{
+				{
+					CheckKey: "SCREEN_LOCK",
+					Status:   checks.StatusFail,
+				},
+			}
+
+			assert.True(t, applyCheckMemory(results, memory))
+			assert.Equal(t, checks.StatusFail, results[0].Status)
+			assert.Equal(t, checks.StatusFail, memory["SCREEN_LOCK"])
+		},
+	)
+
+	t.Run(
+		"recalls last pass for a rememberable unknown",
+		func(t *testing.T) {
+			t.Parallel()
+
+			memory := checkMemory{"SCREEN_LOCK": checks.StatusPass}
+			results := []checks.Result{
+				{
+					CheckKey: "SCREEN_LOCK",
+					Status:   checks.StatusUnknown,
+					Evidence: map[string]any{
+						"backend": "hkey_users",
+						"note":    "no interactive user hives loaded",
+					},
+					Rememberable: true,
+				},
+			}
+
+			assert.False(t, applyCheckMemory(results, memory))
+			assert.Equal(t, checks.StatusPass, results[0].Status)
+			assert.Equal(t, true, results[0].Evidence["screen_lock_enforced"])
+			assert.Equal(t, true, results[0].Evidence["remembered"])
+			assert.Equal(t, "hkey_users", results[0].Evidence["backend"])
+		},
+	)
+
+	t.Run(
+		"leaves rememberable unknown without memory",
+		func(t *testing.T) {
+			t.Parallel()
+
+			memory := checkMemory{}
+			results := []checks.Result{
+				{
+					CheckKey:     "SCREEN_LOCK",
+					Status:       checks.StatusUnknown,
+					Rememberable: true,
+				},
+			}
+
+			assert.False(t, applyCheckMemory(results, memory))
+			assert.Equal(t, checks.StatusUnknown, results[0].Status)
+			assert.Empty(t, memory)
+		},
+	)
+
+	t.Run(
+		"ignores a non-rememberable unknown",
+		func(t *testing.T) {
+			t.Parallel()
+
+			memory := checkMemory{"SCREEN_LOCK": checks.StatusPass}
+			results := []checks.Result{
+				{
+					CheckKey: "SCREEN_LOCK",
+					Status:   checks.StatusUnknown,
+					Evidence: map[string]any{"error": "powershell failed"},
+				},
+			}
+
+			assert.False(t, applyCheckMemory(results, memory))
+			assert.Equal(t, checks.StatusUnknown, results[0].Status)
+			assert.Nil(t, results[0].Evidence["remembered"])
+			assert.Equal(t, checks.StatusPass, memory["SCREEN_LOCK"])
+		},
+	)
+
+	t.Run(
+		"does not store not applicable",
+		func(t *testing.T) {
+			t.Parallel()
+
+			memory := checkMemory{}
+			results := []checks.Result{
+				{CheckKey: "SCREEN_LOCK", Status: checks.StatusNotApplicable},
+			}
+
+			assert.False(t, applyCheckMemory(results, memory))
+			assert.Empty(t, memory)
+		},
+	)
+
+	t.Run(
+		"does not mark dirty when status is unchanged",
+		func(t *testing.T) {
+			t.Parallel()
+
+			memory := checkMemory{"SCREEN_LOCK": checks.StatusFail}
+			results := []checks.Result{
+				{
+					CheckKey: "SCREEN_LOCK",
+					Status:   checks.StatusFail,
+				},
+			}
+
+			assert.False(t, applyCheckMemory(results, memory))
+			assert.Equal(t, checks.StatusFail, memory["SCREEN_LOCK"])
+		},
+	)
+
+	t.Run(
+		"marks dirty when stored status changes",
+		func(t *testing.T) {
+			t.Parallel()
+
+			memory := checkMemory{"SCREEN_LOCK": checks.StatusPass}
+			results := []checks.Result{
+				{
+					CheckKey: "SCREEN_LOCK",
+					Status:   checks.StatusFail,
+				},
+			}
+
+			assert.True(t, applyCheckMemory(results, memory))
+			assert.Equal(t, checks.StatusFail, memory["SCREEN_LOCK"])
+		},
+	)
+}

--- a/pkg/deviceagent/checks/check.go
+++ b/pkg/deviceagent/checks/check.go
@@ -31,6 +31,9 @@ type Result struct {
 	Status     Status
 	Evidence   map[string]any
 	ObservedAt time.Time
+	// Rememberable marks an UNKNOWN that is a missing observation, not a
+	// failed probe. The agent may substitute the last PASS or FAIL.
+	Rememberable bool
 }
 
 // Check runs a single posture check.

--- a/pkg/deviceagent/checks/checks_windows.go
+++ b/pkg/deviceagent/checks/checks_windows.go
@@ -144,7 +144,7 @@ func windowsScreenLock(ctx context.Context) Result {
 	ev["users"] = perUser
 	if len(perUser) == 0 {
 		ev["note"] = "no interactive user hives loaded"
-		return unknown(ev)
+		return unknownRememberable(ev)
 	}
 
 	enforced := anyEnabled && !anyDisabled

--- a/pkg/deviceagent/checks/shared.go
+++ b/pkg/deviceagent/checks/shared.go
@@ -70,6 +70,10 @@ func unknown(ev map[string]any) Result {
 	return Result{Status: StatusUnknown, Evidence: ev}
 }
 
+func unknownRememberable(ev map[string]any) Result {
+	return Result{Status: StatusUnknown, Evidence: ev, Rememberable: true}
+}
+
 func notApplicable(ev map[string]any) Result {
 	return Result{Status: StatusNotApplicable, Evidence: ev}
 }

--- a/pkg/deviceagent/posture_collect_test.go
+++ b/pkg/deviceagent/posture_collect_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync/atomic"
 	"testing"
 
@@ -60,6 +61,19 @@ func passingCheck(key string) stubCheck {
 	}
 }
 
+func rememberableUnknownCheck(key string, ev map[string]any) stubCheck {
+	return stubCheck{
+		key: key,
+		run: func(context.Context) checks.Result {
+			return checks.Result{
+				Status:       checks.StatusUnknown,
+				Evidence:     ev,
+				Rememberable: true,
+			}
+		},
+	}
+}
+
 func TestAgent_CollectOnce(t *testing.T) {
 	t.Parallel()
 
@@ -89,7 +103,8 @@ func TestAgent_CollectOnce(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			a := New(t.TempDir(), "test", nil)
+			dir := t.TempDir()
+			a := New(dir, "test", nil)
 			a.checkSet = func() []checks.Check {
 				return []checks.Check{
 					passingCheck("FIRST"),
@@ -109,6 +124,56 @@ func TestAgent_CollectOnce(t *testing.T) {
 			require.ErrorIs(t, err, context.Canceled)
 			require.Len(t, results, 2)
 			assert.Equal(t, "SECOND", results[1].CheckKey)
+
+			_, statErr := os.Stat(checkMemoryPath(dir))
+			assert.ErrorIs(t, statErr, os.ErrNotExist)
+		},
+	)
+
+	t.Run(
+		"a later rememberable unknown keeps the last pass",
+		func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			a := New(dir, "test", nil)
+			a.checkSet = func() []checks.Check {
+				return []checks.Check{
+					stubCheck{
+						key: "SCREEN_LOCK",
+						run: func(context.Context) checks.Result {
+							return checks.Result{
+								Status:   checks.StatusPass,
+								Evidence: map[string]any{"screen_lock_enforced": true},
+							}
+						},
+					},
+				}
+			}
+
+			first, err := a.CollectOnce(context.Background())
+			require.NoError(t, err)
+			require.Len(t, first, 1)
+			assert.Equal(t, checks.StatusPass, first[0].Status)
+
+			a.checkSet = func() []checks.Check {
+				return []checks.Check{
+					rememberableUnknownCheck(
+						"SCREEN_LOCK",
+						map[string]any{
+							"backend": "hkey_users",
+							"note":    "no interactive user hives loaded",
+						},
+					),
+				}
+			}
+
+			second, err := a.CollectOnce(context.Background())
+			require.NoError(t, err)
+			require.Len(t, second, 1)
+			assert.Equal(t, checks.StatusPass, second[0].Status)
+			assert.Equal(t, true, second[0].Evidence["screen_lock_enforced"])
+			assert.Equal(t, true, second[0].Evidence["remembered"])
 		},
 	)
 }

--- a/pkg/deviceagent/state_cleanup.go
+++ b/pkg/deviceagent/state_cleanup.go
@@ -41,6 +41,9 @@ var stateCleanupNames = []string{
 	KeyFileName + ".old",
 	pendingPosturesFileName,
 	pendingPosturesFileName + ".tmp",
+	checkMemoryFileName,
+	checkMemoryFileName + ".tmp",
+	checkMemoryFileName + ".old",
 }
 
 // RemoveLocalState removes allowlisted state/run files and sigstore-cache.


### PR DESCRIPTION
Per-user screensaver policy disappears from the registry when nobody is signed in, so a host that already passed or failed flapped to UNKNOWN. Persist the last PASS or FAIL on the agent and reuse it for that missing observation only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Windows screen lock check no longer flaps to UNKNOWN when nobody is signed in: per-user screensaver policy disappears from the registry at that point, so the agent now persists the last PASS or FAIL and substitutes it for that missing observation only, marking the result as remembered in the evidence.

### Service **`+151`** **`-2`**

- Adds a `check-memory.json` file on the agent that stores the last PASS or FAIL per check key, written atomically.
- Screen lock UNKNOWN results caused by no interactive user hives are now rememberable and replaced with the last stored status when one exists.
- State cleanup now also removes the check memory file.

### Tests **`+312`** **`-1`**

- Covers load/save/corrupt-file behavior, the apply/recall rules, and the full collect flow keeping the last pass on a later sign-out.
- Adds coredata parsing coverage for remembered screen lock evidence.

### Other **`+3`** **`-0`**

- Updates the agent changelog with the fix.

<sup>Written for commit 86aa6ebfc47bc0067f4ad3a4352e771ae9f237b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

