### PR TITLE
Use OpenAI Responses API

### DIFF
--- a/pkg/llm/openai/provider.go
+++ b/pkg/llm/openai/provider.go
@@ -22,11 +22,11 @@ package openai
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -35,6 +35,7 @@ import (
 	"github.com/openai/openai-go/option"
 	"github.com/openai/openai-go/packages/param"
 	"github.com/openai/openai-go/packages/ssestream"
+	"github.com/openai/openai-go/responses"
 	"github.com/openai/openai-go/shared"
 	"go.probo.inc/probo/pkg/llm"
 )
@@ -122,33 +123,39 @@ func NewProvider(apiKey string, opts ...Option) *Provider {
 func (p *Provider) ChatCompletion(ctx context.Context, req *llm.ChatCompletionRequest) (*llm.ChatCompletionResponse, error) {
 	params := buildParams(req)
 
-	completion, err := p.client.Chat.Completions.New(ctx, params)
+	response, err := p.client.Responses.New(ctx, params)
 	if err != nil {
 		return nil, mapError(err)
 	}
 
-	return mapResponse(completion), nil
+	if response.Status == responses.ResponseStatusFailed {
+		return nil, fmt.Errorf("cannot complete OpenAI response: %s", response.Error.Message)
+	}
+
+	return mapResponse(response), nil
 }
 
 func (p *Provider) ChatCompletionStream(ctx context.Context, req *llm.ChatCompletionRequest) (llm.ChatCompletionStream, error) {
 	params := buildParams(req)
-	params.StreamOptions = openai.ChatCompletionStreamOptionsParam{
-		IncludeUsage: param.NewOpt(true),
-	}
+	stream := p.client.Responses.NewStreaming(ctx, params)
 
-	stream := p.client.Chat.Completions.NewStreaming(ctx, params)
-
-	return &openaiStream{stream: stream}, nil
+	return &openaiStream{
+		stream:      stream,
+		toolIndexes: make(map[int64]int),
+	}, nil
 }
 
-func buildParams(req *llm.ChatCompletionRequest) openai.ChatCompletionNewParams {
-	params := openai.ChatCompletionNewParams{
-		Model:    openai.ChatModel(req.Model),
-		Messages: buildMessages(req.Messages),
+func buildParams(req *llm.ChatCompletionRequest) responses.ResponseNewParams {
+	params := responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: buildInput(req.Messages),
+		},
+		Model: shared.ResponsesModel(req.Model),
+		Store: param.NewOpt(false),
 	}
 
 	if req.MaxTokens != nil {
-		params.MaxCompletionTokens = param.NewOpt(int64(*req.MaxTokens))
+		params.MaxOutputTokens = param.NewOpt(int64(*req.MaxTokens))
 	}
 
 	if req.Temperature != nil {
@@ -157,20 +164,6 @@ func buildParams(req *llm.ChatCompletionRequest) openai.ChatCompletionNewParams 
 
 	if req.TopP != nil {
 		params.TopP = param.NewOpt(*req.TopP)
-	}
-
-	if req.FrequencyPenalty != nil {
-		params.FrequencyPenalty = param.NewOpt(*req.FrequencyPenalty)
-	}
-
-	if req.PresencePenalty != nil {
-		params.PresencePenalty = param.NewOpt(*req.PresencePenalty)
-	}
-
-	if len(req.StopSequences) > 0 {
-		params.Stop = openai.ChatCompletionNewParamsStopUnion{
-			OfStringArray: req.StopSequences,
-		}
 	}
 
 	if len(req.Tools) > 0 {
@@ -186,205 +179,255 @@ func buildParams(req *llm.ChatCompletionRequest) openai.ChatCompletionNewParams 
 	}
 
 	if req.ResponseFormat != nil {
-		params.ResponseFormat = buildResponseFormat(req.ResponseFormat)
+		params.Text.Format = buildResponseFormat(req.ResponseFormat)
 	}
 
 	if req.Thinking != nil && req.Thinking.Enabled && isReasoningModel(req.Model) {
 		switch {
 		case req.Thinking.BudgetTokens <= 1024:
-			params.ReasoningEffort = shared.ReasoningEffortLow
+			params.Reasoning.Effort = shared.ReasoningEffortLow
 		case req.Thinking.BudgetTokens <= 8192:
-			params.ReasoningEffort = shared.ReasoningEffortMedium
+			params.Reasoning.Effort = shared.ReasoningEffortMedium
 		default:
-			params.ReasoningEffort = shared.ReasoningEffortHigh
+			params.Reasoning.Effort = shared.ReasoningEffortHigh
 		}
 	}
 
 	return params
 }
 
-func buildMessages(messages []llm.Message) []openai.ChatCompletionMessageParamUnion {
-	out := make([]openai.ChatCompletionMessageParamUnion, 0, len(messages))
+func buildInput(messages []llm.Message) responses.ResponseInputParam {
+	input := make(responses.ResponseInputParam, 0, len(messages))
 
 	for _, msg := range messages {
 		switch msg.Role {
 		case llm.RoleSystem:
-			out = append(out, openai.SystemMessage(msg.Text()))
+			input = append(
+				input,
+				responses.ResponseInputItemParamOfMessage(
+					msg.Text(),
+					responses.EasyInputMessageRoleSystem,
+				),
+			)
 		case llm.RoleUser:
-			parts := make([]openai.ChatCompletionContentPartUnionParam, 0, len(msg.Parts))
-			for _, p := range msg.Parts {
-				switch p := p.(type) {
-				case llm.TextPart:
-					parts = append(parts, openai.TextContentPart(p.Text))
-				case llm.ImagePart:
-					parts = append(
-						parts,
-						openai.ImageContentPart(
-							openai.ChatCompletionContentPartImageImageURLParam{
-								URL: p.URL,
-							},
-						),
-					)
-				case llm.FilePart:
-					parts = append(parts, buildFilePart(p))
-				}
-			}
-
-			out = append(out, openai.UserMessage(parts))
+			input = append(
+				input,
+				responses.ResponseInputItemParamOfMessage(
+					buildUserContent(msg.Parts),
+					responses.EasyInputMessageRoleUser,
+				),
+			)
 		case llm.RoleAssistant:
-			m := openai.ChatCompletionAssistantMessageParam{
-				Content: openai.ChatCompletionAssistantMessageParamContentUnion{
-					OfString: param.NewOpt(msg.Text()),
-				},
-			}
-			if len(msg.ToolCalls) > 0 {
-				m.ToolCalls = make([]openai.ChatCompletionMessageToolCallParam, len(msg.ToolCalls))
-				for i, tc := range msg.ToolCalls {
-					m.ToolCalls[i] = openai.ChatCompletionMessageToolCallParam{
-						ID: tc.ID,
-						Function: openai.ChatCompletionMessageToolCallFunctionParam{
-							Name:      tc.Function.Name,
-							Arguments: tc.Function.Arguments,
-						},
-					}
-				}
+			if text := msg.Text(); text != "" {
+				input = append(
+					input,
+					responses.ResponseInputItemParamOfMessage(
+						text,
+						responses.EasyInputMessageRoleAssistant,
+					),
+				)
 			}
 
-			out = append(out, openai.ChatCompletionMessageParamUnion{OfAssistant: &m})
+			for _, tc := range msg.ToolCalls {
+				input = append(
+					input,
+					responses.ResponseInputItemParamOfFunctionCall(
+						tc.Function.Arguments,
+						tc.ID,
+						tc.Function.Name,
+					),
+				)
+			}
 		case llm.RoleTool:
-			out = append(out, openai.ToolMessage(msg.Text(), msg.ToolCallID))
+			input = append(
+				input,
+				responses.ResponseInputItemParamOfFunctionCallOutput(
+					msg.ToolCallID,
+					msg.Text(),
+				),
+			)
 		}
 	}
 
-	return out
+	return input
 }
 
-func buildTools(tools []llm.Tool) []openai.ChatCompletionToolParam {
-	out := make([]openai.ChatCompletionToolParam, len(tools))
-	for i, t := range tools {
-		fn := shared.FunctionDefinitionParam{
-			Name:        t.Name,
-			Description: param.NewOpt(t.Description),
-			Strict:      param.NewOpt(true),
-		}
-		if t.Parameters != nil {
-			var params shared.FunctionParameters
-			if err := json.Unmarshal(t.Parameters, &params); err == nil {
-				fn.Parameters = params
+func buildUserContent(parts []llm.Part) responses.ResponseInputMessageContentListParam {
+	content := make(responses.ResponseInputMessageContentListParam, 0, len(parts))
+
+	for _, part := range parts {
+		switch part := part.(type) {
+		case llm.TextPart:
+			content = append(content, responses.ResponseInputContentParamOfInputText(part.Text))
+		case llm.ImagePart:
+			image := responses.ResponseInputImageParam{
+				Detail:   responses.ResponseInputImageDetailAuto,
+				ImageURL: param.NewOpt(part.URL),
 			}
+			content = append(content, responses.ResponseInputContentUnionParam{OfInputImage: &image})
+		case llm.FilePart:
+			content = append(content, buildFilePart(part))
+		}
+	}
+
+	return content
+}
+
+func buildTools(tools []llm.Tool) []responses.ToolUnionParam {
+	out := make([]responses.ToolUnionParam, len(tools))
+	for i, t := range tools {
+		var parameters map[string]any
+		if t.Parameters != nil {
+			_ = json.Unmarshal(t.Parameters, &parameters)
 		}
 
-		out[i] = openai.ChatCompletionToolParam{Function: fn}
+		tool := responses.ToolParamOfFunction(t.Name, parameters, true)
+		if t.Description != "" {
+			tool.OfFunction.Description = param.NewOpt(t.Description)
+		}
+		out[i] = tool
 	}
 
 	return out
 }
 
-func buildToolChoice(tc *llm.ToolChoice) openai.ChatCompletionToolChoiceOptionUnionParam {
+func buildToolChoice(tc *llm.ToolChoice) responses.ResponseNewParamsToolChoiceUnion {
 	switch tc.Type {
 	case llm.ToolChoiceAuto:
-		return openai.ChatCompletionToolChoiceOptionUnionParam{
-			OfAuto: param.NewOpt(string(openai.ChatCompletionToolChoiceOptionAutoAuto)),
+		return responses.ResponseNewParamsToolChoiceUnion{
+			OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsAuto),
 		}
 	case llm.ToolChoiceNone:
-		return openai.ChatCompletionToolChoiceOptionUnionParam{
-			OfAuto: param.NewOpt(string(openai.ChatCompletionToolChoiceOptionAutoNone)),
+		return responses.ResponseNewParamsToolChoiceUnion{
+			OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsNone),
 		}
 	case llm.ToolChoiceRequired:
-		return openai.ChatCompletionToolChoiceOptionUnionParam{
-			OfAuto: param.NewOpt(string(openai.ChatCompletionToolChoiceOptionAutoRequired)),
+		return responses.ResponseNewParamsToolChoiceUnion{
+			OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsRequired),
 		}
 	case llm.ToolChoiceFunction:
-		return openai.ChatCompletionToolChoiceOptionParamOfChatCompletionNamedToolChoice(
-			openai.ChatCompletionNamedToolChoiceFunctionParam{Name: tc.Function},
-		)
+		return responses.ResponseNewParamsToolChoiceUnion{
+			OfFunctionTool: &responses.ToolChoiceFunctionParam{Name: tc.Function},
+		}
 	default:
-		return openai.ChatCompletionToolChoiceOptionUnionParam{}
+		return responses.ResponseNewParamsToolChoiceUnion{}
 	}
 }
 
-func buildResponseFormat(rf *llm.ResponseFormat) openai.ChatCompletionNewParamsResponseFormatUnion {
+func buildResponseFormat(rf *llm.ResponseFormat) responses.ResponseFormatTextConfigUnionParam {
 	switch rf.Type {
 	case llm.ResponseFormatText:
-		return openai.ChatCompletionNewParamsResponseFormatUnion{
+		return responses.ResponseFormatTextConfigUnionParam{
 			OfText: &shared.ResponseFormatTextParam{},
 		}
 	case llm.ResponseFormatJSONObject:
-		return openai.ChatCompletionNewParamsResponseFormatUnion{
+		return responses.ResponseFormatTextConfigUnionParam{
 			OfJSONObject: &shared.ResponseFormatJSONObjectParam{},
 		}
 	case llm.ResponseFormatJSONSchema:
 		if rf.JSONSchema != nil {
-			schema := shared.ResponseFormatJSONSchemaJSONSchemaParam{
+			var schema map[string]any
+			_ = json.Unmarshal(rf.JSONSchema.Schema, &schema)
+
+			format := responses.ResponseFormatTextJSONSchemaConfigParam{
 				Name:   rf.JSONSchema.Name,
 				Strict: param.NewOpt(rf.JSONSchema.Strict),
+				Schema: schema,
 			}
 			if rf.JSONSchema.Description != "" {
-				schema.Description = param.NewOpt(rf.JSONSchema.Description)
+				format.Description = param.NewOpt(rf.JSONSchema.Description)
 			}
 
-			if rf.JSONSchema.Schema != nil {
-				schema.Schema = rf.JSONSchema.Schema
-			}
-
-			return openai.ChatCompletionNewParamsResponseFormatUnion{
-				OfJSONSchema: &shared.ResponseFormatJSONSchemaParam{JSONSchema: schema},
+			return responses.ResponseFormatTextConfigUnionParam{
+				OfJSONSchema: &format,
 			}
 		}
 
-		return openai.ChatCompletionNewParamsResponseFormatUnion{}
+		return responses.ResponseFormatTextConfigUnionParam{}
 	default:
-		return openai.ChatCompletionNewParamsResponseFormatUnion{}
+		return responses.ResponseFormatTextConfigUnionParam{}
 	}
 }
 
-func mapResponse(c *openai.ChatCompletion) *llm.ChatCompletionResponse {
+func mapResponse(response *responses.Response) *llm.ChatCompletionResponse {
 	resp := &llm.ChatCompletionResponse{
-		Model: c.Model,
-		Usage: llm.Usage{
-			InputTokens:  int(c.Usage.PromptTokens),
-			OutputTokens: int(c.Usage.CompletionTokens),
+		Model: string(response.Model),
+		Message: llm.Message{
+			Role:  llm.RoleAssistant,
+			Parts: []llm.Part{llm.TextPart{Text: response.OutputText()}},
 		},
+		Usage: llm.Usage{
+			InputTokens:  int(response.Usage.InputTokens),
+			OutputTokens: int(response.Usage.OutputTokens),
+		},
+		FinishReason: mapFinishReason(response),
 	}
 
-	if len(c.Choices) > 0 {
-		choice := c.Choices[0]
-		resp.FinishReason = mapFinishReason(choice.FinishReason)
-
-		resp.Message = llm.Message{
-			Role:  llm.RoleAssistant,
-			Parts: []llm.Part{llm.TextPart{Text: choice.Message.Content}},
-		}
-		if len(choice.Message.ToolCalls) > 0 {
-			resp.Message.ToolCalls = make([]llm.ToolCall, len(choice.Message.ToolCalls))
-			for i, tc := range choice.Message.ToolCalls {
-				resp.Message.ToolCalls[i] = llm.ToolCall{
-					ID: tc.ID,
+	for _, output := range response.Output {
+		if output.Type == "function_call" {
+			resp.Message.ToolCalls = append(
+				resp.Message.ToolCalls,
+				llm.ToolCall{
+					ID: output.CallID,
 					Function: llm.FunctionCall{
-						Name:      tc.Function.Name,
-						Arguments: tc.Function.Arguments,
+						Name:      output.Name,
+						Arguments: output.Arguments,
 					},
-				}
-			}
+				},
+			)
 		}
 	}
 
 	return resp
 }
 
-func mapFinishReason(reason string) llm.FinishReason {
-	switch reason {
-	case "stop":
-		return llm.FinishReasonStop
-	case "tool_calls":
-		return llm.FinishReasonToolCalls
-	case "length":
+func mapFinishReason(response *responses.Response) llm.FinishReason {
+	if response.IncompleteDetails.Reason == "max_output_tokens" {
 		return llm.FinishReasonLength
-	case "content_filter":
-		return llm.FinishReasonContentFilter
-	default:
-		return llm.FinishReasonStop
 	}
+
+	if response.IncompleteDetails.Reason == "content_filter" {
+		return llm.FinishReasonContentFilter
+	}
+
+	for _, output := range response.Output {
+		if output.Type == "function_call" {
+			return llm.FinishReasonToolCalls
+		}
+	}
+
+	return llm.FinishReasonStop
+}
+
+func buildFilePart(part llm.FilePart) responses.ResponseInputContentUnionParam {
+	dataURL := (&url.URL{
+		Scheme: "data",
+		Opaque: part.MimeType + ";base64," + part.Data,
+	}).String()
+
+	if strings.HasPrefix(part.MimeType, "image/") {
+		image := responses.ResponseInputImageParam{
+			Detail:   responses.ResponseInputImageDetailAuto,
+			ImageURL: param.NewOpt(dataURL),
+		}
+		return responses.ResponseInputContentUnionParam{OfInputImage: &image}
+	}
+
+	file := responses.ResponseInputFileParam{
+		FileData: param.NewOpt(dataURL),
+		Filename: param.NewOpt(part.Filename),
+	}
+	return responses.ResponseInputContentUnionParam{OfInputFile: &file}
+}
+
+func isReasoningModel(model string) bool {
+	for _, prefix := range []string{"o1", "o3", "o4", "gpt-5"} {
+		if model == prefix || strings.HasPrefix(model, prefix+"-") || strings.HasPrefix(model, prefix+".") {
+			return true
+		}
+	}
+
+	return false
 }
 
 func mapError(err error) error {
@@ -431,21 +474,25 @@ func parseRetryAfter(resp *http.Response) time.Duration {
 	return 0
 }
 
-// openaiStream adapts an OpenAI SSE stream to our ChatCompletionStream interface.
 type openaiStream struct {
-	stream  *ssestream.Stream[openai.ChatCompletionChunk]
-	current llm.ChatCompletionStreamEvent
+	stream      *ssestream.Stream[responses.ResponseStreamEventUnion]
+	current     llm.ChatCompletionStreamEvent
+	toolIndexes map[int64]int
+	err         error
 }
 
 func (s *openaiStream) Next() bool {
-	if !s.stream.Next() {
-		return false
+	for s.stream.Next() {
+		event, ok := s.mapEvent(s.stream.Current())
+		if !ok {
+			continue
+		}
+
+		s.current = event
+		return true
 	}
 
-	chunk := s.stream.Current()
-	s.current = mapChunkToEvent(&chunk)
-
-	return true
+	return false
 }
 
 func (s *openaiStream) Event() llm.ChatCompletionStreamEvent {
@@ -453,6 +500,10 @@ func (s *openaiStream) Event() llm.ChatCompletionStreamEvent {
 }
 
 func (s *openaiStream) Err() error {
+	if s.err != nil {
+		return s.err
+	}
+
 	err := s.stream.Err()
 	if err != nil {
 		return mapError(err)
@@ -465,79 +516,75 @@ func (s *openaiStream) Close() error {
 	return s.stream.Close()
 }
 
-func mapChunkToEvent(chunk *openai.ChatCompletionChunk) llm.ChatCompletionStreamEvent {
-	event := llm.ChatCompletionStreamEvent{
-		Model: chunk.Model,
-	}
-
-	if chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 {
-		usage := llm.Usage{
-			InputTokens:  int(chunk.Usage.PromptTokens),
-			OutputTokens: int(chunk.Usage.CompletionTokens),
-		}
-		event.Usage = &usage
-	}
-
-	if len(chunk.Choices) > 0 {
-		choice := chunk.Choices[0]
-		delta := choice.Delta
-
-		event.Delta.Content = delta.Content
-
-		if len(delta.ToolCalls) > 0 {
-			event.Delta.ToolCalls = make([]llm.ToolCallDelta, len(delta.ToolCalls))
-			for i, tc := range delta.ToolCalls {
-				event.Delta.ToolCalls[i] = llm.ToolCallDelta{
-					Index:     int(tc.Index),
-					ID:        tc.ID,
-					Name:      tc.Function.Name,
-					Arguments: tc.Function.Arguments,
-				}
-			}
+func (s *openaiStream) mapEvent(raw responses.ResponseStreamEventUnion) (llm.ChatCompletionStreamEvent, bool) {
+	switch event := raw.AsAny().(type) {
+	case responses.ResponseCreatedEvent:
+		return llm.ChatCompletionStreamEvent{
+			Model: string(event.Response.Model),
+		}, true
+	case responses.ResponseTextDeltaEvent:
+		return llm.ChatCompletionStreamEvent{
+			Delta: llm.MessageDelta{Content: event.Delta},
+		}, true
+	case responses.ResponseOutputItemAddedEvent:
+		if event.Item.Type != "function_call" {
+			return llm.ChatCompletionStreamEvent{}, false
 		}
 
-		if choice.FinishReason != "" {
-			fr := mapFinishReason(choice.FinishReason)
-			event.FinishReason = &fr
-		}
-	}
+		toolIndex := len(s.toolIndexes)
+		s.toolIndexes[event.OutputIndex] = toolIndex
 
-	return event
-}
-
-// isReasoningModel returns true for OpenAI models that support
-// reasoning_effort (o1, o3-mini, o3, and their dated variants).
-func isReasoningModel(model string) bool {
-	for _, prefix := range []string{"o1", "o3"} {
-		if model == prefix || strings.HasPrefix(model, prefix+"-") {
-			return true
-		}
-	}
-
-	return false
-}
-
-func buildFilePart(p llm.FilePart) openai.ChatCompletionContentPartUnionParam {
-	switch {
-	case strings.HasPrefix(p.MimeType, "image/"):
-		return openai.ImageContentPart(
-			openai.ChatCompletionContentPartImageImageURLParam{
-				URL: fmt.Sprintf("data:%s;base64,%s", p.MimeType, p.Data),
+		return llm.ChatCompletionStreamEvent{
+			Delta: llm.MessageDelta{
+				ToolCalls: []llm.ToolCallDelta{
+					{
+						Index: toolIndex,
+						ID:    event.Item.CallID,
+						Name:  event.Item.Name,
+					},
+				},
 			},
-		)
-	case strings.HasPrefix(p.MimeType, "text/"):
-		decoded, err := base64.StdEncoding.DecodeString(p.Data)
-		if err != nil {
-			return openai.TextContentPart(fmt.Sprintf("[file: %s, type: %s, error decoding content]", p.Filename, p.MimeType))
+		}, true
+	case responses.ResponseFunctionCallArgumentsDeltaEvent:
+		toolIndex, ok := s.toolIndexes[event.OutputIndex]
+		if !ok {
+			return llm.ChatCompletionStreamEvent{}, false
 		}
 
-		return openai.TextContentPart(fmt.Sprintf("File: %s\n\n%s", p.Filename, string(decoded)))
+		return llm.ChatCompletionStreamEvent{
+			Delta: llm.MessageDelta{
+				ToolCalls: []llm.ToolCallDelta{
+					{
+						Index:     toolIndex,
+						Arguments: event.Delta,
+					},
+				},
+			},
+		}, true
+	case responses.ResponseCompletedEvent:
+		return finalStreamEvent(&event.Response), true
+	case responses.ResponseIncompleteEvent:
+		return finalStreamEvent(&event.Response), true
+	case responses.ResponseErrorEvent:
+		s.err = fmt.Errorf("cannot stream OpenAI response: %s", event.Message)
+		return llm.ChatCompletionStreamEvent{}, false
+	case responses.ResponseFailedEvent:
+		s.err = fmt.Errorf("cannot stream OpenAI response: %s", event.Response.Error.Message)
+		return llm.ChatCompletionStreamEvent{}, false
 	default:
-		return openai.FileContentPart(
-			openai.ChatCompletionContentPartFileFileParam{
-				FileData: param.NewOpt(fmt.Sprintf("data:%s;base64,%s", p.MimeType, p.Data)),
-				Filename: param.NewOpt(p.Filename),
-			},
-		)
+		return llm.ChatCompletionStreamEvent{}, false
+	}
+}
+
+func finalStreamEvent(response *responses.Response) llm.ChatCompletionStreamEvent {
+	finishReason := mapFinishReason(response)
+
+	return llm.ChatCompletionStreamEvent{
+		Model: string(response.Model),
+		Usage: &llm.Usage{
+			InputTokens:  int(response.Usage.InputTokens),
+			OutputTokens: int(response.Usage.OutputTokens),
+		},
+		FinishReason: &finishReason,
 	}
 }

--- a/pkg/llm/openai/provider.go
+++ b/pkg/llm/openai/provider.go
@@ -121,7 +121,10 @@ func NewProvider(apiKey string, opts ...Option) *Provider {
 }
 
 func (p *Provider) ChatCompletion(ctx context.Context, req *llm.ChatCompletionRequest) (*llm.ChatCompletionResponse, error) {
-	params := buildParams(req)
+	params, err := buildParams(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build OpenAI response parameters: %w", err)
+	}
 
 	response, err := p.client.Responses.New(ctx, params)
 	if err != nil {
@@ -136,7 +139,11 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *llm.ChatCompletionRe
 }
 
 func (p *Provider) ChatCompletionStream(ctx context.Context, req *llm.ChatCompletionRequest) (llm.ChatCompletionStream, error) {
-	params := buildParams(req)
+	params, err := buildParams(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build OpenAI response parameters: %w", err)
+	}
+
 	stream := p.client.Responses.NewStreaming(ctx, params)
 
 	return &openaiStream{
@@ -145,7 +152,11 @@ func (p *Provider) ChatCompletionStream(ctx context.Context, req *llm.ChatComple
 	}, nil
 }
 
-func buildParams(req *llm.ChatCompletionRequest) responses.ResponseNewParams {
+func buildParams(req *llm.ChatCompletionRequest) (responses.ResponseNewParams, error) {
+	if len(req.StopSequences) > 0 {
+		return responses.ResponseNewParams{}, errors.New("stop sequences are not supported by OpenAI Responses API")
+	}
+
 	params := responses.ResponseNewParams{
 		Input: responses.ResponseNewParamsInputUnion{
 			OfInputItemList: buildInput(req.Messages),
@@ -193,7 +204,7 @@ func buildParams(req *llm.ChatCompletionRequest) responses.ResponseNewParams {
 		}
 	}
 
-	return params
+	return params, nil
 }
 
 func buildInput(messages []llm.Message) responses.ResponseInputParam {
@@ -285,6 +296,7 @@ func buildTools(tools []llm.Tool) []responses.ToolUnionParam {
 		if t.Description != "" {
 			tool.OfFunction.Description = param.NewOpt(t.Description)
 		}
+
 		out[i] = tool
 	}
 
@@ -327,6 +339,7 @@ func buildResponseFormat(rf *llm.ResponseFormat) responses.ResponseFormatTextCon
 	case llm.ResponseFormatJSONSchema:
 		if rf.JSONSchema != nil {
 			var schema map[string]any
+
 			_ = json.Unmarshal(rf.JSONSchema.Schema, &schema)
 
 			format := responses.ResponseFormatTextJSONSchemaConfigParam{
@@ -410,6 +423,7 @@ func buildFilePart(part llm.FilePart) responses.ResponseInputContentUnionParam {
 			Detail:   responses.ResponseInputImageDetailAuto,
 			ImageURL: param.NewOpt(dataURL),
 		}
+
 		return responses.ResponseInputContentUnionParam{OfInputImage: &image}
 	}
 
@@ -417,6 +431,7 @@ func buildFilePart(part llm.FilePart) responses.ResponseInputContentUnionParam {
 		FileData: param.NewOpt(dataURL),
 		Filename: param.NewOpt(part.Filename),
 	}
+
 	return responses.ResponseInputContentUnionParam{OfInputFile: &file}
 }
 
@@ -489,6 +504,7 @@ func (s *openaiStream) Next() bool {
 		}
 
 		s.current = event
+
 		return true
 	}
 

--- a/pkg/llm/openai/provider_test.go
+++ b/pkg/llm/openai/provider_test.go
@@ -37,6 +37,7 @@ func TestProvider_UsesResponsesEndpoint(t *testing.T) {
 	t.Parallel()
 
 	var requestBody map[string]any
+
 	server := httptest.NewServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -209,6 +210,42 @@ func TestProvider_UsesResponsesEndpoint(t *testing.T) {
 		t,
 		"data:application/pdf;base64,cGRm",
 		userContent[2].(map[string]any)["file_data"],
+	)
+}
+
+func TestProvider_RejectsStopSequences(t *testing.T) {
+	t.Parallel()
+
+	req := &llm.ChatCompletionRequest{
+		Model:         "gpt-4o",
+		StopSequences: []string{"STOP"},
+	}
+	provider := &Provider{}
+
+	t.Run(
+		"chat completion",
+		func(t *testing.T) {
+			t.Parallel()
+
+			response, err := provider.ChatCompletion(context.Background(), req)
+
+			require.Error(t, err)
+			assert.Nil(t, response)
+			assert.ErrorContains(t, err, "stop sequences are not supported by OpenAI Responses API")
+		},
+	)
+
+	t.Run(
+		"streaming chat completion",
+		func(t *testing.T) {
+			t.Parallel()
+
+			stream, err := provider.ChatCompletionStream(context.Background(), req)
+
+			require.Error(t, err)
+			assert.Nil(t, stream)
+			assert.ErrorContains(t, err, "stop sequences are not supported by OpenAI Responses API")
+		},
 	)
 }
 

--- a/pkg/llm/openai/provider_test.go
+++ b/pkg/llm/openai/provider_test.go
@@ -1,0 +1,276 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/llm"
+)
+
+func TestProvider_UsesResponsesEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var requestBody map[string]any
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/v1/responses", r.URL.Path)
+
+				err := json.NewDecoder(r.Body).Decode(&requestBody)
+				require.NoError(t, err)
+
+				w.Header().Set("Content-Type", "application/json")
+				_, err = fmt.Fprint(
+					w,
+					`{
+						"id": "resp_1",
+						"object": "response",
+						"created_at": 1,
+						"status": "completed",
+						"model": "gpt-5.6",
+						"output": [
+							{
+								"id": "msg_1",
+								"type": "message",
+								"status": "completed",
+								"role": "assistant",
+								"content": [
+									{"type": "output_text", "text": "done", "annotations": []}
+								]
+							},
+							{
+								"id": "fc_1",
+								"type": "function_call",
+								"status": "completed",
+								"call_id": "call_2",
+								"name": "lookup",
+								"arguments": "{\"id\":\"2\"}"
+							}
+						],
+						"usage": {
+							"input_tokens": 12,
+							"output_tokens": 4,
+							"total_tokens": 16,
+							"input_tokens_details": {"cached_tokens": 0},
+							"output_tokens_details": {"reasoning_tokens": 0}
+						}
+					}`,
+				)
+				require.NoError(t, err)
+			},
+		),
+	)
+	t.Cleanup(server.Close)
+
+	maxTokens := 2048
+	temperature := 0.4
+	topP := 0.9
+	parallelToolCalls := true
+	provider := NewProvider(
+		"test-key",
+		WithBaseURL(server.URL+"/v1"),
+		WithMaxRetries(0),
+	)
+
+	response, err := provider.ChatCompletion(
+		context.Background(),
+		&llm.ChatCompletionRequest{
+			Model: "gpt-5.6",
+			Messages: []llm.Message{
+				{
+					Role:  llm.RoleSystem,
+					Parts: []llm.Part{llm.TextPart{Text: "Follow instructions."}},
+				},
+				{
+					Role: llm.RoleUser,
+					Parts: []llm.Part{
+						llm.TextPart{Text: "Review this."},
+						llm.ImagePart{URL: "https://example.com/image.png"},
+						llm.FilePart{
+							Data:     "cGRm",
+							MimeType: "application/pdf",
+							Filename: "report.pdf",
+						},
+					},
+				},
+				{
+					Role: llm.RoleAssistant,
+					ToolCalls: []llm.ToolCall{
+						{
+							ID: "call_1",
+							Function: llm.FunctionCall{
+								Name:      "lookup",
+								Arguments: `{"id":"1"}`,
+							},
+						},
+					},
+				},
+				{
+					Role:       llm.RoleTool,
+					Parts:      []llm.Part{llm.TextPart{Text: `{"name":"Probo"}`}},
+					ToolCallID: "call_1",
+				},
+			},
+			MaxTokens:         &maxTokens,
+			Temperature:       &temperature,
+			TopP:              &topP,
+			ParallelToolCalls: &parallelToolCalls,
+			Tools: []llm.Tool{
+				{
+					Name:        "lookup",
+					Description: "Look up a record",
+					Parameters:  json.RawMessage(`{"type":"object"}`),
+				},
+			},
+			ToolChoice: &llm.ToolChoice{
+				Type:     llm.ToolChoiceFunction,
+				Function: "lookup",
+			},
+			ResponseFormat: &llm.ResponseFormat{
+				Type: llm.ResponseFormatJSONSchema,
+				JSONSchema: &llm.JSONSchema{
+					Name:   "result",
+					Schema: json.RawMessage(`{"type":"object"}`),
+					Strict: true,
+				},
+			},
+			Thinking: &llm.ThinkingConfig{
+				Enabled:      true,
+				BudgetTokens: 4096,
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, "gpt-5.6", response.Model)
+	assert.Equal(t, "done", response.Message.Text())
+	assert.Equal(t, llm.FinishReasonToolCalls, response.FinishReason)
+	assert.Equal(t, llm.Usage{InputTokens: 12, OutputTokens: 4}, response.Usage)
+	assert.Equal(
+		t,
+		[]llm.ToolCall{
+			{
+				ID: "call_2",
+				Function: llm.FunctionCall{
+					Name:      "lookup",
+					Arguments: `{"id":"2"}`,
+				},
+			},
+		},
+		response.Message.ToolCalls,
+	)
+
+	assert.Equal(t, "gpt-5.6", requestBody["model"])
+	assert.Equal(t, false, requestBody["store"])
+	assert.Equal(t, float64(maxTokens), requestBody["max_output_tokens"])
+	assert.Equal(t, "medium", requestBody["reasoning"].(map[string]any)["effort"])
+	assert.Equal(t, "json_schema", requestBody["text"].(map[string]any)["format"].(map[string]any)["type"])
+
+	input, ok := requestBody["input"].([]any)
+	require.True(t, ok)
+	require.Len(t, input, 4)
+	assert.Equal(t, "system", input[0].(map[string]any)["role"])
+	assert.Equal(t, "user", input[1].(map[string]any)["role"])
+	assert.Equal(t, "function_call", input[2].(map[string]any)["type"])
+	assert.Equal(t, "function_call_output", input[3].(map[string]any)["type"])
+
+	userContent := input[1].(map[string]any)["content"].([]any)
+	require.Len(t, userContent, 3)
+	assert.Equal(t, "input_image", userContent[1].(map[string]any)["type"])
+	assert.Equal(t, "input_file", userContent[2].(map[string]any)["type"])
+	assert.Equal(
+		t,
+		"data:application/pdf;base64,cGRm",
+		userContent[2].(map[string]any)["file_data"],
+	)
+}
+
+func TestProvider_StreamsResponsesEvents(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/v1/responses", r.URL.Path)
+
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, err := fmt.Fprint(
+					w,
+					"data: "+`{"type":"response.created","sequence_number":0,"response":{"model":"gpt-5.6"}}`+"\n\n"+
+						"data: "+`{"type":"response.output_item.added","sequence_number":1,"output_index":1,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"lookup","arguments":""}}`+"\n\n"+
+						"data: "+`{"type":"response.function_call_arguments.delta","sequence_number":2,"output_index":1,"item_id":"fc_1","delta":"{\"id\":"}`+"\n\n"+
+						"data: "+`{"type":"response.function_call_arguments.delta","sequence_number":3,"output_index":1,"item_id":"fc_1","delta":"\"1\"}"}`+"\n\n"+
+						"data: "+`{"type":"response.output_text.delta","sequence_number":4,"output_index":2,"content_index":0,"item_id":"msg_1","delta":"done"}`+"\n\n"+
+						"data: "+`{"type":"response.completed","sequence_number":5,"response":{"model":"gpt-5.6","status":"completed","output":[{"type":"function_call","call_id":"call_1","name":"lookup","arguments":"{\"id\":\"1\"}"}],"usage":{"input_tokens":8,"output_tokens":3,"total_tokens":11,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`+"\n\n"+
+						"data: [DONE]\n\n",
+				)
+				require.NoError(t, err)
+			},
+		),
+	)
+	t.Cleanup(server.Close)
+
+	provider := NewProvider(
+		"test-key",
+		WithBaseURL(server.URL+"/v1"),
+		WithMaxRetries(0),
+	)
+	stream, err := provider.ChatCompletionStream(
+		context.Background(),
+		&llm.ChatCompletionRequest{
+			Model: "gpt-5.6",
+			Messages: []llm.Message{
+				{
+					Role:  llm.RoleUser,
+					Parts: []llm.Part{llm.TextPart{Text: "Look it up."}},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, stream.Close()) })
+
+	var events []llm.ChatCompletionStreamEvent
+	for stream.Next() {
+		events = append(events, stream.Event())
+	}
+
+	require.NoError(t, stream.Err())
+	require.Len(t, events, 6)
+	assert.Equal(t, "gpt-5.6", events[0].Model)
+	assert.Equal(t, 0, events[1].Delta.ToolCalls[0].Index)
+	assert.Equal(t, "call_1", events[1].Delta.ToolCalls[0].ID)
+	assert.Equal(t, "lookup", events[1].Delta.ToolCalls[0].Name)
+	assert.Equal(t, `{"id":`, events[2].Delta.ToolCalls[0].Arguments)
+	assert.Equal(t, `"1"}`, events[3].Delta.ToolCalls[0].Arguments)
+	assert.Equal(t, "done", events[4].Delta.Content)
+	assert.Equal(t, &llm.Usage{InputTokens: 8, OutputTokens: 3}, events[5].Usage)
+	assert.Equal(t, new(llm.FinishReasonToolCalls), events[5].FinishReason)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- route OpenAI requests through the Responses API instead of legacy chat completions
- translate messages, tools, files, structured output, reasoning, and finish reasons to the new API
- adapt Responses streaming events while preserving contiguous gateway tool-call indexes
- disable response storage to preserve existing privacy behavior
- reject unsupported stop sequences explicitly instead of silently ignoring them

## Testing
- `go test -v ./pkg/llm/openai`
- `go test -race ./pkg/llm/...`
- `go vet ./pkg/llm/...`
- `GOTOOLCHAIN=go1.27.1 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./pkg/llm/openai`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed2eadc6-5614-4b97-99f5-94a9bab8f4d8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed2eadc6-5614-4b97-99f5-94a9bab8f4d8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the OpenAI gateway off legacy chat completions onto the Responses API so current models work for both regular and streaming requests. The gateway's existing message, tool, file, structured-output, and usage contracts are preserved, response storage stays disabled for the current privacy behavior, and requests with stop sequences are now rejected instead of silently ignored.

### Service **`+279`** **`-216`**

- Routes `ChatCompletion` and `ChatCompletionStream` through the Responses endpoint with `store: false`.
- Translates messages, tools, tool choices, files, structured output, and reasoning effort to Responses equivalents.
- Rejects `StopSequences` explicitly because the Responses API cannot represent them.
- Maps Responses streaming events while preserving contiguous gateway tool-call indexes; finish reasons, usage, and error mapping behave as before.

### Tests **`+313`** **`-0`**

- Adds `provider_test.go` covering the Responses request body, streaming event mapping, and stop-sequence rejection.

<sup>Written for commit a754b38795695026a3927a894d545caa9be2d4aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

