### PR TITLE
Protect leaked cloud API tokens

### DIFF
--- a/pkg/coredata/oauth2_access_token.go
+++ b/pkg/coredata/oauth2_access_token.go
@@ -185,6 +185,49 @@ LIMIT 1;
 	return nil
 }
 
+func (t *OAuth2AccessToken) LoadByHashedValueForUpdate(
+	ctx context.Context,
+	conn pg.Tx,
+	hashedValue []byte,
+) error {
+	q := `
+SELECT
+	id,
+	name,
+	hashed_value,
+	client_id,
+	identity_id,
+	resources,
+	scopes,
+	created_at,
+	expires_at
+FROM
+	iam_oauth2_access_tokens
+WHERE
+	hashed_value = @hashed_value
+LIMIT 1
+FOR UPDATE;
+`
+
+	rows, err := conn.Query(ctx, q, pgx.StrictNamedArgs{"hashed_value": hashedValue})
+	if err != nil {
+		return fmt.Errorf("cannot query oauth2_access_token for update: %w", err)
+	}
+
+	token, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[OAuth2AccessToken])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect oauth2_access_token for update: %w", err)
+	}
+
+	*t = token
+
+	return nil
+}
+
 func (t *OAuth2AccessToken) LoadByHashedValueAndClientID(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/iam/oauth2/leaked_manual_access_token_test.go
+++ b/pkg/iam/oauth2/leaked_manual_access_token_test.go
@@ -46,7 +46,7 @@ func TestRevokeLeakedManualAccessToken_RevokesAndNotifiesOnce(t *testing.T) {
 	ctx := t.Context()
 	pgClient := test.PGClient(t)
 	baseURL := uri.URI("https://us.probo.com")
-	tokenValue := newManualAccessToken(baseURL)
+	tokenValue := newManualAccessToken()
 	identityID := gid.New(gid.NilTenant, coredata.IdentityEntityType)
 	tokenID := gid.New(identityID.TenantID(), coredata.OAuth2AccessTokenEntityType)
 	emailAddress, err := mail.ParseAddr(fmt.Sprintf("%s@example.com", identityID))
@@ -123,7 +123,7 @@ func TestRevokeLeakedManualAccessToken_RevokesAndNotifiesOnce(t *testing.T) {
 	assert.Equal(t, 1, countNotificationEmails(t, pgClient, emailAddress.String()))
 }
 
-func TestRevokeLeakedManualAccessToken_IgnoresSelfHostedToken(t *testing.T) {
+func TestRevokeLeakedManualAccessToken_IgnoresLegacyToken(t *testing.T) {
 	t.Parallel()
 
 	service := NewService(nil, nil, "https://probo.example.com", log.NewLogger())

--- a/pkg/iam/oauth2/leaked_manual_access_token_test.go
+++ b/pkg/iam/oauth2/leaked_manual_access_token_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package oauth2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/internal/test"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/crypto/hash"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/mail"
+	"go.probo.inc/probo/pkg/uri"
+)
+
+func TestRevokeLeakedManualAccessToken_RevokesAndNotifiesOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	pgClient := test.PGClient(t)
+	baseURL := uri.URI("https://us.probo.com")
+	tokenValue := newManualAccessToken(baseURL)
+	identityID := gid.New(gid.NilTenant, coredata.IdentityEntityType)
+	tokenID := gid.New(identityID.TenantID(), coredata.OAuth2AccessTokenEntityType)
+	emailAddress, err := mail.ParseAddr(fmt.Sprintf("%s@example.com", identityID))
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	identity := &coredata.Identity{
+		ID:                   identityID,
+		EmailAddress:         emailAddress,
+		FullName:             "Secret Scanning Test",
+		EmailAddressVerified: true,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+	accessToken := &coredata.OAuth2AccessToken{
+		ID:          tokenID,
+		Name:        "Leaked test token",
+		HashedValue: hash.SHA256String(tokenValue),
+		IdentityID:  identityID,
+		Resources:   []uri.URI{baseURL},
+		Scopes:      coredata.OAuth2Scopes{"v1:org:read"},
+		CreatedAt:   now,
+		ExpiresAt:   now.Add(time.Hour),
+	}
+
+	require.NoError(
+		t,
+		pgClient.WithTx(
+			ctx,
+			func(ctx context.Context, tx pg.Tx) error {
+				if err := identity.Insert(ctx, tx); err != nil {
+					return fmt.Errorf("cannot insert identity: %w", err)
+				}
+
+				if err := accessToken.Insert(ctx, tx); err != nil {
+					return fmt.Errorf("cannot insert access token: %w", err)
+				}
+
+				return nil
+			},
+		),
+	)
+	t.Cleanup(
+		func() {
+			_ = pgClient.WithTx(
+				context.Background(),
+				func(ctx context.Context, tx pg.Tx) error {
+					if _, err := tx.Exec(
+						ctx,
+						"DELETE FROM emails WHERE recipient_email = @recipient_email",
+						pgx.StrictNamedArgs{"recipient_email": emailAddress},
+					); err != nil {
+						return err
+					}
+
+					return (&coredata.Identity{ID: identityID}).Delete(ctx, tx)
+				},
+			)
+		},
+	)
+
+	service := NewService(pgClient, nil, baseURL, log.NewLogger())
+	revoked, err := service.RevokeLeakedManualAccessToken(ctx, tokenValue)
+	require.NoError(t, err)
+	assert.True(t, revoked)
+
+	_, err = service.LoadAccessToken(ctx, tokenValue)
+	assert.ErrorIs(t, err, coredata.ErrResourceNotFound)
+	assert.Equal(t, 1, countNotificationEmails(t, pgClient, emailAddress.String()))
+
+	revoked, err = service.RevokeLeakedManualAccessToken(ctx, tokenValue)
+	require.NoError(t, err)
+	assert.False(t, revoked)
+	assert.Equal(t, 1, countNotificationEmails(t, pgClient, emailAddress.String()))
+}
+
+func TestRevokeLeakedManualAccessToken_IgnoresSelfHostedToken(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(nil, nil, "https://probo.example.com", log.NewLogger())
+
+	revoked, err := service.RevokeLeakedManualAccessToken(
+		t.Context(),
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	)
+
+	require.NoError(t, err)
+	assert.False(t, revoked)
+}
+
+func countNotificationEmails(t *testing.T, pgClient *pg.Client, recipientEmail string) int {
+	t.Helper()
+
+	var count int
+	err := pgClient.WithConn(
+		t.Context(),
+		func(ctx context.Context, conn pg.Querier) error {
+			err := conn.QueryRow(
+				ctx,
+				`SELECT COUNT(id) FROM emails WHERE recipient_email = @recipient_email AND subject = @subject`,
+				pgx.StrictNamedArgs{
+					"recipient_email": recipientEmail,
+					"subject":         "Your Probo API token was revoked",
+				},
+			).Scan(&count)
+			if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("cannot count notification emails: %w", err)
+			}
+
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	return count
+}

--- a/pkg/iam/oauth2/manual_access_token.go
+++ b/pkg/iam/oauth2/manual_access_token.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package oauth2
+
+import (
+	"hash/crc32"
+	"net/url"
+	"strings"
+
+	"go.probo.inc/probo/pkg/crypto/rand"
+	"go.probo.inc/probo/pkg/uri"
+)
+
+const (
+	base62Alphabet            = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	cloudTokenRandomLength    = 32
+	cloudTokenChecksumLength  = 6
+	cloudUSAPITokenPrefix     = "prb_a1u_"
+	cloudEUAPITokenPrefix     = "prb_a1e_"
+	cloudUSSecretScanningType = "probo_cloud_api_token_us"
+	cloudEUSecretScanningType = "probo_cloud_api_token_eu"
+	cloudUSHostname           = "us.probo.com"
+	cloudEUHostname           = "eu.probo.com"
+)
+
+func newManualAccessToken(baseURL uri.URI) string {
+	prefix, _ := cloudManualAccessTokenFormat(baseURL)
+	if prefix == "" {
+		return rand.MustHexString(tokenByteLength)
+	}
+
+	randomValue := rand.MustStringFromAlphabet(base62Alphabet, cloudTokenRandomLength)
+
+	return prefix + randomValue + encodeBase62Checksum(crc32.ChecksumIEEE([]byte(randomValue)))
+}
+
+func isValidManualAccessToken(baseURL uri.URI, token string) bool {
+	prefix, _ := cloudManualAccessTokenFormat(baseURL)
+	if prefix == "" || !strings.HasPrefix(token, prefix) {
+		return false
+	}
+
+	body := strings.TrimPrefix(token, prefix)
+	if len(body) != cloudTokenRandomLength+cloudTokenChecksumLength {
+		return false
+	}
+
+	randomValue := body[:cloudTokenRandomLength]
+	checksum := body[cloudTokenRandomLength:]
+
+	for _, value := range randomValue + checksum {
+		if !strings.ContainsRune(base62Alphabet, value) {
+			return false
+		}
+	}
+
+	expected := encodeBase62Checksum(crc32.ChecksumIEEE([]byte(randomValue)))
+
+	return checksum == expected
+}
+
+func cloudManualAccessTokenFormat(baseURL uri.URI) (string, string) {
+	parsed, err := url.Parse(baseURL.String())
+	if err != nil {
+		return "", ""
+	}
+
+	switch strings.ToLower(parsed.Hostname()) {
+	case cloudUSHostname:
+		return cloudUSAPITokenPrefix, cloudUSSecretScanningType
+	case cloudEUHostname:
+		return cloudEUAPITokenPrefix, cloudEUSecretScanningType
+	default:
+		return "", ""
+	}
+}
+
+func encodeBase62Checksum(value uint32) string {
+	encoded := [cloudTokenChecksumLength]byte{}
+
+	for i := len(encoded) - 1; i >= 0; i-- {
+		encoded[i] = base62Alphabet[value%uint32(len(base62Alphabet))]
+		value /= uint32(len(base62Alphabet))
+	}
+
+	return string(encoded[:])
+}

--- a/pkg/iam/oauth2/manual_access_token.go
+++ b/pkg/iam/oauth2/manual_access_token.go
@@ -22,49 +22,37 @@ package oauth2
 
 import (
 	"hash/crc32"
-	"net/url"
 	"strings"
 
 	"go.probo.inc/probo/pkg/crypto/rand"
-	"go.probo.inc/probo/pkg/uri"
 )
 
 const (
 	base62Alphabet            = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	cloudTokenRandomLength    = 32
-	cloudTokenChecksumLength  = 6
-	cloudUSAPITokenPrefix     = "prb_a1u_"
-	cloudEUAPITokenPrefix     = "prb_a1e_"
-	cloudUSSecretScanningType = "probo_cloud_api_token_us"
-	cloudEUSecretScanningType = "probo_cloud_api_token_eu"
-	cloudUSHostname           = "us.probo.com"
-	cloudEUHostname           = "eu.probo.com"
+	manualTokenRandomLength   = 32
+	manualTokenChecksumLength = 6
+	manualAPITokenPrefix      = "prb_a1_"
+	secretScanningTokenType   = "probo_api_token"
 )
 
-func newManualAccessToken(baseURL uri.URI) string {
-	prefix, _ := cloudManualAccessTokenFormat(baseURL)
-	if prefix == "" {
-		return rand.MustHexString(tokenByteLength)
-	}
+func newManualAccessToken() string {
+	randomValue := rand.MustStringFromAlphabet(base62Alphabet, manualTokenRandomLength)
 
-	randomValue := rand.MustStringFromAlphabet(base62Alphabet, cloudTokenRandomLength)
-
-	return prefix + randomValue + encodeBase62Checksum(crc32.ChecksumIEEE([]byte(randomValue)))
+	return manualAPITokenPrefix + randomValue + encodeBase62Checksum(crc32.ChecksumIEEE([]byte(randomValue)))
 }
 
-func isValidManualAccessToken(baseURL uri.URI, token string) bool {
-	prefix, _ := cloudManualAccessTokenFormat(baseURL)
-	if prefix == "" || !strings.HasPrefix(token, prefix) {
+func isValidManualAccessToken(token string) bool {
+	if !strings.HasPrefix(token, manualAPITokenPrefix) {
 		return false
 	}
 
-	body := strings.TrimPrefix(token, prefix)
-	if len(body) != cloudTokenRandomLength+cloudTokenChecksumLength {
+	body := strings.TrimPrefix(token, manualAPITokenPrefix)
+	if len(body) != manualTokenRandomLength+manualTokenChecksumLength {
 		return false
 	}
 
-	randomValue := body[:cloudTokenRandomLength]
-	checksum := body[cloudTokenRandomLength:]
+	randomValue := body[:manualTokenRandomLength]
+	checksum := body[manualTokenRandomLength:]
 
 	for _, value := range randomValue + checksum {
 		if !strings.ContainsRune(base62Alphabet, value) {
@@ -77,24 +65,8 @@ func isValidManualAccessToken(baseURL uri.URI, token string) bool {
 	return checksum == expected
 }
 
-func cloudManualAccessTokenFormat(baseURL uri.URI) (string, string) {
-	parsed, err := url.Parse(baseURL.String())
-	if err != nil {
-		return "", ""
-	}
-
-	switch strings.ToLower(parsed.Hostname()) {
-	case cloudUSHostname:
-		return cloudUSAPITokenPrefix, cloudUSSecretScanningType
-	case cloudEUHostname:
-		return cloudEUAPITokenPrefix, cloudEUSecretScanningType
-	default:
-		return "", ""
-	}
-}
-
 func encodeBase62Checksum(value uint32) string {
-	encoded := [cloudTokenChecksumLength]byte{}
+	encoded := [manualTokenChecksumLength]byte{}
 
 	for i := len(encoded) - 1; i >= 0; i-- {
 		encoded[i] = base62Alphabet[value%uint32(len(base62Alphabet))]

--- a/pkg/iam/oauth2/manual_access_token_test.go
+++ b/pkg/iam/oauth2/manual_access_token_test.go
@@ -27,70 +27,33 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.probo.inc/probo/pkg/uri"
+	"go.gearno.de/kit/log"
 )
 
-func TestNewManualAccessToken_CloudFormat(t *testing.T) {
+func TestNewManualAccessToken_Format(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name      string
-		baseURL   uri.URI
-		prefix    string
-		tokenType string
-	}{
-		{
-			name:      "US cloud",
-			baseURL:   "https://us.probo.com",
-			prefix:    cloudUSAPITokenPrefix,
-			tokenType: cloudUSSecretScanningType,
-		},
-		{
-			name:      "EU cloud",
-			baseURL:   "https://eu.probo.com",
-			prefix:    cloudEUAPITokenPrefix,
-			tokenType: cloudEUSecretScanningType,
-		},
-	}
+	token := newManualAccessToken()
 
-	for _, tt := range tests {
-		t.Run(
-			tt.name,
-			func(t *testing.T) {
-				t.Parallel()
-
-				token := newManualAccessToken(tt.baseURL)
-				prefix, tokenType := cloudManualAccessTokenFormat(tt.baseURL)
-
-				assert.Equal(t, tt.prefix, prefix)
-				assert.Equal(t, tt.tokenType, tokenType)
-				assert.Len(t, token, len(tt.prefix)+cloudTokenRandomLength+cloudTokenChecksumLength)
-				assert.True(t, strings.HasPrefix(token, tt.prefix))
-				assert.True(t, isValidManualAccessToken(tt.baseURL, token))
-			},
-		)
-	}
+	assert.Len(t, token, len(manualAPITokenPrefix)+manualTokenRandomLength+manualTokenChecksumLength)
+	assert.True(t, strings.HasPrefix(token, manualAPITokenPrefix))
+	assert.True(t, isValidManualAccessToken(token))
 }
 
-func TestNewManualAccessToken_SelfHostedLegacyFormat(t *testing.T) {
+func TestService_SecretScanningTokenTypeIsDeploymentIndependent(t *testing.T) {
 	t.Parallel()
 
-	baseURL := uri.URI("https://probo.example.com")
-	token := newManualAccessToken(baseURL)
-	prefix, tokenType := cloudManualAccessTokenFormat(baseURL)
+	first := NewService(nil, nil, "https://first.example.com", log.NewLogger())
+	second := NewService(nil, nil, "https://second.example.com", log.NewLogger())
 
-	assert.Empty(t, prefix)
-	assert.Empty(t, tokenType)
-	assert.Len(t, token, tokenByteLength*2)
-	assert.Regexp(t, "^[0-9a-f]{64}$", token)
-	assert.False(t, isValidManualAccessToken(baseURL, token))
+	assert.Equal(t, secretScanningTokenType, first.SecretScanningTokenType())
+	assert.Equal(t, first.SecretScanningTokenType(), second.SecretScanningTokenType())
 }
 
 func TestIsValidManualAccessToken_RejectsAlteredToken(t *testing.T) {
 	t.Parallel()
 
-	baseURL := uri.URI("https://us.probo.com")
-	token := newManualAccessToken(baseURL)
+	token := newManualAccessToken()
 	last := token[len(token)-1]
 	replacement := byte('0')
 	if last == replacement {
@@ -99,9 +62,12 @@ func TestIsValidManualAccessToken_RejectsAlteredToken(t *testing.T) {
 
 	altered := token[:len(token)-1] + string(replacement)
 
-	assert.False(t, isValidManualAccessToken(baseURL, altered))
-	assert.False(t, isValidManualAccessToken("https://eu.probo.com", token))
-	assert.False(t, isValidManualAccessToken(baseURL, token+"0"))
+	assert.False(t, isValidManualAccessToken(altered))
+	assert.False(t, isValidManualAccessToken(token+"0"))
+	assert.False(
+		t,
+		isValidManualAccessToken("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+	)
 }
 
 func TestEncodeBase62Checksum_GitHubReferenceValue(t *testing.T) {

--- a/pkg/iam/oauth2/manual_access_token_test.go
+++ b/pkg/iam/oauth2/manual_access_token_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package oauth2
+
+import (
+	"hash/crc32"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/uri"
+)
+
+func TestNewManualAccessToken_CloudFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		baseURL   uri.URI
+		prefix    string
+		tokenType string
+	}{
+		{
+			name:      "US cloud",
+			baseURL:   "https://us.probo.com",
+			prefix:    cloudUSAPITokenPrefix,
+			tokenType: cloudUSSecretScanningType,
+		},
+		{
+			name:      "EU cloud",
+			baseURL:   "https://eu.probo.com",
+			prefix:    cloudEUAPITokenPrefix,
+			tokenType: cloudEUSecretScanningType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				token := newManualAccessToken(tt.baseURL)
+				prefix, tokenType := cloudManualAccessTokenFormat(tt.baseURL)
+
+				assert.Equal(t, tt.prefix, prefix)
+				assert.Equal(t, tt.tokenType, tokenType)
+				assert.Len(t, token, len(tt.prefix)+cloudTokenRandomLength+cloudTokenChecksumLength)
+				assert.True(t, strings.HasPrefix(token, tt.prefix))
+				assert.True(t, isValidManualAccessToken(tt.baseURL, token))
+			},
+		)
+	}
+}
+
+func TestNewManualAccessToken_SelfHostedLegacyFormat(t *testing.T) {
+	t.Parallel()
+
+	baseURL := uri.URI("https://probo.example.com")
+	token := newManualAccessToken(baseURL)
+	prefix, tokenType := cloudManualAccessTokenFormat(baseURL)
+
+	assert.Empty(t, prefix)
+	assert.Empty(t, tokenType)
+	assert.Len(t, token, tokenByteLength*2)
+	assert.Regexp(t, "^[0-9a-f]{64}$", token)
+	assert.False(t, isValidManualAccessToken(baseURL, token))
+}
+
+func TestIsValidManualAccessToken_RejectsAlteredToken(t *testing.T) {
+	t.Parallel()
+
+	baseURL := uri.URI("https://us.probo.com")
+	token := newManualAccessToken(baseURL)
+	last := token[len(token)-1]
+	replacement := byte('0')
+	if last == replacement {
+		replacement = '1'
+	}
+
+	altered := token[:len(token)-1] + string(replacement)
+
+	assert.False(t, isValidManualAccessToken(baseURL, altered))
+	assert.False(t, isValidManualAccessToken("https://eu.probo.com", token))
+	assert.False(t, isValidManualAccessToken(baseURL, token+"0"))
+}
+
+func TestEncodeBase62Checksum_GitHubReferenceValue(t *testing.T) {
+	t.Parallel()
+
+	randomValue := "IqIMNOZH6zOwIEB4T9A2g4EHMy8Ji4"
+	require.Len(t, randomValue, 30)
+
+	assert.Equal(t, "2q4HA5", encodeBase62Checksum(crc32.ChecksumIEEE([]byte(randomValue))))
+}

--- a/pkg/iam/oauth2/service.go
+++ b/pkg/iam/oauth2/service.go
@@ -2158,7 +2158,7 @@ func (s *Service) CreateManualAccessToken(
 		return "", nil, NewError(ErrInvalidScope, WithDescription(err.Error()))
 	}
 
-	tokenValue := rand.MustHexString(tokenByteLength)
+	tokenValue := newManualAccessToken(s.baseURL)
 
 	accessToken := &coredata.OAuth2AccessToken{
 		ID:          gid.New(req.IdentityID.TenantID(), coredata.OAuth2AccessTokenEntityType),
@@ -2186,4 +2186,70 @@ func (s *Service) CreateManualAccessToken(
 	}
 
 	return tokenValue, accessToken, nil
+}
+
+func (s *Service) SecretScanningTokenType() string {
+	_, tokenType := cloudManualAccessTokenFormat(s.baseURL)
+
+	return tokenType
+}
+
+func (s *Service) RevokeLeakedManualAccessToken(ctx context.Context, tokenValue string) (bool, error) {
+	if !isValidManualAccessToken(s.baseURL, tokenValue) {
+		return false, nil
+	}
+
+	var revoked bool
+
+	err := s.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			accessToken := &coredata.OAuth2AccessToken{}
+			if err := accessToken.LoadByHashedValueForUpdate(ctx, tx, hash.SHA256String(tokenValue)); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return nil
+				}
+
+				return fmt.Errorf("cannot load leaked oauth2 access token: %w", err)
+			}
+
+			if accessToken.ClientID != nil {
+				return nil
+			}
+
+			identity := &coredata.Identity{}
+			if err := identity.LoadByID(ctx, tx, accessToken.IdentityID); err != nil {
+				return fmt.Errorf("cannot load leaked token identity: %w", err)
+			}
+
+			if err := accessToken.Delete(ctx, tx); err != nil {
+				return fmt.Errorf("cannot revoke leaked oauth2 access token: %w", err)
+			}
+
+			textBody := fmt.Sprintf(
+				"We revoked your Probo API token %q because GitHub detected it in a public location. Create a replacement token before using the API again.",
+				accessToken.Name,
+			)
+			email := coredata.NewEmail(
+				identity.FullName,
+				identity.EmailAddress,
+				"Your Probo API token was revoked",
+				textBody,
+				nil,
+				nil,
+			)
+			if err := email.Insert(ctx, tx); err != nil {
+				return fmt.Errorf("cannot queue leaked token notification: %w", err)
+			}
+
+			revoked = true
+
+			return nil
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	return revoked, nil
 }

--- a/pkg/iam/oauth2/service.go
+++ b/pkg/iam/oauth2/service.go
@@ -2158,7 +2158,7 @@ func (s *Service) CreateManualAccessToken(
 		return "", nil, NewError(ErrInvalidScope, WithDescription(err.Error()))
 	}
 
-	tokenValue := newManualAccessToken(s.baseURL)
+	tokenValue := newManualAccessToken()
 
 	accessToken := &coredata.OAuth2AccessToken{
 		ID:          gid.New(req.IdentityID.TenantID(), coredata.OAuth2AccessTokenEntityType),
@@ -2189,13 +2189,11 @@ func (s *Service) CreateManualAccessToken(
 }
 
 func (s *Service) SecretScanningTokenType() string {
-	_, tokenType := cloudManualAccessTokenFormat(s.baseURL)
-
-	return tokenType
+	return secretScanningTokenType
 }
 
 func (s *Service) RevokeLeakedManualAccessToken(ctx context.Context, tokenValue string) (bool, error) {
-	if !isValidManualAccessToken(s.baseURL, tokenValue) {
+	if !isValidManualAccessToken(tokenValue) {
 		return false, nil
 	}
 

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -224,22 +224,19 @@ func NewServer(cfg Config) (*Server, error) {
 	csrf.AddInsecureBypassPattern("DELETE /mcp/v1")
 	csrf.AddInsecureBypassPattern("DELETE /mcp/v1/{rest...}")
 
-	var secretScanningHandler http.Handler
-	if cfg.IAM.OAuth2ServerService.SecretScanningTokenType() != "" {
-		secretScanningLogger := cfg.Logger.Named("github-secret-scanning.v1")
-		keyProvider := githubsecretscanning_v1.NewGitHubKeyProvider(
-			httpclient.DefaultPooledClient(
-				httpclient.WithLogger(secretScanningLogger),
-				httpclient.WithSSRFProtection(),
-			),
-		)
-		secretScanningHandler = githubsecretscanning_v1.NewMux(
-			secretScanningLogger,
-			cfg.IAM.OAuth2ServerService,
-			keyProvider,
-		)
-		csrf.AddInsecureBypassPattern("POST /github-secret-scanning/v1/alerts")
-	}
+	secretScanningLogger := cfg.Logger.Named("github-secret-scanning.v1")
+	keyProvider := githubsecretscanning_v1.NewGitHubKeyProvider(
+		httpclient.DefaultPooledClient(
+			httpclient.WithLogger(secretScanningLogger),
+			httpclient.WithSSRFProtection(),
+		),
+	)
+	secretScanningHandler := githubsecretscanning_v1.NewMux(
+		secretScanningLogger,
+		cfg.IAM.OAuth2ServerService,
+		keyProvider,
+	)
+	csrf.AddInsecureBypassPattern("POST /github-secret-scanning/v1/alerts")
 
 	csrf.SetDenyHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger := httpserver.LoggerFromContext(r.Context())
@@ -398,12 +395,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// to avoid CORS headers being set on it.
 	router.Mount("/agent/v1", http.StripPrefix("/agent/v1", s.agentHandler))
 
-	if s.secretScanningHandler != nil {
-		router.Mount(
-			"/github-secret-scanning/v1",
-			http.StripPrefix("/github-secret-scanning/v1", s.secretScanningHandler),
-		)
-	}
+	router.Mount(
+		"/github-secret-scanning/v1",
+		http.StripPrefix("/github-secret-scanning/v1", s.secretScanningHandler),
+	)
 
 	router.Group(func(r chi.Router) {
 		r.Use(cors.Handler(corsOpts))

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
+	"go.gearno.de/kit/httpclient"
 	"go.gearno.de/kit/httpserver"
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/accessreview"
@@ -61,6 +62,7 @@ import (
 	console_v1 "go.probo.inc/probo/pkg/server/api/console/v1"
 	cookiebanner_v1 "go.probo.inc/probo/pkg/server/api/cookiebanner/v1"
 	files_v1 "go.probo.inc/probo/pkg/server/api/files/v1"
+	githubsecretscanning_v1 "go.probo.inc/probo/pkg/server/api/githubsecretscanning/v1"
 	mcp_v1 "go.probo.inc/probo/pkg/server/api/mcp/v1"
 	slack_v1 "go.probo.inc/probo/pkg/server/api/slack/v1"
 	"go.probo.inc/probo/pkg/server/gqlutils"
@@ -123,15 +125,16 @@ type (
 	}
 
 	Server struct {
-		cfg                 Config
-		csrf                *http.CrossOriginProtection
-		consoleHandler      http.Handler
-		cookieBannerHandler http.Handler
-		filesHandler        http.Handler
-		mcpHandler          http.Handler
-		slackHandler        http.Handler
-		connectHandler      http.Handler
-		agentHandler        http.Handler
+		cfg                   Config
+		csrf                  *http.CrossOriginProtection
+		consoleHandler        http.Handler
+		cookieBannerHandler   http.Handler
+		filesHandler          http.Handler
+		mcpHandler            http.Handler
+		slackHandler          http.Handler
+		connectHandler        http.Handler
+		agentHandler          http.Handler
+		secretScanningHandler http.Handler
 	}
 )
 
@@ -220,6 +223,23 @@ func NewServer(cfg Config) (*Server, error) {
 	csrf.AddInsecureBypassPattern("POST /mcp/v1/{rest...}")
 	csrf.AddInsecureBypassPattern("DELETE /mcp/v1")
 	csrf.AddInsecureBypassPattern("DELETE /mcp/v1/{rest...}")
+
+	var secretScanningHandler http.Handler
+	if cfg.IAM.OAuth2ServerService.SecretScanningTokenType() != "" {
+		secretScanningLogger := cfg.Logger.Named("github-secret-scanning.v1")
+		keyProvider := githubsecretscanning_v1.NewGitHubKeyProvider(
+			httpclient.DefaultPooledClient(
+				httpclient.WithLogger(secretScanningLogger),
+				httpclient.WithSSRFProtection(),
+			),
+		)
+		secretScanningHandler = githubsecretscanning_v1.NewMux(
+			secretScanningLogger,
+			cfg.IAM.OAuth2ServerService,
+			keyProvider,
+		)
+		csrf.AddInsecureBypassPattern("POST /github-secret-scanning/v1/alerts")
+	}
 
 	csrf.SetDenyHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger := httpserver.LoggerFromContext(r.Context())
@@ -341,6 +361,7 @@ func NewServer(cfg Config) (*Server, error) {
 			cfg.Logger.Named("agent.v1"),
 			cfg.ITAM,
 		),
+		secretScanningHandler: secretScanningHandler,
 	}, nil
 }
 
@@ -376,6 +397,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Agent API should never be called from a browser; mount it outside
 	// to avoid CORS headers being set on it.
 	router.Mount("/agent/v1", http.StripPrefix("/agent/v1", s.agentHandler))
+
+	if s.secretScanningHandler != nil {
+		router.Mount(
+			"/github-secret-scanning/v1",
+			http.StripPrefix("/github-secret-scanning/v1", s.secretScanningHandler),
+		)
+	}
 
 	router.Group(func(r chi.Router) {
 		r.Use(cors.Handler(corsOpts))

--- a/pkg/server/api/githubsecretscanning/v1/handler.go
+++ b/pkg/server/api/githubsecretscanning/v1/handler.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package githubsecretscanning_v1
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"go.gearno.de/kit/httpserver"
+	"go.gearno.de/kit/log"
+)
+
+const (
+	maxAlertBodyBytes = 5 << 20
+
+	publicKeyIdentifierHeader = "Github-Public-Key-Identifier"
+	publicKeySignatureHeader  = "Github-Public-Key-Signature"
+)
+
+type (
+	TokenRevoker interface {
+		SecretScanningTokenType() string
+		RevokeLeakedManualAccessToken(ctx context.Context, tokenValue string) (bool, error)
+	}
+
+	alert struct {
+		Token  string `json:"token"`
+		Type   string `json:"type"`
+		URL    string `json:"url"`
+		Source string `json:"source"`
+	}
+
+	handler struct {
+		logger       *log.Logger
+		tokenRevoker TokenRevoker
+		keyProvider  KeyProvider
+	}
+)
+
+func NewMux(logger *log.Logger, tokenRevoker TokenRevoker, keyProvider KeyProvider) http.Handler {
+	h := &handler{
+		logger:       logger,
+		tokenRevoker: tokenRevoker,
+		keyProvider:  keyProvider,
+	}
+
+	mux := chi.NewMux()
+	mux.Post("/alerts", h.handleAlerts)
+
+	return mux
+}
+
+func (h *handler) handleAlerts(w http.ResponseWriter, r *http.Request) {
+	defer func() { _ = r.Body.Close() }()
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxAlertBodyBytes))
+	if err != nil {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+			renderError(w, http.StatusRequestEntityTooLarge, "request body is too large")
+
+			return
+		}
+
+		renderError(w, http.StatusBadRequest, "invalid request body")
+
+		return
+	}
+
+	keyIdentifier := r.Header.Get(publicKeyIdentifierHeader)
+	signature := r.Header.Get(publicKeySignatureHeader)
+	if keyIdentifier == "" || signature == "" {
+		renderError(w, http.StatusUnauthorized, "invalid signature")
+
+		return
+	}
+
+	key, err := h.keyProvider.PublicKey(r.Context(), keyIdentifier)
+	if err != nil {
+		if errors.Is(err, ErrPublicKeyNotFound) {
+			renderError(w, http.StatusUnauthorized, "invalid signature")
+
+			return
+		}
+
+		h.logger.ErrorCtx(r.Context(), "cannot load GitHub secret scanning public key", log.Error(err))
+		renderError(w, http.StatusServiceUnavailable, "signature verification unavailable")
+
+		return
+	}
+
+	if !verifySignature(body, signature, key) {
+		renderError(w, http.StatusUnauthorized, "invalid signature")
+
+		return
+	}
+
+	var alerts []alert
+	if err := json.Unmarshal(body, &alerts); err != nil || len(alerts) == 0 {
+		renderError(w, http.StatusBadRequest, "invalid alert payload")
+
+		return
+	}
+
+	tokenType := h.tokenRevoker.SecretScanningTokenType()
+	for _, item := range alerts {
+		if item.Type != tokenType || item.Token == "" {
+			continue
+		}
+
+		if _, err := h.tokenRevoker.RevokeLeakedManualAccessToken(r.Context(), item.Token); err != nil {
+			h.logger.ErrorCtx(r.Context(), "cannot revoke leaked Probo API token", log.Error(err))
+			renderError(w, http.StatusInternalServerError, "cannot process alert")
+
+			return
+		}
+	}
+
+	httpserver.RenderJSON(
+		w,
+		http.StatusOK,
+		map[string]bool{
+			"accepted": true,
+		},
+	)
+}
+
+func verifySignature(body []byte, encodedSignature string, key *ecdsa.PublicKey) bool {
+	signature, err := base64.StdEncoding.DecodeString(encodedSignature)
+	if err != nil {
+		return false
+	}
+
+	digest := sha256.Sum256(body)
+
+	return ecdsa.VerifyASN1(key, digest[:], signature)
+}
+
+func renderError(w http.ResponseWriter, status int, message string) {
+	httpserver.RenderJSON(
+		w,
+		status,
+		map[string]string{
+			"error": message,
+		},
+	)
+}

--- a/pkg/server/api/githubsecretscanning/v1/handler_test.go
+++ b/pkg/server/api/githubsecretscanning/v1/handler_test.go
@@ -38,7 +38,7 @@ import (
 	"go.gearno.de/kit/log"
 )
 
-const testTokenType = "probo_cloud_api_token_us"
+const testTokenType = "probo_api_token"
 
 type (
 	staticKeyProvider struct {
@@ -70,14 +70,14 @@ func (r *recordingRevoker) RevokeLeakedManualAccessToken(_ context.Context, toke
 func TestHandler_AcceptsSignedAlerts(t *testing.T) {
 	t.Parallel()
 
-	const body = `[{"token":"prb_a1u_example","type":"probo_cloud_api_token_us","url":"https://github.com/example/repo","source":"content"}]`
+	const body = `[{"token":"prb_a1_example","type":"probo_api_token","url":"https://github.com/example/repo","source":"content"}]`
 
 	privateKey := newTestPrivateKey(t)
 	revoker := &recordingRevoker{tokenType: testTokenType}
 	response := serveAlert(t, body, privateKey, revoker)
 
 	assert.Equal(t, http.StatusOK, response.Code)
-	assert.Equal(t, []string{"prb_a1u_example"}, revoker.tokens)
+	assert.Equal(t, []string{"prb_a1_example"}, revoker.tokens)
 	assert.JSONEq(t, `{"accepted":true}`, response.Body.String())
 }
 
@@ -179,7 +179,7 @@ func TestHandler_ReturnsUnavailableWhenKeysCannotBeLoaded(t *testing.T) {
 func TestHandler_ReturnsErrorWhenRevocationFails(t *testing.T) {
 	t.Parallel()
 
-	const body = `[{"token":"prb_a1u_example","type":"probo_cloud_api_token_us","url":"","source":"content"}]`
+	const body = `[{"token":"prb_a1_example","type":"probo_api_token","url":"","source":"content"}]`
 
 	privateKey := newTestPrivateKey(t)
 	revoker := &recordingRevoker{
@@ -189,7 +189,7 @@ func TestHandler_ReturnsErrorWhenRevocationFails(t *testing.T) {
 	response := serveAlert(t, body, privateKey, revoker)
 
 	assert.Equal(t, http.StatusInternalServerError, response.Code)
-	assert.Equal(t, []string{"prb_a1u_example"}, revoker.tokens)
+	assert.Equal(t, []string{"prb_a1_example"}, revoker.tokens)
 }
 
 func serveAlert(

--- a/pkg/server/api/githubsecretscanning/v1/handler_test.go
+++ b/pkg/server/api/githubsecretscanning/v1/handler_test.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package githubsecretscanning_v1
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/log"
+)
+
+const testTokenType = "probo_cloud_api_token_us"
+
+type (
+	staticKeyProvider struct {
+		key *ecdsa.PublicKey
+		err error
+	}
+
+	recordingRevoker struct {
+		tokenType string
+		tokens    []string
+		err       error
+	}
+)
+
+func (p *staticKeyProvider) PublicKey(context.Context, string) (*ecdsa.PublicKey, error) {
+	return p.key, p.err
+}
+
+func (r *recordingRevoker) SecretScanningTokenType() string {
+	return r.tokenType
+}
+
+func (r *recordingRevoker) RevokeLeakedManualAccessToken(_ context.Context, token string) (bool, error) {
+	r.tokens = append(r.tokens, token)
+
+	return r.err == nil, r.err
+}
+
+func TestHandler_AcceptsSignedAlerts(t *testing.T) {
+	t.Parallel()
+
+	const body = `[{"token":"prb_a1u_example","type":"probo_cloud_api_token_us","url":"https://github.com/example/repo","source":"content"}]`
+
+	privateKey := newTestPrivateKey(t)
+	revoker := &recordingRevoker{tokenType: testTokenType}
+	response := serveAlert(t, body, privateKey, revoker)
+
+	assert.Equal(t, http.StatusOK, response.Code)
+	assert.Equal(t, []string{"prb_a1u_example"}, revoker.tokens)
+	assert.JSONEq(t, `{"accepted":true}`, response.Body.String())
+}
+
+func TestHandler_IgnoresOtherTokenTypes(t *testing.T) {
+	t.Parallel()
+
+	const body = `[{"token":"other-secret","type":"another_provider_token","url":"","source":"content"}]`
+
+	privateKey := newTestPrivateKey(t)
+	revoker := &recordingRevoker{tokenType: testTokenType}
+	response := serveAlert(t, body, privateKey, revoker)
+
+	assert.Equal(t, http.StatusOK, response.Code)
+	assert.Empty(t, revoker.tokens)
+}
+
+func TestHandler_RejectsMissingSignature(t *testing.T) {
+	t.Parallel()
+
+	revoker := &recordingRevoker{tokenType: testTokenType}
+	handler := NewMux(log.NewLogger(), revoker, &staticKeyProvider{})
+	req := httptest.NewRequest(http.MethodPost, "/alerts", strings.NewReader(`[]`))
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, req)
+
+	assert.Equal(t, http.StatusUnauthorized, response.Code)
+	assert.Empty(t, revoker.tokens)
+}
+
+func TestHandler_RejectsInvalidSignature(t *testing.T) {
+	t.Parallel()
+
+	privateKey := newTestPrivateKey(t)
+	revoker := &recordingRevoker{tokenType: testTokenType}
+	req := signedRequest(t, `[{"token":"secret","type":"`+testTokenType+`"}]`, privateKey)
+	req.Header.Set(publicKeySignatureHeader, base64.StdEncoding.EncodeToString([]byte("invalid")))
+	response := httptest.NewRecorder()
+
+	NewMux(
+		log.NewLogger(),
+		revoker,
+		&staticKeyProvider{key: &privateKey.PublicKey},
+	).ServeHTTP(response, req)
+
+	assert.Equal(t, http.StatusUnauthorized, response.Code)
+	assert.Empty(t, revoker.tokens)
+}
+
+func TestHandler_RejectsMalformedSignedPayload(t *testing.T) {
+	t.Parallel()
+
+	privateKey := newTestPrivateKey(t)
+	revoker := &recordingRevoker{tokenType: testTokenType}
+	response := serveAlert(t, `{`, privateKey, revoker)
+
+	assert.Equal(t, http.StatusBadRequest, response.Code)
+	assert.Empty(t, revoker.tokens)
+}
+
+func TestHandler_RejectsOversizedPayload(t *testing.T) {
+	t.Parallel()
+
+	revoker := &recordingRevoker{tokenType: testTokenType}
+	handler := NewMux(log.NewLogger(), revoker, &staticKeyProvider{})
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/alerts",
+		strings.NewReader(strings.Repeat("a", maxAlertBodyBytes+1)),
+	)
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, response.Code)
+	assert.Empty(t, revoker.tokens)
+}
+
+func TestHandler_ReturnsUnavailableWhenKeysCannotBeLoaded(t *testing.T) {
+	t.Parallel()
+
+	revoker := &recordingRevoker{tokenType: testTokenType}
+	handler := NewMux(
+		log.NewLogger(),
+		revoker,
+		&staticKeyProvider{err: errors.New("unavailable")},
+	)
+	req := httptest.NewRequest(http.MethodPost, "/alerts", strings.NewReader(`[]`))
+	req.Header.Set(publicKeyIdentifierHeader, "test-key")
+	req.Header.Set(publicKeySignatureHeader, "signature")
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, response.Code)
+	assert.Empty(t, revoker.tokens)
+}
+
+func TestHandler_ReturnsErrorWhenRevocationFails(t *testing.T) {
+	t.Parallel()
+
+	const body = `[{"token":"prb_a1u_example","type":"probo_cloud_api_token_us","url":"","source":"content"}]`
+
+	privateKey := newTestPrivateKey(t)
+	revoker := &recordingRevoker{
+		tokenType: testTokenType,
+		err:       errors.New("database unavailable"),
+	}
+	response := serveAlert(t, body, privateKey, revoker)
+
+	assert.Equal(t, http.StatusInternalServerError, response.Code)
+	assert.Equal(t, []string{"prb_a1u_example"}, revoker.tokens)
+}
+
+func serveAlert(
+	t *testing.T,
+	body string,
+	privateKey *ecdsa.PrivateKey,
+	revoker TokenRevoker,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := signedRequest(t, body, privateKey)
+	response := httptest.NewRecorder()
+	handler := NewMux(
+		log.NewLogger(),
+		revoker,
+		&staticKeyProvider{key: &privateKey.PublicKey},
+	)
+	handler.ServeHTTP(response, req)
+
+	return response
+}
+
+func signedRequest(t *testing.T, body string, privateKey *ecdsa.PrivateKey) *http.Request {
+	t.Helper()
+
+	digest := sha256.Sum256([]byte(body))
+	signature, err := ecdsa.SignASN1(cryptorand.Reader, privateKey, digest[:])
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/alerts", strings.NewReader(body))
+	req.Header.Set(publicKeyIdentifierHeader, "test-key")
+	req.Header.Set(publicKeySignatureHeader, base64.StdEncoding.EncodeToString(signature))
+
+	return req
+}
+
+func newTestPrivateKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
+	require.NoError(t, err)
+
+	return privateKey
+}

--- a/pkg/server/api/githubsecretscanning/v1/keys.go
+++ b/pkg/server/api/githubsecretscanning/v1/keys.go
@@ -23,6 +23,7 @@ package githubsecretscanning_v1
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -36,8 +37,9 @@ import (
 )
 
 const (
-	publicKeyCacheDuration = time.Hour
-	maxPublicKeyBodyBytes  = 1 << 20
+	publicKeyCacheDuration    = time.Hour
+	unknownKeyRefreshInterval = time.Minute
+	maxPublicKeyBodyBytes     = 1 << 20
 )
 
 type (
@@ -50,10 +52,11 @@ type (
 	}
 
 	GitHubKeyProvider struct {
-		httpClient HTTPClient
-		mu         sync.Mutex
-		keys       map[string]*ecdsa.PublicKey
-		expiresAt  time.Time
+		httpClient  HTTPClient
+		mu          sync.Mutex
+		keys        map[string]*ecdsa.PublicKey
+		expiresAt   time.Time
+		refreshedAt time.Time
 	}
 
 	publicKeyResponse struct {
@@ -81,8 +84,15 @@ func (p *GitHubKeyProvider) PublicKey(ctx context.Context, identifier string) (*
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if key, ok := p.keys[identifier]; ok && time.Now().Before(p.expiresAt) {
+	now := time.Now()
+	if key, ok := p.keys[identifier]; ok && now.Before(p.expiresAt) {
 		return key, nil
+	}
+
+	if _, ok := p.keys[identifier]; !ok &&
+		!p.refreshedAt.IsZero() &&
+		now.Sub(p.refreshedAt) < unknownKeyRefreshInterval {
+		return nil, ErrPublicKeyNotFound
 	}
 
 	if err := p.refresh(ctx); err != nil {
@@ -138,7 +148,8 @@ func (p *GitHubKeyProvider) refresh(ctx context.Context) error {
 	}
 
 	p.keys = keys
-	p.expiresAt = time.Now().Add(publicKeyCacheDuration)
+	p.refreshedAt = time.Now()
+	p.expiresAt = p.refreshedAt.Add(publicKeyCacheDuration)
 
 	return nil
 }
@@ -157,6 +168,9 @@ func parsePublicKey(value string) (*ecdsa.PublicKey, error) {
 	ecdsaKey, ok := key.(*ecdsa.PublicKey)
 	if !ok {
 		return nil, errors.New("public key is not ECDSA")
+	}
+	if ecdsaKey.Curve != elliptic.P256() {
+		return nil, errors.New("public key is not P-256")
 	}
 
 	return ecdsaKey, nil

--- a/pkg/server/api/githubsecretscanning/v1/keys.go
+++ b/pkg/server/api/githubsecretscanning/v1/keys.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package githubsecretscanning_v1
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+const (
+	publicKeyCacheDuration = time.Hour
+	maxPublicKeyBodyBytes  = 1 << 20
+)
+
+type (
+	HTTPClient interface {
+		Do(req *http.Request) (*http.Response, error)
+	}
+
+	KeyProvider interface {
+		PublicKey(ctx context.Context, identifier string) (*ecdsa.PublicKey, error)
+	}
+
+	GitHubKeyProvider struct {
+		httpClient HTTPClient
+		mu         sync.Mutex
+		keys       map[string]*ecdsa.PublicKey
+		expiresAt  time.Time
+	}
+
+	publicKeyResponse struct {
+		PublicKeys []publicKeyEntry `json:"public_keys"`
+	}
+
+	publicKeyEntry struct {
+		Identifier string `json:"key_identifier"`
+		Key        string `json:"key"`
+	}
+)
+
+var (
+	ErrPublicKeyNotFound = errors.New("GitHub secret scanning public key not found")
+)
+
+func NewGitHubKeyProvider(httpClient HTTPClient) *GitHubKeyProvider {
+	return &GitHubKeyProvider{
+		httpClient: httpClient,
+		keys:       make(map[string]*ecdsa.PublicKey),
+	}
+}
+
+func (p *GitHubKeyProvider) PublicKey(ctx context.Context, identifier string) (*ecdsa.PublicKey, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if key, ok := p.keys[identifier]; ok && time.Now().Before(p.expiresAt) {
+		return key, nil
+	}
+
+	if err := p.refresh(ctx); err != nil {
+		return nil, err
+	}
+
+	key, ok := p.keys[identifier]
+	if !ok {
+		return nil, ErrPublicKeyNotFound
+	}
+
+	return key, nil
+}
+
+func (p *GitHubKeyProvider) refresh(ctx context.Context) error {
+	endpoint := (&url.URL{
+		Scheme: "https",
+		Host:   "api.github.com",
+		Path:   "/meta/public_keys/secret_scanning",
+	}).String()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("cannot create GitHub public key request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("cannot fetch GitHub public keys: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("cannot fetch GitHub public keys: unexpected status %d", resp.StatusCode)
+	}
+
+	var payload publicKeyResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxPublicKeyBodyBytes)).Decode(&payload); err != nil {
+		return fmt.Errorf("cannot decode GitHub public keys: %w", err)
+	}
+
+	keys := make(map[string]*ecdsa.PublicKey, len(payload.PublicKeys))
+	for _, entry := range payload.PublicKeys {
+		key, err := parsePublicKey(entry.Key)
+		if err != nil {
+			return fmt.Errorf("cannot parse GitHub public key: %w", err)
+		}
+
+		keys[entry.Identifier] = key
+	}
+
+	p.keys = keys
+	p.expiresAt = time.Now().Add(publicKeyCacheDuration)
+
+	return nil
+}
+
+func parsePublicKey(value string) (*ecdsa.PublicKey, error) {
+	block, _ := pem.Decode([]byte(value))
+	if block == nil {
+		return nil, errors.New("invalid PEM block")
+	}
+
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse PKIX public key: %w", err)
+	}
+
+	ecdsaKey, ok := key.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, errors.New("public key is not ECDSA")
+	}
+
+	return ecdsaKey, nil
+}

--- a/pkg/server/api/githubsecretscanning/v1/keys_test.go
+++ b/pkg/server/api/githubsecretscanning/v1/keys_test.go
@@ -79,6 +79,8 @@ func TestGitHubKeyProvider_RejectsUnknownKey(t *testing.T) {
 	provider := NewGitHubKeyProvider(client)
 
 	_, err := provider.PublicKey(context.Background(), "missing-key")
+	assert.ErrorIs(t, err, ErrPublicKeyNotFound)
+	_, err = provider.PublicKey(context.Background(), "missing-key")
 
 	assert.ErrorIs(t, err, ErrPublicKeyNotFound)
 	assert.Equal(t, 1, client.calls)

--- a/pkg/server/api/githubsecretscanning/v1/keys_test.go
+++ b/pkg/server/api/githubsecretscanning/v1/keys_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package githubsecretscanning_v1
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingHTTPClient struct {
+	body  []byte
+	calls int
+}
+
+func (c *recordingHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.calls++
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(c.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestGitHubKeyProvider_CachesPublicKeys(t *testing.T) {
+	t.Parallel()
+
+	privateKey := newTestPrivateKey(t)
+	body := publicKeysBody(t, "test-key", &privateKey.PublicKey)
+	client := &recordingHTTPClient{body: body}
+	provider := NewGitHubKeyProvider(client)
+
+	first, err := provider.PublicKey(context.Background(), "test-key")
+	require.NoError(t, err)
+	second, err := provider.PublicKey(context.Background(), "test-key")
+	require.NoError(t, err)
+
+	assert.Equal(t, &privateKey.PublicKey, first)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, client.calls)
+}
+
+func TestGitHubKeyProvider_RejectsUnknownKey(t *testing.T) {
+	t.Parallel()
+
+	privateKey := newTestPrivateKey(t)
+	client := &recordingHTTPClient{
+		body: publicKeysBody(t, "another-key", &privateKey.PublicKey),
+	}
+	provider := NewGitHubKeyProvider(client)
+
+	_, err := provider.PublicKey(context.Background(), "missing-key")
+
+	assert.ErrorIs(t, err, ErrPublicKeyNotFound)
+	assert.Equal(t, 1, client.calls)
+}
+
+func publicKeysBody(t *testing.T, identifier string, key *ecdsa.PublicKey) []byte {
+	t.Helper()
+
+	der, err := x509.MarshalPKIXPublicKey(key)
+	require.NoError(t, err)
+
+	body, err := json.Marshal(
+		publicKeyResponse{
+			PublicKeys: []publicKeyEntry{
+				{
+					Identifier: identifier,
+					Key: string(
+						pem.EncodeToMemory(
+							&pem.Block{
+								Type:  "PUBLIC KEY",
+								Bytes: der,
+							},
+						),
+					),
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	return body
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- issue one compact `prb_a1_` checksummed API-token format across all deployments
- accept ECDSA P-256-signed GitHub secret scanning alerts on every deployment
- support a central receiver broadcasting GitHub's original body and signature headers unchanged to all managed deployments
- revoke only a matching token in the local deployment database and queue one owner notification
- cache GitHub signing keys and throttle unknown-key refreshes

## Testing

- `go test -race ./pkg/iam/oauth2 ./pkg/server/api/githubsecretscanning/v1 ./pkg/server/api`
- `go vet ./pkg/iam/oauth2 ./pkg/server/api/githubsecretscanning/v1 ./pkg/server/api`
- `make build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83525c29-58f6-467c-8c95-a28de9136725?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83525c29-58f6-467c-8c95-a28de9136725&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Issues a compact, checksummed `prb_a1_` API token format on every deployment and adds a GitHub secret scanning endpoint that verifies ECDSA-signed alerts, revokes matching tokens atomically, and notifies the owner by email.

### Coredata **`+43`** **`-0`**

Adds a method that loads an access token by hashed value with a row lock so revocation can safely delete the matching row.

### Service **`+142`** **`-1`**

All deployments now issue base62 tokens with a CRC32 checksum instead of hex; the revoker ignores legacy non-checksummed tokens. `RevokeLeakedManualAccessToken` validates the checksum, locks and deletes the token in one transaction, and queues exactly one notification email.

### GraphQL API **`+380`** **`-9`**

Mounts `/github-secret-scanning/v1/alerts` on every deployment so a central receiver can broadcast GitHub's original signed payload unchanged. Verifies the ECDSA P-256 signature against cached public keys from GitHub's metadata endpoint, and throttles refreshes for unknown key identifiers to protect that endpoint.

### Tests **`+596`** **`-0`**

Covers token format and checksum rejection, signature and curve verification, key caching and refresh throttling, and atomic revocation with a single notification email.

<sup>Written for commit 48a748d9e1c91742a02cb4b13601f08e012fff5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

