### PR TITLE
Tighten windows agent

### DIFF
--- a/cmd/probo-agent/CHANGELOG.md
+++ b/cmd/probo-agent/CHANGELOG.md
@@ -24,6 +24,10 @@ documented in this file.
 - API calls to `us.probo.com` and `eu.probo.com` require a pinned Probo
   leaf key. A Probo certificate key change fails enroll and heartbeats
   until the agent is updated. Self-hosted servers are unchanged.
+- Windows agent state under `%ProgramData%\Probo\agent` uses an explicit
+  DACL for SYSTEM and Administrators. A standard user cannot read
+  `agent.key` or replace `config.json`. A user-owned or junction squat
+  is refused, and existing files are re-ACL'd when the service starts.
 
 ## [0.6.6] - 2026-09-10
 

--- a/pkg/deviceagent/agent.go
+++ b/pkg/deviceagent/agent.go
@@ -153,6 +153,10 @@ func (a *Agent) ConfigureDevice(
 
 // LoadLocalState loads persisted config and API key.
 func (a *Agent) LoadLocalState() error {
+	if err := ensureSecureAgentDir(a.Dir); err != nil {
+		return err
+	}
+
 	cfg, err := LoadConfig(a.Dir)
 	if err != nil {
 		return err

--- a/pkg/deviceagent/check_memory.go
+++ b/pkg/deviceagent/check_memory.go
@@ -67,8 +67,8 @@ func loadCheckMemory(dir string) (checkMemory, error) {
 
 func saveCheckMemory(dir string, memory checkMemory) error {
 	path := checkMemoryPath(dir)
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return fmt.Errorf("cannot create check memory dir: %w", err)
+	if err := ensureSecureAgentDir(filepath.Dir(path)); err != nil {
+		return err
 	}
 
 	data, err := json.MarshalIndent(memory, "", "  ")

--- a/pkg/deviceagent/config.go
+++ b/pkg/deviceagent/config.go
@@ -102,8 +102,8 @@ func SaveConfig(dir string, cfg *Config) error {
 		dir = DefaultConfigDir()
 	}
 
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("cannot create config dir: %w", err)
+	if err := ensureSecureAgentDir(dir); err != nil {
+		return err
 	}
 
 	cfg.applyDefaults()

--- a/pkg/deviceagent/enroll.go
+++ b/pkg/deviceagent/enroll.go
@@ -57,6 +57,10 @@ func LoadOrExchangeAPIKey(
 	}
 	defer release()
 
+	if err := ensureSecureAgentDir(dir); err != nil {
+		return "", fmt.Errorf("cannot prepare agent data dir: %w", err)
+	}
+
 	apiKey, err := LoadAPIKey(dir)
 	if err == nil {
 		if err := validatePersistedServerURL(dir, normalized); err != nil {

--- a/pkg/deviceagent/enrollment_lock.go
+++ b/pkg/deviceagent/enrollment_lock.go
@@ -53,12 +53,8 @@ func EnrollmentLockPath(configDir string) string {
 func AcquireEnrollmentLock(configDir string) (release func(), err error) {
 	runDir := EnrollmentRunDir(configDir)
 
-	if err := os.MkdirAll(runDir, EnrollmentRunDirMode); err != nil {
-		return nil, fmt.Errorf("cannot create enrollment run dir: %w", err)
-	}
-
-	if err := os.Chmod(runDir, EnrollmentRunDirMode); err != nil {
-		return nil, fmt.Errorf("cannot set enrollment run dir permissions: %w", err)
+	if err := ensureSecureRunDir(runDir); err != nil {
+		return nil, err
 	}
 
 	path := EnrollmentLockPath(configDir)

--- a/pkg/deviceagent/enrollment_state.go
+++ b/pkg/deviceagent/enrollment_state.go
@@ -63,18 +63,26 @@ func enrollmentMarkerPath(runDir string) string {
 	return filepath.Join(runDir, EnrollmentMarkerName)
 }
 
-// IsEnrolled reports whether the enrollment marker exists in runDir.
+// IsEnrolled reports whether runDir contains a trusted enrollment marker.
+// On Windows production paths the marker must be owned by SYSTEM or
+// Administrators; a user-created file is ignored so install proceeds.
 func IsEnrolled(runDir string) (bool, error) {
-	_, err := os.Stat(enrollmentMarkerPath(runDir))
-	if err == nil {
-		return true, nil
+	path := enrollmentMarkerPath(runDir)
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("cannot stat enrollment marker: %w", err)
 	}
 
-	if os.IsNotExist(err) {
+	trusted, err := isTrustedEnrollmentMarker(path)
+	if err != nil || !trusted {
 		return false, nil
 	}
 
-	return false, fmt.Errorf("cannot stat enrollment marker: %w", err)
+	return true, nil
 }
 
 // MarkEnrolled writes the enrollment marker under runDir.
@@ -83,12 +91,8 @@ func MarkEnrolled(runDir string) error {
 		runDir = DefaultEnrollmentRunDir()
 	}
 
-	if err := os.MkdirAll(runDir, EnrollmentRunDirMode); err != nil {
-		return fmt.Errorf("cannot create enrollment run dir: %w", err)
-	}
-
-	if err := os.Chmod(runDir, EnrollmentRunDirMode); err != nil {
-		return fmt.Errorf("cannot set enrollment run dir permissions: %w", err)
+	if err := ensureSecureRunDir(runDir); err != nil {
+		return err
 	}
 
 	path := enrollmentMarkerPath(runDir)

--- a/pkg/deviceagent/enrollment_state.go
+++ b/pkg/deviceagent/enrollment_state.go
@@ -63,11 +63,10 @@ func enrollmentMarkerPath(runDir string) string {
 	return filepath.Join(runDir, EnrollmentMarkerName)
 }
 
-// IsEnrolled reports whether runDir contains a trusted enrollment marker.
-// On Windows production paths the marker must be owned by SYSTEM or
-// Administrators; a user-created file is ignored so install proceeds.
+// IsEnrolled reports whether runDir contains an enrollment marker.
 func IsEnrolled(runDir string) (bool, error) {
 	path := enrollmentMarkerPath(runDir)
+
 	_, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -75,11 +74,6 @@ func IsEnrolled(runDir string) (bool, error) {
 		}
 
 		return false, fmt.Errorf("cannot stat enrollment marker: %w", err)
-	}
-
-	trusted, err := isTrustedEnrollmentMarker(path)
-	if err != nil || !trusted {
-		return false, nil
 	}
 
 	return true, nil

--- a/pkg/deviceagent/keystore.go
+++ b/pkg/deviceagent/keystore.go
@@ -50,8 +50,8 @@ func SaveAPIKey(dir, key string) error {
 		dir = DefaultConfigDir()
 	}
 
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("cannot create keystore dir: %w", err)
+	if err := ensureSecureAgentDir(dir); err != nil {
+		return err
 	}
 
 	path := KeyPath(dir)

--- a/pkg/deviceagent/posture_queue.go
+++ b/pkg/deviceagent/posture_queue.go
@@ -89,8 +89,8 @@ func savePendingPostureBatches(dir string, batches []pendingPostureBatch) error 
 		return nil
 	}
 
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("cannot create pending posture dir: %w", err)
+	if err := ensureSecureAgentDir(dir); err != nil {
+		return err
 	}
 
 	data, err := json.MarshalIndent(batches, "", "  ")

--- a/pkg/deviceagent/secure_dir.go
+++ b/pkg/deviceagent/secure_dir.go
@@ -21,33 +21,50 @@
 package deviceagent
 
 import (
+	"fmt"
 	"os"
-	"path/filepath"
 )
 
-func windowsProgramData() string {
-	programData := os.Getenv("ProgramData")
-	if programData == "" {
-		return `C:\ProgramData`
+type secureDirKind int
+
+const (
+	secureDirRoot secureDirKind = iota
+	secureDirRun
+	secureDirAgent
+)
+
+func ensureSecureRunDir(runDir string) error {
+	if runDir == "" {
+		runDir = DefaultEnrollmentRunDir()
 	}
 
-	return programData
+	if err := ensureProtectedWindowsTree(runDir, secureDirRun); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(runDir, EnrollmentRunDirMode); err != nil {
+		return fmt.Errorf("cannot create enrollment run dir: %w", err)
+	}
+
+	if err := os.Chmod(runDir, EnrollmentRunDirMode); err != nil {
+		return fmt.Errorf("cannot set enrollment run dir permissions: %w", err)
+	}
+
+	return nil
 }
 
-// DefaultProgramDataRoot returns %ProgramData%\Probo, the parent of the
-// agent keystore and the public enrollment run directory.
-func DefaultProgramDataRoot() string {
-	return filepath.Join(windowsProgramData(), "Probo")
-}
+func ensureSecureAgentDir(dir string) error {
+	if dir == "" {
+		dir = DefaultConfigDir()
+	}
 
-// DefaultConfigDir returns the directory under which the agent's config
-// and keystore live on Windows.
-func DefaultConfigDir() string {
-	return filepath.Join(DefaultProgramDataRoot(), "agent")
-}
+	if err := ensureProtectedWindowsTree(dir, secureDirAgent); err != nil {
+		return err
+	}
 
-// DefaultEnrollmentRunDir returns the runtime directory for the public
-// enrollment marker and enrolling.lock on Windows.
-func DefaultEnrollmentRunDir() string {
-	return filepath.Join(DefaultProgramDataRoot(), "run")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("cannot create agent data dir: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/deviceagent/secure_dir_other.go
+++ b/pkg/deviceagent/secure_dir_other.go
@@ -18,36 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//go:build !windows
+
 package deviceagent
 
-import (
-	"os"
-	"path/filepath"
-)
-
-func windowsProgramData() string {
-	programData := os.Getenv("ProgramData")
-	if programData == "" {
-		return `C:\ProgramData`
-	}
-
-	return programData
+func ensureProtectedWindowsTree(string, secureDirKind) error {
+	return nil
 }
 
-// DefaultProgramDataRoot returns %ProgramData%\Probo, the parent of the
-// agent keystore and the public enrollment run directory.
-func DefaultProgramDataRoot() string {
-	return filepath.Join(windowsProgramData(), "Probo")
-}
-
-// DefaultConfigDir returns the directory under which the agent's config
-// and keystore live on Windows.
-func DefaultConfigDir() string {
-	return filepath.Join(DefaultProgramDataRoot(), "agent")
-}
-
-// DefaultEnrollmentRunDir returns the runtime directory for the public
-// enrollment marker and enrolling.lock on Windows.
-func DefaultEnrollmentRunDir() string {
-	return filepath.Join(DefaultProgramDataRoot(), "run")
+func isTrustedEnrollmentMarker(string) (bool, error) {
+	return true, nil
 }

--- a/pkg/deviceagent/secure_dir_other.go
+++ b/pkg/deviceagent/secure_dir_other.go
@@ -25,7 +25,3 @@ package deviceagent
 func ensureProtectedWindowsTree(string, secureDirKind) error {
 	return nil
 }
-
-func isTrustedEnrollmentMarker(string) (bool, error) {
-	return true, nil
-}

--- a/pkg/deviceagent/secure_dir_windows.go
+++ b/pkg/deviceagent/secure_dir_windows.go
@@ -1,0 +1,334 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build windows
+
+package deviceagent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func ensureProtectedWindowsTree(path string, kind secureDirKind) error {
+	if !isProtectedWindowsPath(path) {
+		return nil
+	}
+
+	root := DefaultProgramDataRoot()
+	if err := ensureWindowsProtectedDir(root, secureDirRoot); err != nil {
+		return err
+	}
+
+	if isSameWindowsPath(path, root) {
+		return nil
+	}
+
+	return ensureWindowsProtectedDir(path, kind)
+}
+
+func isTrustedEnrollmentMarker(path string) (bool, error) {
+	if !isProtectedWindowsPath(path) {
+		return true, nil
+	}
+
+	return isTrustedWindowsOwner(path)
+}
+
+func isProtectedWindowsPath(path string) bool {
+	return isPathUnderWindowsRoot(path, DefaultProgramDataRoot())
+}
+
+func isPathUnderWindowsRoot(path, root string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+
+	pathFold := strings.ToLower(filepath.Clean(absPath))
+	rootFold := strings.ToLower(filepath.Clean(absRoot))
+	if pathFold == rootFold {
+		return true
+	}
+
+	return strings.HasPrefix(pathFold, rootFold+string(os.PathSeparator))
+}
+
+func isSameWindowsPath(a, b string) bool {
+	absA, err := filepath.Abs(a)
+	if err != nil {
+		return false
+	}
+
+	absB, err := filepath.Abs(b)
+	if err != nil {
+		return false
+	}
+
+	return strings.EqualFold(filepath.Clean(absA), filepath.Clean(absB))
+}
+
+func ensureWindowsProtectedDir(path string, kind secureDirKind) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return createWindowsProtectedDir(path, kind)
+		}
+
+		return fmt.Errorf("cannot stat %s: %w", path, err)
+	}
+
+	reparse, err := isWindowsReparsePoint(path)
+	if err != nil {
+		return fmt.Errorf("cannot inspect %s: %w", path, err)
+	}
+
+	if reparse || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a reparse point; remove it and retry", path)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", path)
+	}
+
+	trusted, err := isTrustedWindowsOwner(path)
+	if err != nil {
+		return fmt.Errorf("cannot check owner of %s: %w", path, err)
+	}
+
+	if !trusted {
+		return fmt.Errorf(
+			"%s is not owned by SYSTEM or Administrators; remove it and retry",
+			path,
+		)
+	}
+
+	if err := applyWindowsProtectedDACL(path, kind); err != nil {
+		return fmt.Errorf("cannot apply protected DACL to %s: %w", path, err)
+	}
+
+	return nil
+}
+
+func createWindowsProtectedDir(path string, kind secureDirKind) error {
+	acl, err := windowsProtectedACL(kind)
+	if err != nil {
+		return fmt.Errorf("cannot build DACL for %s: %w", path, err)
+	}
+
+	sd, err := windows.NewSecurityDescriptor()
+	if err != nil {
+		return fmt.Errorf("cannot initialize security descriptor for %s: %w", path, err)
+	}
+
+	if err := sd.SetDACL(acl, true, false); err != nil {
+		return fmt.Errorf("cannot set DACL for %s: %w", path, err)
+	}
+
+	if err := sd.SetControl(windows.SE_DACL_PROTECTED, windows.SE_DACL_PROTECTED); err != nil {
+		return fmt.Errorf("cannot protect DACL for %s: %w", path, err)
+	}
+
+	pathUTF16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return fmt.Errorf("cannot encode path %s: %w", path, err)
+	}
+
+	sa := &windows.SecurityAttributes{
+		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
+		SecurityDescriptor: sd,
+	}
+	if err := windows.CreateDirectory(pathUTF16, sa); err != nil {
+		if errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
+			return ensureWindowsProtectedDir(path, kind)
+		}
+
+		return fmt.Errorf("cannot create %s: %w", path, err)
+	}
+
+	runtime.KeepAlive(acl)
+	runtime.KeepAlive(sd)
+
+	if err := applyWindowsProtectedDACL(path, kind); err != nil {
+		return fmt.Errorf("cannot apply protected DACL to %s: %w", path, err)
+	}
+
+	return nil
+}
+
+func applyWindowsProtectedDACL(path string, kind secureDirKind) error {
+	acl, err := windowsProtectedACL(kind)
+	if err != nil {
+		return fmt.Errorf("cannot build DACL: %w", err)
+	}
+
+	err = windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot set named security info: %w", err)
+	}
+
+	runtime.KeepAlive(acl)
+
+	return nil
+}
+
+func windowsProtectedACL(kind secureDirKind) (*windows.ACL, error) {
+	systemSID, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve SYSTEM SID: %w", err)
+	}
+
+	adminSID, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve Administrators SID: %w", err)
+	}
+
+	usersSID, err := windows.CreateWellKnownSid(windows.WinBuiltinUsersSid)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve Users SID: %w", err)
+	}
+
+	var pinner runtime.Pinner
+
+	defer pinner.Unpin()
+
+	pinner.Pin(systemSID)
+	pinner.Pin(adminSID)
+	pinner.Pin(usersSID)
+
+	entries := []windows.EXPLICIT_ACCESS{
+		grantWindowsSID(
+			systemSID,
+			windows.GENERIC_ALL,
+			windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+		),
+		grantWindowsSID(
+			adminSID,
+			windows.GENERIC_ALL,
+			windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+		),
+	}
+
+	switch kind {
+	case secureDirRoot:
+		entries = append(
+			entries,
+			grantWindowsSID(usersSID, windows.FILE_TRAVERSE, windows.NO_INHERITANCE),
+		)
+	case secureDirRun:
+		entries = append(
+			entries,
+			grantWindowsSID(
+				usersSID,
+				windows.FILE_GENERIC_READ|windows.FILE_GENERIC_EXECUTE,
+				windows.SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+			),
+		)
+	}
+
+	acl, err := windows.ACLFromEntries(entries, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot assemble DACL: %w", err)
+	}
+
+	return acl, nil
+}
+
+func grantWindowsSID(
+	sid *windows.SID,
+	perm windows.ACCESS_MASK,
+	inherit uint32,
+) windows.EXPLICIT_ACCESS {
+	return windows.EXPLICIT_ACCESS{
+		AccessPermissions: perm,
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       inherit,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_WELL_KNOWN_GROUP,
+			TrusteeValue: windows.TrusteeValueFromSID(sid),
+		},
+	}
+}
+
+func isTrustedWindowsOwner(path string) (bool, error) {
+	sd, err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		return false, fmt.Errorf("cannot read owner: %w", err)
+	}
+
+	if sd == nil {
+		return false, errors.New("security descriptor is missing")
+	}
+
+	owner, _, err := sd.Owner()
+	if err != nil {
+		return false, fmt.Errorf("cannot parse owner: %w", err)
+	}
+
+	if owner == nil {
+		return false, errors.New("owner SID is missing")
+	}
+
+	return isTrustedWindowsSID(owner), nil
+}
+
+func isTrustedWindowsSID(sid *windows.SID) bool {
+	return sid.IsWellKnown(windows.WinLocalSystemSid) ||
+		sid.IsWellKnown(windows.WinBuiltinAdministratorsSid)
+}
+
+func isWindowsReparsePoint(path string) (bool, error) {
+	pathUTF16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return false, fmt.Errorf("cannot encode path: %w", err)
+	}
+
+	attrs, err := windows.GetFileAttributes(pathUTF16)
+	if err != nil {
+		return false, fmt.Errorf("cannot read file attributes: %w", err)
+	}
+
+	return attrs&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0, nil
+}

--- a/pkg/deviceagent/secure_dir_windows.go
+++ b/pkg/deviceagent/secure_dir_windows.go
@@ -34,6 +34,28 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+const (
+	lgIncludeIndirect  = 0x0001
+	maxPreferredLength = uint32(0xFFFFFFFF)
+)
+
+var (
+	modNetapi32                 = windows.NewLazySystemDLL("netapi32.dll")
+	procNetApiBufferFree        = modNetapi32.NewProc("NetApiBufferFree")
+	procNetLocalGroupGetMembers = modNetapi32.NewProc("NetLocalGroupGetMembers")
+	procNetUserGetLocalGroups   = modNetapi32.NewProc("NetUserGetLocalGroups")
+)
+
+type (
+	localGroupMembersInfo0 struct {
+		sid *windows.SID
+	}
+
+	localGroupUsersInfo0 struct {
+		name *uint16
+	}
+)
+
 func ensureProtectedWindowsTree(path string, kind secureDirKind) error {
 	if !isProtectedWindowsPath(path) {
 		return nil
@@ -49,14 +71,6 @@ func ensureProtectedWindowsTree(path string, kind secureDirKind) error {
 	}
 
 	return ensureWindowsProtectedDir(path, kind)
-}
-
-func isTrustedEnrollmentMarker(path string) (bool, error) {
-	if !isProtectedWindowsPath(path) {
-		return true, nil
-	}
-
-	return isTrustedWindowsOwner(path)
 }
 
 func isProtectedWindowsPath(path string) bool {
@@ -132,7 +146,7 @@ func ensureWindowsProtectedDir(path string, kind secureDirKind) error {
 		)
 	}
 
-	if err := applyWindowsProtectedDACL(path, kind); err != nil {
+	if err := applyWindowsProtectedTree(path, kind); err != nil {
 		return fmt.Errorf("cannot apply protected DACL to %s: %w", path, err)
 	}
 
@@ -140,6 +154,30 @@ func ensureWindowsProtectedDir(path string, kind secureDirKind) error {
 }
 
 func createWindowsProtectedDir(path string, kind secureDirKind) error {
+	err := createWindowsDirectory(path, kind, true)
+	if err != nil {
+		if errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
+			return ensureWindowsProtectedDir(path, kind)
+		}
+
+		err = createWindowsDirectory(path, kind, false)
+		if errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
+			return ensureWindowsProtectedDir(path, kind)
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := applyWindowsProtectedTree(path, kind); err != nil {
+		return fmt.Errorf("cannot apply protected DACL to %s: %w", path, err)
+	}
+
+	return nil
+}
+
+func createWindowsDirectory(path string, kind secureDirKind, setAdminOwner bool) error {
 	acl, err := windowsProtectedACL(kind)
 	if err != nil {
 		return fmt.Errorf("cannot build DACL for %s: %w", path, err)
@@ -158,6 +196,19 @@ func createWindowsProtectedDir(path string, kind secureDirKind) error {
 		return fmt.Errorf("cannot protect DACL for %s: %w", path, err)
 	}
 
+	var adminSID *windows.SID
+
+	if setAdminOwner {
+		adminSID, err = windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+		if err != nil {
+			return fmt.Errorf("cannot resolve Administrators SID: %w", err)
+		}
+
+		if err := sd.SetOwner(adminSID, false); err != nil {
+			return fmt.Errorf("cannot set owner for %s: %w", path, err)
+		}
+	}
+
 	pathUTF16, err := windows.UTF16PtrFromString(path)
 	if err != nil {
 		return fmt.Errorf("cannot encode path %s: %w", path, err)
@@ -168,18 +219,55 @@ func createWindowsProtectedDir(path string, kind secureDirKind) error {
 		SecurityDescriptor: sd,
 	}
 	if err := windows.CreateDirectory(pathUTF16, sa); err != nil {
-		if errors.Is(err, windows.ERROR_ALREADY_EXISTS) {
-			return ensureWindowsProtectedDir(path, kind)
-		}
-
 		return fmt.Errorf("cannot create %s: %w", path, err)
 	}
 
 	runtime.KeepAlive(acl)
 	runtime.KeepAlive(sd)
+	runtime.KeepAlive(adminSID)
 
+	return nil
+}
+
+func applyWindowsProtectedTree(path string, kind secureDirKind) error {
 	if err := applyWindowsProtectedDACL(path, kind); err != nil {
-		return fmt.Errorf("cannot apply protected DACL to %s: %w", path, err)
+		return err
+	}
+
+	if kind != secureDirAgent {
+		return nil
+	}
+
+	return applyWindowsProtectedDACLChildren(path, kind)
+}
+
+func applyWindowsProtectedDACLChildren(dir string, kind secureDirKind) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("cannot list %s: %w", dir, err)
+	}
+
+	for _, entry := range entries {
+		child := filepath.Join(dir, entry.Name())
+
+		reparse, err := isWindowsReparsePoint(child)
+		if err != nil {
+			return fmt.Errorf("cannot inspect %s: %w", child, err)
+		}
+
+		if reparse {
+			return fmt.Errorf("%s is a reparse point; remove it and retry", child)
+		}
+
+		if err := applyWindowsProtectedDACL(child, kind); err != nil {
+			return fmt.Errorf("cannot apply protected DACL to %s: %w", child, err)
+		}
+
+		if entry.IsDir() {
+			if err := applyWindowsProtectedDACLChildren(child, kind); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
@@ -315,8 +403,130 @@ func isTrustedWindowsOwner(path string) (bool, error) {
 }
 
 func isTrustedWindowsSID(sid *windows.SID) bool {
-	return sid.IsWellKnown(windows.WinLocalSystemSid) ||
-		sid.IsWellKnown(windows.WinBuiltinAdministratorsSid)
+	if sid == nil {
+		return false
+	}
+
+	if sid.IsWellKnown(windows.WinLocalSystemSid) ||
+		sid.IsWellKnown(windows.WinBuiltinAdministratorsSid) {
+		return true
+	}
+
+	return sidIsLocalAdministrator(sid)
+}
+
+func sidIsLocalAdministrator(sid *windows.SID) bool {
+	return localAdministratorsContainsSID(sid) || localAdministratorsContainsUser(sid)
+}
+
+func builtinAdministratorsName() (string, error) {
+	adminSID, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve Administrators SID: %w", err)
+	}
+
+	name, _, _, err := adminSID.LookupAccount("")
+	if err != nil {
+		return "", fmt.Errorf("cannot look up Administrators name: %w", err)
+	}
+
+	return name, nil
+}
+
+func localAdministratorsContainsSID(sid *windows.SID) bool {
+	name, err := builtinAdministratorsName()
+	if err != nil {
+		return false
+	}
+
+	namePtr, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return false
+	}
+
+	var (
+		buf          *localGroupMembersInfo0
+		entriesRead  uint32
+		totalEntries uint32
+		resumeHandle uintptr
+	)
+
+	status, _, _ := procNetLocalGroupGetMembers.Call(
+		0,
+		uintptr(unsafe.Pointer(namePtr)),
+		0,
+		uintptr(unsafe.Pointer(&buf)),
+		uintptr(maxPreferredLength),
+		uintptr(unsafe.Pointer(&entriesRead)),
+		uintptr(unsafe.Pointer(&totalEntries)),
+		uintptr(unsafe.Pointer(&resumeHandle)),
+	)
+	if status != 0 || buf == nil || entriesRead == 0 {
+		return false
+	}
+
+	defer procNetApiBufferFree.Call(uintptr(unsafe.Pointer(buf)))
+
+	members := unsafe.Slice(buf, entriesRead)
+	for _, member := range members {
+		if member.sid != nil && member.sid.Equals(sid) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func localAdministratorsContainsUser(sid *windows.SID) bool {
+	account, _, _, err := sid.LookupAccount("")
+	if err != nil || account == "" {
+		return false
+	}
+
+	accountPtr, err := windows.UTF16PtrFromString(account)
+	if err != nil {
+		return false
+	}
+
+	adminName, err := builtinAdministratorsName()
+	if err != nil {
+		return false
+	}
+
+	var (
+		buf          *localGroupUsersInfo0
+		entriesRead  uint32
+		totalEntries uint32
+	)
+
+	status, _, _ := procNetUserGetLocalGroups.Call(
+		0,
+		uintptr(unsafe.Pointer(accountPtr)),
+		0,
+		lgIncludeIndirect,
+		uintptr(unsafe.Pointer(&buf)),
+		uintptr(maxPreferredLength),
+		uintptr(unsafe.Pointer(&entriesRead)),
+		uintptr(unsafe.Pointer(&totalEntries)),
+	)
+	if status != 0 || buf == nil || entriesRead == 0 {
+		return false
+	}
+
+	defer procNetApiBufferFree.Call(uintptr(unsafe.Pointer(buf)))
+
+	groups := unsafe.Slice(buf, entriesRead)
+	for _, group := range groups {
+		if group.name == nil {
+			continue
+		}
+
+		if strings.EqualFold(windows.UTF16PtrToString(group.name), adminName) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func isWindowsReparsePoint(path string) (bool, error) {

--- a/pkg/deviceagent/secure_dir_windows_test.go
+++ b/pkg/deviceagent/secure_dir_windows_test.go
@@ -49,6 +49,23 @@ func TestIsTrustedWindowsSID(t *testing.T) {
 	assert.True(t, isTrustedWindowsSID(adminSID))
 	assert.False(t, isTrustedWindowsSID(usersSID))
 	assert.False(t, isTrustedWindowsSID(worldSID))
+
+	token, err := windows.OpenCurrentProcessToken()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = token.Close() })
+
+	tokenUser, err := token.GetTokenUser()
+	require.NoError(t, err)
+	require.NotNil(t, tokenUser.User.Sid)
+
+	userSID := tokenUser.User.Sid
+	if userSID.IsWellKnown(windows.WinLocalSystemSid) ||
+		userSID.IsWellKnown(windows.WinBuiltinAdministratorsSid) {
+		assert.True(t, isTrustedWindowsSID(userSID))
+		return
+	}
+
+	assert.Equal(t, sidIsLocalAdministrator(userSID), isTrustedWindowsSID(userSID))
 }
 
 func TestIsPathUnderWindowsRoot(t *testing.T) {
@@ -119,6 +136,48 @@ func TestEnsureWindowsProtectedDir_RejectsUntrustedOwner(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not owned by SYSTEM or Administrators")
+}
+
+func TestEnsureWindowsProtectedDir_RewritesChildFileDACL(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "agent")
+	require.NoError(t, os.Mkdir(dir, 0o700))
+
+	child := filepath.Join(dir, "agent.key")
+	require.NoError(t, os.WriteFile(child, []byte("secret\n"), 0o600))
+
+	trusted, err := isTrustedWindowsOwner(dir)
+	require.NoError(t, err)
+	if !trusted {
+		t.Skip("owner is not SYSTEM or Administrators")
+	}
+
+	require.NoError(t, ensureWindowsProtectedDir(dir, secureDirAgent))
+
+	sids, err := daclSIDSet(child)
+	require.NoError(t, err)
+
+	usersSID, err := windows.CreateWellKnownSid(windows.WinBuiltinUsersSid)
+	require.NoError(t, err)
+	assert.False(t, sids[usersSID.String()])
+	assert.True(t, daclIsProtected(t, child))
+}
+
+func TestEnsureProtectedWindowsTree_IgnoresNonProgramDataPath(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "agent")
+	require.NoError(t, os.Mkdir(dir, 0o700))
+
+	before, err := daclSIDSet(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, ensureProtectedWindowsTree(dir, secureDirAgent))
+
+	after, err := daclSIDSet(dir)
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
 }
 
 func TestEnsureWindowsProtectedDir_RejectsReparsePoint(t *testing.T) {

--- a/pkg/deviceagent/secure_dir_windows_test.go
+++ b/pkg/deviceagent/secure_dir_windows_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//go:build windows
+
+package deviceagent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestIsTrustedWindowsSID(t *testing.T) {
+	t.Parallel()
+
+	systemSID, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	require.NoError(t, err)
+	adminSID, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	require.NoError(t, err)
+	usersSID, err := windows.CreateWellKnownSid(windows.WinBuiltinUsersSid)
+	require.NoError(t, err)
+	worldSID, err := windows.CreateWellKnownSid(windows.WinWorldSid)
+	require.NoError(t, err)
+
+	assert.True(t, isTrustedWindowsSID(systemSID))
+	assert.True(t, isTrustedWindowsSID(adminSID))
+	assert.False(t, isTrustedWindowsSID(usersSID))
+	assert.False(t, isTrustedWindowsSID(worldSID))
+}
+
+func TestIsPathUnderWindowsRoot(t *testing.T) {
+	t.Parallel()
+
+	root := `D:\Data\Probo`
+
+	assert.True(t, isPathUnderWindowsRoot(`D:\Data\Probo`, root))
+	assert.True(t, isPathUnderWindowsRoot(`D:\Data\Probo\run\enrolled`, root))
+	assert.True(t, isPathUnderWindowsRoot(`d:\data\probo\agent`, root))
+	assert.False(t, isPathUnderWindowsRoot(`D:\Data`, root))
+	assert.False(t, isPathUnderWindowsRoot(`D:\Data\Probo2`, root))
+	assert.False(t, isPathUnderWindowsRoot(`C:\Temp`, root))
+}
+
+func TestEnsureWindowsProtectedDir_CreatesProtectedDACL(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "run")
+	require.NoError(t, ensureWindowsProtectedDir(dir, secureDirRun))
+
+	sids, err := daclSIDSet(dir)
+	require.NoError(t, err)
+
+	systemSID, err := windows.CreateWellKnownSid(windows.WinLocalSystemSid)
+	require.NoError(t, err)
+	adminSID, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	require.NoError(t, err)
+	usersSID, err := windows.CreateWellKnownSid(windows.WinBuiltinUsersSid)
+	require.NoError(t, err)
+
+	assert.True(t, sids[systemSID.String()])
+	assert.True(t, sids[adminSID.String()])
+	assert.True(t, sids[usersSID.String()])
+	assert.True(t, daclIsProtected(t, dir))
+}
+
+func TestEnsureWindowsProtectedDir_AgentOmitsUsers(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "agent")
+	require.NoError(t, ensureWindowsProtectedDir(dir, secureDirAgent))
+
+	sids, err := daclSIDSet(dir)
+	require.NoError(t, err)
+
+	usersSID, err := windows.CreateWellKnownSid(windows.WinBuiltinUsersSid)
+	require.NoError(t, err)
+
+	assert.False(t, sids[usersSID.String()])
+	assert.True(t, daclIsProtected(t, dir))
+}
+
+func TestEnsureWindowsProtectedDir_RejectsUntrustedOwner(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "probo")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+
+	trusted, err := isTrustedWindowsOwner(dir)
+	require.NoError(t, err)
+
+	err = ensureWindowsProtectedDir(dir, secureDirAgent)
+	if trusted {
+		require.NoError(t, err)
+		return
+	}
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not owned by SYSTEM or Administrators")
+}
+
+func TestEnsureWindowsProtectedDir_RejectsReparsePoint(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	require.NoError(t, os.Mkdir(target, 0o755))
+
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skip(err)
+	}
+
+	err := ensureWindowsProtectedDir(link, secureDirRun)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reparse point")
+}
+
+func TestIsTrustedWindowsOwner_CurrentUserFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "marker")
+	require.NoError(t, os.WriteFile(path, []byte("ok\n"), 0o600))
+
+	trusted, err := isTrustedWindowsOwner(path)
+	require.NoError(t, err)
+
+	sd, err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sd)
+
+	owner, _, err := sd.Owner()
+	require.NoError(t, err)
+	require.NotNil(t, owner)
+	assert.Equal(t, isTrustedWindowsSID(owner), trusted)
+}
+
+func daclIsProtected(t *testing.T, path string) bool {
+	t.Helper()
+
+	sd, err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sd)
+
+	control, _, err := sd.Control()
+	require.NoError(t, err)
+
+	return control&windows.SE_DACL_PROTECTED != 0
+}
+
+func daclSIDSet(path string) (map[string]bool, error) {
+	sd, err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return nil, err
+	}
+
+	found := map[string]bool{}
+	for i := uint16(0); i < dacl.AceCount; i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(dacl, uint32(i), &ace); err != nil {
+			return nil, err
+		}
+
+		sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+		found[sid.String()] = true
+	}
+
+	return found, nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens the Windows agent’s `%ProgramData%\Probo` state and enrollment flow. Instead of trusting any enrollment marker or Unix mode bits, it now uses Windows owner and DACL checks and rejects reparse-point paths; non-Windows behavior remains unchanged.

### Service **`+687`** **`-39`**

- Protects the shared root, `run`, and `agent` paths before reading or writing config, keys, posture data, or locks, and before exchanging enrollment tokens.
- Accepts local Administrators members as trusted owners, assigns Administrators ownership when creating directories, and repairs inherited child ACLs.

### Tests **`+268`** **`-0`**

- Covers trusted SID handling, path scoping, protected DACLs, child ACL repair, owner checks, and reparse-point rejection.

### Other **`+4`** **`-0`**

- Documents that standard users cannot read `agent.key` or replace `config.json`, and that existing state is re-ACL'd at startup.

<sup>Written for commit 503ce2af01c783a306784a75016465c06a5b10e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

