### PR TITLE
Drop @throwOnFieldError so employee assume can still run

### DIFF
--- a/apps/employee-portal/src/pages/iam/_components/errors/AssumeOrganizationSession.tsx
+++ b/apps/employee-portal/src/pages/iam/_components/errors/AssumeOrganizationSession.tsx
@@ -29,7 +29,7 @@ import { useMutation } from "#/lib/relay/useMutation";
 import { MainLayoutSkeleton } from "#/pages/iam/MainLayoutSkeleton";
 
 const assumeOrganizationSessionQuery = graphql`
-  query AssumeOrganizationSessionQuery @throwOnFieldError {
+  query AssumeOrganizationSessionQuery {
     viewer @required(action: THROW) {
       ssoLoginURL
     }


### PR DESCRIPTION
A ssoLoginURL field error aborted the query before assumeOrganizationSession. Without @throwOnFieldError, that error stays null and assume still runs, matching console (@required(action: THROW) on viewer only).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `@throwOnFieldError` from the employee assume query so a `ssoLoginURL` field error no longer aborts the session assumption flow.

### App: employee-portal **`+1`** **`-1`**

The query keeps `@required(action: THROW)` on viewer only, so the field error resolves to null and assume proceeds, matching console behavior.

<sup>Written for commit 0a87309575f5255f100d2a2e32ed99e64d018e76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



