### PR TITLE
Report authoritative access review roles

### DIFF
--- a/pkg/accessreview/drivers/linear.go
+++ b/pkg/accessreview/drivers/linear.go
@@ -59,6 +59,7 @@ type linearUsersResponse struct {
 				Name      string `json:"name"`
 				Active    bool   `json:"active"`
 				Admin     bool   `json:"admin"`
+				Owner     bool   `json:"owner"`
 				Guest     bool   `json:"guest"`
 				LastSeen  string `json:"lastSeen"`
 				CreatedAt string `json:"createdAt"`
@@ -105,9 +106,9 @@ func (d *LinearDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error
 			record := AccountRecord{
 				Email:       u.Email,
 				FullName:    u.Name,
-				Roles:       linearRoles(u.Admin, u.Guest),
+				Roles:       linearRoles(u.Owner, u.Admin, u.Guest),
 				Active:      new(u.Active),
-				IsAdmin:     new(u.Admin),
+				IsAdmin:     new(u.Owner || u.Admin),
 				ExternalID:  u.ID,
 				MFAStatus:   coredata.MFAStatusUnknown,
 				AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
@@ -155,6 +156,7 @@ query AccessReviewLinearUsers($after: String) {
       name
       active
       admin
+      owner
       guest
       lastSeen
       createdAt
@@ -215,8 +217,10 @@ query AccessReviewLinearUsers($after: String) {
 	return &resp, nil
 }
 
-func linearRoles(admin, guest bool) []string {
+func linearRoles(owner, admin, guest bool) []string {
 	switch {
+	case owner:
+		return []string{"Owner"}
 	case admin:
 		return []string{"Admin"}
 	case guest:

--- a/pkg/accessreview/drivers/linear_test.go
+++ b/pkg/accessreview/drivers/linear_test.go
@@ -49,6 +49,36 @@ func TestLinearDriver(t *testing.T) {
 	// Suspended accounts are hidden unless the query opts into them, so the
 	// review would silently lose them.
 	require.Len(t, records, 5)
+	assert.Equal(t, []string{"Owner"}, records[3].Roles)
+	assert.Equal(t, new(true), records[3].IsAdmin)
 	assert.Equal(t, "leaver@example.com", records[4].Email)
 	assert.Equal(t, new(false), records[4].Active)
+}
+
+func TestLinearRoles(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		owner bool
+		admin bool
+		guest bool
+		want  []string
+	}{
+		{name: "owner", owner: true, admin: true, want: []string{"Owner"}},
+		{name: "admin", admin: true, want: []string{"Admin"}},
+		{name: "guest", guest: true, want: []string{"Guest"}},
+		{name: "member", want: []string{"Member"}},
+	}
+
+	for _, c := range cases {
+		t.Run(
+			c.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				assert.Equal(t, c.want, linearRoles(c.owner, c.admin, c.guest))
+			},
+		)
+	}
 }

--- a/pkg/accessreview/drivers/qovery.go
+++ b/pkg/accessreview/drivers/qovery.go
@@ -57,6 +57,7 @@ type qoveryMember struct {
 	LastActivityAt string `json:"last_activity_at"`
 	CreatedAt      string `json:"created_at"`
 	Role           string `json:"role"`
+	RoleName       string `json:"role_name"`
 }
 
 // NewQoveryDriver builds a driver against baseURL, the Qovery API origin
@@ -111,11 +112,12 @@ func (d *QoveryDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error
 			continue
 		}
 
+		role := qoveryRole(member)
 		record := AccountRecord{
 			Email:       member.Email,
 			FullName:    qoveryFullName(member),
-			Roles:       qoveryRoles(member.Role),
-			IsAdmin:     new(qoveryIsAdmin(member.Role)),
+			Roles:       qoveryRoles(role),
+			IsAdmin:     new(qoveryIsAdmin(role)),
 			MFAStatus:   coredata.MFAStatusUnknown,
 			AuthMethod:  coredata.AccessReviewEntryAuthMethodUnknown,
 			AccountType: coredata.AccessReviewEntryAccountTypeUser,
@@ -150,6 +152,14 @@ func qoveryFullName(member qoveryMember) string {
 	}
 
 	return member.Email
+}
+
+func qoveryRole(member qoveryMember) string {
+	if role := strings.TrimSpace(member.RoleName); role != "" {
+		return role
+	}
+
+	return member.Role
 }
 
 func qoveryRoles(role string) []string {

--- a/pkg/accessreview/drivers/qovery_test.go
+++ b/pkg/accessreview/drivers/qovery_test.go
@@ -124,3 +124,18 @@ func TestQoveryRoles(t *testing.T) {
 		})
 	}
 }
+
+func TestQoveryRole_PrefersRoleName(t *testing.T) {
+	t.Parallel()
+
+	member := qoveryMember{
+		Role:     "ADMIN",
+		RoleName: "Developer",
+	}
+
+	role := qoveryRole(member)
+
+	assert.Equal(t, "Developer", role)
+	assert.Equal(t, []string{"Developer"}, qoveryRoles(role))
+	assert.False(t, qoveryIsAdmin(role))
+}

--- a/pkg/accessreview/drivers/testdata/linear.yaml
+++ b/pkg/accessreview/drivers/testdata/linear.yaml
@@ -6,9 +6,9 @@ interactions:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 346
+        content_length: 359
         host: api.linear.app
-        body: '{"query":"\nquery AccessReviewLinearUsers($after: String) {\n  users(first: 100, after: $after, includeDisabled: true) {\n    nodes {\n      id\n      email\n      name\n      active\n      admin\n      guest\n      lastSeen\n      createdAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n","variables":{"after":null}}'
+        body: '{"query":"\nquery AccessReviewLinearUsers($after: String) {\n  users(first: 100, after: $after, includeDisabled: true) {\n    nodes {\n      id\n      email\n      name\n      active\n      admin\n      owner\n      guest\n      lastSeen\n      createdAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n","variables":{"after":null}}'
         headers:
             Accept:
                 - application/json
@@ -23,7 +23,7 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            {"data":{"users":{"nodes":[{"id":"00000001-0000-0000-0000-000000000001","email":"bot-integration@linear.linear.app","name":"Linear","active":true,"admin":false,"guest":false,"lastSeen":"2026-03-24T17:27:44.095Z","createdAt":"2026-03-24T17:27:43.979Z"},{"id":"00000001-0000-0000-0000-000000000002","email":"bot-cursor@oauthapp.linear.app","name":"Cursor","active":true,"admin":false,"guest":false,"lastSeen":"2026-03-17T14:02:50.975Z","createdAt":"2026-03-17T14:02:50.855Z"},{"id":"00000001-0000-0000-0000-000000000003","email":"jane@example.com","name":"Jane Doe","active":true,"admin":false,"guest":false,"lastSeen":"2026-03-09T12:49:53.331Z","createdAt":"2025-01-20T09:12:11.959Z"},{"id":"00000001-0000-0000-0000-000000000004","email":"john@example.com","name":"John Smith","active":true,"admin":true,"guest":false,"lastSeen":"2026-03-26T12:33:50.957Z","createdAt":"2024-07-01T13:19:57.427Z"},{"id":"00000001-0000-0000-0000-000000000005","email":"leaver@example.com","name":"Leaver Example","active":false,"admin":false,"guest":false,"lastSeen":"2025-11-04T08:21:03.114Z","createdAt":"2024-09-12T10:04:22.510Z"}],"pageInfo":{"hasNextPage":false,"endCursor":"00000001-0000-0000-0000-000000000005"}}}}
+            {"data":{"users":{"nodes":[{"id":"00000001-0000-0000-0000-000000000001","email":"bot-integration@linear.linear.app","name":"Linear","active":true,"admin":false,"owner":false,"guest":false,"lastSeen":"2026-03-24T17:27:44.095Z","createdAt":"2026-03-24T17:27:43.979Z"},{"id":"00000001-0000-0000-0000-000000000002","email":"bot-cursor@oauthapp.linear.app","name":"Cursor","active":true,"admin":false,"owner":false,"guest":false,"lastSeen":"2026-03-17T14:02:50.975Z","createdAt":"2026-03-17T14:02:50.855Z"},{"id":"00000001-0000-0000-0000-000000000003","email":"jane@example.com","name":"Jane Doe","active":true,"admin":false,"owner":false,"guest":false,"lastSeen":"2026-03-09T12:49:53.331Z","createdAt":"2025-01-20T09:12:11.959Z"},{"id":"00000001-0000-0000-0000-000000000004","email":"john@example.com","name":"John Smith","active":true,"admin":true,"owner":true,"guest":false,"lastSeen":"2026-03-26T12:33:50.957Z","createdAt":"2024-07-01T13:19:57.427Z"},{"id":"00000001-0000-0000-0000-000000000005","email":"leaver@example.com","name":"Leaver Example","active":false,"admin":false,"owner":false,"guest":false,"lastSeen":"2025-11-04T08:21:03.114Z","createdAt":"2024-09-12T10:04:22.510Z"}],"pageInfo":{"hasNextPage":false,"endCursor":"00000001-0000-0000-0000-000000000005"}}}}
         headers:
             Alt-Svc:
                 - h3=":443"; ma=86400


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- classify Linear workspace owners separately from administrators
- prefer Qovery's authoritative `role_name` over the deprecated `role` field
- add regression coverage for owner precedence and mismatched Qovery role fields

## Testing

- `go test ./pkg/accessreview/drivers -count=1`
- targeted verbose Linear and Qovery driver tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc369661-fc34-4658-a2a9-9bc5ee126f96?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc369661-fc34-4658-a2a9-9bc5ee126f96&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports authoritative access review roles so access reviews reflect each account's real privileges. Linear workspace owners now classify as Owner instead of Admin, and Qovery prefers its authoritative `role_name` over the deprecated `role` field.

### Tests **`+45`** **`-0`**

- Adds regression coverage for Linear owner precedence over admin.
- Covers Qovery preferring `role_name` over `role`.

### Service **`+22`** **`-8`**

- Linear queries the `owner` signal and counts workspace owners as admins while reporting the Owner role.
- Qovery falls back to the deprecated `role` field only when `role_name` is empty.
- Updated the Linear test fixture to match the new query and response.

<sup>Written for commit fcf3746c33bdc3d37472af7ba0ad17373646cb69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

