### PR TITLE
Pin Probo TLS and confirm unknown enrolls

### DIFF
--- a/cmd/probo-agent/CHANGELOG.md
+++ b/cmd/probo-agent/CHANGELOG.md
@@ -5,6 +5,16 @@ documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Browser enrollment (`probo://` deep links) asks the user to confirm the
+  server URL before a privileged install, except when TLS presents a
+  pinned Probo leaf public key. Cancel leaves the device unenrolled.
+  The dialog warns on cleartext HTTP and on hosts that are not pinned.
+- API calls to `us.probo.com` and `eu.probo.com` require a pinned Probo
+  leaf key. A Probo certificate key change fails enroll and heartbeats
+  until the agent is updated. Self-hosted servers are unchanged.
+
 ## [0.6.6] - 2026-09-10
 
 ### Added

--- a/cmd/probo-agent/enroll_confirm_other.go
+++ b/cmd/probo-agent/enroll_confirm_other.go
@@ -18,33 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-//go:build windows
+//go:build !windows
 
-package tray
+package main
 
-import (
-	"fmt"
-
-	"go.probo.inc/probo/pkg/deviceagent/win32"
-	"golang.org/x/sys/windows"
-)
-
-func showAbout(version string) {
-	message := fmt.Sprintf(
-		"Version %s\r\n\r\nReports device posture to your Probo workspace.",
-		version,
-	)
-	_, _ = win32.MessageBox(
-		"Probo Device Posture Agent",
-		message,
-		windows.MB_OK|windows.MB_ICONINFORMATION,
-	)
-}
-
-func showEnrollmentError(message string) {
-	_, _ = win32.MessageBox(
-		"Probo Device Posture Agent",
-		message,
-		windows.MB_OK|windows.MB_ICONERROR,
-	)
+func confirmBrowserEnrollment(string) bool {
+	return true
 }

--- a/cmd/probo-agent/enroll_confirm_windows.go
+++ b/cmd/probo-agent/enroll_confirm_windows.go
@@ -20,40 +20,32 @@
 
 //go:build windows
 
-package tray
+package main
 
 import (
-	"unsafe"
+	"context"
 
+	"go.probo.inc/probo/pkg/deviceagent"
+	"go.probo.inc/probo/pkg/deviceagent/win32"
 	"golang.org/x/sys/windows"
 )
 
-const (
-	mbOK              = 0x00000000
-	mbIconInformation = 0x00000040
-	mbIconError       = 0x00000010
-)
-
-var (
-	modUser32       = windows.NewLazySystemDLL("user32.dll")
-	procMessageBoxW = modUser32.NewProc("MessageBoxW")
-)
-
-func nativeMessageBox(title, message string, flags uint32) {
-	titleUTF16, err := windows.UTF16PtrFromString(title)
-	if err != nil {
-		return
+func confirmBrowserEnrollment(serverURL string) bool {
+	trust := deviceagent.ProbeEnrollmentTrust(context.Background(), serverURL)
+	if !deviceagent.RequiresEnrollmentConfirm(trust) {
+		return true
 	}
 
-	messageUTF16, err := windows.UTF16PtrFromString(message)
-	if err != nil {
-		return
-	}
+	flags := uint32(windows.MB_YESNO | windows.MB_SETFOREGROUND | windows.MB_ICONWARNING)
 
-	_, _, _ = procMessageBoxW.Call(
-		0,
-		uintptr(unsafe.Pointer(messageUTF16)),
-		uintptr(unsafe.Pointer(titleUTF16)),
-		uintptr(flags),
+	ret, err := win32.MessageBox(
+		deviceagent.EnrollmentConfirmTitle,
+		deviceagent.EnrollmentConfirmMessage(serverURL, trust),
+		flags,
 	)
+	if err != nil {
+		return false
+	}
+
+	return ret == win32.IDYes
 }

--- a/cmd/probo-agent/enroll_url_test.go
+++ b/cmd/probo-agent/enroll_url_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/deviceagent"
 )
 
 func TestEnrollURLPreflight(t *testing.T) {
@@ -36,7 +37,7 @@ func TestEnrollURLPreflight(t *testing.T) {
 		"enroll-url",
 		"--preflight",
 		"--dir", t.TempDir(),
-		"probo://enroll?server=https%3A%2F%2Fexample.com&token=abc123",
+		"probo://enroll?server=http%3A%2F%2Flocalhost%3A3000&token=abc123",
 	})
 
 	var stdout bytes.Buffer
@@ -51,10 +52,17 @@ func TestEnrollURLPreflight(t *testing.T) {
 
 	err = json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &payload)
 	require.NoError(t, err)
-	require.Equal(t, "https://example.com", payload.Server)
+	require.Equal(t, "http://localhost:3000", payload.Server)
 	require.Equal(t, "abc123", payload.Token)
 	require.False(t, payload.AlreadyEnrolled)
 	require.Contains(t, payload.ConfigDir, "TestEnrollURLPreflight")
+	require.Equal(t, string(deviceagent.TrustUnknown), payload.Trust)
+	require.Equal(t, deviceagent.EnrollmentConfirmTitle, payload.ConfirmTitle)
+	require.Equal(
+		t,
+		deviceagent.EnrollmentConfirmMessage(payload.Server, deviceagent.TrustUnknown),
+		payload.ConfirmMessage,
+	)
 }
 
 func TestWriteEnrollPreflight(t *testing.T) {
@@ -68,6 +76,7 @@ func TestWriteEnrollPreflight(t *testing.T) {
 		"token-value",
 		"/var/lib/probo-agent",
 		true,
+		deviceagent.TrustUnverified,
 	)
 	require.NoError(t, err)
 
@@ -77,4 +86,11 @@ func TestWriteEnrollPreflight(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, payload.AlreadyEnrolled)
 	require.Equal(t, "token-value", payload.Token)
+	require.Equal(t, string(deviceagent.TrustUnverified), payload.Trust)
+	require.Equal(t, deviceagent.EnrollmentConfirmTitle, payload.ConfirmTitle)
+	require.Equal(
+		t,
+		deviceagent.EnrollmentConfirmMessage("https://example.com", deviceagent.TrustUnverified),
+		payload.ConfirmMessage,
+	)
 }

--- a/cmd/probo-agent/installer/macos/enroll-ui/HelperClient/EnrollmentFlow.swift
+++ b/cmd/probo-agent/installer/macos/enroll-ui/HelperClient/EnrollmentFlow.swift
@@ -6,6 +6,9 @@ public struct EnrollPreflightResult: Decodable {
     public let token: String
     public let alreadyEnrolled: Bool
     public let configDir: String
+    public let trust: String
+    public let confirmTitle: String
+    public let confirmMessage: String
 }
 
 public enum EnrollmentFlow {

--- a/cmd/probo-agent/installer/macos/enroll-ui/URLHandlerSources/main.swift
+++ b/cmd/probo-agent/installer/macos/enroll-ui/URLHandlerSources/main.swift
@@ -66,6 +66,19 @@ private final class URLHandlerApp: NSObject, NSApplicationDelegate {
                     return
                 }
 
+                if preflight.trust != "probo_cloud" {
+                    let confirmed = DispatchQueue.main.sync {
+                        self.presentEnrollmentConfirm(preflight: preflight)
+                    }
+                    if !confirmed {
+                        NSLog("probo-agent url-handler: enrollment canceled")
+                        DispatchQueue.main.async {
+                            NSApp.terminate(nil)
+                        }
+                        return
+                    }
+                }
+
                 NSLog("probo-agent url-handler: install via helper…")
                 try EnrollmentFlow.installViaHelper(preflight: preflight)
                 NSLog("probo-agent url-handler: install completed")
@@ -83,6 +96,23 @@ private final class URLHandlerApp: NSObject, NSApplicationDelegate {
                 }
             }
         }
+    }
+
+    private func presentEnrollmentConfirm(preflight: EnrollPreflightResult) -> Bool {
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
+
+        let alert = NSAlert()
+        alert.messageText = preflight.confirmTitle
+        alert.informativeText = preflight.confirmMessage
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Enroll")
+        alert.addButton(withTitle: "Cancel")
+
+        let response = alert.runModal()
+        NSApp.setActivationPolicy(.accessory)
+
+        return response == .alertFirstButtonReturn
     }
 
     private func presentFailure(_ message: String) {

--- a/cmd/probo-agent/main.go
+++ b/cmd/probo-agent/main.go
@@ -135,7 +135,19 @@ func newEnrollURLCmd() *cobra.Command {
 					return fmt.Errorf("cannot check enrollment state: %w", err)
 				}
 
-				return writeEnrollPreflight(cmd.OutOrStdout(), serverURL, enrollmentToken, dir, enrolled)
+				trust := deviceagent.TrustUnknown
+				if !enrolled {
+					trust = deviceagent.ProbeEnrollmentTrust(cmd.Context(), serverURL)
+				}
+
+				return writeEnrollPreflight(
+					cmd.OutOrStdout(),
+					serverURL,
+					enrollmentToken,
+					dir,
+					enrolled,
+					trust,
+				)
 			}
 
 			already, err := reportIfAlreadyEnrolled(dir)
@@ -144,6 +156,10 @@ func newEnrollURLCmd() *cobra.Command {
 			}
 
 			if already {
+				return nil
+			}
+
+			if !confirmBrowserEnrollment(serverURL) {
 				return nil
 			}
 
@@ -180,18 +196,25 @@ type enrollPreflightResponse struct {
 	Token           string `json:"token"`
 	AlreadyEnrolled bool   `json:"alreadyEnrolled"`
 	ConfigDir       string `json:"configDir"`
+	Trust           string `json:"trust"`
+	ConfirmTitle    string `json:"confirmTitle"`
+	ConfirmMessage  string `json:"confirmMessage"`
 }
 
 func writeEnrollPreflight(
 	w io.Writer,
 	serverURL, enrollmentToken, dir string,
 	alreadyEnrolled bool,
+	trust deviceagent.EnrollmentTrust,
 ) error {
 	payload := enrollPreflightResponse{
 		Server:          serverURL,
 		Token:           enrollmentToken,
 		AlreadyEnrolled: alreadyEnrolled,
 		ConfigDir:       dir,
+		Trust:           string(trust),
+		ConfirmTitle:    deviceagent.EnrollmentConfirmTitle,
+		ConfirmMessage:  deviceagent.EnrollmentConfirmMessage(serverURL, trust),
 	}
 
 	out, err := json.Marshal(payload)

--- a/pkg/deviceagent/client.go
+++ b/pkg/deviceagent/client.go
@@ -46,7 +46,12 @@ type (
 
 // NewClient creates an API client.
 func NewClient(serverURL, apiKey, userAgent string) *Client {
-	httpClient := httpclient.DefaultPooledClient()
+	opts := []httpclient.Option{}
+	if IsProboServers(serverURL) {
+		opts = append(opts, httpclient.WithTLSConfig(proboCloudTLSConfig()))
+	}
+
+	httpClient := httpclient.DefaultPooledClient(opts...)
 	httpClient.Timeout = 30 * time.Second
 
 	return &Client{

--- a/pkg/deviceagent/enroll_probe.go
+++ b/pkg/deviceagent/enroll_probe.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package deviceagent
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type EnrollmentTrust string
+
+const (
+	TrustProboCloud EnrollmentTrust = "probo_cloud"
+	TrustUnverified EnrollmentTrust = "unverified"
+	TrustInsecure   EnrollmentTrust = "insecure"
+	TrustUnknown    EnrollmentTrust = "unknown"
+)
+
+const enrollmentProbeTimeout = 5 * time.Second
+
+// ProbeEnrollmentTrust classifies serverURL for the browser-enrollment
+// confirm dialog. Probo hosts are trusted only when the same pinned
+// HTTP client used for API calls can complete a TLS handshake.
+func ProbeEnrollmentTrust(ctx context.Context, serverURL string) EnrollmentTrust {
+	normalized, err := NormalizeServerURL(serverURL)
+	if err != nil {
+		return TrustUnknown
+	}
+
+	parsed, err := url.Parse(normalized)
+	if err != nil {
+		return TrustUnknown
+	}
+
+	if parsed.Scheme == "http" {
+		if isLoopbackHost(parsed.Hostname()) {
+			return TrustUnknown
+		}
+
+		return TrustInsecure
+	}
+
+	if !IsProboServers(normalized) {
+		return TrustUnverified
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, enrollmentProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodHead, parsed.String(), nil)
+	if err != nil {
+		return TrustUnknown
+	}
+
+	client := NewClient(normalized, "", "probo-agent/enroll-probe")
+	client.HTTP.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return TrustUnknown
+	}
+
+	_ = resp.Body.Close()
+
+	return TrustProboCloud
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+
+	return ip != nil && ip.IsLoopback()
+}

--- a/pkg/deviceagent/enroll_probe_test.go
+++ b/pkg/deviceagent/enroll_probe_test.go
@@ -18,33 +18,39 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-//go:build windows
-
-package tray
+package deviceagent
 
 import (
-	"fmt"
+	"testing"
 
-	"go.probo.inc/probo/pkg/deviceagent/win32"
-	"golang.org/x/sys/windows"
+	"github.com/stretchr/testify/assert"
 )
 
-func showAbout(version string) {
-	message := fmt.Sprintf(
-		"Version %s\r\n\r\nReports device posture to your Probo workspace.",
-		version,
-	)
-	_, _ = win32.MessageBox(
-		"Probo Device Posture Agent",
-		message,
-		windows.MB_OK|windows.MB_ICONINFORMATION,
-	)
-}
+func TestProbeEnrollmentTrust_NoNetwork(t *testing.T) {
+	t.Parallel()
 
-func showEnrollmentError(message string) {
-	_, _ = win32.MessageBox(
-		"Probo Device Posture Agent",
-		message,
-		windows.MB_OK|windows.MB_ICONERROR,
-	)
+	tests := []struct {
+		name  string
+		input string
+		want  EnrollmentTrust
+	}{
+		{name: "non-loopback http", input: "http://evil.example", want: TrustInsecure},
+		{name: "http Probo host", input: "http://us.probo.com", want: TrustInsecure},
+		{name: "loopback http", input: "http://localhost:3000", want: TrustUnknown},
+		{name: "loopback ipv4 http", input: "http://127.0.0.1:3000", want: TrustUnknown},
+		{name: "https self-hosted", input: "https://probo.example.com", want: TrustUnverified},
+		{name: "empty", input: "", want: TrustUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				got := ProbeEnrollmentTrust(t.Context(), tt.input)
+				assert.Equal(t, tt.want, got)
+			},
+		)
+	}
 }

--- a/pkg/deviceagent/server_url.go
+++ b/pkg/deviceagent/server_url.go
@@ -37,7 +37,7 @@ const (
 	EUConsoleURL = "https://" + EUConsoleHost
 )
 
-const DefaultServerURL = USConsoleURL
+const EnrollmentConfirmTitle = "Enroll this device?"
 
 func NormalizeServerURL(host string) (string, error) {
 	raw := strings.TrimSpace(host)
@@ -91,4 +91,41 @@ func ConsoleEnrollURL(serverURL string) (string, error) {
 	}
 
 	return enrollURL, nil
+}
+
+// IsProboServers reports whether serverURL is a US or EU Probo host.
+func IsProboServers(serverURL string) bool {
+	normalized, err := NormalizeServerURL(serverURL)
+	if err != nil {
+		return false
+	}
+
+	parsed, err := url.Parse(normalized)
+	if err != nil {
+		return false
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+
+	return host == USConsoleHost || host == EUConsoleHost
+}
+
+// RequiresEnrollmentConfirm reports whether the browser-enrollment path
+// must show a native confirm dialog. Pinned Probo hosts skip it.
+func RequiresEnrollmentConfirm(trust EnrollmentTrust) bool {
+	return trust != TrustProboCloud
+}
+
+// EnrollmentConfirmMessage is the body of the browser-enrollment confirm dialog.
+func EnrollmentConfirmMessage(serverURL string, trust EnrollmentTrust) string {
+	message := fmt.Sprintf("This device will report to %s.", serverURL)
+
+	switch trust {
+	case TrustInsecure:
+		return message + "\n\nThis connection is not encrypted (http)."
+	case TrustUnknown:
+		return message + "\n\nCould not verify TLS for this server."
+	default:
+		return message + "\n\nThis is not a Probo server."
+	}
 }

--- a/pkg/deviceagent/server_url_test.go
+++ b/pkg/deviceagent/server_url_test.go
@@ -108,3 +108,83 @@ func TestConsoleEnrollURL(t *testing.T) {
 		})
 	}
 }
+
+func TestIsProboServers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "US console", input: USConsoleURL, want: true},
+		{name: "EU console", input: EUConsoleURL, want: true},
+		{name: "mixed-case US host", input: "HTTPS://US.Probo.Com", want: true},
+		{name: "bare EU host", input: "eu.probo.com", want: true},
+		{name: "self-hosted", input: "https://probo.example.com", want: false},
+		{name: "http self-hosted", input: "http://localhost:3000", want: false},
+		{name: "lookalike host", input: "https://us.probo.com.evil.example", want: false},
+		{name: "empty", input: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				assert.Equal(t, tt.want, IsProboServers(tt.input))
+			},
+		)
+	}
+}
+
+func TestRequiresEnrollmentConfirm(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, RequiresEnrollmentConfirm(TrustProboCloud))
+	assert.True(t, RequiresEnrollmentConfirm(TrustUnverified))
+	assert.True(t, RequiresEnrollmentConfirm(TrustInsecure))
+	assert.True(t, RequiresEnrollmentConfirm(TrustUnknown))
+}
+
+func TestEnrollmentConfirmMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		serverURL string
+		trust     EnrollmentTrust
+		want      string
+	}{
+		{
+			name:      "unverified host",
+			serverURL: "https://probo.example.com",
+			trust:     TrustUnverified,
+			want:      "This device will report to https://probo.example.com.\n\nThis is not a Probo server.",
+		},
+		{
+			name:      "cleartext http",
+			serverURL: "http://us.probo.com",
+			trust:     TrustInsecure,
+			want:      "This device will report to http://us.probo.com.\n\nThis connection is not encrypted (http).",
+		},
+		{
+			name:      "probe failed",
+			serverURL: USConsoleURL,
+			trust:     TrustUnknown,
+			want:      "This device will report to https://us.probo.com.\n\nCould not verify TLS for this server.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				assert.Equal(t, tt.want, EnrollmentConfirmMessage(tt.serverURL, tt.trust))
+			},
+		)
+	}
+}

--- a/pkg/deviceagent/tls_pin.go
+++ b/pkg/deviceagent/tls_pin.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package deviceagent
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+)
+
+const (
+	// Leaf SPKI SHA-256 pins for the current ACM certificates.
+	// A key rotation fails Probo API calls until these are updated.
+	usConsoleLeafSPKI = "bc0eedef1d599ad6a77372303b8cc80b3e849c5142a94e8eaec21e369b07b370"
+	euConsoleLeafSPKI = "8df5e1fd2cf07827d75ad186510f5bb203b438617640ecbfc0543ef81c029dad"
+)
+
+var (
+	proboCloudLeafSPKIPins = mustSPKIPins(usConsoleLeafSPKI, euConsoleLeafSPKI)
+
+	ErrProboCloudPinMismatch = errors.New("TLS certificate is not a pinned Probo key")
+)
+
+func proboCloudTLSConfig() *tls.Config {
+	return &tls.Config{
+		MinVersion:            tls.VersionTLS12,
+		VerifyPeerCertificate: verifyProboCloudSPKI,
+	}
+}
+
+func verifyProboCloudSPKI(_ [][]byte, verifiedChains [][]*x509.Certificate) error {
+	return verifySPKIPins(verifiedChains, proboCloudLeafSPKIPins)
+}
+
+func verifySPKIPins(verifiedChains [][]*x509.Certificate, pins [][32]byte) error {
+	for _, chain := range verifiedChains {
+		for _, cert := range chain {
+			if spkiPinned(cert, pins) {
+				return nil
+			}
+		}
+	}
+
+	return ErrProboCloudPinMismatch
+}
+
+func spkiPinned(cert *x509.Certificate, pins [][32]byte) bool {
+	if cert == nil {
+		return false
+	}
+
+	sum := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	matched := false
+
+	for _, pin := range pins {
+		if subtle.ConstantTimeCompare(sum[:], pin[:]) == 1 {
+			matched = true
+		}
+	}
+
+	return matched
+}
+
+func mustSPKIPins(hexes ...string) [][32]byte {
+	pins := make([][32]byte, len(hexes))
+
+	for i, raw := range hexes {
+		decoded, err := hex.DecodeString(raw)
+		if err != nil || len(decoded) != sha256.Size {
+			panic("invalid Probo SPKI pin")
+		}
+
+		copy(pins[i][:], decoded)
+	}
+
+	return pins
+}

--- a/pkg/deviceagent/tls_pin_test.go
+++ b/pkg/deviceagent/tls_pin_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package deviceagent
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifySPKIPins(t *testing.T) {
+	t.Parallel()
+
+	ca, caCert := mustTestCA(t, "Amazon")
+	leaf := mustLeafCert(t, ca, USConsoleHost)
+	other := mustLeafCert(t, ca, USConsoleHost)
+	pin := sha256.Sum256(leaf.RawSubjectPublicKeyInfo)
+	chain := [][]*x509.Certificate{{leaf, caCert}}
+
+	t.Run(
+		"pinned leaf in verified chain",
+		func(t *testing.T) {
+			t.Parallel()
+
+			err := verifySPKIPins(chain, [][32]byte{pin})
+			require.NoError(t, err)
+		},
+	)
+
+	t.Run(
+		"unpinned leaf",
+		func(t *testing.T) {
+			t.Parallel()
+
+			otherPin := sha256.Sum256(other.RawSubjectPublicKeyInfo)
+			err := verifySPKIPins(chain, [][32]byte{otherPin})
+			require.ErrorIs(t, err, ErrProboCloudPinMismatch)
+		},
+	)
+
+	t.Run(
+		"empty verified chains",
+		func(t *testing.T) {
+			t.Parallel()
+
+			err := verifyProboCloudSPKI(nil, nil)
+			require.ErrorIs(t, err, ErrProboCloudPinMismatch)
+		},
+	)
+}
+
+type testCA struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+}
+
+func mustTestCA(t *testing.T, org string) (*testCA, *x509.Certificate) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{org}, CommonName: org + " Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return &testCA{cert: cert, key: key}, cert
+}
+
+func mustLeafCert(t *testing.T, ca *testCA, dnsName string) *x509.Certificate {
+	t.Helper()
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: dnsName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		DNSNames:     []string{dnsName},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, ca.cert, &leafKey.PublicKey, ca.key)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return cert
+}

--- a/pkg/deviceagent/win32/messagebox.go
+++ b/pkg/deviceagent/win32/messagebox.go
@@ -20,31 +20,37 @@
 
 //go:build windows
 
-package tray
+package win32
 
 import (
 	"fmt"
+	"strings"
 
-	"go.probo.inc/probo/pkg/deviceagent/win32"
 	"golang.org/x/sys/windows"
 )
 
-func showAbout(version string) {
-	message := fmt.Sprintf(
-		"Version %s\r\n\r\nReports device posture to your Probo workspace.",
-		version,
-	)
-	_, _ = win32.MessageBox(
-		"Probo Device Posture Agent",
-		message,
-		windows.MB_OK|windows.MB_ICONINFORMATION,
-	)
-}
+// IDYes is the MessageBox result when the user selects Yes.
+const IDYes = 6
 
-func showEnrollmentError(message string) {
-	_, _ = win32.MessageBox(
-		"Probo Device Posture Agent",
-		message,
-		windows.MB_OK|windows.MB_ICONERROR,
-	)
+// MessageBox shows a native Windows dialog and returns the selected button ID.
+func MessageBox(title, message string, flags uint32) (int32, error) {
+	titleUTF16, err := windows.UTF16PtrFromString(title)
+	if err != nil {
+		return 0, fmt.Errorf("cannot encode message box title: %w", err)
+	}
+
+	body := strings.ReplaceAll(message, "\r\n", "\n")
+	body = strings.ReplaceAll(body, "\n", "\r\n")
+
+	messageUTF16, err := windows.UTF16PtrFromString(body)
+	if err != nil {
+		return 0, fmt.Errorf("cannot encode message box message: %w", err)
+	}
+
+	ret, err := windows.MessageBox(0, messageUTF16, titleUTF16, flags)
+	if err != nil {
+		return 0, fmt.Errorf("cannot show message box: %w", err)
+	}
+
+	return ret, nil
 }


### PR DESCRIPTION
A probo:// link enrolled the device as root against any server=
host. Browser enrollment now confirms the destination unless
the same pinned HTTP client used for API calls can reach
us.probo.com or eu.probo.com. Those hosts also fail enroll
and heartbeats when the leaf key does not match. Self-hosted
and cleartext links still ask first.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, a `probo://` link could enroll against any server; Windows and macOS now ask for confirmation before privileged installation unless the destination passes the pinned Probo check, and cancel leaves the device unenrolled. The same pin blocks Probo API enrollments and heartbeats after a certificate key change, while self-hosted servers remain unchanged.

### Tests **`+285`** **`-2`**

- Covers trust classification, exact Probo-host matching, confirmation messages, and pinned SPKI verification.

### Service **`+308`** **`-4`**

- Classifies enrollment targets and probes Probo TLS with a five-second timeout while applying leaf SPKI pins to US and EU Probo API clients.

### Other **`+81`** **`-26`**

- Adds Windows Yes/No and macOS Enroll/Cancel warning dialogs, exposes trust and message fields to the macOS helper, and reuses the Windows message-box wrapper for tray dialogs.
- Non-Windows builds retain an allow-through confirmation stub.

<sup>Written for commit 56624a032ccff517de1aa91433e77ec9055f366a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



