### PR TITLE
Add Spanish employee portal translations

### DIFF
--- a/apps/employee-portal/src/_locales/es-ES.json
+++ b/apps/employee-portal/src/_locales/es-ES.json
@@ -1,0 +1,173 @@
+{
+  "topBar": {
+    "tagline": "Portal del empleado"
+  },
+  "userMenu": {
+    "oauthTokens": "Tokens de OAuth",
+    "switchToDarkMode": "Cambiar al modo oscuro",
+    "switchToLightMode": "Cambiar al modo claro",
+    "help": "Ayuda",
+    "signOut": "Cerrar sesión",
+    "signOutFailed": "No se pudo cerrar la sesión"
+  },
+  "organizationsPage": {
+    "title": "Sus organizaciones",
+    "searchPlaceholder": "Buscar organizaciones",
+    "empty": "Todavía no tiene acceso a ningún portal del empleado.",
+    "emptySearch": "Ninguna organización coincide con la búsqueda.",
+    "status": {
+      "authenticated": "Autenticado",
+      "sessionExpired": "Sesión caducada",
+      "authenticationRequired": "Autenticación necesaria"
+    },
+    "actions": {
+      "open": "Abrir",
+      "continue": "Continuar"
+    }
+  },
+  "breadcrumb": {
+    "nav": "Ruta de navegación"
+  },
+  "homePage": {
+    "breadcrumb": "Inicio",
+    "welcome": "Le damos la bienvenida, {{name}}.",
+    "welcomeFallback": "Le damos la bienvenida.",
+    "getStarted": {
+      "title": "Primeros pasos",
+      "description": "Complete los pasos necesarios para terminar de configurar su portal del empleado.",
+      "signatures": {
+        "count_one": "{{count}} documento por firmar",
+        "count_other": "{{count}} documentos por firmar",
+        "description": "Revise y firme el documento que tiene asignado.",
+        "action": "Firmar"
+      },
+      "approvals": {
+        "count_one": "{{count}} documento por aprobar",
+        "count_other": "{{count}} documentos por aprobar",
+        "description": "Revise y apruebe el documento que tiene asignado.",
+        "action": "Aprobar"
+      }
+    },
+    "dashboard": {
+      "view": "Ver",
+      "allDone": "Ya está todo listo",
+      "signatures": {
+        "title": "Firmas",
+        "description": "Firme los documentos asignados.",
+        "empty": "No hay nada que firmar por ahora",
+        "pendingCount_one": "{{count}} documento por firmar",
+        "pendingCount_other": "{{count}} documentos por firmar",
+        "action": "Empezar a firmar"
+      },
+      "approvals": {
+        "title": "Aprobaciones",
+        "description": "Revise los documentos pendientes de aprobación.",
+        "empty": "No hay nada que aprobar por ahora",
+        "pendingCount_one": "{{count}} documento por aprobar",
+        "pendingCount_other": "{{count}} documentos por aprobar",
+        "action": "Empezar a aprobar"
+      },
+      "devices": {
+        "title": "Dispositivos",
+        "description": "Gestione sus dispositivos de trabajo.",
+        "connected": "Dispositivo conectado",
+        "action": "Registrar un dispositivo"
+      },
+      "slack": {
+        "title": "Slack",
+        "description": "Vincule su cuenta de Slack para que Probot pueda ayudarle.",
+        "connected": "Slack conectado",
+        "hint": "Ejecuta <cmd>/probot login</cmd> en Slack"
+      }
+    }
+  },
+  "common": {
+    "error": "Algo ha ido mal"
+  },
+  "pagination": {
+    "previous": "Anterior",
+    "next": "Siguiente"
+  },
+  "queue": {
+    "previous": "Documento anterior",
+    "next": "Documento siguiente",
+    "close": "Cerrar",
+    "progressSignatures": "Documento {{current}} de {{total}} por firmar",
+    "progressApprovals": "Documento {{current}} de {{total}} por aprobar",
+    "empty": "No quedan documentos en esta cola"
+  },
+  "viewer": {
+    "pageOf": "Página {{current}} de {{total}}",
+    "previousPage": "Página anterior",
+    "nextPage": "Página siguiente",
+    "zoomIn": "Ampliar",
+    "zoomOut": "Reducir",
+    "download": "Descargar PDF"
+  },
+  "documents": {
+    "lastUpdated": "Última actualización",
+    "columns": {
+      "title": "Título",
+      "classification": "Clasificación",
+      "type": "Tipo",
+      "status": "Estado",
+      "action": "Acción"
+    },
+    "types": {
+      "other": "Otro",
+      "governance": "Gobernanza",
+      "policy": "Política",
+      "procedure": "Procedimiento",
+      "plan": "Plan",
+      "register": "Registro",
+      "record": "Registro de actividad",
+      "report": "Informe",
+      "template": "Plantilla",
+      "statement_of_applicability": "Declaración de aplicabilidad"
+    },
+    "classifications": {
+      "public": "Público",
+      "internal": "Interno",
+      "confidential": "Confidencial",
+      "secret": "Secreto"
+    },
+    "versions": {
+      "heading": "Historial de versiones",
+      "count_one": "{{count}} versión",
+      "count_other": "{{count}} versiones",
+      "label": "v{{major}}.{{minor}}",
+      "current": "Actual",
+      "select": "Ver la versión {{major}}.{{minor}}",
+      "status": {
+        "inReview": "En revisión",
+        "approved": "Aprobado",
+        "rejected": "Rechazado",
+        "voided": "Anulado",
+        "signed": "Firmado"
+      }
+    }
+  },
+  "errors": {
+    "notFound": {
+      "title": "Página no encontrada",
+      "description": "La página que busca no existe o puede haberse movido."
+    },
+    "forbidden": {
+      "title": "Acceso denegado",
+      "description": "No tiene permiso para ver esta página. Vuelva a sus organizaciones o contacte con soporte si cree que se trata de un error."
+    },
+    "serverError": {
+      "title": "Algo ha ido mal",
+      "description": "Algo ha ido mal por nuestra parte. Inténtelo de nuevo o contacte con soporte si el problema continúa."
+    },
+    "generic": {
+      "title": "No se pudo cargar la página",
+      "description": "No hemos podido cargar esta página. Inténtelo de nuevo o contacte con soporte si el problema continúa."
+    },
+    "actions": {
+      "tryAgain": "Intentar de nuevo",
+      "backToOrganizations": "Volver a las organizaciones",
+      "contactSupport": "Contactar con soporte"
+    }
+  }
+}

--- a/apps/employee-portal/src/pages/approvals/_locales/es-ES.json
+++ b/apps/employee-portal/src/pages/approvals/_locales/es-ES.json
@@ -1,0 +1,38 @@
+{
+  "title": "Aprobaciones",
+  "breadcrumb": "Aprobaciones",
+  "pending": {
+    "heading": "Pendientes de su aprobación ({{count}})",
+    "summaryTitle_one": "{{count}} documento por aprobar",
+    "summaryTitle_other": "{{count}} documentos por aprobar",
+    "summaryDescription": "Revise y apruebe los documentos necesarios para completar su incorporación.",
+    "action": "Empezar a aprobar",
+    "itemAction": "Aprobar"
+  },
+  "history": {
+    "heading": "Revisados ({{count}})",
+    "statusApproved": "Aprobado",
+    "statusRejected": "Rechazado"
+  },
+  "empty": {
+    "none": {
+      "title": "Todavía no hay solicitudes de aprobación",
+      "description": "Los documentos que necesiten su aprobación aparecerán aquí."
+    },
+    "allDone": {
+      "title": "Ya está todo listo",
+      "description": "Está al día. Los documentos que ya ha revisado aparecen abajo."
+    }
+  },
+  "document": {
+    "instruction": "Revise este documento y después apruébelo o rechácelo.",
+    "reviewAndApprove": "Revisar y aprobar",
+    "reject": "Rechazar",
+    "approved": "Ha aprobado este documento.",
+    "rejected": "Ha rechazado este documento.",
+    "voided": "Esta aprobación ya no es necesaria.",
+    "goToNext": "Ir al documento siguiente",
+    "finish": "Finalizar las aprobaciones",
+    "backToList": "Volver a las aprobaciones"
+  }
+}

--- a/apps/employee-portal/src/pages/bindings/_locales/es-ES.json
+++ b/apps/employee-portal/src/pages/bindings/_locales/es-ES.json
@@ -1,0 +1,57 @@
+{
+  "bind": {
+    "title": "Conectar Slack con Probo",
+    "description": "Vincule esta cuenta de Slack con su identidad de Probo para que Probot pueda ayudarle.",
+    "breadcrumb": "Conectar",
+    "fields": {
+      "tenant": "Espacio de trabajo",
+      "account": "Cuenta"
+    },
+    "actions": {
+      "confirm": "Vincular cuenta de Slack"
+    },
+    "messages": {
+      "linked": "Su cuenta de Slack ya está vinculada con Probo."
+    },
+    "missingToken": {
+      "title": "No hay ningún enlace de confirmación",
+      "description": "Ejecute /probot login en Slack para obtener un enlace de confirmación privado."
+    },
+    "errors": {
+      "linkFailed": "No se pudo vincular la cuenta",
+      "invalidOrExpiredTokenTitle": "Este enlace ha caducado",
+      "invalidOrExpiredToken": "Pida al bot un nuevo enlace de confirmación privado."
+    }
+  },
+  "list": {
+    "title": "Slack",
+    "breadcrumb": "Slack",
+    "description": "Vincule su cuenta de Slack para que Probot pueda ayudarle en esta organización.",
+    "connectedDescription": "{{account}} · {{workspace}}",
+    "providers": {
+      "slack": "Slack"
+    },
+    "columns": {
+      "account": "Cuenta",
+      "action": "Acción"
+    },
+    "actions": {
+      "unlink": "Desvincular",
+      "cancel": "Cancelar"
+    },
+    "empty": {
+      "title": "No hay ninguna cuenta de Slack vinculada",
+      "description": "Ejecute <cmd>/probot login</cmd> en Slack para obtener un enlace de confirmación privado."
+    },
+    "messages": {
+      "unlinked": "Cuenta de Slack desvinculada."
+    },
+    "errors": {
+      "unlinkFailed": "No se pudo desvincular esta cuenta."
+    },
+    "confirmations": {
+      "unlinkTitle": "Desvincular cuenta de Slack",
+      "unlink": "¿Desvincular esta cuenta de Slack? Probot no podrá ayudarle hasta que vuelva a vincularla."
+    }
+  }
+}

--- a/apps/employee-portal/src/pages/devices/_locales/es-ES.json
+++ b/apps/employee-portal/src/pages/devices/_locales/es-ES.json
@@ -1,0 +1,134 @@
+{
+  "title": "Registrar este dispositivo",
+  "breadcrumb": "Dispositivos",
+  "registerBreadcrumb": "Registrar",
+  "addManuallyBreadcrumb": "Añadir manualmente",
+  "list": {
+    "title": "Dispositivos",
+    "register": "Registrar un dispositivo nuevo",
+    "addManually": "Añadir manualmente",
+    "lastActive": "Última actividad",
+    "never": "Nunca",
+    "justNow": "Ahora mismo",
+    "pendingHostname": "Pendiente",
+    "connected": "Conectado",
+    "disconnected": "Desconectado",
+    "columns": {
+      "hostname": "Dispositivo",
+      "details": "Detalles"
+    },
+    "platforms": {
+      "DARWIN": "macOS",
+      "WINDOWS": "Windows",
+      "LINUX": "Linux",
+      "FREEBSD": "FreeBSD"
+    }
+  },
+  "empty": {
+    "title": "Todavía no hay dispositivos",
+    "description": "Registre un dispositivo para conectarlo con su organización y supervisar su estado de seguridad.",
+    "register": "Registrar dispositivo",
+    "addManually": "Añadir manualmente"
+  },
+  "unavailable": {
+    "title": "Registro no disponible",
+    "description": "No tiene permiso para registrar dispositivos en esta organización.",
+    "home": "Volver al inicio"
+  },
+  "steps": {
+    "review": {
+      "title": "Revisar la información del dispositivo",
+      "description": "Consulte qué datos guardará Probo Agent."
+    },
+    "download": {
+      "title": "Descargar el agente",
+      "description": "Instale el agente de escritorio"
+    },
+    "enroll": {
+      "title": "Abrir Probo Agent",
+      "description": "Termine de registrar este dispositivo."
+    }
+  },
+  "review": {
+    "title": "Revisar los datos recopilados",
+    "description": "Probo recopila los siguientes metadatos del dispositivo para el inventario y los informes de postura de seguridad.",
+    "understand": "Lo entiendo",
+    "thisDevice": {
+      "title": "Este dispositivo",
+      "hostname": "Nombre del dispositivo",
+      "platform": "Plataforma",
+      "osVersion": "Versión del sistema operativo"
+    },
+    "identity": {
+      "title": "Identidad del dispositivo",
+      "hardwareUuid": "UUID del hardware",
+      "hostname": "Nombre del dispositivo",
+      "serialNumber": "Número de serie, cuando esté disponible"
+    },
+    "system": {
+      "title": "Detalles del sistema",
+      "platform": "Plataforma",
+      "osVersion": "Versión del sistema operativo",
+      "agentVersion": "Versión de Probo Agent"
+    },
+    "activity": {
+      "title": "Señales de actividad",
+      "enrollmentTime": "Fecha de registro",
+      "heartbeats": "Señales periódicas del agente",
+      "posture": "Resultados de las comprobaciones de postura"
+    }
+  },
+  "download": {
+    "title": "Descargar Probo Agent",
+    "description": "Instale la aplicación para proteger este dispositivo y conectarlo con su organización.",
+    "featured": "Probo Agent para macOS",
+    "continue": "Continuar",
+    "download": "Descargar",
+    "downloadNamed": "Descargar {{title}}",
+    "macosIntel": {
+      "title": "macOS Intel",
+      "meta": "macOS 13.0+"
+    },
+    "windows": {
+      "title": "Windows",
+      "meta": "Windows 11+"
+    }
+  },
+  "enroll": {
+    "title": "Continuar en la aplicación",
+    "description": "Abra Probo Agent para terminar de registrar este dispositivo.",
+    "open": "Abrir Probo Agent",
+    "preparing": "Preparando…",
+    "waiting": "Esperando la primera conexión del agente…",
+    "timedOut": "Todavía no hemos recibido respuesta del agente. Compruebe que el agente de escritorio esté instalado y en ejecución e inténtelo de nuevo.",
+    "failed": "No hemos podido iniciar el registro. Inténtelo de nuevo.",
+    "tryAgain": "Intentar de nuevo",
+    "enrolled": "Este dispositivo está registrado.",
+    "enrolledWithHostname": "{{hostname}} está registrado.",
+    "home": "Volver al inicio"
+  },
+  "addManually": {
+    "title": "Registro manual",
+    "creating": "Creando dispositivo…",
+    "failed": "No hemos podido crear un token de registro. Inténtelo de nuevo.",
+    "created": "Dispositivo creado. Copie ahora el token de registro: no volverá a mostrarse.",
+    "done": "Listo",
+    "retry": "Intentar de nuevo",
+    "back": "Volver a los dispositivos",
+    "copy": "Copiar",
+    "copied": "Copiado",
+    "copyFailed": "No se pudo copiar al portapapeles",
+    "token": {
+      "title": "Token de registro generado",
+      "description": "Comparta este token de registro únicamente con el propietario del dispositivo y mediante un canal seguro. Solo puede utilizarse una vez y caduca a los siete días.",
+      "releaseListHint": "Consulte las <link>versiones de probo-agent en GitHub</link> (etiquetas probo-agent/v*) y elija el archivo para su sistema operativo y arquitectura (por ejemplo, probo-agent_Darwin_arm64.tar.gz, probo-agent_Linux_x86_64.tar.gz o probo-agent_Windows_x86_64.zip). Sustituya vX.Y.Z, OS y ARCH en el comando de descarga por los valores del archivo que haya elegido.",
+      "tabUnix": "macOS / Linux",
+      "tabWindows": "Windows",
+      "installUnix": "Instalar en macOS o Linux (ejecutar desde un intérprete de comandos con acceso sudo)",
+      "installWindows": "Instalar en Windows (ejecutar desde una sesión de PowerShell con privilegios elevados)",
+      "downloadStep": "Descargar y colocar el archivo binario",
+      "enrollStep": "Configurar el dispositivo e iniciar el agente",
+      "securityNotice": "El token se pasa como argumento de la CLI (no mediante un script enviado directamente de curl al intérprete de comandos ni mediante variables de entorno de sudo). Una vez instalado, el agente se actualiza automáticamente desde GitHub Releases y verifica las firmas con cosign."
+    }
+  }
+}

--- a/apps/employee-portal/src/pages/enroll/_locales/es-ES.json
+++ b/apps/employee-portal/src/pages/enroll/_locales/es-ES.json
@@ -1,0 +1,20 @@
+{
+  "title": "Registrar dispositivo",
+  "unavailable": {
+    "title": "Registro no disponible",
+    "description": "No tiene permiso para registrar dispositivos en ninguna organización.",
+    "home": "Volver a las organizaciones"
+  },
+  "steps": {
+    "organization": {
+      "title": "Elegir organización",
+      "description": "Elija a qué organización pertenecerá este dispositivo."
+    }
+  },
+  "organization": {
+    "title": "Elegir organización",
+    "description": "Elija qué organización tendrá y gestionará este dispositivo.",
+    "placeholder": "Seleccione una organización",
+    "continue": "Continuar"
+  }
+}

--- a/apps/employee-portal/src/pages/signatures/_locales/es-ES.json
+++ b/apps/employee-portal/src/pages/signatures/_locales/es-ES.json
@@ -1,0 +1,33 @@
+{
+  "title": "Firmas",
+  "breadcrumb": "Firmas",
+  "pending": {
+    "heading": "Pendientes de su firma ({{count}})",
+    "summaryTitle_one": "{{count}} documento por firmar",
+    "summaryTitle_other": "{{count}} documentos por firmar",
+    "summaryDescription": "Revise y firme los documentos necesarios para completar su incorporación.",
+    "action": "Empezar a firmar",
+    "itemAction": "Firmar"
+  },
+  "history": {
+    "heading": "Firmados ({{count}})"
+  },
+  "empty": {
+    "none": {
+      "title": "Todavía no hay solicitudes de firma",
+      "description": "Los documentos que necesiten su firma aparecerán aquí."
+    },
+    "allDone": {
+      "title": "Ya está todo listo",
+      "description": "Está al día. Los documentos firmados anteriormente aparecen abajo."
+    }
+  },
+  "document": {
+    "instruction": "Revise este documento antes de firmarlo.",
+    "reviewAndSign": "Revisar y firmar",
+    "signed": "Ha firmado este documento.",
+    "goToNext": "Ir al documento siguiente",
+    "finish": "Finalizar las firmas",
+    "backToList": "Volver a las firmas"
+  }
+}


### PR DESCRIPTION
## Summary

- add complete `es-ES` catalogs for the employee portal
- cover organization selection, document signing and approval, Slack bindings, and device enrollment
- preserve all interpolation, markup, and pluralization keys from the English source catalogs

Probo already resolves Spanish browser locales to `es-ES`, but the employee portal currently has no Spanish catalogs and therefore falls back to English. This fills that gap and follows the French and Dutch catalog structure added in #1799. It also addresses the remaining employee-portal portion of #809.

## Validation

- exact key parity against every employee-portal `en-US` catalog
- interpolation and markup token parity
- `npm --workspace @probo/employee-portal run check`
- `npm --workspace @probo/employee-portal run build`
- `npx eslint apps/employee-portal --concurrency auto`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds complete `es-ES` catalogs for the employee portal so Spanish browser locales now resolve to Spanish instead of falling back to English. This closes the remaining employee-portal portion of #809 and follows the French and Dutch catalog structure.

### App: employee-portal **`+455`** **`-0`**

- Adds a main shell catalog plus page-level catalogs for signatures, approvals, Slack bindings, device enrollment, and manual device registration.
- Preserves all interpolation, markup, and pluralization keys from the corresponding `en-US` sources.

<sup>Written for commit 291b0d50e91c62ab20480a35e01c86141aa12439. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

