### PR TITLE
Delete task comments before organization

### DIFF
--- a/e2e/console/organization_relations_test.go
+++ b/e2e/console/organization_relations_test.go
@@ -42,6 +42,7 @@ type organizationRelationGraph struct {
 	controlID              string
 	measureID              string
 	taskID                 string
+	taskCommentID          string
 	soaID                  string
 	assetID                string
 	datumID                string
@@ -110,6 +111,10 @@ func populateOrganizationRelationGraph(
 		Create()
 	g.taskID = factory.NewTask(owner, g.measureID).
 		WithName(marker + " task").
+		Create()
+	g.taskCommentID = factory.NewTaskComment(owner, g.taskID).
+		WithContent(marker + " task comment").
+		WithOwnerID(g.ownerProfileID).
 		Create()
 	g.soaID = factory.NewStatementOfApplicability(owner).
 		WithName(marker + " soa").
@@ -687,6 +692,38 @@ func orgRelationsGovernanceCollections(
 	)
 	assert.GreaterOrEqual(t, result.Node.Tasks.TotalCount, 1)
 	assert.True(t, collectRelationNodeIDs(result.Node.Tasks.Edges)[g.taskID])
+
+	var taskComments struct {
+		Node struct {
+			Comments struct {
+				TotalCount int `json:"totalCount"`
+				Edges      []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"comments"`
+		} `json:"node"`
+	}
+
+	err = owner.Execute(`
+		query($id: ID!) {
+			node(id: $id) {
+				... on Task {
+					comments(first: 50) {
+						totalCount
+						edges { node { id } }
+					}
+				}
+			}
+		}
+	`, map[string]any{"id": g.taskID}, &taskComments)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, taskComments.Node.Comments.TotalCount, 1)
+	assert.True(
+		t,
+		collectRelationNodeIDs(taskComments.Node.Comments.Edges)[g.taskCommentID],
+	)
 
 	var controlResult struct {
 		Node struct {

--- a/pkg/coredata/task_comment.go
+++ b/pkg/coredata/task_comment.go
@@ -343,3 +343,29 @@ WHERE
 
 	return nil
 }
+
+func (c *TaskComments) DeleteByOrganizationID(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+DELETE FROM task_comments
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete task comments: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1026,6 +1026,10 @@ func deleteOrganizationDependencies(
 		return fmt.Errorf("cannot delete findings: %w", err)
 	}
 
+	if err := new(coredata.TaskComments).DeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {
+		return fmt.Errorf("cannot delete task comments: %w", err)
+	}
+
 	// files.organization_id has no foreign key, so they cannot cascade
 	// from the organization delete.
 	if err := new(coredata.Files).SoftDeleteByOrganizationID(ctx, tx, scope, organizationID); err != nil {


### PR DESCRIPTION
Task comments restrict deleting membership profiles, so they must be removed before the organization cascade.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes task comments before the organization cascade so they no longer block removing membership profiles.

### Coredata **`+26`** **`-0`**

Adds `DeleteByOrganizationID` to `TaskComments` to remove all task comments for an organization within the delete transaction.

### Service **`+4`** **`-0`**

Calls `DeleteByOrganizationID` on task comments before the rest of the organization cascade deletes dependencies.

### Tests **`+37`** **`-0`**

Adds a task comment to the organization relation graph fixture and verifies it's returned by the task comments query, covering the delete path for task comments.

<sup>Written for commit b9db94eddece5da7a45e57e8f0dfeb8bbee9dabe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

