### PR TITLE
Add probo-agent RC releases and fleet opt-in

### DIFF
--- a/.github/workflows/release-probo-agent.yaml
+++ b/.github/workflows/release-probo-agent.yaml
@@ -365,7 +365,7 @@ jobs:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           PRERELEASE_FLAG=""
-          if echo "${GITHUB_REF_NAME}" | grep -qE '(alpha|beta|rc)'; then
+          if echo "${GITHUB_REF_NAME}" | grep -qE -- '-rc\.'; then
             PRERELEASE_FLAG="--prerelease"
           fi
 

--- a/cmd/probo-agent/installer/install.sh
+++ b/cmd/probo-agent/installer/install.sh
@@ -33,6 +33,7 @@
 #   PROBO_SERVER_URL               Probo server base URL
 #   PROBO_ENROLLMENT_TOKEN         One-shot enrollment token
 #   PROBO_NO_AUTO_UPDATE           Set to true to pass --no-auto-update
+#   PROBO_ALLOW_PRERELEASES        Set to true to pass --allow-prereleases
 #
 # Never pass the enrollment token in the curl URL.
 
@@ -55,6 +56,7 @@ SERVER_URL="${PROBO_SERVER_URL:-}"
 ENROLLMENT_TOKEN="${PROBO_ENROLLMENT_TOKEN:-}"
 STATE_DIR="${PROBO_AGENT_STATE_DIR:-}"
 NO_AUTO_UPDATE="${PROBO_NO_AUTO_UPDATE:-}"
+ALLOW_PRERELEASES="${PROBO_ALLOW_PRERELEASES:-}"
 SKIP_SERVICE=false
 
 die() {
@@ -91,6 +93,7 @@ Environment variables:
   PROBO_SERVER_URL                    Probo server base URL
   PROBO_ENROLLMENT_TOKEN              One-shot enrollment token
   PROBO_NO_AUTO_UPDATE                Set to true to disable auto-update
+  PROBO_ALLOW_PRERELEASES             Set to true to allow prerelease auto-updates
 EOF
 }
 
@@ -271,6 +274,10 @@ parse_args() {
         NO_AUTO_UPDATE=true
         shift
         ;;
+      --allow-prereleases)
+        ALLOW_PRERELEASES=true
+        shift
+        ;;
       --skip-service)
         SKIP_SERVICE=true
         shift
@@ -298,6 +305,9 @@ run_agent_install() {
   fi
   case "$NO_AUTO_UPDATE" in
     1 | true | TRUE | yes | YES) set -- "$@" --no-auto-update ;;
+  esac
+  case "$ALLOW_PRERELEASES" in
+    1 | true | TRUE | yes | YES) set -- "$@" --allow-prereleases ;;
   esac
   case "$SKIP_SERVICE" in
     1 | true | TRUE | yes | YES) set -- "$@" --skip-service ;;

--- a/cmd/probo-agent/installer/macos/Distribution.xml.tmpl
+++ b/cmd/probo-agent/installer/macos/Distribution.xml.tmpl
@@ -5,8 +5,9 @@
 
   Placeholders are substituted by build.sh:
 
-    @@VERSION@@       agent version, e.g. 0.1.0
-    @@IDENTIFIER@@    package identifier (default com.probo.agent)
+    @@VERSION@@              agent version, e.g. 0.1.0 or 0.1.0-rc.1
+    @@INSTALLER_VERSION@@    X.Y.Z stripped of -rc.N (pkg-ref)
+    @@IDENTIFIER@@           package identifier (default com.probo.agent)
 
   hostArchitectures is fixed to arm64,x86_64 (fat binary installer).
 -->
@@ -39,7 +40,7 @@
     <conclusion file="conclusion.html" mime-type="text/html"/>
 
     <pkg-ref id="@@IDENTIFIER@@"
-             version="@@VERSION@@"
+             version="@@INSTALLER_VERSION@@"
              onConclusion="none">probo-agent-component.pkg</pkg-ref>
 
     <choices-outline>

--- a/cmd/probo-agent/installer/macos/build.sh
+++ b/cmd/probo-agent/installer/macos/build.sh
@@ -5,8 +5,10 @@
 #
 # Required arguments:
 #   --binary  PATH    Path to a compiled probo-agent fat binary.
-#   --version VER     Agent version, e.g. 0.1.0. Defaults to the
-#                     content of cmd/probo-agent/VERSION.
+#   --version VER     Agent version, e.g. 0.1.0 or 0.1.0-rc.1.
+#                     Defaults to cmd/probo-agent/VERSION. The .pkg
+#                     filename keeps the full string; pkgbuild and
+#                     CFBundleVersion strip -rc.N (Apple wants X.Y.Z).
 #   --output  PATH    Output .pkg path. Defaults to
 #                     dist/probo-agent_${VER}_darwin.pkg.
 #
@@ -116,8 +118,14 @@ if [ "${has_arm64}" != true ] || [ "${has_x86_64}" != true ]; then
 fi
 
 if [ -z "${VERSION}" ]; then
-  VERSION="$(cat "${REPO_ROOT}/cmd/probo-agent/VERSION")"
+  VERSION="$(tr -d '[:space:]' <"${REPO_ROOT}/cmd/probo-agent/VERSION")"
 fi
+if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+  echo "error: version must look like X.Y.Z or X.Y.Z-rc.N (got '${VERSION}')" >&2
+  exit 2
+fi
+# pkgbuild / CFBundleVersion require period-separated integers.
+INSTALLER_VERSION="${VERSION%%-*}"
 if [ -z "${OUTPUT}" ]; then
   mkdir -p "${REPO_ROOT}/dist"
   OUTPUT="${REPO_ROOT}/dist/probo-agent_${VERSION}_darwin.pkg"
@@ -259,6 +267,7 @@ build_probo_agent_app() {
 
   sed \
     -e "s|@@VERSION@@|${VERSION}|g" \
+    -e "s|@@INSTALLER_VERSION@@|${INSTALLER_VERSION}|g" \
     -e "s|@@CLIENT_DESIGNATED_REQUIREMENT@@|$(client_requirement)|g" \
     "${ENROLL_UI_DIR}/HelperTool/Info.plist.tmpl" >"${helper_info_plist}"
 
@@ -332,6 +341,7 @@ build_probo_agent_app() {
 
   sed \
     -e "s|@@VERSION@@|${VERSION}|g" \
+    -e "s|@@INSTALLER_VERSION@@|${INSTALLER_VERSION}|g" \
     -e "s|@@HELPER_DESIGNATED_REQUIREMENT@@|${helper_requirement}|g" \
     "${ENROLL_UI_DIR}/Info.plist.tmpl" >"${plist}"
 
@@ -438,7 +448,7 @@ pkgbuild \
   --root "${PAYLOAD}" \
   --scripts "${SCRIPTS}" \
   --identifier "${IDENTIFIER}" \
-  --version "${VERSION}" \
+  --version "${INSTALLER_VERSION}" \
   --install-location "/" \
   "${COMPONENT_PKG}"
 
@@ -447,6 +457,7 @@ rewrite_component_bom "${COMPONENT_PKG}"
 DISTRIBUTION="${STAGE}/Distribution.xml"
 sed \
   -e "s|@@VERSION@@|${VERSION}|g" \
+  -e "s|@@INSTALLER_VERSION@@|${INSTALLER_VERSION}|g" \
   -e "s|@@IDENTIFIER@@|${IDENTIFIER}|g" \
   "${SCRIPT_DIR}/Distribution.xml.tmpl" >"${DISTRIBUTION}"
 

--- a/cmd/probo-agent/installer/macos/enroll-ui/HelperTool/Info.plist.tmpl
+++ b/cmd/probo-agent/installer/macos/enroll-ui/HelperTool/Info.plist.tmpl
@@ -12,7 +12,7 @@
     <key>CFBundleShortVersionString</key>
     <string>@@VERSION@@</string>
     <key>CFBundleVersion</key>
-    <string>@@VERSION@@</string>
+    <string>@@INSTALLER_VERSION@@</string>
     <key>SMAuthorizedClients</key>
     <array>
         <string>@@CLIENT_DESIGNATED_REQUIREMENT@@</string>

--- a/cmd/probo-agent/installer/macos/enroll-ui/Info.plist.tmpl
+++ b/cmd/probo-agent/installer/macos/enroll-ui/Info.plist.tmpl
@@ -6,7 +6,8 @@
 
   Placeholders are substituted by build.sh:
 
-    @@VERSION@@                        agent version, e.g. 0.1.0
+    @@VERSION@@                        agent version, e.g. 0.1.0 or 0.1.0-rc.1
+    @@INSTALLER_VERSION@@              X.Y.Z stripped of -rc.N (CFBundleVersion)
     @@HELPER_DESIGNATED_REQUIREMENT@@  codesign requirement for embedded helper
 -->
 <plist version="1.0">
@@ -28,7 +29,7 @@
     <key>CFBundleShortVersionString</key>
     <string>@@VERSION@@</string>
     <key>CFBundleVersion</key>
-    <string>@@VERSION@@</string>
+    <string>@@INSTALLER_VERSION@@</string>
     <key>LSMinimumSystemVersion</key>
     <string>11.0</string>
     <key>LSUIElement</key>

--- a/cmd/probo-agent/installer/macos/scripts/postinstall
+++ b/cmd/probo-agent/installer/macos/scripts/postinstall
@@ -151,6 +151,7 @@ restart_existing_daemon() {
 #   PROBO_SERVER_URL=https://your-probo-host.example.com
 #   PROBO_ENROLLMENT_TOKEN=<enrollment-token>
 #   PROBO_NO_AUTO_UPDATE=true
+#   PROBO_ALLOW_PRERELEASES=true
 #
 # Parse KEY=VALUE lines without sourcing or eval so a crafted conf
 # file cannot execute arbitrary shell as root.
@@ -169,6 +170,7 @@ if [ -f "${CONF_FILE}" ]; then
     CONF_SERVER=""
     CONF_ENROLLMENT_TOKEN=""
     CONF_NOUPDATE=""
+    CONF_ALLOW_PRERELEASES=""
     while IFS= read -r line || [ -n "$line" ]; do
         line="${line%%#*}"
         line="${line#"${line%%[![:space:]]*}"}"
@@ -184,6 +186,9 @@ if [ -f "${CONF_FILE}" ]; then
                 ;;
             PROBO_NO_AUTO_UPDATE=*)
                 CONF_NOUPDATE="$(strip_conf_value "${line#PROBO_NO_AUTO_UPDATE=}")"
+                ;;
+            PROBO_ALLOW_PRERELEASES=*)
+                CONF_ALLOW_PRERELEASES="$(strip_conf_value "${line#PROBO_ALLOW_PRERELEASES=}")"
                 ;;
         esac
     done < "${CONF_FILE}"
@@ -201,6 +206,9 @@ if [ -f "${CONF_FILE}" ]; then
         )
         case "${CONF_NOUPDATE}" in
             1|true|TRUE|yes|YES) INSTALL_ARGS+=(--no-auto-update) ;;
+        esac
+        case "${CONF_ALLOW_PRERELEASES}" in
+            1|true|TRUE|yes|YES) INSTALL_ARGS+=(--allow-prereleases) ;;
         esac
 
         if "${BINARY}" "${INSTALL_ARGS[@]}"; then

--- a/cmd/probo-agent/installer/windows/build.ps1
+++ b/cmd/probo-agent/installer/windows/build.ps1
@@ -35,7 +35,9 @@
   Path to probo-agent.exe.
 
 .PARAMETER Version
-  Product version (X.Y.Z). Defaults to cmd/probo-agent/VERSION.
+  Agent version (X.Y.Z or X.Y.Z-rc.N). Defaults to
+  cmd/probo-agent/VERSION. The MSI filename keeps the full string;
+  WiX ProductVersion strips -rc.N because MSI requires X.Y.Z.
 
 .PARAMETER Arch
   Target architecture: amd64, x86_64, x64, or arm64.
@@ -79,9 +81,11 @@ if ([string]::IsNullOrWhiteSpace($Version)) {
     $Version = (Get-Content -LiteralPath $VersionFile -Raw).Trim()
 }
 
-if ($Version -notmatch '^\d+\.\d+\.\d+') {
-    throw "error: version must look like X.Y.Z (got '$Version')"
+if ($Version -notmatch '^\d+\.\d+\.\d+(-rc\.\d+)?$') {
+    throw "error: version must look like X.Y.Z or X.Y.Z-rc.N (got '$Version')"
 }
+
+$ProductVersion = ($Version -replace '-rc\.\d+$', '')
 
 switch ($Arch) {
     { $_ -in @("amd64", "x86_64", "x64") } {
@@ -150,7 +154,7 @@ if (-not (Test-Path -LiteralPath $IconPng)) {
 $ProductIcon = Join-Path ([System.IO.Path]::GetTempPath()) "probo-agent-icon-$PID.ico"
 $ProductIconArg = $ProductIcon.Replace('\', '/')
 
-Write-Host "Building MSI: binary=$Binary arch=$WixArch version=$Version output=$Output"
+Write-Host "Building MSI: binary=$Binary arch=$WixArch version=$Version product=$ProductVersion output=$Output"
 
 try {
     Push-Location $RepoRoot
@@ -168,7 +172,7 @@ try {
     & wix build `
         -arch $WixArch `
         -ext WixToolset.UI.wixext `
-        -d "Version=$Version" `
+        -d "Version=$ProductVersion" `
         -d "AgentExe=$Binary" `
         -d "LicenseRtf=$LicenseRtfArg" `
         -d "ProductIcon=$ProductIconArg" `

--- a/cmd/probo-agent/main.go
+++ b/cmd/probo-agent/main.go
@@ -252,7 +252,7 @@ func reportIfAlreadyEnrolled(dir string) (bool, error) {
 //
 // dir is the agent state directory, used to host the Sigstore TUF
 // metadata cache for cosign bundle verification.
-func newUpdater(logger *log.Logger, dir string) *update.Updater {
+func newUpdater(logger *log.Logger, dir string, allowPrereleases bool) *update.Updater {
 	exePath, err := os.Executable()
 	if err != nil || exePath == "" {
 		return nil
@@ -263,6 +263,7 @@ func newUpdater(logger *log.Logger, dir string) *update.Updater {
 		exePath,
 		fmt.Sprintf("probo-agent/%s", version),
 		filepath.Join(dir, "sigstore-cache"),
+		allowPrereleases,
 		logger,
 	)
 }
@@ -285,10 +286,11 @@ func newAgentLogger() *log.Logger {
 
 func newInstallCmd() *cobra.Command {
 	var (
-		serverURL       string
-		enrollmentToken string
-		skipService     bool
-		noAutoUpdate    bool
+		serverURL        string
+		enrollmentToken  string
+		skipService      bool
+		noAutoUpdate     bool
+		allowPrereleases bool
 	)
 
 	cmd := &cobra.Command{
@@ -351,12 +353,18 @@ func newInstallCmd() *cobra.Command {
 			fmt.Printf("Configured device %s (heartbeat %ds, posture %ds)\n",
 				resp.DeviceID, resp.HeartbeatSeconds, resp.PostureSeconds)
 
-			if noAutoUpdate {
-				if err := persistAutoUpdate(dir, false); err != nil {
-					return fmt.Errorf("cannot persist auto-update preference: %w", err)
+			if noAutoUpdate || allowPrereleases {
+				if err := persistInstallFlags(dir, noAutoUpdate, allowPrereleases); err != nil {
+					return fmt.Errorf("cannot persist install flags: %w", err)
 				}
 
-				fmt.Println("Auto-update disabled.")
+				if noAutoUpdate {
+					fmt.Println("Auto-update disabled.")
+				}
+
+				if allowPrereleases {
+					fmt.Println("Prerelease auto-updates enabled.")
+				}
 			}
 
 			if skipService {
@@ -395,6 +403,7 @@ func newInstallCmd() *cobra.Command {
 	cmd.Flags().StringVar(&enrollmentToken, "enrollment-token", "", "one-shot enrollment token issued when the device was created")
 	cmd.Flags().BoolVar(&skipService, "skip-service", false, "register the device but do not install the OS service")
 	cmd.Flags().BoolVar(&noAutoUpdate, "no-auto-update", false, "disable automatic upgrades of the agent binary")
+	cmd.Flags().BoolVar(&allowPrereleases, "allow-prereleases", false, "allow automatic upgrades onto GitHub prereleases")
 
 	return cmd
 }
@@ -411,15 +420,21 @@ func clearEnrollmentMarkerOnSetupFailure(dir string, setupErr error) error {
 	return setupErr
 }
 
-// persistAutoUpdate flips the UpdatesDisabled flag in the agent's
-// on-disk config without disturbing other fields.
-func persistAutoUpdate(dir string, enabled bool) error {
+// persistInstallFlags writes install-time update preferences into the
+// agent's on-disk config without disturbing other fields.
+func persistInstallFlags(dir string, updatesDisabled, allowPrereleases bool) error {
 	cfg, err := deviceagent.LoadConfig(dir)
 	if err != nil {
 		return err
 	}
 
-	cfg.UpdatesDisabled = !enabled
+	if updatesDisabled {
+		cfg.UpdatesDisabled = true
+	}
+
+	if allowPrereleases {
+		cfg.AllowPrereleases = true
+	}
 
 	return deviceagent.SaveConfig(dir, cfg)
 }
@@ -469,9 +484,14 @@ func newRunCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dir := resolveDir(cmd)
 
+			cfg, err := deviceagent.LoadConfig(dir)
+			if err != nil {
+				return fmt.Errorf("cannot load config: %w", err)
+			}
+
 			logger := newAgentLogger()
 			agent := deviceagent.New(dir, version, logger)
-			agent.Updater = newUpdater(logger, dir)
+			agent.Updater = newUpdater(logger, dir, cfg.AllowPrereleases)
 
 			run := func(ctx context.Context) error {
 				err := agent.Run(ctx)
@@ -522,6 +542,7 @@ func newStatusCmd() *cobra.Command {
 			fmt.Printf("Posture interval:     %s\n", cfg.PostureInterval)
 			fmt.Printf("Update interval:      %s\n", cfg.UpdateInterval)
 			fmt.Printf("Auto-update enabled:  %v\n", !cfg.UpdatesDisabled)
+			fmt.Printf("Allow prereleases:    %v\n", cfg.AllowPrereleases)
 			fmt.Printf("API key on disk:      %v\n", haveKey)
 			fmt.Printf("Config directory:     %s\n", dir)
 
@@ -585,7 +606,12 @@ func newUpdateCmd() *cobra.Command {
 			dir := resolveDir(cmd)
 			logger := newAgentLogger()
 
-			updater := newUpdater(logger, dir)
+			cfg, err := deviceagent.LoadConfig(dir)
+			if err != nil {
+				return fmt.Errorf("cannot load config: %w", err)
+			}
+
+			updater := newUpdater(logger, dir, cfg.AllowPrereleases)
 			if updater == nil {
 				return errors.New("cannot resolve current executable path")
 			}

--- a/contrib/claude/release/README.md
+++ b/contrib/claude/release/README.md
@@ -11,7 +11,7 @@ bump the version, write a changelog entry, commit, tag, push.
 | Server (`probod` group) | `probod/v*`                    | [probod.md](./probod.md)         |
 | `probod-bootstrap`      | `probod-bootstrap/v*`          | [probod-bootstrap.md](./probod-bootstrap.md) |
 | `proboctl`              | `proboctl/v*`                  | [proboctl.md](./proboctl.md)     |
-| `probo-agent`           | `probo-agent/v*`               | [probo-agent.md](./probo-agent.md) ([Windows signing setup](./probo-agent-windows-signing.md)) |
+| `probo-agent`           | `probo-agent/v*` (or `…-rc.N`) | [probo-agent.md](./probo-agent.md) ([Windows signing setup](./probo-agent-windows-signing.md); [RC](./probo-agent.md#rc-release)) |
 | `@probo/n8n-nodes-probo` | `@probo/n8n-nodes-probo/v*`   | [n8n-nodes-probo.md](./n8n-nodes-probo.md) |
 | `@probo/cookie-banner`  | `@probo/cookie-banner/v*`      | [cookie-banner.md](./cookie-banner.md) |
 | `@probo/skills`         | `@probo/skills/v*`             | [skills.md](./skills.md)           |
@@ -30,6 +30,10 @@ last tag.
 When the user asks for a release **for a specific track** (e.g. "release
 the CLI", "release probod"), open the corresponding entrypoint above and
 follow it.
+
+`probo-agent` is the only track that may ship an RC. When that track is
+in the release set, follow the ask in [probo-agent.md](./probo-agent.md)
+before bumping its version.
 
 Versions are SemVer in the **0.x** series. Never bump MAJOR.
 Bug fixes only -> bump PATCH; new features or non-breaking changes -> bump

--- a/contrib/claude/release/probo-agent-windows-signing.md
+++ b/contrib/claude/release/probo-agent-windows-signing.md
@@ -254,9 +254,10 @@ Endpoint **must** match the account’s region.
 
 1. Confirm identity validation status is **Completed** and the Public
    Trust profile exists.
-2. Push a prerelease tag, e.g. `probo-agent/v0.0.0-rc.signing-test`
+2. Push a prerelease tag, e.g. `probo-agent/v0.0.0-rc.1`
    (after the usual version/changelog process, or a disposable test tag
-   on a branch that contains the workflow).
+   on a branch that contains the workflow). The tag must be
+   `probo-agent/vX.Y.Z-rc.N`.
 3. Watch **Release probo-agent** → **windows (amd64)** / **windows (arm64)**:
    - Azure login succeeds (OIDC)
    - Sign `probo-agent.exe` succeeds

--- a/contrib/claude/release/probo-agent.md
+++ b/contrib/claude/release/probo-agent.md
@@ -3,10 +3,21 @@
 After confirming commits below, follow the
 [common steps](./README.md#3-common-steps-every-track).
 
+## Stable or RC
+
+This track can ship a GitHub prerelease for fleet testing. **Ask the
+user before bumping the version: stable release, or RC (`-rc.N`)?**
+Do not assume stable. Other tracks have no RC path — do not ask this
+for them.
+
+If they choose RC, follow [RC release](#rc-release) instead of a
+plain `X.Y.Z` bump.
+
 ## Track facts
 
 - **Tag pattern**: `probo-agent/v*`
-- **Version source**: `cmd/probo-agent/VERSION` (single `X.Y.Z` line)
+- **Version source**: `cmd/probo-agent/VERSION` (single `X.Y.Z` or
+  `X.Y.Z-rc.N` line)
 - **Version bump**: Edit `cmd/probo-agent/VERSION` directly
 - **Changelog**: `cmd/probo-agent/CHANGELOG.md`
 - **Files to stage**: `cmd/probo-agent/VERSION`, `cmd/probo-agent/CHANGELOG.md`
@@ -21,6 +32,35 @@ git log $(git describe --tags --abbrev=0 --match='probo-agent/v*')..HEAD --oneli
 ```
 
 If empty or non-user-facing only, do not release this track.
+
+## RC release
+
+Only this track supports RCs. Form is **`probo-agent/vX.Y.Z-rc.N`**
+only (`N` is a positive integer: `-rc.1`, then `-rc.2`). No `alpha`,
+`beta`, or undotted `rc1`.
+
+1. Decide `X.Y.Z` the same way as a stable bump (PATCH vs MINOR).
+2. If no RC exists for that `X.Y.Z`, use `-rc.1`. If `vX.Y.Z-rc.N`
+   already exists, use `-rc.(N+1)`.
+3. Set `cmd/probo-agent/VERSION` to `X.Y.Z-rc.N`.
+4. Changelog heading: `## [X.Y.Z-rc.N] - YYYY-MM-DD`.
+5. Commit subject and annotated tag: `probo-agent/vX.Y.Z-rc.N`.
+6. Push the commit, then the tag **alone**. The workflow marks the
+   GitHub Release as a prerelease when the tag contains `-rc.`.
+
+Promoting to stable later: drop `-rc.N`, reuse the same `X.Y.Z`, and
+add a new changelog heading `## [X.Y.Z]`.
+
+Installer `ProductVersion` / `pkgbuild --version` / `CFBundleVersion`
+strip `-rc.N` to `X.Y.Z`. Filenames, `ldflags`, and
+`CFBundleShortVersionString` keep the full string. MSI/PKG upgrade
+from an RC to the matching stable may be treated as the same product
+version — use auto-update (zip/tar) or uninstall first.
+
+Production auto-update ignores GitHub prereleases. Test-fleet hosts
+set `allow_prereleases: true` in `config.json` (or install with
+`--allow-prereleases` / `PROBO_ALLOW_PRERELEASES=true`) and restart
+the service.
 
 ## Build
 
@@ -273,6 +313,7 @@ Environment variables:
 | `PROBO_SERVER_URL` | Probo server base URL (skip interactive prompt) |
 | `PROBO_ENROLLMENT_TOKEN` | One-shot enrollment token (skip interactive prompt) |
 | `PROBO_NO_AUTO_UPDATE` | Set to `true` to pass `--no-auto-update` |
+| `PROBO_ALLOW_PRERELEASES` | Set to `true` to pass `--allow-prereleases` |
 
 Never pass the enrollment token in the curl URL.
 

--- a/pkg/deviceagent/agent.go
+++ b/pkg/deviceagent/agent.go
@@ -197,6 +197,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		log.Duration("posture_interval", a.cfg.PostureInterval),
 		log.Duration("host_info_refresh_interval", hostInfoRefreshInterval),
 		log.Bool("auto_update_enabled", a.autoUpdateEnabled()),
+		log.Bool("allow_prereleases", a.cfg.AllowPrereleases),
 		log.Duration("update_interval", a.cfg.UpdateInterval),
 	)
 

--- a/pkg/deviceagent/config.go
+++ b/pkg/deviceagent/config.go
@@ -62,6 +62,7 @@ type (
 		PostureInterval   time.Duration `json:"posture_interval,omitempty"`
 		UpdateInterval    time.Duration `json:"update_interval,omitempty"`
 		UpdatesDisabled   bool          `json:"updates_disabled,omitempty"`
+		AllowPrereleases  bool          `json:"allow_prereleases,omitempty"`
 	}
 )
 

--- a/pkg/deviceagent/update/update.go
+++ b/pkg/deviceagent/update/update.go
@@ -96,6 +96,10 @@ type (
 		// probo-agent release workflow.
 		Verifier Verifier
 
+		// AllowPrereleases includes GitHub prerelease tags when
+		// choosing an update. Production hosts leave this false.
+		AllowPrereleases bool
+
 		// GOOS/GOARCH override the values used to compute the
 		// archive name. They default to runtime.GOOS/GOARCH and
 		// exist for tests.
@@ -150,7 +154,14 @@ func (j *jsonTimestamp) UnmarshalJSON(b []byte) error {
 // sigstoreCacheDir is the on-disk directory used to cache Sigstore
 // TUF metadata for cosign bundle verification. It MUST be writable by
 // the agent. A typical value is `<agent state dir>/sigstore-cache`.
-func New(currentVersion, exePath, userAgent, sigstoreCacheDir string, logger *log.Logger) *Updater {
+func New(
+	currentVersion string,
+	exePath string,
+	userAgent string,
+	sigstoreCacheDir string,
+	allowPrereleases bool,
+	logger *log.Logger,
+) *Updater {
 	if logger == nil {
 		logger = log.NewLogger(log.WithName("agent-update"))
 	}
@@ -166,6 +177,7 @@ func New(currentVersion, exePath, userAgent, sigstoreCacheDir string, logger *lo
 		Logger:           logger,
 		HTTP:             defaultHTTPClient(logger),
 		SigstoreCacheDir: sigstoreCacheDir,
+		AllowPrereleases: allowPrereleases,
 		GOOS:             runtime.GOOS,
 		GOARCH:           runtime.GOARCH,
 	}
@@ -201,7 +213,11 @@ func (u *Updater) CheckLatest(ctx context.Context) (*Release, error) {
 
 	for i := range releases {
 		rel := &releases[i]
-		if rel.Draft || rel.Prerelease {
+		if rel.Draft {
+			continue
+		}
+
+		if rel.Prerelease && !u.AllowPrereleases {
 			continue
 		}
 

--- a/pkg/deviceagent/update/update_test.go
+++ b/pkg/deviceagent/update/update_test.go
@@ -53,6 +53,7 @@ func TestParseTag(t *testing.T) {
 		ok     bool
 	}{
 		{"probo-agent/v0.1.0", "probo-agent/v", "0.1.0", true},
+		{"probo-agent/v0.2.0-rc.1", "probo-agent/v", "0.2.0-rc.1", true},
 		{"probo-agent/v1.2.3", "probo-agent/v", "1.2.3", true},
 		{"v1.2.3", "probo-agent/v", "", false},
 		{"probo-agent/vlatest", "probo-agent/v", "", false},
@@ -140,6 +141,10 @@ type fakeReleaseServer struct {
 	prerelease bool
 	draft      bool
 
+	// listed, when non-empty, replaces the single default release
+	// in the GitHub API response.
+	listed []listedRelease
+
 	// archive plumbing
 	binaryContent []byte
 	archiveBytes  []byte
@@ -187,13 +192,21 @@ func newFakeReleaseServer(t *testing.T, tag, version string, layout AssetLayout,
 			})
 		}
 
-		body := []map[string]any{
-			{
-				"tag_name":   frs.tag,
-				"draft":      frs.draft,
-				"prerelease": frs.prerelease,
+		listed := frs.listed
+		if len(listed) == 0 {
+			listed = []listedRelease{
+				{tag: frs.tag, prerelease: frs.prerelease, draft: frs.draft},
+			}
+		}
+
+		body := make([]map[string]any, 0, len(listed))
+		for _, rel := range listed {
+			body = append(body, map[string]any{
+				"tag_name":   rel.tag,
+				"draft":      rel.draft,
+				"prerelease": rel.prerelease,
 				"assets":     assets,
-			},
+			})
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -217,6 +230,12 @@ func newFakeReleaseServer(t *testing.T, tag, version string, layout AssetLayout,
 	t.Cleanup(frs.server.Close)
 
 	return frs
+}
+
+type listedRelease struct {
+	tag        string
+	prerelease bool
+	draft      bool
 }
 
 func (f *fakeReleaseServer) URL() string { return f.server.URL }
@@ -357,6 +376,64 @@ func TestUpdater_CheckLatest(t *testing.T) {
 			u := newTestUpdater(fake, "0.1.0", filepath.Join(t.TempDir(), "probo-agent"), "linux", "amd64")
 			_, err = u.CheckLatest(context.Background())
 			assert.ErrorIs(t, err, ErrNoUpdateAvailable)
+		},
+	)
+
+	t.Run(
+		"selects prerelease when AllowPrereleases is set",
+		func(t *testing.T) {
+			t.Parallel()
+
+			layout, err := LayoutFor("linux", "amd64")
+			require.NoError(t, err)
+			fake := newFakeReleaseServer(t, "probo-agent/v0.2.0-rc.1", "0.2.0-rc.1", layout, []byte("rc"))
+			fake.prerelease = true
+
+			u := newTestUpdater(fake, "0.1.0", filepath.Join(t.TempDir(), "probo-agent"), "linux", "amd64")
+			u.AllowPrereleases = true
+			rel, err := u.CheckLatest(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, "0.2.0-rc.1", rel.Version)
+		},
+	)
+
+	t.Run(
+		"skips drafts even when AllowPrereleases is set",
+		func(t *testing.T) {
+			t.Parallel()
+
+			layout, err := LayoutFor("linux", "amd64")
+			require.NoError(t, err)
+			fake := newFakeReleaseServer(t, "probo-agent/v0.2.0-rc.1", "0.2.0-rc.1", layout, []byte("rc"))
+			fake.prerelease = true
+			fake.draft = true
+
+			u := newTestUpdater(fake, "0.1.0", filepath.Join(t.TempDir(), "probo-agent"), "linux", "amd64")
+			u.AllowPrereleases = true
+			_, err = u.CheckLatest(context.Background())
+			assert.ErrorIs(t, err, ErrNoUpdateAvailable)
+		},
+	)
+
+	t.Run(
+		"picks highest semver among mixed stable and prerelease",
+		func(t *testing.T) {
+			t.Parallel()
+
+			layout, err := LayoutFor("linux", "amd64")
+			require.NoError(t, err)
+			fake := newFakeReleaseServer(t, "probo-agent/v0.2.0", "0.2.0", layout, []byte("rel"))
+			fake.listed = []listedRelease{
+				{tag: "probo-agent/v0.2.0-rc.1", prerelease: true},
+				{tag: "probo-agent/v0.1.0"},
+				{tag: "probo-agent/v0.2.0"},
+			}
+
+			u := newTestUpdater(fake, "0.1.0", filepath.Join(t.TempDir(), "probo-agent"), "linux", "amd64")
+			u.AllowPrereleases = true
+			rel, err := u.CheckLatest(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, "0.2.0", rel.Version)
 		},
 	)
 


### PR DESCRIPTION
Stable agents skip GitHub prereleases, so a test fleet could not exercise a real signed build before it went to every enrolled host.

Tags of the form probo-agent/vX.Y.Z-rc.N now produce a prerelease with installer versions stripped to X.Y.Z. Hosts that set allow_prereleases (install flag, MDM, or config.json) follow those RCs; everyone else stays on the last stable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stable agents previously ignored GitHub prereleases, so a test fleet could not exercise a real signed build before it reached every enrolled host. Tags of the form `probo-agent/vX.Y.Z-rc.N` now produce a GitHub prerelease that only hosts opting in via `--allow-prereleases` (install flag, MDM conf, or `config.json`) will follow; everyone else stays on the last stable.

### Other **`+92`** **`-31`**

- Release workflow marks a GitHub Release as prerelease only when the tag contains `-rc.`.
- macOS and Windows installers strip `-rc.N` to X.Y.Z for `pkgbuild`, `CFBundleVersion`, and MSI `ProductVersion`; filenames and display strings keep the full version.
- `install.sh` and the macOS `postinstall` accept `PROBO_ALLOW_PRERELEASES` / `--allow-prereleases`.
- `main.go` persists the flag into `config.json`, wires it into the updater, and prints it in `status`.

### Service **`+20`** **`-2`**

- `Updater.New` now takes `AllowPrereleases` and `CheckLatest` includes prereleases only when set.
- `deviceagent` config gains `allow_prereleases`.

### Agents **`+50`** **`-4`**

- Release docs describe the RC tag form, version stripping, and opt-in.

### Tests **`+83`** **`-6`**

- Covers RC tag parsing, prerelease selection, draft skipping, and highest-semver choice among mixed stable and prerelease releases.

<sup>Written for commit 27e4357a4aa1193a1d8f7e85c6e62a0034d36ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

